### PR TITLE
fix(wakubridge): fix test failure while bridging messages between Waku v1 and v2 (WIP) 

### DIFF
--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -140,12 +140,12 @@ procSuite "WakuBridge":
 
     v2Node.subscribe(DefaultBridgeTopic, relayHandler)
 
-    await sleepAsync(250.millis)
+    await sleepAsync(5.seconds)
 
     # Test bridging from V2 to V1
     await v2Node.publish(DefaultBridgeTopic, message)
 
-    await sleepAsync(250.millis)
+    await sleepAsync(5.seconds)
 
     check:
       # v1Node received message published by v2Node


### PR DESCRIPTION
This PR partially covers the issues collected by the flaky tests umbrella issue #1357.

> ⚠️ WIP