### PR TITLE
feat(networking): add backoff period after failed dial

### DIFF
--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -43,3 +43,6 @@ proc getRng(): ref rand.HmacDrbgContext =
 
 template rng*(): ref rand.HmacDrbgContext =
   getRng()
+
+proc generateKey*(): crypto.PrivateKey =
+  return crypto.PrivateKey.random(Secp256k1, rng[])[]

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -30,63 +30,51 @@ import
 
 procSuite "Peer Manager":
   asyncTest "Peer dialing works":
-    let
-      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60800))
-      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60802))
-      peerInfo2 = node2.switch.peerInfo
+    # Create 2 nodes
+    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
-    await allFutures([node1.start(), node2.start()])
-
-    await node1.mountRelay()
-    await node2.mountRelay()
+    await allFutures(nodes.mapIt(it.start()))
+    await allFutures(nodes.mapIt(it.mountRelay()))
 
     # Dial node2 from node1
-    let conn = (await node1.peerManager.dialPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec)).get()
+    let conn = (await nodes[0].peerManager.dialPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec)).get()
 
     # Check connection
     check:
       conn.activity
-      conn.peerId == peerInfo2.peerId
+      conn.peerId == nodes[1].peerInfo.peerId
 
     # Check that node2 is being managed in node1
     check:
-      node1.peerManager.peerStore.peers().anyIt(it.peerId == peerInfo2.peerId)
+      nodes[0].peerManager.peerStore.peers().anyIt(it.peerId == nodes[1].peerInfo.peerId)
 
     # Check connectedness
     check:
-      node1.peerManager.peerStore.connectedness(peerInfo2.peerId) == Connectedness.Connected
+      nodes[0].peerManager.peerStore.connectedness(nodes[1].peerInfo.peerId) == Connectedness.Connected
 
-    await allFutures([node1.stop(), node2.stop()])
+    await allFutures(nodes.mapIt(it.stop()))
 
   asyncTest "Dialing fails gracefully":
-    let
-      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60810))
-      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60812))
-      peerInfo2 = node2.switch.peerInfo
+    # Create 2 nodes
+    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
-    await node1.start()
+    await nodes[0].start()
+    await nodes[0].mountRelay()
+
     # Purposefully don't start node2
 
-    await node1.mountRelay()
-    await node2.mountRelay()
-
     # Dial node2 from node1
-    let connOpt = await node1.peerManager.dialPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec, 2.seconds)
+    let connOpt = await nodes[1].peerManager.dialPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec, 2.seconds)
 
     # Check connection failed gracefully
     check:
       connOpt.isNone()
 
-    await node1.stop()
+    await nodes[0].stop()
 
   asyncTest "Adding, selecting and filtering peers work":
     let
-      nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60820))
+      node = WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0))
       # Create filter peer
       filterLoc = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet()
       filterKey = crypto.PrivateKey.random(ECDSA, rng[]).get()
@@ -128,103 +116,93 @@ procSuite "Peer Manager":
 
 
   asyncTest "Peer manager keeps track of connections":
-    let
-      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60830))
-      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60832))
-      peerInfo2 = node2.switch.peerInfo
+    # Create 2 nodes
+    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
-    await node1.start()
+    await nodes[0].start()
+    # Do not start node2
 
-    await node1.mountRelay()
-    await node2.mountRelay()
+    await allFutures(nodes.mapIt(it.mountRelay()))
 
     # Test default connectedness for new peers
-    node1.peerManager.addPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec)
+    nodes[0].peerManager.addPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec)
     check:
       # No information about node2's connectedness
-      node1.peerManager.peerStore.connectedness(peerInfo2.peerId) == NotConnected
+      nodes[0].peerManager.peerStore.connectedness(nodes[1].peerInfo.peerId) == NotConnected
 
     # Purposefully don't start node2
     # Attempt dialing node2 from node1
-    discard await node1.peerManager.dialPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec, 2.seconds)
+    discard await nodes[0].peerManager.dialPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec, 2.seconds)
     check:
       # Cannot connect to node2
