### PR TITLE
feat: add WakuMessage validation in gossipsub

### DIFF
--- a/examples/v2/publisher.nim
+++ b/examples/v2/publisher.nim
@@ -53,6 +53,7 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
 
     await node.start()
     await node.mountRelay()
+    node.peerManager.start()
     if not await node.startDiscv5():
       error "failed to start discv5"
       quit(1)

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -49,6 +49,7 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
 
     await node.start()
     await node.mountRelay()
+    node.peerManager.start()
     if not await node.startDiscv5():
       error "failed to start discv5"
       quit(1)

--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -97,6 +97,17 @@ proc new*(T: type WakuRelay,
       verifySignature = false,
       maxMessageSize = MaxWakuMessageSize
     )
+
+    # Rejects messages that are not WakuMessage
+    proc validator(topic: string, message: messages.Message): Future[ValidationResult] {.async.} =
+      let msg = WakuMessage.decode(message.data)
+      if msg.isOk():
+        return ValidationResult.Accept
+      return ValidationResult.Reject
+
+    # Add validator to all default pubsub topics
+    for pubSubTopic in defaultPubsubTopics:
+      wr.addValidator(pubSubTopic, validator)
   except InitializationError:
     return err("initialization error: " & getCurrentExceptionMsg())
 


### PR DESCRIPTION
**Summary**
* Add new libp2p validator to `WakuRelay`, so that messages that are not `WakuRelay` (aka fail to decode into pb) are rejected and not further gossiped.
* Add unit test testing this new feature.