### PR TITLE
fix(rln): remove kilic submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -106,10 +106,6 @@
 [submodule "vendor/nim-web3"]
 	path = vendor/nim-web3
 	url = https://github.com/status-im/nim-web3.git
-[submodule "vendor/rln"]
-	path = vendor/rln
-	url = https://github.com/kilic/rln
-	branch = master
 [submodule "vendor/nim-testutils"]
 	path = vendor/nim-testutils
 	url = https://github.com/status-im/nim-testutils.git


### PR DESCRIPTION
Removes kilic's rln submodule since we've switched entirely over to zerokit.
