### PR TITLE
chore(networking): unify dialpeer functions

### DIFF
--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -253,7 +253,7 @@ proc info*(node: WakuNode): WakuInfo =
 proc connectToNodes*(node: WakuNode, nodes: seq[RemotePeerInfo] | seq[string], source = "api") {.async.} =
   ## `source` indicates source of node addrs (static config, api call, discovery, etc)
   # NOTE This is dialing on WakuRelay protocol specifically
-  await connectToNodes(node.peerManager, nodes, WakuRelayCodec, source)
+  await connectToNodes(node.peerManager, nodes, WakuRelayCodec, source=source)
 
 
 ## Waku relay


### PR DESCRIPTION
Refactors as part of the networking roadmap.

* Remove metric label `waku_peers_errors.inc["conn_init_failure"]` as its duplicated from `waku_peers_dials.inc(labelValues = ["failed"])`
* Unify `dialPeer` functions where all end up calling the same one but with a different input: `peerInfo`, `peerId`.
* Remove `connectToNode`, as its duplicated from `dialPeer`.
* Merge all two `connectToNodes` into a single one.
* Modify `DefaultDialTimeout` to 10 seconds.