### PR TITLE
fix: improve filter test race condition

### DIFF
--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -112,7 +112,7 @@ suite "Waku Filter":
     require (await client.subscribe(pubsubTopic, contentTopic, pushHandler, peer=serverAddr)).isOk()
 
     # WARN: Sleep necessary to avoid a race condition between the subscription and the handle message proc
-    await sleepAsync(1.seconds)
+    await sleepAsync(500.milliseconds)
 
     await server.handleMessage(pubsubTopic, msg)
 

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -43,24 +43,24 @@ proc newTestWakuFilterClient(switch: Switch): Future[WakuFilterClient] {.async.}
 suite "Waku Filter":
   asyncTest "should forward messages to client after subscribed":
     ## Setup
-    let 
+    let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
 
-    let 
+    let
       server = await newTestWakuFilterNode(serverSwitch)
       client = await newTestWakuFilterClient(clientSwitch)
 
     ## Given
     let serverAddr = serverSwitch.peerInfo.toRemotePeerInfo()
-    
+
     let pushHandlerFuture = newFuture[(string, WakuMessage)]()
     proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.} =
       pushHandlerFuture.complete((pubsubTopic, message))
 
-    let 
+    let
       pubsubTopic = DefaultPubsubTopic
       contentTopic = "test-content-topic"
       msg = fakeWakuMessage(contentTopic=contentTopic)
@@ -69,11 +69,11 @@ suite "Waku Filter":
     require (await client.subscribe(pubsubTopic, contentTopic, pushHandler, peer=serverAddr)).isOk()
 
     # WARN: Sleep necessary to avoid a race condition between the subscription and the handle message proc
-    await sleepAsync(5.milliseconds)
+    await sleepAsync(500.milliseconds)
 
     await server.handleMessage(pubsubTopic, msg)
 
-    require await pushHandlerFuture.withTimeout(5.seconds)
+    require await pushHandlerFuture.withTimeout(3.seconds)
 
     ## Then
     let (pushedMsgPubsubTopic, pushedMsg) = pushHandlerFuture.read()
@@ -86,13 +86,13 @@ suite "Waku Filter":
 
   asyncTest "should not forward messages to client after unsuscribed":
     ## Setup
-    let 
+    let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
-    
-    let 
+
+    let
       server = await newTestWakuFilterNode(serverSwitch)
       client = await newTestWakuFilterClient(clientSwitch)
 
@@ -103,7 +103,7 @@ suite "Waku Filter":
     proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.} =
       pushHandlerFuture.complete()
 
-    let 
+    let
       pubsubTopic = DefaultPubsubTopic
       contentTopic = "test-content-topic"
       msg = fakeWakuMessage(contentTopic=contentTopic)
@@ -112,7 +112,7 @@ suite "Waku Filter":
     require (await client.subscribe(pubsubTopic, contentTopic, pushHandler, peer=serverAddr)).isOk()
 
     # WARN: Sleep necessary to avoid a race condition between the subscription and the handle message proc
-    await sleepAsync(5.milliseconds)
+    await sleepAsync(1.seconds)
 
     await server.handleMessage(pubsubTopic, msg)
 
@@ -124,7 +124,7 @@ suite "Waku Filter":
     require (await client.unsubscribe(pubsubTopic, contentTopic, peer=serverAddr)).isOk()
 
     # WARN: Sleep necessary to avoid a race condition between the unsubscription and the handle message proc
-    await sleepAsync(5.milliseconds)
+    await sleepAsync(500.milliseconds)
 
     await server.handleMessage(pubsubTopic, msg)
 
@@ -132,13 +132,13 @@ suite "Waku Filter":
     let handlerWasCalledAfterUnsubscription = await pushHandlerFuture.withTimeout(1.seconds)
     check:
       not handlerWasCalledAfterUnsubscription
-      
+
     ## Cleanup
     await allFutures(clientSwitch.stop(), serverSwitch.stop())
 
   asyncTest "peer subscription should be dropped if connection fails for second time after the timeout has elapsed":
     ## Setup
-    let 
+    let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
 
@@ -155,7 +155,7 @@ suite "Waku Filter":
     proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.} =
       pushHandlerFuture.complete()
 
-    let 
+    let
       pubsubTopic = DefaultPubsubTopic
       contentTopic = "test-content-topic"
       msg = fakeWakuMessage(contentTopic=contentTopic)
@@ -164,46 +164,46 @@ suite "Waku Filter":
     require (await client.subscribe(pubsubTopic, contentTopic, pushHandler, peer=serverAddr)).isOk()
 
     # WARN: Sleep necessary to avoid a race condition between the unsubscription and the handle message proc
-    await sleepAsync(5.milliseconds)
+    await sleepAsync(500.milliseconds)
 
     await server.handleMessage(DefaultPubsubTopic, msg)
