### PR TITLE
refactor(networking): wait for all futures together in connectToNodes

### DIFF
--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -275,7 +275,7 @@ proc connectToNodes*(pm: PeerManager,
                else: node
     futConns.add(pm.dialPeer(RemotePeerInfo(node), proto, dialTimeout, source))
 
-  allFutures(futConns).await()
+  await allFutures(futConns)
 
   # The issue seems to be around peers not being fully connected when
   # trying to subscribe. So what we do is sleep to guarantee nodes are

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -269,10 +269,13 @@ proc connectToNodes*(pm: PeerManager,
                      source = "api") {.async.} =
   info "connectToNodes", len = nodes.len
 
+  var futConns: seq[Future[Option[Connection]]]
   for node in nodes:
     let node = when node is string: parseRemotePeerInfo(node)
                else: node
-    discard await pm.dialPeer(RemotePeerInfo(node), proto, dialTimeout, source)
+    futConns.add(pm.dialPeer(RemotePeerInfo(node), proto, dialTimeout, source))
+
+  allFutures(futConns).await()
 
   # The issue seems to be around peers not being fully connected when
   # trying to subscribe. So what we do is sleep to guarantee nodes are


### PR DESCRIPTION
- Instead of awaiting on each `dialPeer` individually, this pr triggers all dials, stores the futures in an array and then waits for the futures to be completed. This substantially decreases the time it takes for a nwaku node to reach a reasonable number of connections.
- In several runs, attempting to connect **12 peers** with `connectToNodes` I could verify that the time it tool to connect to all of them decreased from 43/44 seconds to 4/5 seconds. Note that it was tested against our fleets