### PR TITLE
fix(rng): create rng only within isMainModule blocks

### DIFF
--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -25,7 +25,7 @@ type
 
     nodekey* {.
       desc: "P2P node private key as 64 char hex string.",
-      name: "nodekey" }: crypto.PrivateKey
+      name: "nodekey" }: Option[crypto.PrivateKey]
 
     listenAddress* {.
       defaultValue: defaultListenAddress(config)
@@ -329,12 +329,3 @@ func defaultListenAddress*(conf: Chat2Conf): ValidIpAddress =
   # TODO: How should we select between IPv4 and IPv6
   # Maybe there should be a config option for this.
   (static ValidIpAddress.init("0.0.0.0"))
-
-## Overload the Conf.load function to generate a new nodekey if one is not
-## provided. This method allows us to use a custom rng without having to
-## generate a new rng / global rng
-proc load*(T: type Chat2Conf, rng: ref HmacDrbgContext): T =
-  var conf = T.load()
-  if $conf.nodekey == "":
-    conf.nodekey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
-  return conf

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -14,7 +14,7 @@ type
     none
     prod
     test
-  
+
   Chat2Conf* = object
     ## General node config
 
@@ -22,10 +22,9 @@ type
       desc: "Sets the log level."
       defaultValue: LogLevel.INFO
       name: "log-level" }: LogLevel
-    
+
     nodekey* {.
       desc: "P2P node private key as 64 char hex string.",
-      defaultValue: crypto.PrivateKey.random(Secp256k1, crypto.newRng()[]).tryGet()
       name: "nodekey" }: crypto.PrivateKey
 
     listenAddress* {.
@@ -52,35 +51,35 @@ type
       desc: "Specify method to use for determining public address. " &
             "Must be one of: any, none, upnp, pmp, extip:<IP>."
       defaultValue: "any" }: string
-    
+
     ## Persistence config
-    
+
     dbPath* {.
       desc: "The database path for peristent storage",
       defaultValue: ""
       name: "db-path" }: string
-    
+
     persistPeers* {.
       desc: "Enable peer persistence: true|false",
       defaultValue: false
       name: "persist-peers" }: bool
-    
+
     persistMessages* {.
       desc: "Enable message persistence: true|false",
       defaultValue: false
       name: "persist-messages" }: bool
 
     ## Relay config
-    
+
     relay* {.
       desc: "Enable relay protocol: true|false",
       defaultValue: true
       name: "relay" }: bool
-    
+
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."
       name: "staticnode" }: seq[string]
-    
+
     keepAlive* {.
       desc: "Enable keep-alive for idle connections: true|false",
       defaultValue: false
@@ -102,38 +101,38 @@ type
       desc: "Peer multiaddr to query for storage.",
       defaultValue: ""
       name: "storenode" }: string
-    
+
     ## Filter config
 
     filter* {.
       desc: "Enable filter protocol: true|false",
       defaultValue: false
       name: "filter" }: bool
-    
+
     filternode* {.
       desc: "Peer multiaddr to request content filtering of messages.",
       defaultValue: ""
       name: "filternode" }: string
-    
+
     ## Swap config
 
     swap* {.
       desc: "Enable swap protocol: true|false",
       defaultValue: true
       name: "swap" }: bool
-    
+
     ## Lightpush config
 
     lightpush* {.
       desc: "Enable lightpush protocol: true|false",
       defaultValue: false
       name: "lightpush" }: bool
-    
+
     lightpushnode* {.
       desc: "Peer multiaddr to request lightpush of published messages.",
       defaultValue: ""
       name: "lightpushnode" }: string
-    
+
     ## JSON-RPC config
 
     rpc* {.
@@ -150,17 +149,17 @@ type
       desc: "Listening port of the JSON-RPC server.",
       defaultValue: 8545
       name: "rpc-port" }: uint16
-    
+
     rpcAdmin* {.
       desc: "Enable access to JSON-RPC Admin API: true|false",
       defaultValue: false
       name: "rpc-admin" }: bool
-    
+
     rpcPrivate* {.
       desc: "Enable access to JSON-RPC Private API: true|false",
       defaultValue: false
       name: "rpc-private" }: bool
-    
+
     ## Metrics config
 
     metricsServer* {.
@@ -182,26 +181,26 @@ type
       desc: "Enable metrics logging: true|false"
       defaultValue: true
       name: "metrics-logging" }: bool
-    
+
     ## DNS discovery config
-    
+
     dnsDiscovery* {.
       desc: "Enable discovering nodes via DNS"
       defaultValue: false
       name: "dns-discovery" }: bool
