### PR TITLE
fix(rpc): return error if peer cant be connected

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -389,6 +389,15 @@ procSuite "Waku v2 JSON-RPC API":
       getRes.anyIt(it.protocol == WakuRelayCodec and
                    it.multiaddr == constructMultiaddrStr(peerInfo3))
 
+    # Verify that raises an exception if we can't connect to the peer
+    let nonExistentPeer = "/ip4/0.0.0.0/tcp/10000/p2p/16Uiu2HAm6HZZr7aToTvEBPpiys4UxajCTU97zj5v7RNR2gbniy1D"
+    expect(ValueError):
+      discard await client.post_waku_v2_admin_v1_peers(@[nonExistentPeer])
+
+    let malformedPeer = "/malformed/peer"
+    expect(ValueError):
+      discard await client.post_waku_v2_admin_v1_peers(@[malformedPeer])
+
     await server.stop()
     await server.closeWait()
 

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -44,12 +44,11 @@ proc installAdminApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     ## Connect to a list of peers
     debug "post_waku_v2_admin_v1_peers"
 
-    if (await node.connectToNodes(peers).withTimeout(futTimeout)):
-      # Successfully connected to peers
-      return true
-    else:
-      # Failed to connect to peers
-      raise newException(ValueError, "Failed to connect to peers: " & $peers)
+    for i, peer in peers:
+      let conn = await node.peerManager.dialPeer(parseRemotePeerInfo(peer), WakuRelayCodec, source="rpc")
+      if conn.isNone():
+        raise newException(ValueError, "Failed to connect to peer at index: " & $i & " " & $peer)
+    return true
 
   rpcsrv.rpc("get_waku_v2_admin_v1_peers") do() -> seq[WakuPeer]:
     ## Returns a list of peers registered for this node


### PR DESCRIPTION
Closes #1469

Summary:
* When trying to connect to a i) peer not listening or ii) malformed multiaddress via the RPC, the api was returning `result:true` which is missleading since no connection was made.
* Moreover `connectToNodes` was used with a timeout but `dialPeer` already has a timeout. And note that `connectToNodes` discards the dialing result, so we can't know if the connection failed.
* This PR uses `dialPeer` instead and raises an exception if we can't connect to the peer and adds a unit test for the bug it fixes.
* Relevant for `wakurtosis` testing efforts.