### PR TITLE
chore(build): simplify project makefile and update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:edge AS nim-build
 
 ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2
-ARG RLN=true
+ARG EXPERIMENTAL=true
 
 # Get build tools and required header files
 RUN apk add --no-cache bash git cargo build-base pcre-dev linux-headers
@@ -16,10 +16,11 @@ COPY . .
 RUN git submodule update --init --recursive
 
 # Slowest build step for the sake of caching layers
-RUN make -j$(nproc) deps RLN="$RLN"
+RUN make -j$(nproc) deps
 
 # Build the final node binary
-RUN make -j$(nproc) $MAKE_TARGET NIMFLAGS="$NIMFLAGS" RLN="$RLN"
+RUN make -j$(nproc) $MAKE_TARGET NIMFLAGS="${NIMFLAGS}" EXPERIMENTAL="${EXPERIMENTAL}"
+
 
 # ACTUAL IMAGE -------------------------------------------------------
 
@@ -28,7 +29,7 @@ FROM alpine:3.16
 ARG MAKE_TARGET=wakunode2
 
 LABEL maintainer="jakub@status.im"
-LABEL source="https://github.com/status-im/nim-waku"
+LABEL source="https://github.com/waku-org/nwaku"
 LABEL description="Wakunode: Waku and Whisper client"
 LABEL commit="unknown"
 

--- a/Makefile
+++ b/Makefile
@@ -1,64 +1,16 @@
-# Copyright (c) 2020 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2022 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
-
-SHELL := bash # the shell used internally by Make
-
-# used inside the included makefiles
 BUILD_SYSTEM_DIR := vendor/nimbus-build-system
-
-# -d:insecure - Necessary to enable Prometheus HTTP endpoint for metrics
-# -d:chronicles_colors:none - Necessary to disable colors in logs for Docker
-DOCKER_IMAGE_NIMFLAGS ?= -d:chronicles_colors:none -d:insecure
-
 EXCLUDED_NIM_PACKAGES := vendor/nim-dnsdisc/vendor
-
 LINK_PCRE := 0
-
-
-# Get git version
-GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
-
-# Detecting the os
-ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
- detected_OS := Windows
-else ifeq ($(strip $(shell uname)),Darwin)
- detected_OS := macOS
-else
- # e.g. Linux
- detected_OS := $(strip $(shell uname))
-endif
-
 
 # we don't want an error here, so we can handle things later, in the ".DEFAULT" target
 -include $(BUILD_SYSTEM_DIR)/makefiles/variables.mk
 
-.PHONY: \
-	all \
-	test \
-	update \
-	clean \
-	libbacktrace \
-	deps \
-	deps2 \
-	v1 \
-	v2 \
-	test1 \
-	test2 \
-	wakunode1 \
-	example1 \
-	sim1 \
-	wakunode2 \
-	example2 \
-	sim2 \
-	wakubridge \
-	chat2 \
-	chat2bridge \
-	libwaku.so \
-	wrappers
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.
@@ -75,22 +27,48 @@ GIT_SUBMODULE_UPDATE := git submodule update --init --recursive
 
 else # "variables.mk" was included. Business as usual until the end of this file.
 
+
+##########
+## Main ##
+##########
+.PHONY: all test update clean v1 v2
+
 # default target, because it's the first one that doesn't start with '.'
 all: | v1 v2
 
-v1: | wakunode1 example1 sim1 
-v2: | wakunode2 example2 sim2 wakubridge chat2 chat2bridge
-
-# Builds and run the test suite (Waku v1 + v2)
 test: | test1 test2
 
+v1: | wakunode1 example1 sim1
+v2: | wakunode2 example2 sim2 wakubridge chat2 chat2bridge
+
+waku.nims:
+	ln -s waku.nimble $@
+
+update: | update-common
+	rm -rf waku.nims && \
+		$(MAKE) waku.nims $(HANDLE_OUTPUT)
+
+clean:
+	rm -rf build
 
 # must be included after the default target
 -include $(BUILD_SYSTEM_DIR)/makefiles/targets.mk
 
 
