### PR TITLE
chore(peer_manager): added peer_manager barrel module

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -29,7 +29,7 @@ import
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/node/[waku_node, waku_payload, waku_metrics],
   ../../waku/v2/node/dnsdisc/waku_dnsdisc,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/utils/[peers, time],
   ../../waku/common/utils/nat,
   ./config_chat2

--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -28,7 +28,7 @@ import
   ../../waku/v2/utils/time,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/waku_node,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/node/jsonrpc/[debug_api,
                               filter_api,
                               relay_api,

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -25,7 +25,7 @@ import
   ../../waku/common/sqlite,
   ../../waku/common/utils/nat,
   ../../waku/common/logging,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/node/peer_manager/peer_store/waku_peer_storage,
   ../../waku/v2/node/peer_manager/peer_store/migrations as peer_store_sqlite_migrations,
   ../../waku/v2/node/dnsdisc/waku_dnsdisc,

--- a/examples/v2/publisher.nim
+++ b/examples/v2/publisher.nim
@@ -12,7 +12,7 @@ import
 import
   ../../../waku/common/logging,
   ../../../waku/v2/node/discv5/waku_discv5,
-  ../../../waku/v2/node/peer_manager/peer_manager,
+  ../../../waku/v2/node/peer_manager,
   ../../../waku/v2/node/waku_node,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/utils/time,

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -12,7 +12,7 @@ import
 import
   ../../../waku/common/logging,
   ../../../waku/v2/node/discv5/waku_discv5,
-  ../../../waku/v2/node/peer_manager/peer_manager,
+  ../../../waku/v2/node/peer_manager,
   ../../../waku/v2/node/waku_node,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/utils/wakuenr

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -14,7 +14,7 @@ import
   libp2p/protocols/pubsub/rpc/message
 import
   ../../waku/v1/node/rpc/hexstrings,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/node/jsonrpc/[store_api,
                               relay_api,

--- a/tests/v2/test_waku_dnsdisc.nim
+++ b/tests/v2/test_waku_dnsdisc.nim
@@ -11,7 +11,7 @@ import
   eth/keys,
   discovery/dnsdisc/builder
 import
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/node/dnsdisc/waku_dnsdisc,
   ../../waku/v2/node/waku_node,
   ../test_helpers

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -7,7 +7,7 @@ import
   chronos,
   libp2p/crypto/crypto
 import
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_filter/client,

--- a/tests/v2/test_waku_lightpush.nim
+++ b/tests/v2/test_waku_lightpush.nim
@@ -6,7 +6,7 @@ import
   chronos, 
   libp2p/crypto/crypto
 import
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/protocol/waku_lightpush/client,

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -12,7 +12,7 @@ import
   eth/p2p/discoveryv5/enr
 import
   ../../waku/v2/node/waku_node,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/node/discv5/waku_discv5,
   ../../waku/v2/protocol/waku_peer_exchange,
   ../../waku/v2/protocol/waku_peer_exchange/rpc,

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -16,7 +16,7 @@ import
   libp2p/nameresolving/mockresolver
 import
   ../../waku/v2/node/waku_node,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/utils/peers

--- a/tests/v2/test_wakunode_filter.nim
+++ b/tests/v2/test_wakunode_filter.nim
@@ -7,7 +7,7 @@ import
   chronos, 
   libp2p/crypto/crypto
 import
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/utils/peers,

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -10,7 +10,7 @@ import
 import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_lightpush,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/utils/peers,
   ../../waku/v2/node/waku_node,
   ./testlib/common

--- a/tests/v2/test_wakunode_relay.nim
+++ b/tests/v2/test_wakunode_relay.nim
@@ -17,7 +17,7 @@ import
   libp2p/protocols/pubsub/gossipsub
 import
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/utils/peers,
   ../../waku/v2/node/waku_node
 

--- a/tests/v2/waku_archive/test_waku_archive.nim
+++ b/tests/v2/waku_archive/test_waku_archive.nim
@@ -7,7 +7,6 @@ import
   libp2p/crypto/crypto
 import
   ../../../waku/common/sqlite,
-  ../../../waku/v2/node/peer_manager/peer_manager,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/protocol/waku_archive/driver/sqlite_driver,
   ../../../waku/v2/protocol/waku_archive,

--- a/tests/v2/waku_store/test_resume.nim
+++ b/tests/v2/waku_store/test_resume.nim
@@ -9,7 +9,7 @@ import
 import
   ../../waku/common/sqlite,
   ../../waku/v2/node/message_store/sqlite_store,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_store,
   ./testlib/common,

--- a/tests/v2/waku_store/test_waku_store.nim
+++ b/tests/v2/waku_store/test_waku_store.nim
@@ -7,7 +7,7 @@ import
   chronicles,
   libp2p/crypto/crypto
 import
-  ../../../waku/v2/node/peer_manager/peer_manager,
+  ../../../waku/v2/node/peer_manager,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/protocol/waku_store,
   ../../../waku/v2/protocol/waku_store/client,

--- a/tests/v2/waku_store/test_wakunode_store.nim
+++ b/tests/v2/waku_store/test_wakunode_store.nim
@@ -14,7 +14,7 @@ import
   libp2p/protocols/pubsub/gossipsub
 import
   ../../../waku/common/sqlite,
-  ../../../waku/v2/node/peer_manager/peer_manager,
+  ../../../waku/v2/node/peer_manager,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/protocol/waku_archive,
   ../../../waku/v2/protocol/waku_archive/driver/sqlite_driver,

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -22,7 +22,7 @@ import
   ../../waku/v2/node/discv5/waku_discv5,
   ../../apps/wakunode2/wakunode2,
   ../../waku/v2/node/dnsdisc/waku_dnsdisc,
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/utils/wakuenr,
   ../../waku/v2/protocol/waku_message,

--- a/tools/wakucanary/wakucanary.nim
+++ b/tools/wakucanary/wakucanary.nim
@@ -10,7 +10,7 @@ import
   libp2p/nameresolving/nameresolver,
   libp2p/nameresolving/dnsresolver
 import
-  ../../waku/v2/node/peer_manager/peer_manager,
+  ../../waku/v2/node/peer_manager,
   ../../waku/v2/utils/peers,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/node/waku_payload,

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -13,7 +13,7 @@ import
   ../../protocol/waku_filter,
   ../../protocol/waku_relay,
   ../../protocol/waku_swap/waku_swap,
-  ../peer_manager/peer_manager,
+  ../peer_manager,
   ../waku_node,
   ./jsonrpc_types
 

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -12,7 +12,7 @@ import
   ../../protocol/waku_store/rpc,
   ../../utils/time,
   ../waku_node,
-  ../peer_manager/peer_manager,
+  ../peer_manager,
   ./jsonrpc_types,
   ./jsonrpc_utils
 

--- a/waku/v2/node/peer_manager.nim
+++ b/waku/v2/node/peer_manager.nim
@@ -1,0 +1,5 @@
+import
+  ./peer_manager/peer_manager
+
+export
+  peer_manager

--- a/waku/v2/node/waku_metrics.nim
+++ b/waku/v2/node/waku_metrics.nim
@@ -12,7 +12,7 @@ import
 import
   ../protocol/waku_filter/protocol_metrics as filter_metrics,
   ../utils/collector,
-  ./peer_manager/peer_manager,
+  ./peer_manager,
   ./waku_node
 
 when defined(rln):

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -39,7 +39,7 @@ import
   ../utils/peers,
   ../utils/wakuenr,
   ../utils/time,
-  ./peer_manager/peer_manager,
+  ./peer_manager,
   ./dnsdisc/waku_dnsdisc,
   ./discv5/waku_discv5,
   ./wakuswitch

--- a/waku/v2/protocol/waku_filter/client.nim
+++ b/waku/v2/protocol/waku_filter/client.nim
@@ -13,7 +13,7 @@ import
   libp2p/protocols/protocol as libp2p_protocol
 import
   ../waku_message,
-  ../../node/peer_manager/peer_manager,
+  ../../node/peer_manager,
   ../../utils/requests,
   ./rpc,
   ./rpc_codec,

--- a/waku/v2/protocol/waku_filter/protocol.nim
+++ b/waku/v2/protocol/waku_filter/protocol.nim
@@ -9,7 +9,7 @@ import
   libp2p/crypto/crypto
 import
   ../waku_message,
-  ../../node/peer_manager/peer_manager,
+  ../../node/peer_manager,
   ./rpc,
   ./rpc_codec,
   ./protocol_metrics

--- a/waku/v2/protocol/waku_lightpush/client.nim
+++ b/waku/v2/protocol/waku_lightpush/client.nim
@@ -11,7 +11,7 @@ import
   metrics,
   bearssl/rand
 import
-  ../../node/peer_manager/peer_manager,
+  ../../node/peer_manager,
   ../../utils/requests,
   ../waku_message,
   ./protocol,

--- a/waku/v2/protocol/waku_lightpush/protocol.nim
+++ b/waku/v2/protocol/waku_lightpush/protocol.nim
@@ -11,7 +11,7 @@ import
   metrics,
   bearssl/rand
 import
-  ../../node/peer_manager/peer_manager,
+  ../../node/peer_manager,
   ../waku_message,
   ./rpc,
   ./rpc_codec,

--- a/waku/v2/protocol/waku_peer_exchange/protocol.nim
+++ b/waku/v2/protocol/waku_peer_exchange/protocol.nim
@@ -8,7 +8,7 @@ import
   libp2p/crypto/crypto,
   eth/p2p/discoveryv5/enr
 import
-  ../../node/peer_manager/peer_manager,
+  ../../node/peer_manager,
   ../../node/discv5/waku_discv5,
   ../waku_message,
   ../waku_relay,

--- a/waku/v2/protocol/waku_store/client.nim
+++ b/waku/v2/protocol/waku_store/client.nim
@@ -11,7 +11,7 @@ import
   metrics,
   bearssl/rand
 import
-  ../../node/peer_manager/peer_manager,
+  ../../node/peer_manager,
   ../../utils/requests,
   ../../utils/time,
   ../waku_message,

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -18,7 +18,7 @@ import
   libp2p/stream/connection,
   metrics
 import
-  ../../node/peer_manager/peer_manager,
+  ../../node/peer_manager,
   ../../utils/time,
   ../waku_message,
   ./common,

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -43,7 +43,7 @@ import
   libp2p/protocols/protocol,
   libp2p/protobuf/minprotobuf,
   libp2p/stream/connection,
-  ../../node/peer_manager/peer_manager,
+  ../../node/peer_manager,
   ./waku_swap_types,
   ../../../common/protobuf,
   ../../waku/v2/protocol/waku_swap/waku_swap_contracts

--- a/waku/v2/protocol/waku_swap/waku_swap_types.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_types.nim
@@ -7,7 +7,7 @@ import
   std/tables,
   bearssl/rand,
   libp2p/protocols/protocol,
-  ../../node/peer_manager/peer_manager
+  ../../node/peer_manager
 
 const
   MaxChequeSize* = 64*1024 # Used for read buffers. 64kB should be more than enough for swap cheque


### PR DESCRIPTION
Another gardening PR 🪴

- [x] Added a barrel module that reexports the `peer_manager` module to avoid importing a redundant path: `.../node/peer_manager/peer_manager -> .../node/peer_manager`.
- [x] Updated all imports accordingly. 