-      node1.peerManager.peerStore.connectedness(peerInfo2.peerId) == CannotConnect
+      nodes[0].peerManager.peerStore.connectedness(nodes[1].peerInfo.peerId) == CannotConnect
 
     # Successful connection
-    await node2.start()
-    discard await node1.peerManager.dialPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec, 2.seconds)
+    await nodes[1].start()
+    discard await nodes[0].peerManager.dialPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec, 2.seconds)
     check:
       # Currently connected to node2
-      node1.peerManager.peerStore.connectedness(peerInfo2.peerId) == Connected
+      nodes[0].peerManager.peerStore.connectedness(nodes[1].peerInfo.peerId) == Connected
 
     # Stop node. Gracefully disconnect from all peers.
-    await node1.stop()
+    await nodes[0].stop()
     check:
       # Not currently connected to node2, but had recent, successful connection.
-      node1.peerManager.peerStore.connectedness(peerInfo2.peerId) == CanConnect
+      nodes[0].peerManager.peerStore.connectedness(nodes[1].peerInfo.peerId) == CanConnect
 
-    await node2.stop()
+    await nodes[1].stop()
 
   asyncTest "Peer manager updates failed peers correctly":
-    let
-      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60880))
-      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60881))
-      peerInfo2 = node2.switch.peerInfo
+    # Create 2 nodes
+    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
-    await node1.start()
-    await node1.mountRelay()
-    node1.peerManager.addPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec)
+    await nodes[0].start()
+    await nodes[0].mountRelay()
+    nodes[0].peerManager.addPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec)
 
     # Set a low backoff to speed up test
-    node1.peerManager.initialBackoffInSec = 4
+    nodes[0].peerManager.initialBackoffInSec = 2
 
     # node2 is not started, so dialing will fail
-    let conn1 = await node1.peerManager.dialPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec, 1.seconds)
+    let conn1 = await nodes[0].peerManager.dialPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec, 1.seconds)
     check:
       # Cannot connect to node2
-      node1.peerManager.peerStore.connectedness(peerInfo2.peerId) == CannotConnect
-      node1.peerManager.peerStore[ConnectionBook][peerInfo2.peerId] == CannotConnect
-      node1.peerManager.peerStore[NumberFailedConnBook][peerInfo2.peerId] == 1
+      nodes[0].peerManager.peerStore.connectedness(nodes[1].peerInfo.peerId) == CannotConnect
+      nodes[0].peerManager.peerStore[ConnectionBook][nodes[1].peerInfo.peerId] == CannotConnect
+      nodes[0].peerManager.peerStore[NumberFailedConnBook][nodes[1].peerInfo.peerId] == 1
 
       # And the connection failed
       conn1.isNone() == true
 
       # Right after failing there is a backoff period
-      node1.peerManager.peerStore.canBeConnected(peerInfo2.peerId, node1.peerManager.initialBackoffInSec) == false
+      nodes[0].peerManager.peerStore.canBeConnected(nodes[1].peerInfo.peerId, nodes[0].peerManager.initialBackoffInSec) == false
 
     # We wait the first backoff period
-    await sleepAsync(5.seconds)
+    await sleepAsync(2.seconds)
 
     # And backoff period is over
     check:
-      node1.peerManager.peerStore.canBeConnected(peerInfo2.peerId, node1.peerManager.initialBackoffInSec) == true
+      nodes[0].peerManager.peerStore.canBeConnected(nodes[1].peerInfo.peerId, nodes[0].peerManager.initialBackoffInSec) == true
 
-    await node2.start()
-    await node2.mountRelay()
+    await nodes[1].start()
+    await nodes[1].mountRelay()
 
     # Now we can connect and failed count is reset
-    let conn2 = await node1.peerManager.dialPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec, 1.seconds)
+    let conn2 = await nodes[0].peerManager.dialPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec, 1.seconds)
     check:
       conn2.isNone() == false
-      node1.peerManager.peerStore[NumberFailedConnBook][peerInfo2.peerId] == 0
+      nodes[0].peerManager.peerStore[NumberFailedConnBook][nodes[1].peerInfo.peerId] == 0
 
