### PR TITLE
refactor(relay): simplify relay publish jsonrpc api

### DIFF
--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -364,8 +364,7 @@ proc publish*(node: WakuNode, topic: PubsubTopic, message: WakuMessage) {.async,
 
   trace "publish", topic=topic, contentTopic=message.contentTopic
 
-  let data = message.encode().buffer
-  discard await node.wakuRelay.publish(topic, data)
+  discard await node.wakuRelay.publish(topic, message)
 
 proc startRelay*(node: WakuNode) {.async.} =
   ## Setup and start relay protocol

--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -147,10 +147,10 @@ method publish*(w: WakuRelay, pubsubTopic: PubsubTopic, message: WakuMessage|seq
 
   var data: seq[byte]
   when message is WakuMessage:
-    data = message.encode()
+    data = message.encode().buffer
   else:
     data = message
 
-  return await procCall GossipSub(w).publish(pubsubTopic, message)
+  return await procCall GossipSub(w).publish(pubsubTopic, data)
 
 


### PR DESCRIPTION
Remove a duplicated encoding by delegating on the Waku relay publish method. This is minor code cleanup.