### PR TITLE
feat(rln): use zerokit as static lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,5 @@ CMD ["--help"]
 
 FROM prod AS experimental
 
-# If RLN enabled, copy the librln artifacts
-COPY --from=nim-build /app/vendor/zerokit/target/release/librln.so vendor/zerokit/target/release/librln.so
+# If RLN enabled, copy RLN resources (WASM ZK circuit, proving and verification keys) used by tests
 COPY --from=nim-build /app/vendor/zerokit/rln/resources/ vendor/zerokit/rln/resources/

--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,9 @@ endif
 LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit/target/release
 
 ifeq ($(OS),Windows_NT)
-LIBRLN_FILE := rln.dll
-else ifeq ($(shell uname -s),Darwin)
-LIBRLN_FILE := librln.dylib
+LIBRLN_FILE := rln.lib
 else
-LIBRLN_FILE := librln.so
+LIBRLN_FILE := librln.a
 endif
 
 $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE):
@@ -122,7 +120,7 @@ $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE):
 ifneq ($(RLN), true)
 librln: ; # noop
 else
-EXPERIMENTAL_PARAMS += -d:rln -d:rln_libpath=$(LIBRLN_BUILDDIR)/$(LIBRLN_FILE)
+EXPERIMENTAL_PARAMS += -d:rln --dynlibOverride:rln --passL:$(LIBRLN_BUILDDIR)/$(LIBRLN_FILE) --passL:-lm
 librln: $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE)
 endif
 

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -9,10 +9,6 @@ else:
   {.push raises: [].}
 
 
-const rln_libpath {.strdefine.} = "vendor/zerokit/target/release/librln.so"
-
-{.push dynlib: static(rln_libpath).}
-
 ## Buffer struct is taken from
 # https://github.com/celo-org/celo-threshold-bls-rs/blob/master/crates/threshold-bls-ffi/src/ffi.rs
 type Buffer* = object
@@ -152,5 +148,3 @@ proc hash*(ctx: ptr RLN,
 ## inputs_buffer holds the hash input as a byte seq
 ## the hash output is generated and populated inside output_buffer
 ## the output_buffer contains 32 bytes hash output
-
-{.pop.}


### PR DESCRIPTION
This PR addresses the first, second, forth item of https://github.com/status-im/nwaku/issues/1380

The RLN flags management in the makefile has been refactored so that rln flags (`rln` and `onchain_rln`) together with rlnlib compilation and library linking are processed only when `rlnlib` target is compiled. 

This avoid to pass unnecessary rln flags to e.g. v1 targets when targets are **not** compiled in parallel, and ensures the RLN library to be eventually linked only after it has been effectively compiled. See https://github.com/status-im/nwaku/pull/1385#issuecomment-1317816904 for more details/limitations of current implementation.

This branch has been deployed on test fleet and the chat2 app with RLN enabled worked as expected.

Minor: I added a yellow warning that tells the user that onchain and RLN tests will not be compiled when only the flag `ONCHAIN_RLN` is set to true and `RLN` remains unset.