-    
+
     # Push handler should be called
     require await pushHandlerFuture.withTimeout(1.seconds)
 
     # Stop client node to test timeout unsubscription
     await clientSwitch.stop()
 
-    await sleepAsync(5.milliseconds)
-    
+    await sleepAsync(500.milliseconds)
+
     # First failure should not remove the subscription
     await server.handleMessage(DefaultPubsubTopic, msg)
-    let 
+    let
       subscriptionsBeforeTimeout = server.subscriptions.len()
       failedPeersBeforeTimeout = server.failedPeers.len()
-    
+
     # Wait for the configured peer connection timeout to elapse (200ms)
     await sleepAsync(200.milliseconds)
-    
+
     # Second failure should remove the subscription
     await server.handleMessage(DefaultPubsubTopic, msg)
-    let 
+    let
       subscriptionsAfterTimeout = server.subscriptions.len()
       failedPeersAfterTimeout = server.failedPeers.len()
-    
+
     ## Then
     check:
       subscriptionsBeforeTimeout == 1
       failedPeersBeforeTimeout == 1
       subscriptionsAfterTimeout == 0
       failedPeersAfterTimeout == 0
-  
+
     ## Cleanup
     await serverSwitch.stop()
 
   asyncTest "peer subscription should not be dropped if connection recovers before timeout elapses":
     ## Setup
-    let 
+    let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
 
@@ -220,7 +220,7 @@ suite "Waku Filter":
     proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.} =
       pushHandlerFuture.complete()
 
-    let 
+    let
       pubsubTopic = DefaultPubsubTopic
       contentTopic = "test-content-topic"
       msg = fakeWakuMessage(contentTopic=contentTopic)
@@ -229,13 +229,13 @@ suite "Waku Filter":
     require (await client.subscribe(pubsubTopic, contentTopic, pushHandler, peer=serverAddr)).isOk()
 
     # WARN: Sleep necessary to avoid a race condition between the unsubscription and the handle message proc
-    await sleepAsync(5.milliseconds)
+    await sleepAsync(500.milliseconds)
 
     await server.handleMessage(DefaultPubsubTopic, msg)
-    
+
     # Push handler should be called
     require await pushHandlerFuture.withTimeout(1.seconds)
-    
+
     let
       subscriptionsBeforeFailure = server.subscriptions.len()
       failedPeersBeforeFailure = server.failedPeers.len()
@@ -243,19 +243,19 @@ suite "Waku Filter":
     # Stop switch to test unsubscribe
     await clientSwitch.stop()
 
-    await sleepAsync(5.milliseconds)
-    
+    await sleepAsync(500.milliseconds)
+
     # First failure should add to failure list
     await server.handleMessage(DefaultPubsubTopic, msg)
-    
+
     pushHandlerFuture = newFuture[void]()
 
-    let 
+    let
       subscriptionsAfterFailure = server.subscriptions.len()
       failedPeersAfterFailure = server.failedPeers.len()
-    
+
     await sleepAsync(100.milliseconds)
-    
+
     # Start switch with same key as before
     let clientSwitch2 = newTestSwitch(
       some(clientSwitch.peerInfo.privateKey),
@@ -264,15 +264,15 @@ suite "Waku Filter":
     await clientSwitch2.start()
     await client.start()
     clientSwitch2.mount(client)
-    
+
     # If push succeeds after failure, the peer should removed from failed peers list
     await server.handleMessage(DefaultPubsubTopic, msg)
     let handlerShouldHaveBeenCalled = await pushHandlerFuture.withTimeout(1.seconds)
 
-    let 
+    let
       subscriptionsAfterSuccessfulConnection = server.subscriptions.len()
       failedPeersAfterSuccessfulConnection = server.failedPeers.len()
-    
+
     ## Then
     check:
       handlerShouldHaveBeenCalled
@@ -286,6 +286,6 @@ suite "Waku Filter":
       failedPeersBeforeFailure == 0
       failedPeersAfterFailure == 1
       failedPeersAfterSuccessfulConnection == 0
-  
+
     ## Cleanup
     await allFutures(clientSwitch2.stop(), serverSwitch.stop())


### PR DESCRIPTION
Partially addresses https://github.com/waku-org/nwaku/issues/1357

Currently the most common cause for test failures in the `CI` pipeline, seems to be related to filter tests.

This is caused by a race condition between a subscribing client and a publishing filter service node. In each case I looked at, the race condition was a matter of ~100ms or less, so extra time padding should improve this.

Longer term this race condition should be avoided by using [the improved filter specification](https://github.com/waku-org/nwaku/issues/1357) and waiting for the subscribe transaction to be complete.

NB: I think .editorconfig changed quite a lot on this one! Please ignore whitespace to see the diff.