### PR TITLE
fix(node): remove subscription to waku default network topic (#1545)

### DIFF
--- a/tests/v2/test_peer_exchange.nim
+++ b/tests/v2/test_peer_exchange.nim
@@ -18,7 +18,7 @@ import
 procSuite "Peer Exchange":
   asyncTest "GossipSub (relay) peer exchange":
     ## Tests peer exchange
-    
+
     # Create nodes and ENR. These will be added to the discoverable list
     let
       bindIp = ValidIpAddress.init("0.0.0.0")
@@ -28,41 +28,41 @@ procSuite "Peer Exchange":
       node2 = WakuNode.new(nodeKey2, bindIp, Port(61102), sendSignedPeerRecord = true)
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node3 = WakuNode.new(nodeKey3, bindIp, Port(61103), sendSignedPeerRecord = true)
-    
+
     var
       peerExchangeHandler, emptyHandler: RoutingRecordsHandler
       completionFut = newFuture[bool]()
-    
+
     proc ignorePeerExchange(peer: PeerId, topic: string,
-                            peers: seq[RoutingRecordsPair]) {.gcsafe, raises: [Defect].} =
+                            peers: seq[RoutingRecordsPair]) {.gcsafe.} =
       discard
-    
+
     proc handlePeerExchange(peer: PeerId, topic: string,
-                            peers: seq[RoutingRecordsPair]) {.gcsafe, raises: [Defect].} =
+                            peers: seq[RoutingRecordsPair]) {.gcsafe.} =
       ## Handle peers received via gossipsub peer exchange
       let peerRecords = peers.mapIt(it.record.get())
-      
+
       check:
         # Node 3 is informed of node 2 via peer exchange
         peer == node1.switch.peerInfo.peerId
         topic == DefaultPubsubTopic
         peerRecords.countIt(it.peerId == node2.switch.peerInfo.peerId) == 1
-      
+
       if (not completionFut.completed()):
         completionFut.complete(true)
 
     peerExchangeHandler = handlePeerExchange
     emptyHandler = ignorePeerExchange
 
-    await node1.mountRelay(peerExchangeHandler = some(emptyHandler))
-    await node2.mountRelay(peerExchangeHandler = some(emptyHandler))
-    await node3.mountRelay(peerExchangeHandler = some(peerExchangeHandler))
+    await node1.mountRelay(topics = @[DefaultPubsubTopic], peerExchangeHandler = some(emptyHandler))
+    await node2.mountRelay(topics = @[DefaultPubsubTopic], peerExchangeHandler = some(emptyHandler))
+    await node3.mountRelay(topics = @[DefaultPubsubTopic], peerExchangeHandler = some(peerExchangeHandler))
 
     # Ensure that node1 prunes all peers after the first connection
     node1.wakuRelay.parameters.dHigh = 1
 
     await allFutures([node1.start(), node2.start(), node3.start()])
-    
+
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     await node3.connectToNodes(@[node1.switch.peerInfo.toRemotePeerInfo()])

--- a/tests/v2/test_rest_relay_api.nim
+++ b/tests/v2/test_rest_relay_api.nim
@@ -68,7 +68,7 @@ suite "REST API - Relay":
 
     check:
       # Node should be subscribed to default + new topics
-      toSeq(node.wakuRelay.subscribedTopics).len == 1 + pubSubTopics.len
+      toSeq(node.wakuRelay.subscribedTopics).len == pubSubTopics.len
 
     await restServer.stop()
     await restServer.closeWait()
@@ -191,7 +191,7 @@ suite "REST API - Relay":
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
-    # At this stage the node is only subscribed to the default topic
+    node.subscribe(DefaultPubsubTopic)
     require:
       toSeq(node.wakuRelay.subscribedTopics).len == 1
 

--- a/tests/v2/test_wakunode_rln_relay.nim
+++ b/tests/v2/test_wakunode_rln_relay.nim
@@ -23,7 +23,7 @@ import
 from std/times import epochTime
 
 
-  
+
 const RlnRelayPubsubTopic = "waku/2/rlnrelay/proto"
 
 procSuite "WakuNode - RLN relay":
@@ -47,7 +47,7 @@ procSuite "WakuNode - RLN relay":
 
     # set up three nodes
     # node1
-    await node1.mountRelay(@[rlnRelayPubSubTopic])
+    await node1.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
 
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
@@ -59,7 +59,7 @@ procSuite "WakuNode - RLN relay":
     await node1.start()
 
     # node 2