-
-    await node1.stop()
-    await node2.stop()
+    await allFutures(nodes.mapIt(it.stop()))
 
   asyncTest "Peer manager can use persistent storage and survive restarts":
     let
       database = SqliteDatabase.new(":memory:")[]
       storage = WakuPeerStorage.new(database)[]
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60840), peerStorage = storage)
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60842))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       peerInfo2 = node2.switch.peerInfo
 
     await node1.start()
@@ -243,7 +221,7 @@ procSuite "Peer Manager":
     # Simulate restart by initialising a new node using the same storage
     let
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60844), peerStorage = storage)
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
 
     await node3.start()
     check:
@@ -268,9 +246,9 @@ procSuite "Peer Manager":
       database = SqliteDatabase.new(":memory:")[]
       storage = WakuPeerStorage.new(database)[]
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60850), peerStorage = storage)
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60852))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       peerInfo2 = node2.switch.peerInfo
       betaCodec = "/vac/waku/relay/2.0.0-beta2"
       stableCodec = "/vac/waku/relay/2.0.0"
@@ -294,7 +272,7 @@ procSuite "Peer Manager":
     # Simulate restart by initialising a new node using the same storage
     let
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60854), peerStorage = storage)
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
 
     await node3.mountRelay()
     node3.wakuRelay.codec = stableCodec
@@ -322,11 +300,7 @@ procSuite "Peer Manager":
 
   asyncTest "Peer manager connects to all peers supporting a given protocol":
     # Create 4 nodes
-    var nodes: seq[WakuNode]
-    for i in 0..<4:
-      let nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      let node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60860 + i))
-      nodes &= node
+    let nodes = toSeq(0..<4).mapIt(WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
     # Start them
     await allFutures(nodes.mapIt(it.start()))
@@ -366,11 +340,7 @@ procSuite "Peer Manager":
 
   asyncTest "Peer store keeps track of incoming connections":
     # Create 4 nodes
-    var nodes: seq[WakuNode]
-    for i in 0..<4:
-      let nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      let node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60865 + i))
-      nodes &= node
+    let nodes = toSeq(0..<4).mapIt(WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
     # Start them
     await allFutures(nodes.mapIt(it.start()))

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -160,8 +160,9 @@ procSuite "Peer Manager":
     await nodes[0].mountRelay()
     nodes[0].peerManager.addPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec)
 
-    # Set a low backoff to speed up test
+    # Set a low backoff to speed up test: 2, 4, 8, 16
     nodes[0].peerManager.initialBackoffInSec = 2
+    nodes[0].peerManager.backoffFactor = 2
 
     # node2 is not started, so dialing will fail
     let conn1 = await nodes[0].peerManager.dialPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuRelayCodec, 1.seconds)
@@ -175,14 +176,20 @@ procSuite "Peer Manager":
       conn1.isNone() == true
 
       # Right after failing there is a backoff period
-      nodes[0].peerManager.peerStore.canBeConnected(nodes[1].peerInfo.peerId, nodes[0].peerManager.initialBackoffInSec) == false
+      nodes[0].peerManager.peerStore.canBeConnected(
+        nodes[1].peerInfo.peerId,
+        nodes[0].peerManager.initialBackoffInSec,
+        nodes[0].peerManager.backoffFactor) == false
 
     # We wait the first backoff period
-    await sleepAsync(2.seconds)
+    await sleepAsync(2100.milliseconds)
 
     # And backoff period is over
     check:
-      nodes[0].peerManager.peerStore.canBeConnected(nodes[1].peerInfo.peerId, nodes[0].peerManager.initialBackoffInSec) == true
+      nodes[0].peerManager.peerStore.canBeConnected(
+        nodes[1].peerInfo.peerId,
+        nodes[0].peerManager.initialBackoffInSec,
+        nodes[0].peerManager.backoffFactor) == true
 
     await nodes[1].start()
     await nodes[1].mountRelay()

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -204,11 +204,18 @@ procSuite "Peer Manager":
     check:
       node1.peerManager.peerStore.canBeConnected(peerInfo2.peerId, node1.peerManager.initialBackoffInSec) == true
 
