### PR TITLE
ci: don't build waku v2 simulation binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ all: | v1 v2
 test: | test1 test2
 
 v1: | wakunode1 example1 sim1
-v2: | wakunode2 example2 sim2 wakubridge chat2 chat2bridge
+v2: | wakunode2 example2 wakubridge chat2 chat2bridge
 
 waku.nims:
 	ln -s waku.nimble $@


### PR DESCRIPTION
In the past 6 months, the simulation binaries have not been used nor updated. We are building them as part of the `v2` target four times every push in the CI pipelines consuming extra time.

- [x] Remove `sim2` target from `v2` dependencies list, so we don't build the binaries.