### PR TITLE
fix(jenkins): fix typo

### DIFF
--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -52,7 +52,7 @@ pipeline {
           "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
           "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
           "--build-arg=EXPERIMENTAL='${params.EXPERIMENTAL}' " +
-          "--target=${params.EXPERIMENTAL ? "experiemental" : "prod"} ."
+          "--target=${params.EXPERIMENTAL ? "experimental" : "prod"} ."
         )
       } }
     }


### PR DESCRIPTION
Fixes typo in Jenkins release which prevents deployment with Experimental features enabled.