### PR TITLE
chore: remove unused test fixture file

### DIFF
--- a/tests/v2/00002_test.up.sql
+++ b/tests/v2/00002_test.up.sql
@@ -1,8 +1,0 @@
-CREATE TABLE IF NOT EXISTS Message_backup (
-        id BLOB PRIMARY KEY,
-        timestamp INTEGER NOT NULL,
-        contentTopic BLOB NOT NULL,
-        pubsubTopic BLOB NOT NULL,
-        payload BLOB,
-        version INTEGER NOT NULL
-    ) WITHOUT ROWID;


### PR DESCRIPTION
A micro-gardening PR 🪴

- [x] Removed a remaining unused test fixture file from the original migration tests.