### PR TITLE
ci(jenkins): split dockerfile into production and experimental stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,11 @@ docs: | build deps
 # -d:insecure - Necessary to enable Prometheus HTTP endpoint for metrics
 # -d:chronicles_colors:none - Necessary to disable colors in logs for Docker
 DOCKER_IMAGE_NIMFLAGS ?= -d:chronicles_colors:none -d:insecure
+DOCKER_IMAGE_STAGE ?= prod
+
+ifeq ($(EXPERIMENTAL), true)
+DOCKER_IMAGE_STAGE := experimental
+endif
 
 # build a docker image for the fleet
 docker-image: MAKE_TARGET ?= wakunode2
@@ -241,6 +246,7 @@ docker-image:
 		--build-arg="NIMFLAGS=$(DOCKER_IMAGE_NIMFLAGS)" \
 		--build-arg="EXPERIMENTAL=$(EXPERIMENTAL)" \
 		--label="commit=$(GIT_VERSION)" \
+		--target $(DOCKER_IMAGE_STAGE) \
 		--tag $(DOCKER_IMAGE_NAME) .
 
 docker-push:

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -47,11 +47,12 @@ pipeline {
     stage('Build') {
       steps { script {
         image = docker.build(
-          "${params.IMAGE_NAME}:${env.GIT_COMMIT.take(8)}",
+          "${params.IMAGE_NAME}:${env.GIT_COMMIT.take(8)}" + (params.EXPERIMENTAL ? "-experimental": ""),
           "--label=commit='${env.GIT_COMMIT.take(8)}' " +
           "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
           "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
-          "--build-arg=EXPERIMENTAL='${params.EXPERIMENTAL}' ."
+          "--build-arg=EXPERIMENTAL='${params.EXPERIMENTAL}' " +
+          "--target=${params.EXPERIMENTAL ? "experiemental" : "prod"} ."
         )
       } }
     }


### PR DESCRIPTION
With the new `EXPERIMENTAL` build argument, as the `librln` artifacts are not built, the docker image build fails with the following error:

```
COPY failed: stat app/vendor/zerokit/target/release/librln.so: file does not exist
```