### PR TITLE
feat(networking): integrate autonat service to request if we are dialable

### DIFF
--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -12,6 +12,7 @@ import
   libp2p/protocols/pubsub/gossipsub,
   libp2p/nameresolving/nameresolver,
   libp2p/builders,
+  libp2p/switch,
   libp2p/transports/[transport, tcptransport, wstransport]
 
 # override nim-libp2p default value (which is also 1)
@@ -74,8 +75,9 @@ proc newWakuSwitch*(
     wssEnabled: bool = false,
     secureKeyPath: string = "",
     secureCertPath: string = "",
-    agentString = none(string),    # defaults to nim-libp2p version,
+    agentString = none(string),    # defaults to nim-libp2p version
     peerStoreCapacity = none(int), # defaults to nim-libp2p max size
+    services: seq[switch.Service] = @[],
     ): Switch
     {.raises: [Defect, IOError, LPError].} =
 
@@ -110,5 +112,8 @@ proc newWakuSwitch*(
 
     else :
       b = b.withAddress(address)
+
+    if services.len > 0:
+      b = b.withServices(services)
 
     b.build()


### PR DESCRIPTION
Closes https://github.com/waku-org/nwaku/issues/1206

**Summary:**
This PR integrates the brand new `AutonatService` added in `nim-libp2p`. This service runs in the background asking other outbound connected peers to dial us, informing us if we are `Reachable` or `NotReachable` by them.
* Reachability state is logged every 2 minutes: `Reachable`/`NotReachable`.
* `nim-libp2p` metric can be reused. See:
 ```
libp2p_autonat_reachability_confidence{reachability="Reachable"} 1.0
libp2p_autonat_reachability_confidence{reachability="NotReachable"} 0.0
 ```

Done:
- [x] Integrate autonatservice.
- [x] Test `Reachable` state (opening ports)
- [x] Test `NotReeachable` state (closing ports)

Note that this is an experimental feature that was never tested in `nim-libp2p` in a production environment, but it only impact logs and one metric, so its impact is really low.
