### PR TITLE
fix: add safe default values for peer-store-capacity

### DIFF
--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -87,8 +87,7 @@ type
 
     peerStoreCapacity* {.
       desc: "Maximum stored peers in the peerstore."
-      defaultValue: 100
-      name: "peer-store-capacity" }: int
+      name: "peer-store-capacity" }: Option[int]
 
     peerPersistence* {.
       desc: "Enable peer persistence.",
@@ -494,6 +493,11 @@ proc parseCmdArg*(T: type Port, p: string): T =
 proc completeCmdArg*(T: type Port, val: string): seq[string] =
   return @[]
 
+proc parseCmdArg*(T: type Option[int], p: string): T =
+  try:
+    some(parseInt(p))
+  except:
+    raise newException(ConfigurationError, "Invalid number")
 
 ## Configuration validation
 

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -288,7 +288,7 @@ proc initNode(conf: WakuNodeConf,
                         dns4DomainName,
                         discv5UdpPort,
                         some(conf.agentString),
-                        some(conf.peerStoreCapacity))
+                        conf.peerStoreCapacity)
   except:
     return err("failed to create waku node instance: " & getCurrentExceptionMsg())
 

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -150,7 +150,7 @@ proc new*(T: type WakuNode,
           dns4DomainName = none(string),
           discv5UdpPort = none(Port),
           agentString = none(string),    # defaults to nim-libp2p version
-          peerStoreCapacity = none(int), # defaults to nim-libp2p max size
+          peerStoreCapacity = none(int), # defaults to 1.25 maxConnections
           ): T {.raises: [Defect, LPError, IOError, TLSStreamProtocolError].} =
   ## Creates a Waku Node instance.
 

--- a/waku/v2/node/wakuswitch.nim
+++ b/waku/v2/node/wakuswitch.nim
@@ -5,7 +5,7 @@ else:
   {.push raises: [].}
 
 import
-  std/options,
+  std/[options, math],
   chronos, chronicles,
   eth/keys,
   libp2p/crypto/crypto,
@@ -76,7 +76,7 @@ proc newWakuSwitch*(
     secureKeyPath: string = "",
     secureCertPath: string = "",
     agentString = none(string),    # defaults to nim-libp2p version
-    peerStoreCapacity = none(int), # defaults to nim-libp2p max size
+    peerStoreCapacity = none(int), # defaults to 1.25 maxConnections
     services: seq[switch.Service] = @[],
     ): Switch
     {.raises: [Defect, IOError, LPError].} =
@@ -98,6 +98,9 @@ proc newWakuSwitch*(
 
     if peerStoreCapacity.isSome():
       b = b.withPeerStore(peerStoreCapacity.get())
+    else:
+      let defaultPeerStoreCapacity = int(round(float64(maxConnections)*1.25))
+      b = b.withPeerStore(defaultPeerStoreCapacity)
     if agentString.isSome():
       b = b.withAgentVersion(agentString.get())
     if privKey.isSome():


### PR DESCRIPTION
* add safe default values for peer-store-capacity. If not set, just take 1.25 times the max number of connections.
* the lack of this safe default value currently breaks the current infra config.