### PR TITLE
feat(networking): add service slots to peer manager

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -41,6 +41,7 @@ import
   ../../waku/v2/protocol/waku_archive/retention_policy/retention_policy_capacity,
   ../../waku/v2/protocol/waku_archive/retention_policy/retention_policy_time,
   ../../waku/v2/protocol/waku_peer_exchange,
+  ../../waku/v2/protocol/waku_store,
   ../../waku/v2/utils/peers,
   ../../waku/v2/utils/wakuenr,
   ./wakunode2_setup_rest,
@@ -401,7 +402,9 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
   if conf.storenode != "":
     try:
       mountStoreClient(node)
-      setStorePeer(node, conf.storenode)
+      #setStorePeer(node, conf.storenode)
+      let remoteNode = parseRemotePeerInfo(conf.storenode)
+      node.peerManager.addServicePeer(remoteNode, WakuStoreCodec)
     except:
       return err("failed to set node waku store peer: " & getCurrentExceptionMsg())
 

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -505,11 +505,9 @@ proc startNode(node: WakuNode, conf: WakuNodeConf,
   if conf.keepAlive:
     node.startKeepalive()
 
-  asyncSpawn node.peerManager.serviceConnectivityLoop()
-
   # Maintain relay connections
   if conf.relay:
-    asyncSpawn node.peerManager.relayConnectivityLoop()
+    node.peerManager.start()
 
   return ok()
 

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -505,7 +505,11 @@ proc startNode(node: WakuNode, conf: WakuNodeConf,
   if conf.keepAlive:
     node.startKeepalive()
 
-  asyncSpawn node.peerManager.keepSlotPeersConnected()
+  asyncSpawn node.peerManager.serviceConnectivityLoop()
+
+  # Maintain relay connections
+  if conf.relay:
+    asyncSpawn node.peerManager.relayConnectivityLoop()
 
   return ok()
 

--- a/tests/v2/test_peer_store_extended.nim
+++ b/tests/v2/test_peer_store_extended.nim
@@ -267,16 +267,6 @@ suite "Extended nim-libp2p Peer Store":
       peerStore.hasPeers(protocolMatcher("/vac/waku/store/2.0.0"))
       not peerStore.hasPeers(protocolMatcher("/vac/waku/does-not-exist/2.0.0"))
 
-  test "selectPeer() returns if a peer supports a given protocol":
-    # When
-    let swapPeer = peerStore.selectPeer("/vac/waku/swap/2.0.0")
-
-    # Then
-    check:
-      swapPeer.isSome()
-      swapPeer.get().peerId == p5
-      swapPeer.get().protocols == @["/vac/waku/swap/2.0.0", "/vac/waku/store/2.0.0-beta2"]
-
   test "getPeersByDirection()":
     # When
     let inPeers = peerStore.getPeersByDirection(Inbound)

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -13,7 +13,7 @@ import
   ../../utils/time,
   ../waku_node,
   ../peer_manager/peer_manager,
-  ./jsonrpc_types, 
+  ./jsonrpc_types,
   ./jsonrpc_utils
 
 export jsonrpc_types
@@ -30,7 +30,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     ## Returns history for a list of content topics with optional paging
     debug "get_waku_v2_store_v1_messages"
 
-    let peerOpt = node.peerManager.peerStore.selectPeer(WakuStoreCodec)
+    let peerOpt = node.peerManager.selectPeer(WakuStoreCodec)
     if peerOpt.isNone():
       raise newException(ValueError, "no suitable remote store peers")
 
@@ -52,7 +52,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
     if not await queryFut.withTimeout(futTimeout):
       raise newException(ValueError, "No history response received (timeout)")
-    
+
     let res = queryFut.read()
     if res.isErr():
       raise newException(ValueError, $res.error)

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -428,7 +428,7 @@ proc selectPeer*(pm: PeerManager, proto: string): Option[RemotePeerInfo] =
   if proto == WakuRelayCodec:
     # TODO: proper heuristic here that compares peer scores and selects "best" one. For now the first peer for the given protocol is returned
     if peers.len > 0:
-      return some(peers[rand(1..<peers.len)].toRemotePeerInfo())
+      return some(peers[0].toRemotePeerInfo())
     return none(RemotePeerInfo)
 
   # For other protocols, we select the peer that is slotted for the given protocol
@@ -438,5 +438,5 @@ proc selectPeer*(pm: PeerManager, proto: string): Option[RemotePeerInfo] =
   # If not slotted, we select a random peer for the given protocol
   else:
     if peers.len > 0:
-      return some(peers[rand(1..<peers.len)].toRemotePeerInfo())
+      return some(peers[0].toRemotePeerInfo())
     return none(RemotePeerInfo)

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -152,6 +152,10 @@ proc connectedness*(peerStore: PeerStore, peerId: PeerID): Connectedness =
   # TODO: richer return than just bool, e.g. add enum "CanConnect", "CannotConnect", etc. based on recent connection attempts
   return peerStore[ConnectionBook].book.getOrDefault(peerId, NotConnected)
 
+proc isConnected*(peerStore: PeerStore, peerId: PeerID): bool =
+  # Returns `true` if the peer is connected
+  peerStore.connectedness(peerId) == Connected
+
 proc hasPeer*(peerStore: PeerStore, peerId: PeerID, proto: string): bool =
   # Returns `true` if peer is included in manager for the specified protocol
   # TODO: What if peer does not exist in the peerStore?
@@ -170,3 +174,6 @@ proc getPeersByDirection*(peerStore: PeerStore, direction: PeerDirection): seq[S
 
 proc getNotConnectedPeers*(peerStore: PeerStore): seq[StoredInfo] =
   return peerStore.peers.filterIt(it.connectedness != Connected)
+
+proc getPeersByProtocol*(peerStore: PeerStore, proto: string): seq[StoredInfo] =
+  return peerStore.peers.filterIt(it.protos.contains(proto))

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[tables, sequtils, sets, options, times, math, random],
+  std/[tables, sequtils, sets, options, times, math],
   chronos,
   libp2p/builders,
   libp2p/peerstore

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[tables, sequtils, sets, options, times, math],
+  std/[tables, sequtils, sets, options, times, math, random],
   chronos,
   libp2p/builders,
   libp2p/peerstore
@@ -164,18 +164,6 @@ proc hasPeers*(peerStore: PeerStore, proto: string): bool =
 proc hasPeers*(peerStore: PeerStore, protocolMatcher: Matcher): bool =
   # Returns `true` if the peerstore has any peer matching the protocolMatcher
   toSeq(peerStore[ProtoBook].book.values()).anyIt(it.anyIt(protocolMatcher(it)))
-
-proc selectPeer*(peerStore: PeerStore, proto: string): Option[RemotePeerInfo] =
-  # Selects the best peer for a given protocol
-  let peers = peerStore.peers().filterIt(it.protos.contains(proto))
-
-  if peers.len >= 1:
-     # TODO: proper heuristic here that compares peer scores and selects "best" one. For now the first peer for the given protocol is returned
-    let peerStored = peers[0]
-
-    return some(peerStored.toRemotePeerInfo())
-  else:
-    return none(RemotePeerInfo)
 
 proc getPeersByDirection*(peerStore: PeerStore, direction: PeerDirection): seq[StoredInfo] =
   return peerStore.peers.filterIt(it.direction == direction)

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -1005,8 +1005,6 @@ proc stop*(node: WakuNode) {.async.} =
     discard await node.stopDiscv5()
 
   await node.switch.stop()
-
-  node.peerManager.serviceLoopUp = false
-  node.peerManager.relayLoopUp = false
+  node.peerManager.stop()
 
   node.started = false

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -526,7 +526,7 @@ proc subscribe*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopics: Content
     error "cannot register filter subscription to topic", error="waku filter client is nil"
     return
 
-  let peerOpt = node.peerManager.peerStore.selectPeer(WakuFilterCodec)
+  let peerOpt = node.peerManager.selectPeer(WakuFilterCodec)
   if peerOpt.isNone():
     error "cannot register filter subscription to topic", error="no suitable remote peers"
     return
@@ -541,7 +541,7 @@ proc unsubscribe*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopics: Conte
     error "cannot unregister filter subscription to content", error="waku filter client is nil"
     return
 
-  let peerOpt = node.peerManager.peerStore.selectPeer(WakuFilterCodec)
+  let peerOpt = node.peerManager.selectPeer(WakuFilterCodec)
   if peerOpt.isNone():
     error "cannot register filter subscription to topic", error="no suitable remote peers"
     return
@@ -699,7 +699,7 @@ proc query*(node: WakuNode, query: HistoryQuery): Future[WakuStoreResult[History
   if node.wakuStoreClient.isNil():
     return err("waku store client is nil")
 
-  let peerOpt = node.peerManager.peerStore.selectPeer(WakuStoreCodec)
+  let peerOpt = node.peerManager.selectPeer(WakuStoreCodec)
   if peerOpt.isNone():
     error "no suitable remote peers"
     return err("peer_not_found_failure")
@@ -788,7 +788,7 @@ proc lightpushPublish*(node: WakuNode, pubsubTopic: PubsubTopic, message: WakuMe
     error "failed to publish message", error="waku lightpush client is nil"
     return
 
-  let peerOpt = node.peerManager.peerStore.selectPeer(WakuLightPushCodec)
+  let peerOpt = node.peerManager.selectPeer(WakuLightPushCodec)
   if peerOpt.isNone():
     error "failed to publish message", error="no suitable remote peers"
     return

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -391,9 +391,6 @@ proc startRelay*(node: WakuNode) {.async.} =
                                           protocolMatcher(WakuRelayCodec),
                                           backoffPeriod)
 
-  # Maintain relay connections
-  asyncSpawn node.peerManager.relayConnectivityLoop()
-
   # Start the WakuRelay protocol
   await node.wakuRelay.start()
 
@@ -1008,5 +1005,8 @@ proc stop*(node: WakuNode) {.async.} =
     discard await node.stopDiscv5()
 
   await node.switch.stop()
+
+  node.peerManager.serviceLoopUp = false
+  node.peerManager.relayLoopUp = false
 
   node.started = false

--- a/waku/v2/protocol/waku_peer_exchange/protocol.nim
+++ b/waku/v2/protocol/waku_peer_exchange/protocol.nim
@@ -77,7 +77,7 @@ proc request(wpx: WakuPeerExchange, numPeers: uint64, peer: RemotePeerInfo): Fut
   return ok()
 
 proc request*(wpx: WakuPeerExchange, numPeers: uint64): Future[WakuPeerExchangeResult[void]] {.async, gcsafe.} =
-  let peerOpt = wpx.peerManager.peerStore.selectPeer(WakuPeerExchangeCodec)
+  let peerOpt = wpx.peerManager.selectPeer(WakuPeerExchangeCodec)
   if peerOpt.isNone():
     waku_px_errors.inc(labelValues = [peerNotFoundFailure])
     return err(peerNotFoundFailure)
@@ -106,7 +106,7 @@ proc respond(wpx: WakuPeerExchange, enrs: seq[enr.Record], peer: RemotePeerInfo 
   return ok()
 
 proc respond(wpx: WakuPeerExchange, enrs: seq[enr.Record]): Future[WakuPeerExchangeResult[void]] {.async, gcsafe.} =
-  let peerOpt = wpx.peerManager.peerStore.selectPeer(WakuPeerExchangeCodec)
+  let peerOpt = wpx.peerManager.selectPeer(WakuPeerExchangeCodec)
   if peerOpt.isNone():
     waku_px_errors.inc(labelValues = [peerNotFoundFailure])
     return err(peerNotFoundFailure)

--- a/waku/v2/protocol/waku_store/client.nim
+++ b/waku/v2/protocol/waku_store/client.nim
@@ -210,7 +210,7 @@ when defined(waku_exp_store_resume):
     else:
       debug "no candidate list is provided, selecting a random peer"
       # if no peerList is set then query from one of the peers stored in the peer manager
-      let peerOpt = w.peerManager.peerStore.selectPeer(WakuStoreCodec)
+      let peerOpt = w.peerManager.selectPeer(WakuStoreCodec)
       if peerOpt.isNone():
         warn "no suitable remote peers"
         waku_store_errors.inc(labelValues = [peerNotFoundFailure])


### PR DESCRIPTION
Related https://github.com/waku-org/nwaku/issues/1461

Background:
* Until we further decentralise the waku network, service peers (peers supporting service protocols such as store, lightpush, etc) have to be treated differently than relay peers.
* For example, looking at this from the store protocol perspective, since we don't have any consensus on the data that is stored, there is some level of trust on the node we are quering. So in most cases we wan't to specify the nodes that are used for these services. Note that this feature already exists, but this PR fixes some of the issues around this.

Summary of changes:
* This PR adds the concept of `serviceSlots`, which contains a set of "slotted" or "preferred" peers for the services, or in other words, any protocol that is not `WakuRelayProtocol`.
  * `WakuStoreCodec`
  * `WakuFilterCodec`
  * `WakuLightPushCodec`
  * `WakuPeerExchangeCodec`
* ~~The peer manager constantly checks that we are connected to these "slot" peers (if any), and if not it attempts a connection every `x` interval. This can speed things up if at some point we need something from that peers, since we are already connected.~~
* Now every time we use `selectPeer()` we get a different peer depending the protocol that is requested, with the following priorities.
  * For relay we just get the first peer of the peerstore, same behaviour as before.
  * For non-relay protocols (service peers) now we first lookup the service peers, and if empty, we return one from the peerstore. In other words, peers specified with `setstore`, `setxxx` with the cli flags always take precendence.