### PR TITLE
feat(archive): respond with error on more than 10 content topics query

### DIFF
--- a/tests/v2/waku_archive/test_waku_archive.nim
+++ b/tests/v2/waku_archive/test_waku_archive.nim
@@ -214,6 +214,29 @@ procSuite "Waku Archive - find messages":
       response.messages.anyIt(it == msg1)
       response.messages.anyIt(it == msg3)
 
+  test "handle query with more than 10 content filters":
+    ## Setup
+    let
+      driver = newTestArchiveDriver()
+      archive = newTestWakuArchive(driver)
+
+    let queryTopics = toSeq(1..15).mapIt(ContentTopic($it))
+
+    ## Given
+    let req = ArchiveQuery(contentTopics: queryTopics)
+
+    ## When
+    let queryRes = archive.findMessages(req)
+
+    ## Then
+    check:
+      queryRes.isErr()
+
+    let error = queryRes.tryError()
+    check:
+      error.kind == ArchiveErrorKind.INVALID_QUERY
+      error.cause == "too many content topics"
+
   test "handle query with pubsub topic filter":
     ## Setup
     let

--- a/waku/v2/protocol/waku_archive/archive.nim
+++ b/waku/v2/protocol/waku_archive/archive.nim
@@ -126,6 +126,8 @@ proc findMessages*(w: WakuArchive, query: ArchiveQuery): ArchiveResult {.gcsafe.
                    else: min(query.pageSize, MaxPageSize)
     qAscendingOrder = query.ascending
 
+  if qContentTopics.len > 10:
+    return err(ArchiveError.invalidQuery("too many content topics"))
 
   let queryStartTime = getTime().toUnixFloat()
 

--- a/waku/v2/protocol/waku_archive/common.nim
+++ b/waku/v2/protocol/waku_archive/common.nim
@@ -85,3 +85,6 @@ proc `$`*(err: ArchiveError): string =
     "INVALID_QUERY: " & err.cause
   of ArchiveErrorKind.UNKNOWN:
     "UNKNOWN"
+
+proc invalidQuery*(T: type ArchiveError, cause: string): T =
+  ArchiveError(kind: ArchiveErrorKind.INVALID_QUERY, cause: cause)


### PR DESCRIPTION
Specifying and implementing the new Waku store protocol will take some time. We have implemented an intermediate limit to mitigate DoS caused by queries with a content topics list greater than 10. 

**:warning: The Waku store v2 client will perceive this as an `INVALID_CURSOR` error.**

- [x] Limit the maximum number of content filters to 10.
- [x] Return a bad request error code if the number of topics exceeds the limit.
- [x] Extend Waku archive module test coverage. 

This issue resolves #1292 
