### PR TITLE
fix(ci): explicitly pass MAKEFLAGS content to make (WIP)

### DIFF
--- a/.github/workflows/test1.yml
+++ b/.github/workflows/test1.yml
@@ -31,7 +31,6 @@ jobs:
       matrix:
         env:
           - NPROC: 2
-            MAKEFLAGS: "-j${NPROC}"
             NIMFLAGS: "--parallelBuild:${NPROC}"
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
@@ -57,10 +56,10 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.env.NPROC }}-nim-${{ hashFiles('.gitmodules') }}
 
       - name: Update dependencies
-        run: make ${{MAKEFLAGS}} V=1 update
+        run: make -j${NPROC} V=1 update
 
       - name: Build V1 binaries
-        run: make ${{MAKEFLAGS}} LOG_LEVEL=TRACE v1
+        run: make -j${NPROC} LOG_LEVEL=TRACE v1
 
       - name: Run V1 Tests
-        run: make ${{MAKEFLAGS}} test1
+        run: make -j${NPROC} test1

--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -35,7 +35,6 @@ jobs:
       matrix:
         env:
           - NPROC: 2
-            MAKEFLAGS: "-j${NPROC}"
             NIMFLAGS: "--parallelBuild:${NPROC}"
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
@@ -61,10 +60,10 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.env.NPROC }}-nim-${{ hashFiles('.gitmodules') }}
 
       - name: Update dependencies
-        run: make ${{MAKEFLAGS}} V=1 update
+        run: make -j${NPROC} V=1 update
 
       - name: Build V2 binaries
-        run: make ${{MAKEFLAGS}} LOG_LEVEL=TRACE v2
+        run: make -j${NPROC} LOG_LEVEL=TRACE v2
 
       - name: Run V2 Tests
-        run: make ${{MAKEFLAGS}} test2
+        run: make -j${NPROC} test2


### PR DESCRIPTION
It seems that `make` is compiling `nwaku` targets using a single job.

This PR passes explicitly the `MAKEFLAGS`' content to all `make` instances in test1 and test2 workflows, and removes its redundant definition in order to test if it is effectively the case.