-    # TODO: now connect and check that its ok.
-    # and this is reset to 0 node1.peerManager.peerStore[NumberFailedConnBook][peerInfo2.peerId] == 0
+    await node2.start()
+    await node2.mountRelay()
+
+    # Now we can connect and failed count is reset
+    let conn2 = await node1.peerManager.dialPeer(peerInfo2.toRemotePeerInfo(), WakuRelayCodec, 1.seconds)
+    check:
+      conn2.isNone() == false
+      node1.peerManager.peerStore[NumberFailedConnBook][peerInfo2.peerId] == 0
+
 
     await node1.stop()
-    await node2.stop() #needed?
+    await node2.stop()
 
   asyncTest "Peer manager can use persistent storage and survive restarts":
     let

--- a/tests/v2/test_peer_store_extended.nim
+++ b/tests/v2/test_peer_store_extended.nim
@@ -1,8 +1,10 @@
 {.used.}
 
 import
-  std/[options,sequtils],
+  std/[options,sequtils, times],
+  chronos,
   libp2p/crypto/crypto,
+  libp2p/peerid,
   libp2p/peerstore,
   libp2p/multiaddress,
   testutils/unittests
@@ -10,8 +12,7 @@ import
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/peer_manager/waku_peer_store,
   ../../waku/v2/node/waku_node,
-  ../test_helpers,
-  ./testlib/testutils
+  ../test_helpers
 
 
 suite "Extended nim-libp2p Peer Store":
@@ -45,6 +46,8 @@ suite "Extended nim-libp2p Peer Store":
     peerStore[DisconnectBook][p1] = 0
     peerStore[SourceBook][p1] = Discv5
     peerStore[DirectionBook][p1] = Inbound
+    peerStore[NumberFailedConnBook][p1] = 1
+    peerStore[LastFailedConnBook][p1] = Moment.init(1001, Second)
 
     # Peer2: Connected
     peerStore[AddressBook][p2] = @[MultiAddress.init("/ip4/127.0.0.1/tcp/2").tryGet()]
@@ -56,6 +59,8 @@ suite "Extended nim-libp2p Peer Store":
     peerStore[DisconnectBook][p2] = 0
     peerStore[SourceBook][p2] = Discv5
     peerStore[DirectionBook][p2] = Inbound
+    peerStore[NumberFailedConnBook][p2] = 2
+    peerStore[LastFailedConnBook][p2] = Moment.init(1002, Second)
 
     # Peer3: Connected
     peerStore[AddressBook][p3] = @[MultiAddress.init("/ip4/127.0.0.1/tcp/3").tryGet()]
@@ -67,6 +72,8 @@ suite "Extended nim-libp2p Peer Store":
     peerStore[DisconnectBook][p3] = 0
     peerStore[SourceBook][p3] = Discv5
     peerStore[DirectionBook][p3] = Inbound
+    peerStore[NumberFailedConnBook][p3] = 3
+    peerStore[LastFailedConnBook][p3] = Moment.init(1003, Second)
 
     # Peer4: Added but never connected
     peerStore[AddressBook][p4] = @[MultiAddress.init("/ip4/127.0.0.1/tcp/4").tryGet()]
@@ -78,6 +85,8 @@ suite "Extended nim-libp2p Peer Store":
     peerStore[DisconnectBook][p4] = 0
     peerStore[SourceBook][p4] = Discv5
     peerStore[DirectionBook][p4] = Inbound
+    peerStore[NumberFailedConnBook][p4] = 4
+    peerStore[LastFailedConnBook][p4] = Moment.init(1004, Second)
 
     # Peer5: Connecteed in the past
     peerStore[AddressBook][p5] = @[MultiAddress.init("/ip4/127.0.0.1/tcp/5").tryGet()]
@@ -89,6 +98,8 @@ suite "Extended nim-libp2p Peer Store":
     peerStore[DisconnectBook][p5] = 1000
     peerStore[SourceBook][p5] = Discv5
     peerStore[DirectionBook][p5] = Outbound
+    peerStore[NumberFailedConnBook][p5] = 5
+    peerStore[LastFailedConnBook][p5] = Moment.init(1005, Second)
 
   test "get() returns the correct StoredInfo for a given PeerId":
     # When