-    
+
     dnsDiscoveryUrl* {.
       desc: "URL for DNS node list in format 'enrtree://<key>@<fqdn>'",
       defaultValue: ""
       name: "dns-discovery-url" }: string
-    
+
     dnsDiscoveryNameServers* {.
       desc: "DNS name server IPs to query. Argument may be repeated."
       defaultValue: @[ValidIpAddress.init("1.1.1.1"), ValidIpAddress.init("1.0.0.1")]
       name: "dns-discovery-name-server" }: seq[ValidIpAddress]
 
     ## Chat2 configuration
-    
+
     fleet* {.
       desc: "Select the fleet to connect to. This sets the DNS discovery URL to the selected fleet."
       defaultValue: Fleet.prod
@@ -217,19 +216,19 @@ type
       desc: "Enable websocket:  true|false",
       defaultValue: false
       name: "websocket-support"}: bool
-    
+
     websocketPort* {.
       desc: "WebSocket listening port."
       defaultValue: 8000
       name: "websocket-port" }: Port
-    
+
     websocketSecureSupport* {.
       desc: "WebSocket Secure Support."
       defaultValue: false
       name: "websocket-secure-support" }: bool
 
     ## rln-relay configuration
-  
+
     rlnRelay* {.
       desc: "Enable spam protection through rln-relay: true|false",
       defaultValue: false
@@ -239,7 +238,7 @@ type
       desc: "The path for peristing rln-relay credential",
       defaultValue: ""
       name: "rln-relay-cred-path" }: string
-   
+
     rlnRelayMembershipIndex* {.
       desc: "(experimental) the index of node in the rln-relay group: a value between 0-99 inclusive",
       defaultValue: 0
@@ -254,48 +253,48 @@ type
       desc: "the pubsub topic for which rln-relay gets enabled",
       defaultValue: "/waku/2/default-waku/proto"
       name: "rln-relay-pubsub-topic" }: string
-      
+
     rlnRelayDynamic* {.
       desc: "Enable waku-rln-relay with on-chain dynamic group management: true|false",
       defaultValue: false
       name: "rln-relay-dynamic" }: bool
-  
+
     rlnRelayIdKey* {.
-      desc: "Rln relay identity secret key as a Hex string", 
+      desc: "Rln relay identity secret key as a Hex string",
       defaultValue: ""
       name: "rln-relay-id-key" }: string
-    
+
     rlnRelayIdCommitmentKey* {.
-      desc: "Rln relay identity commitment key as a Hex string", 
+      desc: "Rln relay identity commitment key as a Hex string",
       defaultValue: ""
       name: "rln-relay-id-commitment-key" }: string
-  
+
     rlnRelayEthAccountAddress* {.
       desc: "Ethereum account address for an Ethereum testnet",
       # NOTE: This can be derived from the private key, but kept for future use
       defaultValue: ""
       name: "rln-relay-eth-account-address" }: string
-    
+
     rlnRelayEthAccountPrivateKey* {.
       desc: "Account private key for an Ethereum testnet",
       defaultValue: ""
       name: "rln-relay-eth-account-private-key" }: string
-    
+
     rlnRelayEthClientAddress* {.
       desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",
       defaultValue: "ws://localhost:8540/"
       name: "rln-relay-eth-client-address" }: string
-    
+
     rlnRelayEthContractAddress* {.
-      desc: "Address of membership contract on an Ethereum testnet", 
+      desc: "Address of membership contract on an Ethereum testnet",
       defaultValue: ""
       name: "rln-relay-eth-contract-address" }: string
 
     rlnRelayCredentialsPassword* {.
-      desc: "Password for encrypting RLN credentials", 
+      desc: "Password for encrypting RLN credentials",
       defaultValue: ""
       name: "rln-relay-cred-password" }: string
-    
+
 # NOTE: Keys are different in nim-libp2p
 proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
   try:
@@ -330,3 +329,12 @@ func defaultListenAddress*(conf: Chat2Conf): ValidIpAddress =
   # TODO: How should we select between IPv4 and IPv6
   # Maybe there should be a config option for this.
   (static ValidIpAddress.init("0.0.0.0"))
