### PR TITLE
feat(peerstore): store peer direction

### DIFF
--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -314,3 +314,56 @@ procSuite "Peer Manager":
       nodes[0].peerManager.peerStore[ConnectionBook][nodes[3].switch.peerInfo.peerId] == Connected
 
     await allFutures(nodes.mapIt(it.stop()))
+
+  asyncTest "Peer store keeps track of incoming connections":
+    # Create 4 nodes
+    var nodes: seq[WakuNode]
+    for i in 0..<4:
+      let nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      let node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60865 + i))
+      nodes &= node
+
+    # Start them
+    await allFutures(nodes.mapIt(it.start()))
+    await allFutures(nodes.mapIt(it.mountRelay()))
+
+    # Get all peer infos
+    let peerInfos = nodes.mapIt(it.switch.peerInfo.toRemotePeerInfo())
+
+    # all nodes connect to peer 0
+    discard await nodes[1].peerManager.dialPeer(peerInfos[0], WakuRelayCodec, 2.seconds)
+    discard await nodes[2].peerManager.dialPeer(peerInfos[0], WakuRelayCodec, 2.seconds)
+    discard await nodes[3].peerManager.dialPeer(peerInfos[0], WakuRelayCodec, 2.seconds)
+
+    check:
+      # Peerstore track all three peers
+      nodes[0].peerManager.peerStore.peers().len == 3
+
+      # TODO: Test get count of incoming connections when ready
+
+      # All peer ids are correct
+      nodes[0].peerManager.peerStore.peers().anyIt(it.peerId == nodes[1].switch.peerInfo.peerId)
+      nodes[0].peerManager.peerStore.peers().anyIt(it.peerId == nodes[2].switch.peerInfo.peerId)
+      nodes[0].peerManager.peerStore.peers().anyIt(it.peerId == nodes[3].switch.peerInfo.peerId)
+
+      # All peers support the relay protocol
+      nodes[0].peerManager.peerStore[ProtoBook][nodes[1].switch.peerInfo.peerId].contains(WakuRelayCodec)
+      nodes[0].peerManager.peerStore[ProtoBook][nodes[2].switch.peerInfo.peerId].contains(WakuRelayCodec)
+      nodes[0].peerManager.peerStore[ProtoBook][nodes[3].switch.peerInfo.peerId].contains(WakuRelayCodec)
+
+      # All peers are connected
+      nodes[0].peerManager.peerStore[ConnectionBook][nodes[1].switch.peerInfo.peerId] == Connected
+      nodes[0].peerManager.peerStore[ConnectionBook][nodes[2].switch.peerInfo.peerId] == Connected
+      nodes[0].peerManager.peerStore[ConnectionBook][nodes[3].switch.peerInfo.peerId] == Connected
+
+      # All peers are Inbound in peer 0
+      nodes[0].peerManager.peerStore[DirectionBook][nodes[1].switch.peerInfo.peerId] == Inbound
+      nodes[0].peerManager.peerStore[DirectionBook][nodes[2].switch.peerInfo.peerId] == Inbound
+      nodes[0].peerManager.peerStore[DirectionBook][nodes[3].switch.peerInfo.peerId] == Inbound
+
+      # All peers have an Outbound connection with peer 0
+      nodes[1].peerManager.peerStore[DirectionBook][nodes[0].switch.peerInfo.peerId] == Outbound
+      nodes[2].peerManager.peerStore[DirectionBook][nodes[0].switch.peerInfo.peerId] == Outbound
+      nodes[3].peerManager.peerStore[DirectionBook][nodes[0].switch.peerInfo.peerId] == Outbound
+
+    await allFutures(nodes.mapIt(it.stop()))

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -339,7 +339,15 @@ procSuite "Peer Manager":
       # Peerstore track all three peers
       nodes[0].peerManager.peerStore.peers().len == 3
 
-      # TODO: Test get count of incoming connections when ready
+      # Inbound/Outbound number of peers match
+      nodes[0].peerManager.peerStore.getPeersByDirection(Inbound).len == 3
+      nodes[0].peerManager.peerStore.getPeersByDirection(Outbound).len == 0
+      nodes[1].peerManager.peerStore.getPeersByDirection(Inbound).len == 0
+      nodes[1].peerManager.peerStore.getPeersByDirection(Outbound).len == 1
+      nodes[2].peerManager.peerStore.getPeersByDirection(Inbound).len == 0
+      nodes[2].peerManager.peerStore.getPeersByDirection(Outbound).len == 1
+      nodes[3].peerManager.peerStore.getPeersByDirection(Inbound).len == 0
+      nodes[3].peerManager.peerStore.getPeersByDirection(Outbound).len == 1
 
       # All peer ids are correct
       nodes[0].peerManager.peerStore.peers().anyIt(it.peerId == nodes[1].switch.peerInfo.peerId)

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -118,18 +118,16 @@ proc loadFromStorage(pm: PeerManager) =
 ##################
 
 proc onConnEvent(pm: PeerManager, peerId: PeerID, event: ConnEvent) {.async.} =
-  if not pm.peerStore[AddressBook].contains(peerId):
-    ## We only consider connection events if we
-    ## already track some addresses for this peer
-    return
 
   case event.kind
   of ConnEventKind.Connected:
     pm.peerStore[ConnectionBook][peerId] = Connected