@@ -108,17 +119,21 @@ suite "Extended nim-libp2p Peer Store":
       storedInfoPeer1.connectedness == Connected
       storedInfoPeer1.disconnectTime == 0
       storedInfoPeer1.origin == Discv5
+      storedInfoPeer1.numberFailedConn == 1
+      storedInfoPeer1.lastFailedConn == Moment.init(1001, Second)
 
     check:
-      # fields are empty
+      # fields are empty, not part of the peerstore
       storedInfoPeer6.peerId == p6
       storedInfoPeer6.addrs.len == 0
       storedInfoPeer6.protos.len == 0
-      storedInfoPeer6.agent == ""
-      storedInfoPeer6.protoVersion == ""
-      storedInfoPeer6.connectedness == NotConnected
-      storedInfoPeer6.disconnectTime == 0
-      storedInfoPeer6.origin == UnknownOrigin
+      storedInfoPeer6.agent == default(string)
+      storedInfoPeer6.protoVersion == default(string)
+      storedInfoPeer6.connectedness == default(Connectedness)
+      storedInfoPeer6.disconnectTime == default(int)
+      storedInfoPeer6.origin == default(PeerOrigin)
+      storedInfoPeer6.numberFailedConn == default(int)
+      storedInfoPeer6.lastFailedConn == default(Moment)
 
   test "peers() returns all StoredInfo of the PeerStore":
     # When
@@ -146,6 +161,8 @@ suite "Extended nim-libp2p Peer Store":
       p3.connectedness == Connected
       p3.disconnectTime == 0
       p3.origin == Discv5
+      p3.numberFailedConn == 3
+      p3.lastFailedConn == Moment.init(1003, Second)
 
   test "peers() returns all StoredInfo matching a specific protocol":
     # When
@@ -280,3 +297,76 @@ suite "Extended nim-libp2p Peer Store":
       disconnedtedPeers.anyIt(it.peerId == p4)
       disconnedtedPeers.anyIt(it.peerId == p5)
       not disconnedtedPeers.anyIt(it.connectedness == Connected)
+
+  test "del() successfully deletes waku custom books":
+    # Given
+    let peerStore = PeerStore.new(capacity = 5)
+    var p1: PeerId
+    require p1.init("QmeuZJbXrszW2jdT7GdduSjQskPU3S7vvGWKtKgDfkDvW" & "1")
+    peerStore[AddressBook][p1] = @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
+    peerStore[ProtoBook][p1] = @["proto"]
+    peerStore[KeyBook][p1] = KeyPair.random(ECDSA, rng[]).tryGet().pubkey
+    peerStore[AgentBook][p1] = "agent"
+    peerStore[ProtoVersionBook][p1] = "version"
+    peerStore[LastFailedConnBook][p1] = Moment.init(getTime().toUnix, Second)
+    peerStore[NumberFailedConnBook][p1] = 1
+    peerStore[ConnectionBook][p1] = Connected
+    peerStore[DisconnectBook][p1] = 0
+    peerStore[SourceBook][p1] = Discv5
+    peerStore[DirectionBook][p1] = Inbound
+
+    # When
+    peerStore.del(p1)
+
+    # Then
+    check:
+      peerStore[AddressBook][p1] == newSeq[MultiAddress](0)
+      peerStore[ProtoBook][p1] == newSeq[string](0)
+      peerStore[KeyBook][p1] == default(PublicKey)
+      peerStore[AgentBook][p1] == ""
+      peerStore[ProtoVersionBook][p1] == ""
+      peerStore[LastFailedConnBook][p1] == default(Moment)
+      peerStore[NumberFailedConnBook][p1] == 0
+      peerStore[ConnectionBook][p1] == default(Connectedness)
+      peerStore[DisconnectBook][p1] == 0
+      peerStore[SourceBook][p1] == default(PeerOrigin)
+      peerStore[DirectionBook][p1] == default(PeerDirection)
+
+  asyncTest "canBeConnected() returns correct value":
+    let peerStore = PeerStore.new(capacity = 5)
+    var p1: PeerId
+    require p1.init("QmeuZJbXrszW2jdT7GdduSjQskPU3S7vvGWKtKgDfkDvW" & "1")
+
+    # With InitialBackoffInSec = 1
+    # backoffs are: 2, 4, 8
+    let initialBackoffInSec = 2
+
+    # new peer with no errors can be connected
+    check:
+      peerStore.canBeConnected(p1, initialBackoffInSec) == true
+
+    # peer with ONE error that just failed
+    peerStore[NumberFailedConnBook][p1] = 1
+    peerStore[LastFailedConnBook][p1] = Moment.init(getTime().toUnix, Second)
+    # we cant connect right now
+    check:
+      peerStore.canBeConnected(p1, initialBackoffInSec) == false
+
+    # but we can after the first backoff of 1 second
+    await sleepAsync(2200)
+    check:
+      peerStore.canBeConnected(p1, initialBackoffInSec) == true
+
+    # peer with TWO errors
+    peerStore[NumberFailedConnBook][p1] = 2
+    peerStore[LastFailedConnBook][p1] = Moment.init(getTime().toUnix, Second)
+
+    # cant be connected after 1 second (1 < 4)
+    await sleepAsync(1000)
+    check:
+      peerStore.canBeConnected(p1, initialBackoffInSec) == false
+
+    # but we can after the second backoff of 4 seconds
+    await sleepAsync(3200)
+    check:
+      peerStore.canBeConnected(p1, initialBackoffInSec) == true

