### PR TITLE
feat: enable AutoNAT and libp2p circuit relay

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -52,7 +52,7 @@ import
   ./v2/test_peer_exchange,
   ./v2/test_waku_noise,
   ./v2/test_waku_noise_sessions,
-  ./v2/test_circuitrelay,
+  ./v2/test_waku_switch,
   # Utils
   ./v2/test_utils_keyfile
 

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -52,6 +52,7 @@ import
   ./v2/test_peer_exchange,
   ./v2/test_waku_noise,
   ./v2/test_waku_noise_sessions,
+  ./v2/test_circuitrelay,
   # Utils
   ./v2/test_utils_keyfile
 

--- a/tests/v2/test_circuitrelay.nim
+++ b/tests/v2/test_circuitrelay.nim
@@ -1,0 +1,82 @@
+{.used.}
+
+import
+  testutils/unittests,
+  chronos,
+  libp2p,
+  libp2p/protocols/connectivity/relay/relay,
+  libp2p/protocols/connectivity/relay/client,
+  stew/byteutils
+import
+  ../../waku/v2/node/wakuswitch
+
+procSuite "Circuit Relay":
+  proc createCircuitRelayClientSwitch(relayClient: RelayClient): Switch =
+    SwitchBuilder.new()
+      .withRng(newRng())
+      .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
+      .withTcpTransport()
+      .withMplex()
+      .withNoise()
+      .withCircuitRelay(relayClient)
+      .build()
+
+  asyncTest "Waku Switch acts as circuit relayer":
+    ## Setup
+    let
+      wakuSwitch = newWakuSwitch()
+      sourceClient = RelayClient.new()
+      destClient = RelayClient.new()
+      sourceSwitch = createCircuitRelayClientSwitch(sourceClient)
+      destSwitch = createCircuitRelayClientSwitch(destClient)
+
+    # Setup client relays
+    sourceClient.setup(sourceSwitch)
+    destClient.setup(destSwitch)
+
+    await allFutures(wakuSwitch.start(), sourceSwitch.start(), destSwitch.start())
+
+    ## Given
+
+    let
+      # Create a relay address to destSwitch using wakuSwitch as the relay
+      addrs = MultiAddress.init($wakuSwitch.peerInfo.addrs[0] & "/p2p/" &
+                                $wakuSwitch.peerInfo.peerId & "/p2p-circuit/p2p/" &
+                                $destSwitch.peerInfo.peerId).get()
+      msg = "Just one relay away..."
+
+    # Create a custom protocol
+    let customProtoCodec = "/vac/waku/test/1.0.0"
+    var
+      completionFut = newFuture[bool]()
+      proto = new LPProtocol
+    proto.codec = customProtoCodec
+    proto.handler = proc(conn: Connection, proto: string) {.async.} =
+      assert (await conn.readLp(1024)) == msg.toBytes()
+      completionFut.complete(true)
+
+    await proto.start()
+    destSwitch.mount(proto)
+
+    ## When
+
+    # Connect destSwitch to the relay
+    await destSwitch.connect(wakuSwitch.peerInfo.peerId, wakuSwitch.peerInfo.addrs)
+
+    # Connect sourceSwitch to the relay
+    await sourceSwitch.connect(wakuSwitch.peerInfo.peerId, wakuSwitch.peerInfo.addrs)
+
+    # destClient reserves a slot on the relay.
+    let rsvp = await destClient.reserve(wakuSwitch.peerInfo.peerId, wakuSwitch.peerInfo.addrs)
+
+    # sourceSwitch dial destSwitch using the relay
+    let conn = await sourceSwitch.dial(destSwitch.peerInfo.peerId, @[addrs], customProtoCodec)
+
+    await conn.writeLp(msg)
+
+    ## Then
+    check:
+      await completionFut.withTimeout(3.seconds)
+
+    ## Teardown
+    await allFutures(wakuSwitch.stop(), sourceSwitch.stop(), destSwitch.stop())

--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -89,6 +89,7 @@ proc newWakuSwitch*(
       .withNameResolver(nameResolver)
       .withSignedPeerRecord(sendSignedPeerRecord)
       .withCircuitRelay()
+      .withAutonat()
 
     if peerStoreCapacity.isSome():
       b = b.withPeerStore(peerStoreCapacity.get())

--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -88,6 +88,7 @@ proc newWakuSwitch*(
       .withTcpTransport(transportFlags)
       .withNameResolver(nameResolver)
       .withSignedPeerRecord(sendSignedPeerRecord)
+      .withCircuitRelay()
 
     if peerStoreCapacity.isSome():
       b = b.withPeerStore(peerStoreCapacity.get())


### PR DESCRIPTION
## Summary

Closes #1402 
Enables two features on the nwaku switch and tests each functionality:

### 1. libp2p circuit relay

nwaku can serve as a libp2p circuit-relay server. Using a nwaku node as a circuit-relay server is an intermediate step within the NAT hole punching procedure. See [this document](https://status-im.github.io/nim-libp2p/docs/circuitrelay/) for more on circuit relay.

### 2. AutoNAT

Peers can request dialbacks from nwaku nodes to verify that they are publicly reachable. This is the first step before attempting a NAT hole punching procedure. AutoNAT is also a requirement towards: https://github.com/waku-org/nwaku/issues/1206

## Configurability

For now I don't see a good reason to make either protocol configurable. A node can enable circuit relay and AutoNAT with default configuration by default.
See [this issue](https://github.com/waku-org/pm/issues/7#issuecomment-1324013387) for more on the use of AutoNAT and libp2p circuit relay in the NAT hole punching procedure.