-# git version
-NIM_PARAMS := $(NIM_PARAMS) -d:git_version:\"$(GIT_VERSION)\"
+## Git version
+GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
+NIM_PARAMS := $(NIM_PARAMS) -d:git_version=\"$(GIT_VERSION)\"
+
+
+##################
+## Dependencies ##
+##################
+.PHONY: deps libbacktrace
+
+deps: | deps-common nat-libs waku.nims
+
+
+### nim-libbacktrace
 
 # "-d:release" implies "--stacktrace:off" and it cannot be added to config.nims
 ifeq ($(USE_LIBBACKTRACE), 0)
@@ -99,40 +77,124 @@ else
 NIM_PARAMS := $(NIM_PARAMS) -d:release
 endif
 
-
-# symlink
-waku.nims:
-	ln -s waku.nimble $@
-
-# nim-libbacktrace
 libbacktrace:
 	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
 
+clean-libbacktrace:
+	+ $(MAKE) -C vendor/nim-libbacktrace clean $(HANDLE_OUTPUT)
 
-# Common dependencies
-deps: | deps-common nat-libs waku.nims
+# Extend deps and clean targets
 ifneq ($(USE_LIBBACKTRACE), 0)
 deps: | libbacktrace
 endif
 
-# Waku v2-only dependencies
-deps2: | rlnlib
+clean: | clean-libbacktrace
 
 
-#- deletes and recreates "waku.nims" which on Windows is a copy instead of a proper symlink
-update: | update-common
-	rm -rf waku.nims && \
-		$(MAKE) waku.nims $(HANDLE_OUTPUT)
+##################
+## Experimental ##
+##################
+.PHONY: librln
+
+EXPERIMENTAL ?= false
+EXPERIMENTAL_PARAMS ?= $(EMPTY)
+
+ifeq ($(EXPERIMENTAL), true)
+RLN := true
+endif
+
+### RLN
+
+LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit/target/release
+
+ifeq ($(OS),Windows_NT)
+LIBRLN_FILE := rln.dll
+else ifeq ($(shell uname -s),Darwin)
+LIBRLN_FILE := librln.dylib
+else
+LIBRLN_FILE := librln.so
+endif
+
+$(LIBRLN_BUILDDIR)/$(LIBRLN_FILE):
+	echo -e $(BUILD_MSG) "$@" && \
+		cargo build --manifest-path vendor/zerokit/rln/Cargo.toml --release
+
+ifneq ($(RLN), true)
+librln: ; # noop
+else
+EXPERIMENTAL_PARAMS += -d:rln -d:rln_libpath=$(LIBRLN_BUILDDIR)/$(LIBRLN_FILE)
+librln: $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE)
+endif
+
+clean-librln:
+	cargo clean --manifest-path vendor/zerokit/rln/Cargo.toml
+
+# Extend clean target
+clean: | clean-librln
 
 
-## Whisper targets
+#############
+## Waku v2 ##
+#############
+.PHONY: test2 wakunode2 example2 sim2 scripts2 wakubridge chat2 chat2bridge
+
+test2: | build deps librln
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
+
+wakunode2: | build deps librln
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim wakunode2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
+
+example2: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim example2 $(NIM_PARAMS) waku.nims
+
+# TODO: Remove unused target
+sim2: | build deps wakunode2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim sim2 $(NIM_PARAMS) waku.nims
+
+# TODO: Remove unused target
+scripts2: | build deps wakunode2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim scripts2 $(NIM_PARAMS) waku.nims
+
+wakubridge: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim bridge $(NIM_PARAMS) waku.nims
+
+chat2: | build deps librln
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim chat2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
+
+chat2bridge: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim chat2bridge $(NIM_PARAMS) waku.nims
+
+
+###################
+## Waku v2 tools ##
+###################
+.PHONY: wakucanary networkmonitor
+
+wakucanary: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim wakucanary $(NIM_PARAMS) waku.nims
+
+networkmonitor: | build deps
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim networkmonitor $(NIM_PARAMS) waku.nims
+
+
+#################
+## Waku legacy ##
+#################
+.PHONY: testwhisper test1 wakunode1 example1 sim1
 
 testwhisper: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim testwhisper $(NIM_PARAMS) waku.nims
-
-
-## Waku v1 targets
 
 test1: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
@@ -151,107 +213,44 @@ sim1: | build deps wakunode1
 		$(ENV_SCRIPT) nim sim1 $(NIM_PARAMS) waku.nims
 
 
-## Waku v2 targets
+###################
+## Documentation ##
+###################
+.PHONY: docs
 
