### PR TITLE
refactor(archive): sqlite query optimization. replace or-ed equal conditions list with in-list

### DIFF
--- a/waku/v2/protocol/waku_archive/driver/sqlite_driver/queries.nim
+++ b/waku/v2/protocol/waku_archive/driver/sqlite_driver/queries.nim
@@ -255,10 +255,10 @@ proc whereClause(cursor: Option[DbCursor],
   let contentTopicClause = if contentTopic.len <= 0:
         none(string)
       else:
-        var where = "("
-        where &= "contentTopic = (?)"
-        for _ in contentTopic[1..^1]:
-          where &= " OR contentTopic = (?)"
+        var where = "contentTopic IN ("
+        where &= "?"
+        for _ in 1..<contentTopic.len:
+          where &= ", ?"
         where &= ")"
         some(where)
 


### PR DESCRIPTION
A small optimization for the "find messages by" query.

Source: https://stackoverflow.com/a/3074846/1099999

> The OR operator needs a much more complex evaluation process than the IN construct because it allows many conditions, not only equals like IN.

Source: https://stackoverflow.com/a/73079261/1099999

> IN may be significantly faster. E.g. table with ~23M rows.
> OR -> Execution Time: 4540.829 ms
> IN -> Execution Time: 855.743 ms

With 20 million message archive sizes, I think this query optimization will have a significant impact helping us to squeeze the Sqlite lemon a little bit more 🍋 