### PR TITLE
refactor(utils): moved noise/compat payload encryption code to utils

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -27,17 +27,21 @@ import
   ../../waku/v2/protocol/waku_lightpush/rpc,
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_store,
-  ../../waku/v2/node/[waku_node, waku_payload, waku_metrics],
+  ../../waku/v2/node/waku_node,
+  ../../waku/v2/node/waku_metrics,
   ../../waku/v2/node/dnsdisc/waku_dnsdisc,
   ../../waku/v2/node/peer_manager,
-  ../../waku/v2/utils/[peers, time],
+  ../../waku/v2/utils/compat,
+  ../../waku/v2/utils/peers,
+  ../../waku/v2/utils/time,
   ../../waku/common/utils/nat,
   ./config_chat2
 
 when defined(rln):
   import
     libp2p/protocols/pubsub/rpc/messages,
-    libp2p/protocols/pubsub/pubsub,
+    libp2p/protocols/pubsub/pubsub
+  import
     ../../waku/v2/protocol/waku_rln_relay
 
 const Help = """

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -4,7 +4,9 @@ import
   ./v2/test_confutils_envvar,
   ./v2/test_sqlite_migrations
 
-## Waku archive test suite
+## Waku v2
+
+# Waku archive test suite
 import
   ./v2/waku_archive/test_driver_queue_index,
   ./v2/waku_archive/test_driver_queue_pagination,
@@ -15,7 +17,7 @@ import
   ./v2/waku_archive/test_retention_policy,
   ./v2/waku_archive/test_waku_archive
 
-## Waku store test suite
+# Waku store test suite
 import
   ./v2/waku_store/test_rpc_codec,
   ./v2/waku_store/test_waku_store,
@@ -38,7 +40,6 @@ import
   ./v2/test_wakunode_filter,
   ./v2/test_waku_peer_exchange,
   ./v2/test_peer_store_extended,
-  ./v2/test_waku_payload,
   ./v2/test_waku_swap,
   ./v2/test_utils_peers,
   ./v2/test_message_cache,
@@ -62,6 +63,7 @@ import
   ./v2/test_waku_noise_sessions,
   ./v2/test_waku_switch,
   # Utils
+  ./v2/test_utils_compat,
   ./v2/test_utils_keyfile
 
 
@@ -72,7 +74,6 @@ when defined(rln):
     ./v2/test_waku_rln_relay,
     ./v2/test_wakunode_rln_relay,
     ./v2/test_waku_rln_relay_onchain
-
 
 
 # TODO: Only enable this once swap module is integrated more nicely as a dependency, i.e. as submodule with CI etc

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -32,6 +32,7 @@ import
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_filter/rpc,
   ../../waku/v2/protocol/waku_filter/client,
+  ../../waku/v2/utils/compat,
   ../../waku/v2/utils/peers,
   ../../waku/v2/utils/time,
   ./testlib/common,

--- a/tests/v2/test_utils_compat.nim
+++ b/tests/v2/test_utils_compat.nim
@@ -1,9 +1,10 @@
 {.used.}
 
 import
-  testutils/unittests,
+  testutils/unittests
+import
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/node/waku_payload,
+  ../../waku/v2/utils/compat,
   ../../waku/v2/utils/time
 
 procSuite "Waku Payload":
@@ -120,28 +121,28 @@ procSuite "Waku Payload":
       payload = @[byte 0, 1, 2]
       timestamp = Timestamp(10)
       msg = WakuMessage(payload: payload, version: version, timestamp: timestamp)
-      
+
     ## When
     let pb =  msg.encode()
     let msgDecoded = WakuMessage.decode(pb.buffer)
-    
+
     ## Then
     check:
       msgDecoded.isOk()
-    
+
     let timestampDecoded = msgDecoded.value.timestamp
     check:
       timestampDecoded == timestamp
 
   test "Encode/Decode waku message without timestamp":
-    ## Test the encoding and decoding of a WakuMessage with an empty timestamp field  
+    ## Test the encoding and decoding of a WakuMessage with an empty timestamp field
 
     ## Given
     let
       version = 0'u32
       payload = @[byte 0, 1, 2]
       msg = WakuMessage(payload: payload, version: version)
-    
+
     ## When
     let pb =  msg.encode()
     let msgDecoded = WakuMessage.decode(pb.buffer)
@@ -149,7 +150,7 @@ procSuite "Waku Payload":
     ## Then
     check:
       msgDecoded.isOk()
-    
+
     let timestampDecoded = msgDecoded.value.timestamp
     check:
       timestampDecoded == Timestamp(0)

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -18,7 +18,8 @@ import
 import
   ../../waku/v1/protocol/waku_protocol,
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/node/[waku_node, waku_payload],
+  ../../waku/v2/node/waku_node,
+  ../../waku/v2/utils/compat,
   ../../waku/v2/utils/peers,
   ../../apps/wakubridge/wakubridge,
   ../test_helpers

--- a/tools/wakucanary/wakucanary.nim
+++ b/tools/wakucanary/wakucanary.nim
@@ -7,13 +7,10 @@ import
 import
   libp2p/protocols/ping,
   libp2p/crypto/[crypto, secp],
-  libp2p/nameresolving/nameresolver,
   libp2p/nameresolving/dnsresolver
 import
   ../../waku/v2/node/peer_manager,
-  ../../waku/v2/utils/peers,
   ../../waku/v2/node/waku_node,
-  ../../waku/v2/node/waku_payload,
   ../../waku/v2/utils/peers
 
 # protocols and their tag
@@ -60,7 +57,7 @@ type
 proc parseCmdArg*(T: type chronos.Duration, p: string): T =
   try:
       result = chronos.seconds(parseInt(p))
-  except CatchableError as e:
+  except CatchableError:
     raise newException(ConfigurationError, "Invalid timeout value")
 
 proc completeCmdArg*(T: type chronos.Duration, val: string): seq[string] =

--- a/waku/v2/node/jsonrpc/jsonrpc_utils.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_utils.nim
@@ -9,8 +9,8 @@ import
   ../../protocol/waku_message,
   ../../protocol/waku_store,
   ../../protocol/waku_store/rpc,
+  ../../utils/compat,
   ../../utils/time,
-  ../waku_payload,
   ./hexstrings,
   ./jsonrpc_types
 

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -2,8 +2,6 @@
 ##
 ## See https://github.com/vacp2p/specs/blob/master/specs/waku/v2/waku-message.md
 ## for spec.
-##
-## For payload content and encryption, see waku/v2/node/waku_payload.nim
 
 when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}

--- a/waku/v2/utils/compat.nim
+++ b/waku/v2/utils/compat.nim
@@ -3,13 +3,14 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
+
 import
   std/options,
-  eth/keys,
+  stew/results,
+  eth/keys
+import
   ../../whisper/whisper_types,
-  ../protocol/waku_message,
-  ../protocol/waku_noise/noise_types,
-  ../protocol/waku_noise/noise_utils
+  ../protocol/waku_message
 
 export whisper_types, keys, options
 
@@ -28,9 +29,6 @@ type
     of None:
       discard
 
-  # NOTE: Currently only used here, if we start using it elsewhere pull it out.
-  WakuResult*[T] = Result[T, cstring]
-
 
 # TODO:
 # - This is using `DecodedPayload` from Waku v1 / Whisper and could be altered
@@ -41,7 +39,7 @@ type
 # - For now this `KeyInfo` is a bit silly also, but perhaps with v2 or
 # adjustments to Waku v1 encoding, it can be better.
 proc decodePayload*(message: WakuMessage, keyInfo: KeyInfo):
-    WakuResult[DecodedPayload] =
+    Result[DecodedPayload, cstring] =
   case message.version
   of 0:
     return ok(DecodedPayload(payload:message.payload))
@@ -69,7 +67,7 @@ proc decodePayload*(message: WakuMessage, keyInfo: KeyInfo):
 # TODO: same story as for `decodedPayload`, but then regarding the `Payload`
 # object.
 proc encode*(payload: Payload, version: uint32, rng: var HmacDrbgContext):
-    WakuResult[seq[byte]] =
+    Result[seq[byte], cstring] =
   case version
   of 0:
     # This is rather silly
@@ -82,36 +80,3 @@ proc encode*(payload: Payload, version: uint32, rng: var HmacDrbgContext):
       return err("Couldn't encode the payload")
   else:
     return err("Unsupported WakuMessage version")
-
-
-# Decodes a WakuMessage to a PayloadV2
-# Currently, this is just a wrapper over deserializePayloadV2 and encryption/decryption is done on top (no KeyInfo)
-proc decodePayloadV2*(message: WakuMessage): WakuResult[PayloadV2] 
-  {.raises: [Defect, NoiseMalformedHandshake, NoisePublicKeyError].} =
-  # We check message version (only 2 is supported in this proc)
-  case message.version
-  of 2:
-    # We attempt to decode the WakuMessage payload
-    let deserializedPayload2 = deserializePayloadV2(message.payload)
-    if deserializedPayload2.isOk():
-      return ok(deserializedPayload2.get())
-    else:
-      return err("Failed to decode WakuMessage")
-  else:
-    return err("Wrong message version while decoding payload")
-
-
-# Encodes a PayloadV2 to a WakuMessage
-# Currently, this is just a wrapper over serializePayloadV2 and encryption/decryption is done on top (no KeyInfo)
-proc encodePayloadV2*(payload2: PayloadV2, contentTopic: ContentTopic = default(ContentTopic)): WakuResult[WakuMessage] 
-  {.raises: [Defect, NoiseMalformedHandshake, NoisePublicKeyError].} =
-
-  # We attempt to encode the PayloadV2
-  let serializedPayload2 = serializePayloadV2(payload2)
-  if not serializedPayload2.isOk():
-    return err("Failed to encode PayloadV2")
-
-  # If successful, we create and return a WakuMessage 
-  let msg = WakuMessage(payload: serializedPayload2.get(), version: 2, contentTopic: contentTopic)
-  
-  return ok(msg)

--- a/waku/v2/utils/noise.nim
+++ b/waku/v2/utils/noise.nim
@@ -1,0 +1,44 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  stew/results
+import
+  ../protocol/waku_message,
+  ../protocol/waku_noise/noise_types,
+  ../protocol/waku_noise/noise_utils
+
+
+# Decodes a WakuMessage to a PayloadV2
+# Currently, this is just a wrapper over deserializePayloadV2 and encryption/decryption is done on top (no KeyInfo)
+proc decodePayloadV2*(message: WakuMessage): Result[PayloadV2, cstring]
+  {.raises: [NoiseMalformedHandshake, NoisePublicKeyError].} =
+  # We check message version (only 2 is supported in this proc)
+  case message.version
+  of 2:
+    # We attempt to decode the WakuMessage payload
+    let deserializedPayload2 = deserializePayloadV2(message.payload)
+    if deserializedPayload2.isOk():
+      return ok(deserializedPayload2.get())
+    else:
+      return err("Failed to decode WakuMessage")
+  else:
+    return err("Wrong message version while decoding payload")
+
+
+# Encodes a PayloadV2 to a WakuMessage
+# Currently, this is just a wrapper over serializePayloadV2 and encryption/decryption is done on top (no KeyInfo)
+proc encodePayloadV2*(payload2: PayloadV2, contentTopic: ContentTopic = default(ContentTopic)): Result[WakuMessage, cstring]
+  {.raises: [NoiseMalformedHandshake, NoisePublicKeyError].} =
+
+  # We attempt to encode the PayloadV2
+  let serializedPayload2 = serializePayloadV2(payload2)
+  if not serializedPayload2.isOk():
+    return err("Failed to encode PayloadV2")
+
+  # If successful, we create and return a WakuMessage
+  let msg = WakuMessage(payload: serializedPayload2.get(), version: 2, contentTopic: contentTopic)
+
+  return ok(msg)


### PR DESCRIPTION
The `waku_payload` is an odd module inside the `node` module. This is an intermediate and temporary refactoring to isolate the backward compatibility code.

- [x] Split the `waku_payload` module into two `utils` submodules: `noise` and `compat` (whisper and waku v1 payload encryption compatibility).
- [x] Renamed the `test_waku_payload` test suite to `test_utils_compat`.
- [x] Updated all the imports accordingly.

This is another gardening PR 🪴, part of the upcoming MUID implementation.