### PR TITLE
chore(wakunode): handle sigsegv signal

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -691,7 +691,7 @@ when isMainModule:
     when defined(windows):
       # workaround for https://github.com/nim-lang/Nim/issues/4057
       setupForeignThreadGc()
-    info "Shutting down after receiving SIGINT"
+    notice "Shutting down after receiving SIGINT"
     waitFor node.stop()
     quit(QuitSuccess)
 
@@ -700,11 +700,24 @@ when isMainModule:
   # Handle SIGTERM
   when defined(posix):
     proc handleSigterm(signal: cint) {.noconv.} =
-      info "Shutting down after receiving SIGTERM"
+      notice "Shutting down after receiving SIGTERM"
       waitFor node.stop()
       quit(QuitSuccess)
 
     c_signal(ansi_c.SIGTERM, handleSigterm)
+
+  # Handle SIGSEGV
+  when defined(posix):
+    proc handleSigsegv(signal: cint) {.noconv.} =
+      fatal "Shutting down after receiving SIGSEGV"
+      waitFor node.stop()
+
+      # Only available with --stacktrace:on --linetrace:on
+      writeStackTrace()
+
+      quit(QuitFailure)
+
+    c_signal(ansi_c.SIGSEGV, handleSigsegv)
 
   info "Node setup complete"
 


### PR DESCRIPTION
* Handles `sigsegv` signal.
* Shuts down wakunode gracefully.

Note that the stacktrace won't be printed in `release` mode (default one in `make wakunode2`) but it can be enabled as follows. See `--stacktrace:on --linetrace:on`:

```
nim c --out:build/wakunode2 -d:chronicles_log_level=TRACE --verbosity:0 --hints:off -d:git_version:"v0.13.0-28-g3474be" --stacktrace:on --linetrace:on apps/wakunode2/wakunode2.nim
```

Related #1391 