--- a/tests/v2/test_peer_store_extended.nim
+++ b/tests/v2/test_peer_store_extended.nim
@@ -337,8 +337,7 @@ suite "Extended nim-libp2p Peer Store":
     var p1: PeerId
     require p1.init("QmeuZJbXrszW2jdT7GdduSjQskPU3S7vvGWKtKgDfkDvW" & "1")
 
-    # With InitialBackoffInSec = 1
-    # backoffs are: 2, 4, 8
+    # with InitialBackoffInSec = 2 backoffs are: 2, 4, 8
     let initialBackoffInSec = 2
 
     # new peer with no errors can be connected
@@ -352,7 +351,7 @@ suite "Extended nim-libp2p Peer Store":
     check:
       peerStore.canBeConnected(p1, initialBackoffInSec) == false
 
-    # but we can after the first backoff of 1 second
+    # but we can after the first backoff of 2 seconds
     await sleepAsync(2200)
     check:
       peerStore.canBeConnected(p1, initialBackoffInSec) == true
@@ -361,12 +360,12 @@ suite "Extended nim-libp2p Peer Store":
     peerStore[NumberFailedConnBook][p1] = 2
     peerStore[LastFailedConnBook][p1] = Moment.init(getTime().toUnix, Second)
 
-    # cant be connected after 1 second (1 < 4)
-    await sleepAsync(1000)
+    # cant be connected after 3 second (3 < 4)
+    await sleepAsync(3000)
     check:
       peerStore.canBeConnected(p1, initialBackoffInSec) == false
 
-    # but we can after the second backoff of 4 seconds
-    await sleepAsync(3200)
+    # but we can after the second backoff of >4 seconds
+    await sleepAsync(1200)
     check:
       peerStore.canBeConnected(p1, initialBackoffInSec) == true