-    await node2.mountRelay(@[rlnRelayPubSubTopic])
+    await node2.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayPubsubTopic: rlnRelayPubSubTopic,
@@ -70,7 +70,7 @@ procSuite "WakuNode - RLN relay":
     await node2.start()
 
     # node 3
-    await node3.mountRelay(@[rlnRelayPubSubTopic])
+    await node3.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
 
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayPubsubTopic: rlnRelayPubSubTopic,
@@ -136,7 +136,7 @@ procSuite "WakuNode - RLN relay":
     # node1
     # set up three nodes
     # node1
-    await node1.mountRelay(@[rlnRelayPubSubTopic])
+    await node1.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
 
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
@@ -148,7 +148,7 @@ procSuite "WakuNode - RLN relay":
     await node1.start()
 
     # node 2
-    await node2.mountRelay(@[rlnRelayPubSubTopic])
+    await node2.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayPubsubTopic: rlnRelayPubSubTopic,
@@ -159,7 +159,7 @@ procSuite "WakuNode - RLN relay":
     await node2.start()
 
     # node 3
-    await node3.mountRelay(@[rlnRelayPubSubTopic])
+    await node3.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
 
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayPubsubTopic: rlnRelayPubSubTopic,
@@ -196,7 +196,7 @@ procSuite "WakuNode - RLN relay":
     let
       contentTopicBytes = contentTopic.toBytes
       input = concat(payload, contentTopicBytes)
-      extraBytes: seq[byte] = @[byte(1),2,3] 
+      extraBytes: seq[byte] = @[byte(1),2,3]
       rateLimitProofRes = node1.wakuRlnRelay.rlnInstance.proofGen(data = concat(input, extraBytes),   # we add extra bytes to invalidate proof verification against original payload
                                                               memKeys = node1.wakuRlnRelay.identityCredential,
                                                               memIndex = MembershipIndex(1),
@@ -243,7 +243,7 @@ procSuite "WakuNode - RLN relay":
 
     # set up three nodes
     # node1
-    await node1.mountRelay(@[rlnRelayPubSubTopic])
+    await node1.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
 
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
@@ -255,7 +255,7 @@ procSuite "WakuNode - RLN relay":
     await node1.start()
 
     # node 2
-    await node2.mountRelay(@[rlnRelayPubSubTopic])
+    await node2.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
 
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
@@ -267,7 +267,7 @@ procSuite "WakuNode - RLN relay":
     await node2.start()
 
     # node 3
-    await node3.mountRelay(@[rlnRelayPubSubTopic])
+    await node3.mountRelay(@[DefaultPubsubTopic, rlnRelayPubSubTopic])
 
     # mount rlnrelay in off-chain mode
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -38,7 +38,7 @@ procSuite "Waku v2 JSON-RPC API - Relay":
   asyncTest "subscribe, unsubscribe and publish":
     await node.start()
 
-    await node.mountRelay()
+    await node.mountRelay(topics = @[DefaultPubsubTopic])
 
     # RPC server setup
     let
@@ -101,13 +101,13 @@ procSuite "Waku v2 JSON-RPC API - Relay":
       message2 = WakuMessage(payload: payload2, contentTopic: contentTopic)
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node3.start()
-    await node3.mountRelay(@[pubSubTopic])
+    await node3.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
     await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
@@ -191,13 +191,13 @@ procSuite "Waku v2 JSON-RPC API - Relay":
       topicCache = newTestMessageCache()
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node3.start()
-    await node3.mountRelay(@[pubSubTopic])
+    await node3.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
     await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
@@ -282,13 +282,13 @@ procSuite "Waku v2 JSON-RPC API - Relay":
       topicCache = newTestMessageCache()
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node3.start()
-    await node3.mountRelay(@[pubSubTopic])
+    await node3.mountRelay(@[DefaultPubsubTopic, pubSubTopic])
 
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
     await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -548,9 +548,6 @@ proc mountRelay*(node: WakuNode,
 
   info "relay mounted successfully"
 
-  # TODO: As part of #1545, remove this and update the tests cases
-  node.subscribe(DefaultPubsubTopic)
-
   # Subscribe to topics
   for topic in topics:
     node.subscribe(topic)


### PR DESCRIPTION
As part of the scaling initiative, requirements have changed. This PR removes the `wakunode2`'s implicit subscription to the default pub-sub topic. If the CLI argument is not specified, the node will subscribe to the default pub-sub topic.

- [x] Remove the implicit subscription to `/waku/2/default-waku/proto`.

This PR resolves #1545.
