### PR TITLE
refactor(px): refactor peer exchange + tests

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -529,10 +529,13 @@ proc startNode(node: WakuNode, conf: WakuNodeConf,
   if conf.peerExchangeNode != "":
     info "Retrieving peer info via peer exchange protocol"
     let desiredOutDegree = node.wakuRelay.parameters.d.uint64()
-    try:
-      discard await node.wakuPeerExchange.request(desiredOutDegree)
-    except:
-      return err("failed to retrieve peer info via peer exchange protocol: " & getCurrentExceptionMsg())
+    let pxPeersRes = await node.wakuPeerExchange.request(desiredOutDegree)
+    if pxPeersRes.isOk:
+      let pxPeers = pxPeersRes.get().peerInfos
+      echo "----pxPeers, ", pxPeers
+    else:
+      #error is tosevere?
+      warn "failed to retrieve peer info via peer exchange protocol"
 
   # Start keepalive, if enabled
   if conf.keepAlive:

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -1,12 +1,13 @@
 {.used.}
 
 import
-  std/options,
+  std/[options, sequtils],
   testutils/unittests,
   chronos,
   chronicles,
   stew/shims/net,
   libp2p/switch,
+  libp2p/peerId,
   libp2p/crypto/crypto,
   eth/keys,
   eth/p2p/discoveryv5/enr
@@ -18,7 +19,8 @@ import
   ../../waku/v2/protocol/waku_peer_exchange/rpc,
   ../../waku/v2/protocol/waku_peer_exchange/rpc_codec,
   ../test_helpers,
-  ./utils
+  ./utils,
+  ./testlib/testutils
 
 
 # TODO: Extend test coverage
@@ -30,8 +32,8 @@ procSuite "Waku Peer Exchange":
       enr1 = enr.Record(seqNum: 0, raw: @[])
       enr2 = enr.Record(seqNum: 0, raw: @[])
 
-    discard enr1.fromUri("enr:-JK4QPmO-sE2ELiWr8qVFs1kaY4jQZQpNaHvSPRmKiKcaDoqYRdki2c1BKSliImsxFeOD_UHnkddNL2l0XT9wlsP0WEBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQIMwKqlOl3zpwnrsKRKHuWPSuFzit1Cl6IZvL2uzBRe8oN0Y3CC6mKDdWRwgiMqhXdha3UyDw")
-    discard enr2.fromUri("enr:-Iu4QK_T7kzAmewG92u1pr7o6St3sBqXaiIaWIsFNW53_maJEaOtGLSN2FUbm6LmVxSfb1WfC7Eyk-nFYI7Gs3SlchwBgmlkgnY0gmlwhI5d6VKJc2VjcDI1NmsxoQLPYQDvrrFdCrhqw3JuFaGD71I8PtPfk6e7TJ3pg_vFQYN0Y3CC6mKDdWRwgiMq")
+    check enr1.fromUri("enr:-JK4QPmO-sE2ELiWr8qVFs1kaY4jQZQpNaHvSPRmKiKcaDoqYRdki2c1BKSliImsxFeOD_UHnkddNL2l0XT9wlsP0WEBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQIMwKqlOl3zpwnrsKRKHuWPSuFzit1Cl6IZvL2uzBRe8oN0Y3CC6mKDdWRwgiMqhXdha3UyDw")
+    check enr2.fromUri("enr:-Iu4QK_T7kzAmewG92u1pr7o6St3sBqXaiIaWIsFNW53_maJEaOtGLSN2FUbm6LmVxSfb1WfC7Eyk-nFYI7Gs3SlchwBgmlkgnY0gmlwhI5d6VKJc2VjcDI1NmsxoQLPYQDvrrFdCrhqw3JuFaGD71I8PtPfk6e7TJ3pg_vFQYN0Y3CC6mKDdWRwgiMq")
 
     let peerInfos = @[
       PeerExchangePeerInfo(enr: enr1.raw),
@@ -127,20 +129,63 @@ procSuite "Waku Peer Exchange":
     await node1.mountPeerExchange()
     await node3.mountPeerExchange()
 
-    await sleepAsync(3000.millis) # Give the algorithm some time to work its magic
+    # Give the algorithm some time to work its magic
+    await sleepAsync(3000.millis)
 
     asyncSpawn node1.wakuPeerExchange.runPeerExchangeDiscv5Loop()
 
-    node3.setPeerExchangePeer(node1.peerInfo.toRemotePeerInfo())
+    let connOpt = await node3.peerManager.dialPeer(node1.switch.peerInfo.toRemotePeerInfo(), WakuPeerExchangeCodec)
+    check:
+      connOpt.isSome
+
+    # Give the algorithm some time to work its magic
+    await sleepAsync(2000.millis)
 
     ## When
-    discard waitFor node3.wakuPeerExchange.request(1)
-
-    await sleepAsync(2000.millis) # Give the algorithm some time to work its magic
+    let response = await node3.wakuPeerExchange.request(1, connOpt.get())
 
     ## Then
     check:
+      response.isOk
+      response.get().peerInfos.len == 1
       node1.wakuDiscv5.protocol.nodesDiscovered > 0
-      node3.switch.peerStore[AddressBook].contains(node2.switch.peerInfo.peerId)
 
     await allFutures([node1.stop(), node2.stop(), node3.stop()])
+
+  asyncTest "peer exchange request returns some discovered peers":
+    let
+      node1 = WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node2 = WakuNode.new(generateKey(), ValidIpAddress.init("0.0.0.0"), Port(0))
+
+    # Start and mount peer exchange
+    await allFutures([node1.start(), node2.start()])
+    await allFutures([node1.mountPeerExchange(), node2.mountPeerExchange()])
+
+    # Create connection
+    let connOpt = await node2.peerManager.dialPeer(node1.switch.peerInfo.toRemotePeerInfo(), WakuPeerExchangeCodec)
+    check:
+      connOpt.isSome
+
+    # Create some enr and add to peer exchange (sumilating disv5)
+    var enr1, enr2 = enr.Record()
+    check enr1.fromUri("enr:-Iu4QGNuTvNRulF3A4Kb9YHiIXLr0z_CpvWkWjWKU-o95zUPR_In02AWek4nsSk7G_-YDcaT4bDRPzt5JIWvFqkXSNcBgmlkgnY0gmlwhE0WsGeJc2VjcDI1NmsxoQKp9VzU2FAh7fwOwSpg1M_Ekz4zzl0Fpbg6po2ZwgVwQYN0Y3CC6mCFd2FrdTIB")
+    check enr2.fromUri("enr:-Iu4QGJllOWlviPIh_SGR-VVm55nhnBIU5L-s3ran7ARz_4oDdtJPtUs3Bc5aqZHCiPQX6qzNYF2ARHER0JPX97TFbEBgmlkgnY0gmlwhE0WsGeJc2VjcDI1NmsxoQP3ULycvday4EkvtVu0VqbBdmOkbfVLJx8fPe0lE_dRkIN0Y3CC6mCFd2FrdTIB")
+
+    # Mock that we have discovered these enrs
+    node1.wakuPeerExchange.enrCache.add(enr1)
+    node1.wakuPeerExchange.enrCache.add(enr2)
+
+    # Request 2 peer from px
+    let response = await node1.wakuPeerExchange.request(2, connOpt.get())
+    let pxPeers = response.get().peerInfos
+
+    # Check the response was ok and we got the correct enrs
+    check:
+      response.isOk
+      response.get().peerInfos.len == 2
+
+      # Since it can return duplicates test that at least one of the enrs is in the response
+      pxPeers.anyIt(it.enr == enr1.raw) or pxPeers.anyIt(it.enr == enr2.raw)
+
+
+# TODO: Test setPeerExchangePeer #node3.setPeerExchangePeer(node1.peerInfo.toRemotePeerInfo())

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -26,7 +26,7 @@ import
 # TODO: Extend test coverage
 procSuite "Waku Peer Exchange":
 
-  xasyncTest "encode and decode peer exchange response":
+  asyncTest "encode and decode peer exchange response":
     ## Setup
     var
       enr1 = enr.Record(seqNum: 0, raw: @[])
@@ -69,7 +69,7 @@ procSuite "Waku Peer Exchange":
       resEnr1 == enr1
       resEnr2 == enr2
 
-  xasyncTest "retrieve and provide peer exchange peers from discv5":
+  asyncTest "retrieve and provide peer exchange peers from discv5":
     ## Setup (copied from test_waku_discv5.nim)
     let
       bindIp = ValidIpAddress.init("0.0.0.0")
@@ -217,7 +217,3 @@ procSuite "Waku Peer Exchange":
 
     # Check that it failed gracefully
     check: response.isErr
-
-# TODO: Test setPeerExchangePeer #node3.setPeerExchangePeer(node1.peerInfo.toRemotePeerInfo())
-
-# TODO: test with dead connection or failed peers.

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -175,5 +175,8 @@ proc getPeersByDirection*(peerStore: PeerStore, direction: PeerDirection): seq[S
 proc getNotConnectedPeers*(peerStore: PeerStore): seq[StoredInfo] =
   return peerStore.peers.filterIt(it.connectedness != Connected)
 
+proc getConnectedPeers*(peerStore: PeerStore): seq[StoredInfo] =
+  return peerStore.peers.filterIt(it.connectedness == Connected)
+
 proc getPeersByProtocol*(peerStore: PeerStore, proto: string): seq[StoredInfo] =
   return peerStore.peers.filterIt(it.protos.contains(proto))

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -968,9 +968,9 @@ proc fetchPeerExchangePeers*(node: Wakunode, amount: uint64) {.async, raises: [D
   info "Retrieving peer info via peer exchange protocol"
   let pxPeersRes = await node.wakuPeerExchange.request(amount)
   if pxPeersRes.isOk:
-    var record: enr.Record
     var validPeers = 0
     for pi in pxPeersRes.get().peerInfos:
+      var record: enr.Record
       if enr.fromBytes(record, pi.enr):
         # TODO: Add source: PX
         node.peerManager.addPeer(record.toRemotePeerInfo().get, WakuRelayCodec)

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -960,6 +960,25 @@ proc mountPeerExchange*(node: WakuNode) {.async, raises: [Defect, LPError].} =
 
   node.switch.mount(node.wakuPeerExchange, protocolMatcher(WakuPeerExchangeCodec))
 
+proc fetchPeerExchangePeers*(node: Wakunode, amount: uint64) {.async, raises: [Defect].} =
+  if node.wakuPeerExchange.isNil():
+    error "could not get peers from px, waku peer-exchange is nil"
+    return
+
+  info "Retrieving peer info via peer exchange protocol"
+  let pxPeersRes = await node.wakuPeerExchange.request(amount)
+  if pxPeersRes.isOk:
+    var record: enr.Record
+    var validPeers = 0
+    for pi in pxPeersRes.get().peerInfos:
+      if enr.fromBytes(record, pi.enr):
+        # TODO: Add source: PX
+        node.peerManager.addPeer(record.toRemotePeerInfo().get, WakuRelayCodec)
+        validPeers += 1
+    info "Retrieved peer info via peer exchange protocol", validPeers = validPeers
+  else:
+    warn "Failed to retrieve peer info via peer exchange protocol", error = pxPeersRes.error
+
 # TODO: Move to application module (e.g., wakunode2.nim)
 proc setPeerExchangePeer*(node: WakuNode, peer: RemotePeerInfo|string) {.raises: [Defect, ValueError, LPError].} =
   if node.wakuPeerExchange.isNil():

--- a/waku/v2/protocol/waku_peer_exchange/protocol.nim
+++ b/waku/v2/protocol/waku_peer_exchange/protocol.nim
@@ -29,7 +29,7 @@ logScope:
 const
   # We add a 64kB safety buffer for protocol overhead.
   # 10x-multiplier also for safety
-  MaxRpcSize = 10 * MaxWakuMessageSize + 64 * 1024 # TODO what is the expected size of a PX message? As currently specified, it can contain an arbitary number of ENRs...
+  MaxRpcSize* = 10 * MaxWakuMessageSize + 64 * 1024 # TODO what is the expected size of a PX message? As currently specified, it can contain an arbitary number of ENRs...
   MaxCacheSize = 1000
   CacheCleanWindow = 200
 

--- a/waku/v2/protocol/waku_peer_exchange/protocol.nim
+++ b/waku/v2/protocol/waku_peer_exchange/protocol.nim
@@ -55,17 +55,17 @@ proc request*(wpx: WakuPeerExchange, numPeers: uint64, conn: Connection): Future
   let rpc = PeerExchangeRpc(
     request: PeerExchangeRequest(numPeers: numPeers))
 
+  var buffer: seq[byte]
   try:
     await conn.writeLP(rpc.encode().buffer)
+    buffer = await conn.readLp(MaxRpcSize.int)
   except CatchableError as exc:
     waku_px_errors.inc(labelValues = [exc.msg])
-    return err(exc.msg)
+    return err("write/read failed: " & $exc.msg)
 
-  let buffer = await conn.readLp(MaxRpcSize.int)
   let decodedBuff = PeerExchangeRpc.decode(buffer)
   if decodedBuff.isErr():
     return err("decode failed: " & $decodedBuff.error)
-
   return ok(decodedBuff.get().response)
 
 proc request*(wpx: WakuPeerExchange, numPeers: uint64, peer: RemotePeerInfo): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async, gcsafe.} =
@@ -145,33 +145,39 @@ proc initProtocolHandler(wpx: WakuPeerExchange) =
     let rpc = res.get()
 
     # handle peer exchange request
+    # TODO
     if rpc.request != PeerExchangeRequest():
       trace "peer exchange request received"
       let enrs = wpx.getEnrsFromCache(rpc.request.numPeers)
+      # TODO we shouldnt discard this?
       discard await wpx.respond(enrs, conn)
       waku_px_peers_sent.inc(enrs.len().int64())
 
     # handle peer exchange response
     # TODO: wondering if this should not be part of the protocol
     # whats done with the peers is not part of the protocol
-    if rpc.response != PeerExchangeResponse():
+
+    # TODO: This could technically allow to inject unsolicitated responses that
+    # were not originated by a request. Possible attack.
+    #if rpc.response != PeerExchangeResponse():
+    #  echo "---enter in response"
       # todo: error handling
-      trace "peer exchange response received"
-      var record: enr.Record
-      var remotePeerInfoList: seq[RemotePeerInfo]
-      waku_px_peers_received_total.inc(rpc.response.peerInfos.len().int64())
-      for pi in rpc.response.peerInfos:
-        discard enr.fromBytes(record, pi.enr)
-        remotePeerInfoList.add(record.toRemotePeerInfo().get)
+    #  trace "peer exchange response received"
+    #  var record: enr.Record
+    #  var remotePeerInfoList: seq[RemotePeerInfo]
+    #  waku_px_peers_received_total.inc(rpc.response.peerInfos.len().int64())
+    #  for pi in rpc.response.peerInfos:
+    #    discard enr.fromBytes(record, pi.enr)
+    #    remotePeerInfoList.add(record.toRemotePeerInfo().get)
 
-      let newPeers = remotePeerInfoList.filterIt(
-        not wpx.peerManager.switch.isConnected(it.peerId))
+    #  let newPeers = remotePeerInfoList.filterIt(
+    #    not wpx.peerManager.switch.isConnected(it.peerId))
 
-      if newPeers.len() > 0:
-        waku_px_peers_received_unknown.inc(newPeers.len().int64())
-        debug "Connecting to newly discovered peers", count=newPeers.len()
-        # TODO: This should just add peers to the peerstore, not trying to connect to them
-        await wpx.peerManager.connectToNodes(newPeers, WakuRelayCodec, source = "peer exchange")
+    #  if newPeers.len() > 0:
+    #    waku_px_peers_received_unknown.inc(newPeers.len().int64())
+    #    debug "Connecting to newly discovered peers", count=newPeers.len()
+    #    # TODO: This should just add peers to the peerstore, not trying to connect to them
+    #    await wpx.peerManager.connectToNodes(newPeers, WakuRelayCodec, source = "peer exchange")
 
   wpx.handler = handler
   wpx.codec = WakuPeerExchangeCodec

--- a/waku/v2/protocol/waku_peer_exchange/rpc.nim
+++ b/waku/v2/protocol/waku_peer_exchange/rpc.nim
@@ -8,7 +8,6 @@ type
   PeerExchangeResponse* = object
     peerInfos*: seq[PeerExchangePeerInfo]
 
-# TODO: is this even needed?
   PeerExchangeRpc* = object
     request*: PeerExchangeRequest
     response*: PeerExchangeResponse

--- a/waku/v2/protocol/waku_peer_exchange/rpc.nim
+++ b/waku/v2/protocol/waku_peer_exchange/rpc.nim
@@ -8,6 +8,7 @@ type
   PeerExchangeResponse* = object
     peerInfos*: seq[PeerExchangePeerInfo]
 
+# TODO: is this even needed?
   PeerExchangeRpc* = object
     request*: PeerExchangeRequest
     response*: PeerExchangeResponse

--- a/waku/v2/protocol/waku_peer_exchange/rpc_codec.nim
+++ b/waku/v2/protocol/waku_peer_exchange/rpc_codec.nim
@@ -83,7 +83,8 @@ proc decode*(T: type PeerExchangeRpc, buffer: seq[byte]): ProtoResult[T] =
   var rpc = PeerExchangeRpc()
 
   var requestBuffer: seq[byte]
-  discard ?pb.getField(1, requestBuffer)
+  if not ?pb.getField(1, requestBuffer):
+    return err(ProtoError.RequiredFieldMissing)
   rpc.request = ?PeerExchangeRequest.decode(requestBuffer)
 
   var responseBuffer: seq[byte]


### PR DESCRIPTION
Last item to close https://github.com/waku-org/nwaku/issues/1463

Some refactoring in the px protocol + more tests + moving the "what to do with the peers we got via px" logic to the application. Some discussions started in https://github.com/waku-org/nwaku/issues/1463 and this prepares the ground for https://github.com/waku-org/nwaku/issues/1521.

**Summary of changes**:
* Improve error handling using `Result` and catch exceptions (mainly `readLp` and `writeLp` since can raise an Exception if the stream is prematurely closed)
* No longer handle the px response on the protocol. The response should be handled by the application, which now adds the peers to the peerstore intead of trying to connect to them.
* Changes `respond` proc, reusing the existing connection instead of attempting to create a new one.
* Fixes possible vulnerability [here](https://github.com/waku-org/nwaku/blob/master/waku/v2/protocol/waku_peer_exchange/protocol.nim#L170-L187), since one could inject unsolicitatede responses to a node that never requested px. In other words, you could send a `PeerExchangeResponse` to a px node without that node ever requesting anything from you.
* Add new tests for all `request` proc variants both succesfull and not.

Test:

- [x] Once approved manually test it.

## End to end test

Node that discovers peers and runs peer exchange:
```
./build/wakunode2 \
--dns-discovery=true \
--dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im \
--discv5-discovery=true \
--discv5-enr-auto-update=True \
--nodekey=161c2836197e8918d7eb1039758423795f0dc697a018ed55d5931aa9b0e5efb3 \
--peer-exchange
```

Node that sets the above one as px node
```
./build/wakunode2 \
--tcp-port=30305 \
--ports-shift=1 \
--peer-exchange-node=/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2HAm2ZuRHGZUzG6JGJeY1nGKHXLGrQYnZ7mZToymHtFfYFFf
```

Peers are succesfuly retrieved in the second node and added to the peerstore.