--- a/waku/v2/node/discv5/waku_discv5.nim
+++ b/waku/v2/node/discv5/waku_discv5.nim
@@ -95,9 +95,6 @@ proc findRandomPeers*(wakuDiscv5: WakuDiscoveryV5): Future[Result[seq[RemotePeer
       error "Failed to convert ENR to peer info", enr= $node.record, err=res.error()
       waku_discv5_errors.inc(labelValues = ["peer_info_failure"])
 
-  if discoveredPeers.len > 0:
-    info "Successfully discovered nodes", count=discoveredPeers.len
-    waku_discv5_discovered.inc(discoveredPeers.len.int64)
 
   return ok(discoveredPeers)
 

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -349,18 +349,18 @@ proc relayConnectivityLoop*(pm: PeerManager) {.async.} =
       await sleepAsync(ConnectivityLoopInterval)
       continue
 
-    var notConnectedPeers = pm.peerStore.getNotConnectedPeers().mapIt(RemotePeerInfo.init(it.peerId, it.addrs))
-    var withinBackoffPeers = notConnectedPeers.filterIt(pm.peerStore.canBeConnected(it.peerId,
+    let notConnectedPeers = pm.peerStore.getNotConnectedPeers().mapIt(RemotePeerInfo.init(it.peerId, it.addrs))
+    let outsideBackoffPeers = notConnectedPeers.filterIt(pm.peerStore.canBeConnected(it.peerId,
                                                                                     pm.initialBackoffInSec,
                                                                                     pm.backoffFactor))
-    let numPeersToConnect = min(min(maxConnections - numConPeers, withinBackoffPeers.len), MaxParalelDials)
+    let numPeersToConnect = min(min(maxConnections - numConPeers, outsideBackoffPeers.len), MaxParalelDials)
 
     info "Relay connectivity loop",
       connectedPeers = numConPeers,
       targetConnectedPeers = maxConnections,
       notConnectedPeers = notConnectedPeers.len,
-      withinBackoffPeers = withinBackoffPeers.len
+      outsideBackoffPeers = outsideBackoffPeers.len
 
-    await pm.connectToNodes(withinBackoffPeers[0..<numPeersToConnect], WakuRelayCodec)
+    await pm.connectToNodes(outsideBackoffPeers[0..<numPeersToConnect], WakuRelayCodec)
 
     await sleepAsync(ConnectivityLoopInterval)

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -81,15 +81,11 @@ proc dialPeer(pm: PeerManager, peerId: PeerID,
   debug "Dialing peer", wireAddr = addrs, peerId = peerId, failedAttempts=failedAttempts
 
   # Dial Peer
-  var deadline = sleepAsync(dialTimeout)
   let dialFut = pm.switch.dial(peerId, addrs, proto)
 
   var reasonFailed = ""
   try:
-    await dialFut or deadline
-    if dialFut.finished():
-      if not deadline.finished():
-        deadline.cancel()
+    if (await dialFut.withTimeout(DefaultDialTimeout)):
       waku_peers_dials.inc(labelValues = ["successful"])
       # TODO: This will be populated from the peerstore info when ready
       waku_node_conns_initiated.inc(labelValues = [source])

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -77,7 +77,8 @@ type
 
 proc canBeConnected*(peerStore: PeerStore,
                      peerId: PeerId,
-                     initialBackoffInSec: int): bool =
+                     initialBackoffInSec: int,
+                     backoffFactor: int): bool =
   # Returns if we can try to connect to this peer, based on past failed attempts
   # It uses an exponential backoff. Each connection attempt makes us
   # wait more before trying again.
@@ -91,7 +92,7 @@ proc canBeConnected*(peerStore: PeerStore,
   # the more failed attemps, the greater the backoff since last attempt
   let now = Moment.init(getTime().toUnix, Second)
   let lastFailed = peerStore[LastFailedConnBook][peerId]
-  let backoff = chronos.seconds(initialBackoffInSec^failedAttempts)
+  let backoff = chronos.seconds(initialBackoffInSec*(backoffFactor^(failedAttempts-1)))
   if now >= (lastFailed + backoff):
     return true
   return false


### PR DESCRIPTION
Closes https://github.com/waku-org/nwaku/issues/1414

**Summary:**
After failing to dial a peer, it adds a backoff to it so that we don't attempt to dial the same peer again during some time. The time to wait depends on the amount of consecutive failures, calculated with the following formula:

```
initialBackoffInSec*(backoffFactor^(failedAttempts-1))
```

Note that `initialBackoffInSec` and `backoffFactor` are configurable values that allow to configure how aggressive the backoffs are. Using `initialBackoffInSec=120` and `backoffFactor=4` the times to wait would be:

```
120s, 480s, 1920, 7680s
```

This PR helps nodes to rapidly increase their number of connections, since less time is wasted in trying to connect to nodes that fail. This improvement is even more noticeable in networks whith a high ratio of non reachable peers. Note that this backoff only applies to `relay` peers.

**Changes**:
- [x] Add exponential backoff after a failed dial.
- [x] Some minor test refactoring.
- [x] Some minor logging improvements.
- [x] Directly use `switch.dial` in ping (keep alive)