### PR TITLE
chore(rln-relay): re-enable root validation

### DIFF
--- a/waku/v2/protocol/waku_rln_relay/protocol_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/protocol_types.nim
@@ -7,7 +7,6 @@ import
   std/[options, tables, deques],
   stew/arrayops,
   chronos, 
-  stint,
   web3,
   eth/keys
 import

--- a/waku/v2/protocol/waku_rln_relay/utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/utils.nim
@@ -734,11 +734,10 @@ proc validateMessage*(rlnPeer: WakuRLNRelay, msg: WakuMessage,
     waku_rln_invalid_messages_total.inc(labelValues=["invalid_epoch"])
     return MessageValidationResult.Invalid
 
-  ## TODO: FIXME after resolving this issue https://github.com/status-im/nwaku/issues/1247
   if not rlnPeer.validateRoot(proof.merkleRoot):
     debug "invalid message: provided root does not belong to acceptable window of roots", provided=proof.merkleRoot, validRoots=rlnPeer.validMerkleRoots.mapIt(it.inHex())
     waku_rln_invalid_messages_total.inc(labelValues=["invalid_root"])
-  #   return MessageValidationResult.Invalid
+    return MessageValidationResult.Invalid
 
   # verify the proof
   let


### PR DESCRIPTION
Root validation was disabled due to intermittent connections with ethereum nodes, which was preventing nodes from updating their local merkle tree of memberships. Since the underlying issue has been resolved, we can re-enable the check.


- fix(rln-relay): enable root validation
- fix(rln-relay): unused import
