### PR TITLE
[WIP] feat(lightpush): Dandelion support

### DIFF
--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -251,6 +251,11 @@ type
       desc: "Peer multiaddr to request lightpush of published messages.",
       defaultValue: ""
       name: "lightpushnode" }: string
+
+    dandelion* {.
+      desc: "Enable dandelion stem relaying: true|false",
+      defaultValue: false
+      name: "dandelion" }: bool
     
     ## JSON-RPC config
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -567,7 +567,7 @@ proc mountRelay*(node: WakuNode,
         
   info "relay mounted successfully"
 
-proc mountLightPush*(node: WakuNode) {.async, raises: [Defect, LPError].} =
+proc mountLightPush*(node: WakuNode, dandelion: bool = false) {.async, raises: [Defect, LPError].} =
   info "mounting light push"
 
   if node.wakuRelay.isNil:
@@ -575,7 +575,9 @@ proc mountLightPush*(node: WakuNode) {.async, raises: [Defect, LPError].} =
     node.wakuLightPush = WakuLightPush.init(node.peerManager, node.rng, nil)
   else:
     debug "mounting lightpush with relay"
-    node.wakuLightPush = WakuLightPush.init(node.peerManager, node.rng, nil, node.wakuRelay)
+    if dandelion:
+      debug "activate lightpush dandelion relay"
+    node.wakuLightPush = WakuLightPush.init(node.peerManager, node.rng, nil, node.wakuRelay, dandelion)
   
   if node.started:
     # Node has started already. Let's start lightpush too.
@@ -1095,8 +1097,8 @@ when isMainModule:
         setStorePeer(node, conf.storenode)
 
     # NOTE Must be mounted after relay
-    if (conf.lightpushnode != "") or (conf.lightpush):
-      waitFor mountLightPush(node)
+    if (conf.lightpushnode != "") or (conf.lightpush) or (conf.dandelion):
+      waitFor mountLightPush(node, conf.dandelion)
 
       if conf.lightpushnode != "":
         setLightPushPeer(node, conf.lightpushnode)


### PR DESCRIPTION
This PR adds basic Waku Dandelion stem support to lightpush,
and addresses part of the [Dandelion++ for Waku v2 Milestone](https://github.com/vacp2p/research/issues/119).

Currently, this PR is WIP and mainly serves as an example for the discussion in: https://github.com/vacp2p/rfc/pull/541

This PR does not feature the fail-safe.
I'd suggest adding the fail-safe in a future PR.

## Open Tasks

* [ ] randomly select peers from the mesh peer set
  - left this open because of the planned peer store restructuring
* [ ] select two peers per epoch, and implement the connection to stem-relay mapping 
* [ ] more analysis
  - e.g. lightpush replies with confirmations. Do we want this for the stem phase?
