### PR TITLE
chore: add better e2e trace logging for relay

### DIFF
--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -38,6 +38,7 @@ import
   ../protocol/waku_peer_exchange,
   ../utils/peers,
   ../utils/wakuenr,
+  ../utils/time,
   ./peer_manager/peer_manager,
   ./dnsdisc/waku_dnsdisc,
   ./discv5/waku_discv5,
@@ -300,13 +301,16 @@ proc subscribe(node: WakuNode, topic: PubsubTopic, handler: Option[TopicHandler]
 
   proc defaultHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
     # A default handler should be registered for all topics
-    trace "Hit default handler", topic=topic, data=data
 
     let msg = WakuMessage.decode(data)
     if msg.isErr():
       # TODO: Add metric to track waku message decode errors
       return
 
+    trace "waku.relay received",
+      pubsubTopic=topic,
+      hash=MultiHash.digest("sha2-256", data).expect("valid hash").data.buffer.to0xHex(), # TODO: this could be replaced by a message UID
+      receivedTime=getNowInNanosecondTime()
 
     # Notify mounted protocols of new message
     if not node.wakuFilter.isNil():
@@ -371,9 +375,12 @@ proc publish*(node: WakuNode, topic: PubsubTopic, message: WakuMessage) {.async,
     # TODO: Improve error handling
     return
 
-  trace "publish", topic=topic, contentTopic=message.contentTopic
-
   discard await node.wakuRelay.publish(topic, message)
+
+  trace "waku.relay published",
+    pubsubTopic=topic,
+    hash=MultiHash.digest("sha2-256", message.encode().buffer).expect("valid hash").data.buffer.to0xHex(), # TODO: this could be replaced by a message UID
+    publishTime=getNowInNanosecondTime()
 
 proc startRelay*(node: WakuNode) {.async.} =
   ## Setup and start relay protocol

--- a/waku/v2/utils/time.nim
+++ b/waku/v2/utils/time.nim
@@ -4,26 +4,29 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import 
+import
   std/times,
   metrics
 
-type Timestamp* = int64 
+type Timestamp* = int64
 
-proc getNanosecondTime*[T](timeInSeconds: T): Timestamp = 
+proc getNanosecondTime*[T](timeInSeconds: T): Timestamp =
   var ns = Timestamp(timeInSeconds.int64 * 1000_000_000.int64)
   return ns
 
-proc getMicrosecondTime*[T](timeInSeconds: T): Timestamp = 
+proc getMicrosecondTime*[T](timeInSeconds: T): Timestamp =
   var us = Timestamp(timeInSeconds.int64 * 1000_000.int64)
   return us
 
-proc getMillisecondTime*[T](timeInSeconds: T): Timestamp = 
+proc getMillisecondTime*[T](timeInSeconds: T): Timestamp =
   var ms = Timestamp(timeInSeconds.int64 * 1000.int64)
   return ms
 
 proc nowInUnixFloat(): float =
   return getTime().toUnixFloat()
+
+proc getNowInNanosecondTime*(): Timestamp =
+  return getNanosecondTime(nowInUnixFloat())
 
 template nanosecondTime*(collector: Summary | Histogram, body: untyped) =
   when defined(metrics):


### PR DESCRIPTION
Hopefully an easy fix for https://github.com/waku-org/nwaku/issues/1394

Improves relay trace logging on publishing and receiving a message, to log:

- a hash of the message
- publish/arrival timestamp
- pubsubTopic

@Daimakaimura my understanding is that this will cover your needs? Anything else that would be required/nice to have?

This will result in the following example trace log on the relaying node:

```
TRC 2023-02-01 14:48:52.270+02:00 waku.relay received                        topics="waku node" tid=22467 file=waku_node.nim:310 pubsubTopic=/waku/2/default-waku/proto hash=0x1220b9cb650d6af10c34d9d882a609d9aa6d506b0831f8f01a8e27be3c665d889974 receivedTime=1675255732000000000
```

and on the publishing node

```
TRC 2023-02-01 14:48:52.270+02:00 waku.relay published                        topics="waku node" tid=22467 file=waku_node.nim:310 pubsubTopic=/waku/2/default-waku/proto hash=0x1220b9cb650d6af10c34d9d882a609d9aa6d506b0831f8f01a8e27be3c665d889974 publishTime=1675255732000000000
```

## Note:

- log format and hash selected to be roughly similar to go-waku: https://github.com/waku-org/go-waku/commit/a247e8346d458ce3d4ac6726ae98fb7a2428c5d1
- hash computation currently done inside trace log statement (to skip compilation when trace logs not enabled), should probably replaced by the message UID concept being developed