### PR TITLE
fix(ci): repo not cloned on startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+    - uses: actions/checkout@v3
+      name: Checkout code
+      id: checkout
     - uses: dorny/paths-filter@v2
       id: filter
       with:


### PR DESCRIPTION
dorny/paths-filter needs the repo to be checked out for push events