-test2: | build deps deps2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) waku.nims
-
-wakunode2: | build deps deps2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim wakunode2 $(NIM_PARAMS) waku.nims
-
-example2: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim example2 $(NIM_PARAMS) waku.nims
-
-sim2: | build deps deps2 wakunode2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim sim2 $(NIM_PARAMS) waku.nims
-
-scripts2: | build deps wakunode2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim scripts2 $(NIM_PARAMS) waku.nims
-
-wakubridge: | build deps deps2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim bridge $(NIM_PARAMS) waku.nims
-
-chat2: | build deps deps2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim chat2 $(NIM_PARAMS) waku.nims
-
-chat2bridge: | build deps deps2
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim chat2bridge $(NIM_PARAMS) waku.nims
-
-## Waku v2 tooling targets
-
-wakucanary: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim wakucanary $(NIM_PARAMS) waku.nims
-
-networkmonitor: | build deps
-	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim networkmonitor $(NIM_PARAMS) waku.nims
-
-## Waku docs
-
+# TODO: Remove unused target
 docs: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim doc --accept --index:on --project --out:.gh-pages waku/waku.nim waku.nims
 
 
-## RLN
-
-# Experimental flag for all experimental features
-ifeq ($(EXPERIMENTAL), true)
-$(eval RLN := true)
-endif
-
-# control rln code compilation
-ifeq ($(RLN), true)
-$(eval NIM_PARAMS := $(NIM_PARAMS) -d:rln)
-endif
-
-rlnlib:
-ifeq ($(RLN), true)
-	cargo build --manifest-path vendor/zerokit/rln/Cargo.toml --release
-endif
-
-# clean the rln build (forces recompile of old crates on next build)
-cleanrln:
-	cargo clean --manifest-path vendor/zerokit/rln/Cargo.toml
-
-
-## Container image targets
+#####################
+## Container image ##
+#####################
+# -d:insecure - Necessary to enable Prometheus HTTP endpoint for metrics
+# -d:chronicles_colors:none - Necessary to disable colors in logs for Docker
+DOCKER_IMAGE_NIMFLAGS ?= -d:chronicles_colors:none -d:insecure
 
 # build a docker image for the fleet
-docker-image: MAKE_TARGET ?= wakunode1
-docker-image: DOCKER_IMAGE_TAG ?= $(MAKE_TARGET)
+docker-image: MAKE_TARGET ?= wakunode2
+docker-image: DOCKER_IMAGE_TAG ?= $(MAKE_TARGET)$(GIT_VERSION)
 docker-image: DOCKER_IMAGE_NAME ?= statusteam/nim-waku:$(DOCKER_IMAGE_TAG)
 docker-image:
 	docker build \
 		--build-arg="MAKE_TARGET=$(MAKE_TARGET)" \
 		--build-arg="NIMFLAGS=$(DOCKER_IMAGE_NIMFLAGS)" \
+		--build-arg="EXPERIMENTAL=$(EXPERIMENTAL)" \
+		--label="commit=$(GIT_VERSION)" \
 		--tag $(DOCKER_IMAGE_NAME) .
 
 docker-push:
 	docker push $(DOCKER_IMAGE_NAME)
 
-# usual cleaning
-clean: | cleanrln
-	rm -rf build
-ifneq ($(USE_LIBBACKTRACE), 0)
-	+ $(MAKE) -C vendor/nim-libbacktrace clean $(HANDLE_OUTPUT)
-endif
 
-
-endif # "variables.mk" was not included
-
-
-## Waku wrappers targets
-
+##############
+## Wrappers ##
+##############
+# TODO: Remove unused target
 libwaku.so: | build deps deps2
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim c --app:lib --noMain --nimcache:nimcache/libwaku $(NIM_PARAMS) -o:build/$@.0 wrappers/libwaku.nim && \
@@ -260,8 +259,12 @@ libwaku.so: | build deps deps2
 
 # libraries for dynamic linking of non-Nim objects
 EXTRA_LIBS_DYNAMIC := -L"$(CURDIR)/build" -lwaku -lm
