### PR TITLE
fix(makefile): fix NIM_PARAMS flag update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ endif
 
 # control rln code compilation
 ifeq ($(RLN), true)
-	NIM_PARAMS := $(NIM_PARAMS) -d:rln
+$(eval NIM_PARAMS := $(NIM_PARAMS) -d:rln)
 endif
 
 rlnlib:


### PR DESCRIPTION
Test fleet is not correctly loading the rln flag passed to NIM_PARAMS. This PR fixes it by updating its value with `eval` command,