### PR TITLE
fix(rng): use only one instance of rng

### DIFF
--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -8,6 +8,7 @@ import
   eth/keys
 import
   ../../../waku/v2/protocol/waku_message
+  ../../../waku/common/crypto as wakuCrypto
 
 type
   Fleet* =  enum
@@ -25,7 +26,7 @@ type
     
     nodekey* {.
       desc: "P2P node private key as 64 char hex string.",
-      defaultValue: crypto.PrivateKey.random(Secp256k1, crypto.newRng()[]).tryGet()
+      defaultValue: crypto.PrivateKey.random(Secp256k1, wakuCrypto.getRng()[]).tryGet()
       name: "nodekey" }: crypto.PrivateKey
 
     listenAddress* {.

--- a/apps/wakubridge/config.nim
+++ b/apps/wakubridge/config.nim
@@ -4,11 +4,11 @@ import
   confutils,
   confutils/defs,
   confutils/std/net,
-  libp2p/crypto/crypto,
   libp2p/crypto/secp,
   eth/keys
 
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/common/logging
 
 
@@ -124,7 +124,7 @@ type
 
     nodekeyV2* {.
       desc: "P2P node private key as hex"
-      defaultValue: crypto.PrivateKey.random(Secp256k1, crypto.newRng()[]).tryGet()
+      defaultValue: crypto.PrivateKey.random(Secp256k1, wakuCrypto.getRng()[]).tryGet()
       name: "nodekey-v2" }: crypto.PrivateKey
 
     store* {.

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -15,7 +15,8 @@ import
 import
   ../../waku/common/confutils/envvar/defs as confEnvvarDefs,
   ../../waku/common/confutils/envvar/std/net as confEnvvarNet,
-  ../../waku/common/logging
+  ../../waku/common/logging,
+  ../../waku/common/crypto as wakuCrypto
 
 export
   confTomlDefs,
@@ -467,7 +468,7 @@ proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
 proc defaultPrivateKey*(): PrivateKey =
-  crypto.PrivateKey.random(Secp256k1, crypto.newRng()[]).value
+  crypto.PrivateKey.random(Secp256k1, wakuCrypto.getRng()[]).value
 
 
 proc parseCmdArg*(T: type ValidIpAddress, p: string): T =

--- a/examples/v2/publisher.nim
+++ b/examples/v2/publisher.nim
@@ -11,6 +11,7 @@ import
 
 import
   ../../../waku/common/logging,
+  ../../../waku/common/crypto as wakuCrypto,
   ../../../waku/v2/node/discv5/waku_discv5,
   ../../../waku/v2/node/peer_manager/peer_manager,
   ../../../waku/v2/node/waku_node,
@@ -33,7 +34,7 @@ proc setupAndPublish() {.async.} =
     setupLogLevel(logging.LogLevel.NOTICE)
     notice "starting publisher", wakuPort=wakuPort, discv5Port=discv5Port
     let
-        nodeKey = crypto.PrivateKey.random(Secp256k1, crypto.newRng()[])[]
+        nodeKey = crypto.PrivateKey.random(Secp256k1, wakuCrypto.getRng()[])[]
         ip = ValidIpAddress.init("0.0.0.0")
         node = WakuNode.new(nodeKey, ip, Port(wakuPort))
         flags = initWakuFlags(lightpush = false, filter = false, store = false, relay = true)

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -5,12 +5,12 @@ import
   chronicles,
   chronos,
   confutils,
-  libp2p/crypto/crypto,
   eth/keys,
   eth/p2p/discoveryv5/enr
 
 import
   ../../../waku/common/logging,
+  ../../../waku/common/crypto as wakuCrypto,
   ../../../waku/v2/node/discv5/waku_discv5,
   ../../../waku/v2/node/peer_manager/peer_manager,
   ../../../waku/v2/node/waku_node,
@@ -29,7 +29,7 @@ proc setupAndSubscribe() {.async.} =
     setupLogLevel(logging.LogLevel.NOTICE)
     notice "starting subscriber", wakuPort=wakuPort, discv5Port=discv5Port
     let
-        nodeKey = crypto.PrivateKey.random(Secp256k1, crypto.newRng()[])[]
+        nodeKey = crypto.PrivateKey.random(Secp256k1, wakuCrypto.getRng()[])[]
         ip = ValidIpAddress.init("0.0.0.0")
         node = WakuNode.new(nodeKey, ip, Port(wakuPort))
         flags = initWakuFlags(lightpush = false, filter = false, store = false, relay = true)

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -9,10 +9,10 @@ import
   libp2p/[builders, switch, multiaddress],
   libp2p/protobuf/minprotobuf,
   libp2p/stream/[bufferstream, connection],
-  libp2p/crypto/crypto,
   libp2p/protocols/pubsub/pubsub,
   libp2p/protocols/pubsub/rpc/message
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v1/node/rpc/hexstrings,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/waku_node,
@@ -51,7 +51,7 @@ proc put(store: ArchiveDriver, pubsubTopic: PubsubTopic, message: WakuMessage): 
 
 procSuite "Waku v2 JSON-RPC API":
   let
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     privkey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")

--- a/tests/v2/test_rest_debug_api.nim
+++ b/tests/v2/test_rest_debug_api.nim
@@ -5,9 +5,9 @@ import
   testutils/unittests,
   presto, presto/client as presto_client,
   libp2p/peerinfo,
-  libp2p/multiaddress,
-  libp2p/crypto/crypto
+  libp2p/multiaddress
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/node/rest/[server, client, utils],
   ../../waku/v2/node/rest/debug/debug_api
@@ -15,7 +15,7 @@ import
 
 proc testWakuNode(): WakuNode = 
   let 
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     privkey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")

--- a/tests/v2/test_rest_relay_api.nim
+++ b/tests/v2/test_rest_relay_api.nim
@@ -6,9 +6,9 @@ import
   stew/shims/net,
   testutils/unittests,
   presto, presto/client as presto_client,
-  libp2p/crypto/crypto,
   libp2p/protocols/pubsub/pubsub
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/node/rest/[server, client, base64, utils],
@@ -19,7 +19,7 @@ import
 
 proc testWakuNode(): WakuNode = 
   let 
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     privkey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")

--- a/tests/v2/test_utils_crypto.nim
+++ b/tests/v2/test_utils_crypto.nim
@@ -1,0 +1,13 @@
+{.used.}
+
+import
+  testutils/unittests
+import
+  ../../waku/common/crypto
+
+suite "Utils - Crypto":
+  
+  test "Returns a valid rng":
+    let rng = getRng()
+    check:
+      rng is ref HmacDrbgContext

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -6,7 +6,6 @@ import
   stew/shims/net as stewNet,
   testutils/unittests,
   chronos,
-  libp2p/crypto/crypto,
   libp2p/crypto/secp,
   libp2p/peerid,
   libp2p/multiaddress,
@@ -16,6 +15,7 @@ import
   eth/p2p,
   eth/keys
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v1/protocol/waku_protocol,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/[waku_node, waku_payload],
@@ -32,7 +32,7 @@ procSuite "WakuBridge":
 
   let
     rng = keys.newRng()
-    cryptoRng = crypto.newRng()
+    cryptoRng = wakuCrypto.getRng()
 
     # Bridge
     nodev1Key = keys.KeyPair.random(rng[])

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -4,9 +4,9 @@ import
   std/[options, tables],
   testutils/unittests,
   chronicles,
-  chronos,
-  libp2p/crypto/crypto
+  chronos
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_filter,
@@ -19,7 +19,7 @@ import
 proc newTestWakuFilterNode(switch: Switch, timeout: Duration = 2.hours): Future[WakuFilter] {.async.} =
   let
     peerManager = PeerManager.new(switch)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     proto = WakuFilter.new(peerManager, rng, timeout)
 
   await proto.start()
@@ -30,7 +30,7 @@ proc newTestWakuFilterNode(switch: Switch, timeout: Duration = 2.hours): Future[
 proc newTestWakuFilterClient(switch: Switch): Future[WakuFilterClient] {.async.} =
   let
     peerManager = PeerManager.new(switch)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     proto = WakuFilterClient.new(peerManager, rng)
 
   await proto.start()

--- a/tests/v2/test_waku_lightpush.nim
+++ b/tests/v2/test_waku_lightpush.nim
@@ -3,9 +3,9 @@
 import
   testutils/unittests, 
   chronicles,
-  chronos, 
-  libp2p/crypto/crypto
+  chronos
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_lightpush,
@@ -17,7 +17,7 @@ import
 proc newTestWakuLightpushNode(switch: Switch, handler: PushMessageHandler): Future[WakuLightPush] {.async.} =
   let
     peerManager = PeerManager.new(switch)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     proto = WakuLightPush.new(peerManager, rng, handler)
 
   await proto.start()
@@ -28,7 +28,7 @@ proc newTestWakuLightpushNode(switch: Switch, handler: PushMessageHandler): Futu
 proc newTestWakuLightpushClient(switch: Switch): WakuLightPushClient =
   let
     peerManager = PeerManager.new(switch)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
   WakuLightPushClient.new(peerManager, rng)
 
 

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -6,7 +6,6 @@ import
   testutils/unittests,
   chronicles,
   chronos,
-  libp2p/crypto/crypto,
   libp2p/crypto/secp,
   libp2p/multiaddress,
   libp2p/switch,
@@ -15,6 +14,7 @@ import
   libp2p/protocols/pubsub/gossipsub,
   libp2p/nameresolving/mockresolver
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/protocol/waku_message,
@@ -23,7 +23,7 @@ import
 
 
 procSuite "WakuNode":
-  let rng = crypto.newRng()
+  let rng = wakuCrypto.getRng()
 
   asyncTest "Protocol matcher works as expected":
     let

--- a/tests/v2/test_wakunode_filter.nim
+++ b/tests/v2/test_wakunode_filter.nim
@@ -4,9 +4,9 @@ import
   stew/shims/net as stewNet, 
   testutils/unittests,
   chronicles,
-  chronos, 
-  libp2p/crypto/crypto
+  chronos
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/protocol/waku_message,
@@ -18,7 +18,7 @@ suite "WakuNode - Filter":
  
   asyncTest "subscriber should receive the message handled by the publisher":
     ## Setup
-    let rng = crypto.newRng()
+    let rng = wakuCrypto.getRng()
     let
       serverKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
       server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60110))

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -5,9 +5,9 @@ import
   testutils/unittests,
   chronicles,
   chronos, 
-  libp2p/crypto/crypto,
   libp2p/switch
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/node/peer_manager/peer_manager,
@@ -17,7 +17,7 @@ import
 
 
 procSuite "WakuNode - Lightpush":
-  let rng = crypto.newRng()
+  let rng = wakuCrypto.getRng()
  
   asyncTest "Lightpush message return success":
     ## Setup

--- a/tests/v2/test_wakunode_relay.nim
+++ b/tests/v2/test_wakunode_relay.nim
@@ -7,7 +7,6 @@ import
   testutils/unittests,
   chronicles, 
   chronos, 
-  libp2p/crypto/crypto,
   libp2p/crypto/secp,
   libp2p/peerid,
   libp2p/multiaddress,
@@ -16,6 +15,7 @@ import
   libp2p/protocols/pubsub/pubsub,
   libp2p/protocols/pubsub/gossipsub
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
@@ -27,7 +27,7 @@ const KEY_PATH = sourceDir / "resources/test_key.pem"
 const CERT_PATH = sourceDir / "resources/test_cert.pem"
 
 procSuite "WakuNode - Relay":
-  let rng = crypto.newRng()
+  let rng = wakuCrypto.getRng()
   
   asyncTest "Relay protocol is started correctly":
     let

--- a/tests/v2/waku_store/test_resume.nim
+++ b/tests/v2/waku_store/test_resume.nim
@@ -4,9 +4,9 @@ import
   std/[options, tables, sets],
   testutils/unittests,
   chronos,
-  chronicles,
-  libp2p/crypto/crypto
+  chronicles
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/common/sqlite,
   ../../waku/v2/node/message_store/sqlite_store,
   ../../waku/v2/node/peer_manager/peer_manager,
@@ -27,7 +27,7 @@ proc newTestArchiveDriver(): ArchiveDriver =
 proc newTestWakuStore(switch: Switch, store=newTestMessageStore()): Future[WakuStore] {.async.} =
   let
     peerManager = PeerManager.new(switch)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     proto = WakuStore.init(peerManager, rng, store)
 
   await proto.start()
@@ -38,7 +38,7 @@ proc newTestWakuStore(switch: Switch, store=newTestMessageStore()): Future[WakuS
 proc newTestWakuStoreClient(switch: Switch, store: MessageStore = nil): WakuStoreClient =
   let
     peerManager = PeerManager.new(switch)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
   WakuStoreClient.new(peerManager, rng, store)
 
 

--- a/tests/v2/waku_store/test_waku_store.nim
+++ b/tests/v2/waku_store/test_waku_store.nim
@@ -4,8 +4,7 @@ import
   std/options,
   testutils/unittests,
   chronos,
-  chronicles,
-  libp2p/crypto/crypto
+  chronicles
 import
   ../../../waku/v2/node/peer_manager/peer_manager,
   ../../../waku/v2/protocol/waku_message,
@@ -19,7 +18,7 @@ import
 proc newTestWakuStore(switch: Switch, handler: HistoryQueryHandler): Future[WakuStore] {.async.} =
   let
     peerManager = PeerManager.new(switch)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     proto = WakuStore.new(peerManager, rng, handler)
 
   await proto.start()
@@ -30,7 +29,7 @@ proc newTestWakuStore(switch: Switch, handler: HistoryQueryHandler): Future[Waku
 proc newTestWakuStoreClient(switch: Switch): WakuStoreClient =
   let
     peerManager = PeerManager.new(switch)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
   WakuStoreClient.new(peerManager, rng)
 
 

--- a/tests/v2/waku_store/test_waku_store.nim
+++ b/tests/v2/waku_store/test_waku_store.nim
@@ -6,6 +6,7 @@ import
   chronos,
   chronicles
 import
+  ../../../waku/common/crypto as wakuCrypto,
   ../../../waku/v2/node/peer_manager/peer_manager,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/protocol/waku_store,

--- a/tests/v2/waku_store/test_wakunode_store.nim
+++ b/tests/v2/waku_store/test_wakunode_store.nim
@@ -5,7 +5,6 @@ import
   testutils/unittests,
   chronicles,
   chronos,
-  libp2p/crypto/crypto,
   libp2p/peerid,
   libp2p/multiaddress,
   libp2p/switch,
@@ -13,6 +12,7 @@ import
   libp2p/protocols/pubsub/pubsub,
   libp2p/protocols/pubsub/gossipsub
 import
+  ../../../waku/common/crypto as wakuCrypto,
   ../../../waku/common/sqlite,
   ../../../waku/v2/node/peer_manager/peer_manager,
   ../../../waku/v2/protocol/waku_message,
@@ -39,7 +39,7 @@ proc computeTestCursor(pubsubTopic: PubsubTopic, message: WakuMessage): HistoryC
 
 procSuite "WakuNode - Store":
   ## Fixtures
-  let rng = crypto.newRng()
+  let rng = wakuCrypto.getRng()
 
   let timeOrigin = now()
   let msgListA = @[

--- a/tools/simulation/start_network2.nim
+++ b/tools/simulation/start_network2.nim
@@ -4,9 +4,10 @@ import
   eth/keys,
   stew/shims/net as stewNet,
   libp2p/multiaddress,
-  libp2p/crypto/crypto,
   libp2p/crypto/secp,
   libp2p/peerinfo
+
+import ../../waku/common/crypto as wakuCrypto
 
 # Fix ambiguous call error
 import strutils except fromHex
@@ -61,7 +62,7 @@ proc debugPrintEnrURI(enrUri: string) =
 # NOTE: Don't distinguish between node types here a la full node, light node etc
 proc initNodeCmd(shift: int, staticNodes: seq[string] = @[], master = false, label: string, discv5BootStrapEnrs: seq[string] = @[]): NodeInfo =
   let
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     key = SkPrivateKey.random(rng[])
     hkey = key.getBytes().toHex()
     rkey = SkPrivateKey.init(fromHex(hkey))[] #assumes ok

--- a/tools/wakucanary/wakucanary.nim
+++ b/tools/wakucanary/wakucanary.nim
@@ -6,10 +6,11 @@ import
   chronicles/topics_registry
 import
   libp2p/protocols/ping,
-  libp2p/crypto/[crypto, secp],
+  libp2p/crypto/secp,
   libp2p/nameresolving/nameresolver,
   libp2p/nameresolving/dnsresolver
 import
+  ../../waku/common/crypto as wakuCrypto,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/utils/peers,
   ../../waku/v2/node/waku_node,
@@ -113,7 +114,7 @@ proc main(): Future[int] {.async.} =
 
   let
     peer: RemotePeerInfo = parseRemotePeerInfo(conf.address)
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
     node = WakuNode.new(
       nodeKey,

--- a/waku/common/crypto.nim
+++ b/waku/common/crypto.nim
@@ -1,0 +1,3 @@
+import ./utils/crypto
+
+export crypto

--- a/waku/common/utils/crypto.nim
+++ b/waku/common/utils/crypto.nim
@@ -1,0 +1,17 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import libp2p/crypto/crypto as libp2pCrypto
+
+export libp2pCrypto
+
+type RngCtx = ref HmacDrbgContext
+
+var rng {.threadvar.}: RngCtx
+
+proc getRng*(): RngCtx =
+  if rng == nil:
+    rng = libp2pCrypto.newRng()
+  return rng

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -25,6 +25,7 @@ import
   libp2p/transports/tcptransport,
   libp2p/transports/wstransport
 import
+  ../../common/crypto as wakuCrypto,
   ../protocol/waku_message,
   ../protocol/waku_relay,
   ../protocol/waku_archive,
@@ -197,7 +198,7 @@ proc new*(T: type WakuNode,
 
   ## Initialize peer
   let
-    rng = crypto.newRng()
+    rng = wakuCrypto.getRng()
     enrIp = if extIp.isSome(): extIp
             else: some(bindIp)
     enrTcpPort = if extPort.isSome(): extPort

--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -8,12 +8,13 @@ import
   std/options,
   chronos, chronicles,
   eth/keys,
-  libp2p/crypto/crypto,
   libp2p/protocols/pubsub/gossipsub,
   libp2p/nameresolving/nameresolver,
   libp2p/builders,
   libp2p/switch,
   libp2p/transports/[transport, tcptransport, wstransport]
+
+import ../../common/crypto as wakuCrypto 
 
 # override nim-libp2p default value (which is also 1)
 const MaxConnectionsPerPeer* = 1
@@ -63,7 +64,7 @@ proc newWakuSwitch*(
         SecureProtocol.Noise,
       ],
     transportFlags: set[ServerFlags] = {},
-    rng = crypto.newRng(),
+    rng = wakuCrypto.getRng(),
     inTimeout: Duration = 5.minutes,
     outTimeout: Duration = 5.minutes,
     maxConnections = MaxConnections,


### PR DESCRIPTION
! WIP: DO NOT MERGE !

as per 
https://github.com/status-im/nim-libp2p/blob/c11772c94e44f0987b79d6593f34d6a4f92f07c5/libp2p/crypto/crypto.nim#L165-L167

We're only supposed to use one instance of the rng per app/library.

As per [nim-libp2p's](https://github.com/status-im/nim-libp2p/blob/4bce8f38c9b9c55c8bf0dc88cf5843662d85d78f/tests/helpers.nim#L67-L74) implementation, this may cause compilation errors on macos. This PR tests if that is the case using CI.

This PR replaces all usages of `crypto.newRng()` with `wakuCrypto.getRng()`