-wrappers: | build deps deps2 libwaku.so
+
+# TODO: Remove unused target
+wrappers: | build deps librln libwaku.so
 	echo -e $(BUILD_MSG) "build/C_wrapper_example" && \
 		 $(CC) wrappers/wrapper_example.c -Wl,-rpath,'$$ORIGIN' $(EXTRA_LIBS_DYNAMIC) -g -o build/C_wrapper_example
 	echo -e $(BUILD_MSG) "build/go_wrapper_example" && \
 		go build -ldflags "-linkmode external -extldflags '$(EXTRA_LIBS_DYNAMIC)'" -o build/go_wrapper_example wrappers/wrapper_example.go #wrappers/cfuncs.go
+
+endif # "variables.mk" was not included

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -1,26 +1,17 @@
-# this module contains the Nim wrappers for the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
+## Nim wrappers for the functions defined in librln
+import
+  ./protocol_types
+
 
 when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}
 
-import
-  os,
-  ./protocol_types
 
-const libPath = "vendor/zerokit/target/release/"
+const rln_libpath {.strdefine.} = "vendor/zerokit/target/release/librln.so"
 
-when defined(Windows):
-  const libName* = libPath / "rln.dll"
-elif defined(Linux):
-  const libName* = libPath / "librln.so"
-elif defined(MacOsX):
-  const libName* = libPath / "librln.dylib"
-
-# all the following procedures are Nim wrappers for the functions defined in libName
-{.push dynlib: libName, raises: [Defect].}
-
+{.push dynlib: static(rln_libpath).}
 
 ## Buffer struct is taken from
 # https://github.com/celo-org/celo-threshold-bls-rs/blob/master/crates/threshold-bls-ffi/src/ffi.rs
@@ -98,7 +89,7 @@ proc generate_proof*(ctx: ptr RLN,
 ## output_buffer holds the proof data and should be parsed as [ proof<128> | root<32> | epoch<32> | share_x<32> | share_y<32> | nullifier<32> | rln_identifier<32> ]
 ## integers wrapped in <> indicate value sizes in bytes
 ## the return bool value indicates the success or failure of the operation
- 
+
 proc verify*(ctx: ptr RLN,
                        proof_buffer: ptr Buffer,
                        proof_is_valid_ptr: ptr bool): bool {.importc: "verify_rln_proof".}
@@ -111,7 +102,7 @@ proc verify_with_roots*(ctx: ptr RLN,
                       roots_buffer: ptr Buffer,
                       proof_is_valid_ptr: ptr bool): bool {.importc: "verify_with_roots".}
 ## proof_buffer has to be serialized as [ proof<128> | root<32> | epoch<32> | share_x<32> | share_y<32> | nullifier<32> | rln_identifier<32> | signal_len<8> | signal<var> ]
-## roots_buffer contains the concatenation of 32 bytes long serializations in little endian of root values 
+## roots_buffer contains the concatenation of 32 bytes long serializations in little endian of root values
 ## the return bool value indicates the success or failure of the call to the verify function
 ## the verification of the zk proof is available in proof_is_valid_ptr, where a value of true indicates success and false a failure
 
@@ -158,8 +149,8 @@ proc hash*(ctx: ptr RLN,
            output_buffer: ptr Buffer): bool {.importc: "hash".}
 ## it hashes (sha256) the plain text supplied in inputs_buffer and then maps it to a field element
 ## this proc is used to map arbitrary signals to field element for the sake of proof generation
-## inputs_buffer holds the hash input as a byte seq 
-## the hash output is generated and populated inside output_buffer 
-## the output_buffer contains 32 bytes hash output 
+## inputs_buffer holds the hash input as a byte seq
+## the hash output is generated and populated inside output_buffer
+## the output_buffer contains 32 bytes hash output
 
 {.pop.}


### PR DESCRIPTION
Splitting the Makefile/Dockerfile changes in a separate PR from #1385:

- [x] Move all experimental features under `EXPERIMENTAL=true` flag. 
    + We are keeping `RLN=true` for local development purposes.
    + The `test2-experimental` CI job is already passing the `EXPERIMENTAL=true` env variable.
- [x] Simplify experimental dependencies flow (check the `librln` section in the `Makefile`)
- [x] Renamed RLN targets: `rlnlib` to `librln`, `cleanrln` to `clean-librln`
- [x] Pass the shared library artifact path using Nim compile-time defines and `{.strdefine.}` to `rln.nim` file. This is temporary; after the #1385 issues are solved, we'll remove this.
- [x] Pass `EXPERIMENTAL` build argument to `docker-image` build target.
- [x] Pass the `GIT_VERSION` to `docker-image` target as the `commit` container image label. 
