### PR TITLE
ci(jenkins): support experimental flag in the pr and release pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:edge AS nim-build
 
 ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2
-ARG EXPERIMENTAL=true
+ARG EXPERIMENTAL=false
 
 # Get build tools and required header files
 RUN apk add --no-cache bash git cargo build-base pcre-dev linux-headers

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -29,6 +29,11 @@ pipeline {
       description: 'Makefile flags.',
       defaultValue: params.MAKEFLAGS ?: '-j6'
     )
+    booleanParam(
+      name: 'EXPERIMENTAL',
+      description: 'Enable experimental features.',
+      defaultValue: false
+    )
   }
 
   options {
@@ -59,7 +64,7 @@ pipeline {
 
     stage('Binaries') {
       parallel {
-        stage('V1') { 
+        stage('V1') {
           when { expression { v1changed } }
           steps { script {
             nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} v1")
@@ -68,7 +73,7 @@ pipeline {
         stage('V2') {
           when { expression { v2changed } }
           steps { script {
-            nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} v2")
+            nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} EXPERIMENTAL=${params.EXPERIMENTAL} v2")
           } }
         }
       }
@@ -85,7 +90,7 @@ pipeline {
         stage('V2') {
           when { expression { v2changed } }
           steps { script {
-            nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} test2")
+            nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} EXPERIMENTAL=${params.EXPERIMENTAL} test2")
           } }
         }
       }

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -36,6 +36,11 @@ pipeline {
         '-d:insecure',
       ].join(' ')
     )
+    booleanParam(
+      name: 'EXPERIMENTAL',
+      description: 'Enable experimental features.',
+      defaultValue: false
+    )
   }
 
   stages {
@@ -45,7 +50,8 @@ pipeline {
           "${params.IMAGE_NAME}:${env.GIT_COMMIT.take(8)}",
           "--label=commit='${env.GIT_COMMIT.take(8)}' " +
           "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
-          "--build-arg=NIMFLAGS='${params.NIMFLAGS}' ."
+          "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
+          "--build-arg=EXPERIMENTAL='${params.EXPERIMENTAL}' ."
         )
       } }
     }


### PR DESCRIPTION
Recently the `EXPERIMENTAL` flag was added to the `Makefile` to compile the experimental features into the nwaku node binary conditionally.

- [x] Add a UI parameter to allow building/testing an experimental image
- [x] Pass the experimental flag to the make processes and the docker build command
- [x] Default to false the `EXPERIMENTAL` build argument in the Dockerfile 

-------

### Context

The problem is that we have been deploying EXPERIMENTAL images to the production/test fleets. Causing the fleets to fail with the following error:

```
could not load: /app/vendor/zerokit/target/release/librln.so
```
