### PR TITLE
chore(store): remove obsolete metrics and error labels

### DIFF
--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -7,7 +7,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[tables, times, sequtils, options, algorithm],
+  std/options,
   stew/results,
   chronicles,
   chronos,

--- a/waku/v2/protocol/waku_store/protocol_metrics.nim
+++ b/waku/v2/protocol/waku_store/protocol_metrics.nim
@@ -6,18 +6,12 @@ else:
 import metrics
 
 
-declarePublicGauge waku_store_messages, "number of historical messages", ["type"]
 declarePublicGauge waku_store_errors, "number of store protocol errors", ["type"]
 declarePublicGauge waku_store_queries, "number of store queries received"
-declarePublicHistogram waku_store_insert_duration_seconds, "message insertion duration"
-declarePublicHistogram waku_store_query_duration_seconds, "history query duration"
 
 
 # Error types (metric label values)
 const
-  invalidMessage* = "invalid_message"
-  insertFailure* = "insert_failure"
-  retPolicyFailure* = "retpolicy_failure"
   dialFailure* = "dial_failure"
   decodeRpcFailure* = "decode_rpc_failure"
   peerNotFoundFailure* = "peer_not_found_failure"


### PR DESCRIPTION
These metrics were moved to the `waku_archive_` namespace. Removing those that are obsolete.