### PR TITLE
fix: call runPeerExchangeDiscv5Loop

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -363,6 +363,8 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf, mStorage: MessageStore):
     except:
       return err("failed to mount waku peer-exchange protocol: " & getCurrentExceptionMsg())
 
+    asyncSpawn runPeerExchangeDiscv5Loop(node.wakuPeerExchange)
+
     if conf.peerExchangeNode != "":
       try:
         setPeerExchangePeer(node, conf.peerExchangeNode)


### PR DESCRIPTION
This PR adds a call to `runPeerExchangeDiscv5Loop` in `wakunode2.nim`.
`runPeerExchangeDiscv5Loop` asynchronously fills the px peer list via discv5.
Thanks @richard-ramos for pointing this out :).