### PR TITLE
fix(archive): reverse the db query results in the waku archive front-end

### DIFF
--- a/tests/v2/waku_archive/test_driver_queue_query.nim
+++ b/tests/v2/waku_archive/test_driver_queue_query.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options, sequtils, random],
+  std/[options, sequtils, random, algorithm],
   testutils/unittests,
   chronos,
   chronicles
@@ -160,7 +160,7 @@ suite "Queue driver - query by content topic":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[6..7]
+      filteredMessages == expected[6..7].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -510,7 +510,7 @@ suite "Queue driver - query by cursor":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[2..3]
+      filteredMessages == expected[2..3].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -600,7 +600,7 @@ suite "Queue driver - query by cursor":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[2..5]
+      filteredMessages == expected[2..5].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -706,7 +706,7 @@ suite "Queue driver - query by cursor":
     let expectedMessages = expected.mapIt(it[1])
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expectedMessages[4..5]
+      filteredMessages == expectedMessages[4..5].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -980,7 +980,7 @@ suite "Queue driver - query by time range":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[2..6]
+      filteredMessages == expected[2..6].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -1078,7 +1078,7 @@ suite "Queue driver - query by time range":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[3..4]
+      filteredMessages == expected[3..4].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -1188,7 +1188,7 @@ suite "Queue driver - query by time range":
     let expectedMessages = expected.mapIt(it[1])
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expectedMessages[4..5]
+      filteredMessages == expectedMessages[4..5].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")

--- a/tests/v2/waku_archive/test_driver_sqlite_query.nim
+++ b/tests/v2/waku_archive/test_driver_sqlite_query.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options, sequtils, random],
+  std/[options, sequtils, random, algorithm],
   testutils/unittests,
   chronos,
   chronicles
@@ -164,7 +164,7 @@ suite "SQLite driver - query by content topic":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[6..7]
+      filteredMessages == expected[6..7].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -514,7 +514,7 @@ suite "SQLite driver - query by cursor":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[2..3]
+      filteredMessages == expected[2..3].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -604,7 +604,7 @@ suite "SQLite driver - query by cursor":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[2..5]
+      filteredMessages == expected[2..5].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -710,7 +710,7 @@ suite "SQLite driver - query by cursor":
     let expectedMessages = expected.mapIt(it[1])
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expectedMessages[4..5]
+      filteredMessages == expectedMessages[4..5].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -984,7 +984,7 @@ suite "SQLite driver - query by time range":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[2..6]
+      filteredMessages == expected[2..6].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -1082,7 +1082,7 @@ suite "SQLite driver - query by time range":
 
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expected[3..4]
+      filteredMessages == expected[3..4].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")
@@ -1192,7 +1192,7 @@ suite "SQLite driver - query by time range":
     let expectedMessages = expected.mapIt(it[1])
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
-      filteredMessages == expectedMessages[4..5]
+      filteredMessages == expectedMessages[4..5].reversed()
 
     ## Cleanup
     driver.close().expect("driver to close")

--- a/waku/v2/protocol/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/v2/protocol/waku_archive/driver/queue_driver/queue_driver.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[options, algorithm],
+  std/options,
   stew/results,
   stew/sorted_set,
   chronicles
@@ -279,13 +279,7 @@ method getMessages*(
   if pageRes.isErr():
     return err($pageRes.error)
 
-  var rows = pageRes.value
-
-  # All messages MUST be returned in chronological order
-  if not ascendingOrder:
-    reverse(rows)
-
-  ok(rows)
+  ok(pageRes.value)
 
 
 method getMessagesCount*(driver: QueueDriver): ArchiveDriverResult[int64] =

--- a/waku/v2/protocol/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/v2/protocol/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -6,7 +6,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[options, algorithm],
+  std/options,
   stew/[byteutils, results],
   chronicles
 import
@@ -107,7 +107,7 @@ method getMessages*(
 ): ArchiveDriverResult[seq[ArchiveRow]] =
   let cursor = cursor.map(toDbCursor)
 
-  var rows = ?s.db.selectMessagesByHistoryQueryWithLimit(
+  let rows = ?s.db.selectMessagesByHistoryQueryWithLimit(
     contentTopic,
     pubsubTopic,
     cursor,
@@ -116,10 +116,6 @@ method getMessages*(
     limit=maxPageSize,
     ascending=ascendingOrder
   )
-
-  # All messages MUST be returned in chronological order
-  if not ascendingOrder:
-    reverse(rows)
 
   ok(rows)
 


### PR DESCRIPTION
This regression was introduced during the Waku archive and the Waku store code split. The Waku archive test did not cover the query chain responses. And the regression was not detected by the Status app since they only use the forward pagination.

- [x] Fixed the backwards pagination regression by moving the query result rows reordering step to the archive front-end.
- [x] Updated the test cases to cover this scenario.
- [x] Improved code readability of the findMessages Waku archive method. 

This PR resolves #1502 regression.