+    pm.peerStore[DirectionBook][peerId] = if event.incoming: Inbound else: Outbound
     if not pm.storage.isNil:
       pm.storage.insertOrReplace(peerId, pm.peerStore.get(peerId), Connected)
     return
   of ConnEventKind.Disconnected:
+    pm.peerStore[DirectionBook][peerId] = UnknownDirection
     pm.peerStore[ConnectionBook][peerId] = CanConnect
     if not pm.storage.isNil:
       pm.storage.insertOrReplace(peerId, pm.peerStore.get(peerId), CanConnect, getTime().toUnix)

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -87,6 +87,7 @@ proc get*(peerStore: PeerStore,
     direction: peerStore[DirectionBook][peerId],
   )
 
+# TODO: Rename peers() to getPeersByProtocol()
 proc peers*(peerStore: PeerStore): seq[StoredInfo] =
   ## Get all the stored information of every peer.
   let allKeys = concat(toSeq(peerStore[AddressBook].book.keys()),
@@ -140,5 +141,5 @@ proc selectPeer*(peerStore: PeerStore, proto: string): Option[RemotePeerInfo] =
   else:
     return none(RemotePeerInfo)
 
-# TODO proc getAmountInboundPeers()
-# TODO proc getAmountOutboundPeers()
+proc getPeersByDirection*(peerStore: PeerStore, direction: Direction): seq[StoredInfo] =
+  return peerStore.peers().filterIt(it.direction == direction)

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -27,10 +27,15 @@ type
     Connected
 
   PeerOrigin* = enum
-    Unknown,
+    UnknownOrigin,
     Discv5,
     Static,
     Dns
+
+  Direction* = enum
+    UnknownDirection,
+    Inbound,
+    Outbound
 
   # Keeps track of the Connectedness state of a peer
   ConnectionBook* = ref object of PeerBook[Connectedness]
@@ -40,6 +45,9 @@ type
 
   # Keeps track of the origin of a peer
   SourceBook* = ref object of PeerBook[PeerOrigin]
+
+  # Direction
+  DirectionBook* = ref object of PeerBook[Direction]
 
   StoredInfo* = object
     # Taken from nim-libp2
@@ -54,6 +62,7 @@ type
     connectedness*: Connectedness
     disconnectTime*: int64
     origin*: PeerOrigin
+    direction*: Direction
 
 ##################
 # Peer Store API #
@@ -75,6 +84,7 @@ proc get*(peerStore: PeerStore,
     connectedness: peerStore[ConnectionBook][peerId],
     disconnectTime: peerStore[DisconnectBook][peerId],
     origin: peerStore[SourceBook][peerId],
+    direction: peerStore[DirectionBook][peerId],
   )
 
 proc peers*(peerStore: PeerStore): seq[StoredInfo] =
@@ -129,3 +139,6 @@ proc selectPeer*(peerStore: PeerStore, proto: string): Option[RemotePeerInfo] =
     return some(peerStored.toRemotePeerInfo())
   else:
     return none(RemotePeerInfo)
+
+# TODO proc getAmountInboundPeers()
+# TODO proc getAmountOutboundPeers()

--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -65,6 +65,7 @@ proc newWakuSwitch*(
     maxConnections = MaxConnections,
     maxIn = -1,
     maxOut = -1,
+    # TODO: Use our own value set 1 one.
     maxConnsPerPeer = MaxConnectionsPerPeer,
     nameResolver: NameResolver = nil,
     sendSignedPeerRecord = false,

--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -14,6 +14,9 @@ import
   libp2p/builders,
   libp2p/transports/[transport, tcptransport, wstransport]
 
+# override nim-libp2p default value (which is also 1)
+const MaxConnectionsPerPeer* = 1
+
 proc withWsTransport*(b: SwitchBuilder): SwitchBuilder =
   b.withTransport(proc(upgr: Upgrade): Transport = WsTransport.new(upgr))
 
@@ -65,7 +68,6 @@ proc newWakuSwitch*(
     maxConnections = MaxConnections,
     maxIn = -1,
     maxOut = -1,
-    # TODO: Use our own value set 1 one.
     maxConnsPerPeer = MaxConnectionsPerPeer,
     nameResolver: NameResolver = nil,
     sendSignedPeerRecord = false,


### PR DESCRIPTION
- [x] Store connection direction of each peer in the peerstore: `Inbound` or `Outbound`.
- [x] Add function in the peer store to retrieve peers by direction `getPeersByDirection`.
- [x] Add new metric `waku_connected_peers` with `direction` label.
- [x] Set `MaxConnectionsPerPeer` to `1` to ensure we only support one connection per peer. Note that this value was already set to `1` in `nim-libp2p` but it may change. If in the future we decide to support multiple connections, we would need to revisit this. Note that there is no change in here, we were not supporting multiple connections before.

Useful for debugging. A reachable node should have some `Inbound` peers.

```console
$ curl localhost:8003/metrics | grep waku_connected_peers

# HELP waku_connected_peers number of connected peers per direction inbound|outbound
# TYPE waku_connected_peers gauge
waku_connected_peers{direction="Outbound"} 12.0
waku_connected_peers_created{direction="Outbound"} 1669729760.0
```

Related https://github.com/waku-org/nwaku/issues/1206