### PR TITLE
fix(noise): `T_ss` should be `ss` not `se`

### DIFF
--- a/waku/v2/protocol/waku_noise/noise_types.nim
+++ b/waku/v2/protocol/waku_noise/noise_types.nim
@@ -96,7 +96,7 @@ type
     T_es = "es"
     T_ee = "ee"
     T_se = "se"
-    T_ss = "se"
+    T_ss = "ss"
     T_psk = "psk"
 
   # The direction of a (pre)message pattern in canonical form (i.e. Alice-initiated form)


### PR DESCRIPTION
This PR fixes a bug in the definition of the `T_ss` type in Noise module, that should be equal to the string `ss` and not `se`.

A great catch from @richard-ramos !