+
+## Overload the Conf.load function to generate a new nodekey if one is not
+## provided. This method allows us to use a custom rng without having to
+## generate a new rng / global rng
+proc load*(T: type Chat2Conf, rng: ref HmacDrbgContext): T =
+  var conf = T.load()
+  if $conf.nodekey == "":
+    conf.nodekey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
+  return conf

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -53,7 +53,6 @@ type
 
     nodekey* {.
       desc: "P2P node private key as 64 char hex string.",
-      defaultValue: defaultPrivateKey()
       name: "nodekey" }: PrivateKey
 
     listenAddress* {.
@@ -466,9 +465,6 @@ proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
 proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
-proc defaultPrivateKey*(): PrivateKey =
-  crypto.PrivateKey.random(Secp256k1, crypto.newRng()[]).value
-
 
 proc parseCmdArg*(T: type ValidIpAddress, p: string): T =
   try:
@@ -543,9 +539,9 @@ proc readValue*(r: var EnvvarReader, value: var crypto.PrivateKey) {.raises: [Se
 
 {.push warning[ProveInit]: off.}
 
-proc load*(T: type WakuNodeConf, version=""): ConfResult[T] =
+proc load*(T: type WakuNodeConf, version="", rng: ref HmacDrbgContext): ConfResult[T] =
   try:
-    let conf = WakuNodeConf.load(
+    var conf = WakuNodeConf.load(
       version=version,
       secondarySources = proc (conf: WakuNodeConf, sources: auto) =
         sources.addConfigFile(Envvar, InputFile("wakunode2"))
@@ -553,6 +549,9 @@ proc load*(T: type WakuNodeConf, version=""): ConfResult[T] =
         if conf.configFile.isSome():
           sources.addConfigFile(Toml, conf.configFile.get())
     )
+    if $conf.nodekey == "":
+      conf.nodekey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
+
     ok(conf)
   except CatchableError:
     err(getCurrentExceptionMsg())

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -53,7 +53,7 @@ type
 
     nodekey* {.
       desc: "P2P node private key as 64 char hex string.",
-      name: "nodekey" }: PrivateKey
+      name: "nodekey" }: Option[PrivateKey]
 
     listenAddress* {.
       defaultValue: defaultListenAddress()
@@ -539,9 +539,9 @@ proc readValue*(r: var EnvvarReader, value: var crypto.PrivateKey) {.raises: [Se
 
 {.push warning[ProveInit]: off.}
 
-proc load*(T: type WakuNodeConf, version="", rng: ref HmacDrbgContext): ConfResult[T] =
+proc load*(T: type WakuNodeConf, version=""): ConfResult[T] =
   try:
-    var conf = WakuNodeConf.load(
+    let conf = WakuNodeConf.load(
       version=version,
       secondarySources = proc (conf: WakuNodeConf, sources: auto) =
         sources.addConfigFile(Envvar, InputFile("wakunode2"))
@@ -549,9 +549,6 @@ proc load*(T: type WakuNodeConf, version="", rng: ref HmacDrbgContext): ConfResu
         if conf.configFile.isSome():
           sources.addConfigFile(Toml, conf.configFile.get())
     )
-    if $conf.nodekey == "":
-      conf.nodekey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
-
     ok(conf)
   except CatchableError:
     err(getCurrentExceptionMsg())

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -214,9 +214,9 @@ proc retrieveDynamicBootstrapNodes*(dnsDiscovery: bool, dnsDiscoveryUrl: string,
   ok(newSeq[RemotePeerInfo]()) # Return an empty seq by default
 
 proc initNode(conf: WakuNodeConf,
+              rng: ref HmacDrbgContext,
               peerStore: Option[WakuPeerStorage],
-              dynamicBootstrapNodes: openArray[RemotePeerInfo] = @[],
-              rng: ref HmacDrbgContext): SetupResult[WakuNode] =
+              dynamicBootstrapNodes: openArray[RemotePeerInfo] = @[]): SetupResult[WakuNode] =
 
   ## Setup a basic Waku v2 node based on a supplied configuration
   ## file. Optionally include persistent peer storage.
@@ -232,6 +232,13 @@ proc initNode(conf: WakuNodeConf,
     dnsResolver = DnsResolver.new(nameServers)
 
   let
+    nodekey = if conf.nodekey.isSome():
+                conf.nodekey.get()
+              else:
+                let nodekeyRes = crypto.PrivateKey.random(Secp256k1, rng[])
+                if nodekeyRes.isErr():
+                  return err("failed to generate nodekey: " & $nodekeyRes.error)
+                nodekeyRes.get()
     ## `udpPort` is only supplied to satisfy underlying APIs but is not
     ## actually a supported transport for libp2p traffic.
     udpPort = conf.tcpPort
@@ -272,7 +279,7 @@ proc initNode(conf: WakuNodeConf,
   let pStorage = if peerStore.isNone(): nil
                  else: peerStore.get()
   try:
-    node = WakuNode.new(conf.nodekey,
+    node = WakuNode.new(nodekey,
                         conf.listenAddress, Port(uint16(conf.tcpPort) + conf.portsShift),
                         extIp, extPort,
                         extMultiAddrs,
@@ -320,7 +327,7 @@ proc initNode(conf: WakuNodeConf,
       discv5UdpPort.get(),
       discv5BootstrapEnrs,
       conf.discv5EnrAutoUpdate,
-      keys.PrivateKey(conf.nodekey.skkey),
+      keys.PrivateKey(nodekey.skkey),
       wakuFlags,
       [], # Empty enr fields, for now
       node.rng,
@@ -574,8 +581,7 @@ when isMainModule:
   const versionString = "version / git commit hash: " & git_version
   let rng = crypto.newRng()
 
-  let confRes = WakuNodeConf.load(version=versionString,
-                                  rng = rng)
+  let confRes = WakuNodeConf.load(version=versionString)
   if confRes.isErr():
     error "failure while loading the configuration", error=confRes.error
     quit(QuitFailure)
@@ -659,7 +665,7 @@ when isMainModule:
 
   var node: WakuNode  # This is the node we're going to setup using the conf
 
-  let initNodeRes = initNode(conf, peerStore, dynamicBootstrapNodes, rng)
+  let initNodeRes = initNode(conf, rng, peerStore, dynamicBootstrapNodes)
   if initNodeRes.isok():
     node = initNodeRes.get()
   else:

--- a/tests/v2/test_waku_switch.nim
+++ b/tests/v2/test_waku_switch.nim
@@ -10,6 +10,7 @@ import
   stew/byteutils
 import
   ../../waku/v2/node/wakuswitch,
+  ../test_helpers,
   ./testlib/switch
 
 proc newCircuitRelayClientSwitch(relayClient: RelayClient): Switch =
@@ -28,7 +29,7 @@ procSuite "Waku Switch":
     ## Given
     let
       sourceSwitch = newTestSwitch()
-      wakuSwitch = newWakuSwitch()
+      wakuSwitch = newWakuSwitch(rng = rng())
     await sourceSwitch.start()
     await wakuSwitch.start()
 
@@ -46,7 +47,7 @@ procSuite "Waku Switch":
   asyncTest "Waku Switch acts as circuit relayer":
     ## Setup
     let
-      wakuSwitch = newWakuSwitch()
+      wakuSwitch = newWakuSwitch(rng = rng())
       sourceClient = RelayClient.new()
       destClient = RelayClient.new()
       sourceSwitch = newCircuitRelayClientSwitch(sourceClient)

--- a/tools/wakucanary/wakucanary.nim
+++ b/tools/wakucanary/wakucanary.nim
@@ -86,7 +86,7 @@ proc areProtocolsSupported(
 
   return false
 
-proc main(): Future[int] {.async.} =
+proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
   let conf: WakuCanaryConf = WakuCanaryConf.load()
 
   # create dns resolver
@@ -113,7 +113,6 @@ proc main(): Future[int] {.async.} =
 
   let
     peer: RemotePeerInfo = parseRemotePeerInfo(conf.address)
-    rng = crypto.newRng()
     nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
     node = WakuNode.new(
       nodeKey,
@@ -141,7 +140,8 @@ proc main(): Future[int] {.async.} =
   return 0
 
 when isMainModule:
-  let status = waitFor main()
+  let rng = crypto.newRng()
+  let status = waitFor main(rng)
   if status == 0:
     info "The node is reachable and supports all specified protocols"
   else:

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -151,6 +151,8 @@ proc new*(T: type WakuNode,
           discv5UdpPort = none(Port),
           agentString = none(string),    # defaults to nim-libp2p version
           peerStoreCapacity = none(int), # defaults to nim-libp2p max size
+          # TODO: make this argument required after tests are updated
+          rng: ref HmacDrbgContext = crypto.newRng()
           ): T {.raises: [Defect, LPError, IOError, TLSStreamProtocolError].} =
   ## Creates a Waku Node instance.
 
@@ -197,7 +199,6 @@ proc new*(T: type WakuNode,
 
   ## Initialize peer
   let
-    rng = crypto.newRng()
     enrIp = if extIp.isSome(): extIp
             else: some(bindIp)
     enrTcpPort = if extPort.isSome(): extPort

--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -63,7 +63,7 @@ proc newWakuSwitch*(
         SecureProtocol.Noise,
       ],
     transportFlags: set[ServerFlags] = {},
-    rng = crypto.newRng(),
+    rng: ref HmacDrbgContext,
     inTimeout: Duration = 5.minutes,
     outTimeout: Duration = 5.minutes,
     maxConnections = MaxConnections,


### PR DESCRIPTION
As a follow up to #1522, this method is more surgical, and does not make use of global variables (sort of).

Makes the rng required by all the procs which consume it, except for WakuNode.new(), because refactoring this will require updating a lot of tests, which can be done in a follow up PR.
