### PR TITLE
fix(tests): do not specify port number

### DIFF
--- a/tests/v2/test_peer_exchange.nim
+++ b/tests/v2/test_peer_exchange.nim
@@ -22,11 +22,11 @@ procSuite "Peer Exchange":
     let
       bindIp = ValidIpAddress.init("0.0.0.0")
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(61100))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(61102), sendSignedPeerRecord = true)
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(0), sendSignedPeerRecord = true)
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(61103), sendSignedPeerRecord = true)
+      node3 = WakuNode.new(nodeKey3, bindIp, Port(0), sendSignedPeerRecord = true)
 
     var
       peerExchangeHandler, emptyHandler: RoutingRecordsHandler

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -403,7 +403,7 @@ procSuite "Peer Manager":
     let basePeerId = "16Uiu2HAm7QGEZKujdSbbo1aaQyfDPQ6Bw3ybQnj6fruH5Dxwd7D"
 
     let
-      node = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60932))
+      node = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
       peer1 = parseRemotePeerInfo("/ip4/0.0.0.0/tcp/30300/p2p/" & basePeerId & "1")
       peer2 = parseRemotePeerInfo("/ip4/0.0.0.0/tcp/30301/p2p/" & basePeerId & "2")
       peer3 = parseRemotePeerInfo("/ip4/0.0.0.0/tcp/30302/p2p/" & basePeerId & "3")

--- a/tests/v2/test_waku_keepalive.nim
+++ b/tests/v2/test_waku_keepalive.nim
@@ -23,9 +23,9 @@ suite "Waku Keepalive":
   asyncTest "handle ping keepalives":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(63010))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(63012))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     var completionFut = newFuture[bool]()
 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -26,7 +26,7 @@ suite "Waku rln relay":
   asyncTest "mount waku-rln-relay in the off-chain mode":
     let
       nodeKey = generateSecp256k1Key()
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60200))
+      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
     await node.start()
 
     # preparing inputs to mount rln-relay

--- a/tests/v2/test_waku_rln_relay_onchain.nim
+++ b/tests/v2/test_waku_rln_relay_onchain.nim
@@ -385,7 +385,7 @@ procSuite "Waku-rln-relay":
     # preparation ------------------------------
     let
       nodeKey = generateSecp256k1Key()
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60110))
+      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
     await node.start()
 
     # create current peer's pk
@@ -453,7 +453,7 @@ procSuite "Waku-rln-relay":
     # preparation ------------------------------
     let
       nodeKey = generateSecp256k1Key()
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60111))
+      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
     await node.start()
 
     # deploy the contract
@@ -568,12 +568,12 @@ procSuite "Waku-rln-relay":
     # prepare two nodes
     let
       nodeKey = generateSecp256k1Key()
-      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(60112))
+      node = WakuNode.new(nodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
     await node.start()
 
     let
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60113))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
     await node2.start()
 
      # create an Ethereum private key and the corresponding account

--- a/tests/v2/test_wakunode_filter.nim
+++ b/tests/v2/test_wakunode_filter.nim
@@ -21,9 +21,9 @@ suite "WakuNode - Filter":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60110))
+      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60111))
+      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(server.start(), client.start())
 

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -22,11 +22,11 @@ procSuite "WakuNode - Lightpush":
     ## Setup
     let
       lightNodeKey = generateSecp256k1Key()
-      lightNode = WakuNode.new(lightNodeKey, ValidIpAddress.init("0.0.0.0"), Port(60010))
+      lightNode = WakuNode.new(lightNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       bridgeNodeKey = generateSecp256k1Key()
-      bridgeNode = WakuNode.new(bridgeNodeKey, ValidIpAddress.init("0.0.0.0"), Port(60012))
+      bridgeNode = WakuNode.new(bridgeNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       destNodeKey = generateSecp256k1Key()
-      destNode = WakuNode.new(destNodeKey, ValidIpAddress.init("0.0.0.0"), Port(60013))
+      destNode = WakuNode.new(destNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(destNode.start(), bridgeNode.start(), lightNode.start())
 

--- a/tests/v2/test_wakunode_rln_relay.nim
+++ b/tests/v2/test_wakunode_rln_relay.nim
@@ -33,13 +33,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60300))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Relay node
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60302))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Subscriber
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60303))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")
@@ -121,13 +121,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60310))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Relay node
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60312))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Subscriber
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60313))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")
@@ -230,13 +230,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60320))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Relay node
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60322))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Subscriber
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60323))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")

--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -33,7 +33,7 @@ suite "WakuNode - Relay":
   asyncTest "Relay protocol is started correctly":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60400))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     # Relay protocol starts if mounted after node start
 
@@ -47,7 +47,7 @@ suite "WakuNode - Relay":
 
     let
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60402))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await node2.mountRelay()
 
@@ -66,11 +66,11 @@ suite "WakuNode - Relay":
   asyncTest "Messages are correctly relayed":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60410))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60412))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60413))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
       pubSubTopic = "test"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
@@ -124,13 +124,13 @@ suite "WakuNode - Relay":
     let
       # publisher node
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60420))
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Relay node
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60422))
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Subscriber
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60423))
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
 
       pubSubTopic = "test"
       contentTopic1 = ContentTopic("/waku/2/default-content/proto")

--- a/tests/v2/waku_store/test_resume.nim
+++ b/tests/v2/waku_store/test_resume.nim
@@ -214,9 +214,9 @@ suite "WakuNode - waku store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60412))
+      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60410))
+      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start())
 
@@ -248,9 +248,9 @@ suite "WakuNode - waku store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60422))
+      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60420))
+      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(server.start(), client.start())
     await server.mountStore(store=StoreQueueRef.new())

--- a/tests/v2/waku_store/test_wakunode_store.nim
+++ b/tests/v2/waku_store/test_wakunode_store.nim
@@ -67,9 +67,9 @@ procSuite "WakuNode - Store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60422))
+      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60420))
+      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start())
 
@@ -99,9 +99,9 @@ procSuite "WakuNode - Store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60432))
+      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60430))
+      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start())
 
@@ -148,9 +148,9 @@ procSuite "WakuNode - Store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60432))
+      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60430))
+      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start())
 
@@ -198,11 +198,11 @@ procSuite "WakuNode - Store":
     ## Setup
     let
       filterSourceKey = generateSecp256k1Key()
-      filterSource = WakuNode.new(filterSourceKey, ValidIpAddress.init("0.0.0.0"), Port(60404))
+      filterSource = WakuNode.new(filterSourceKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(60402))
+      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(60400))
+      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start(), filterSource.start())
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_debug.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_debug.nim
@@ -22,7 +22,7 @@ procSuite "Waku v2 JSON-RPC API - Debug":
     privkey = generateSecp256k1Key()
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")
-    port = Port(9000)
+    port = Port(0)
     node = WakuNode.new(privkey, bindIp, port, some(extIp), some(port))
 
   asyncTest "get node info":

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_filter.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_filter.nim
@@ -32,9 +32,9 @@ procSuite "Waku v2 JSON-RPC API - Filter":
   asyncTest "subscribe and unsubscribe":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(60390))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(60392))
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(0))
 
     await allFutures(node1.start(), node2.start())
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -32,7 +32,7 @@ procSuite "Waku v2 JSON-RPC API - Relay":
     privkey = generateSecp256k1Key()
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")
-    port = Port(9000)
+    port = Port(0)
     node = WakuNode.new(privkey, bindIp, port, some(extIp), some(port))
 
   asyncTest "subscribe, unsubscribe and publish":
@@ -88,11 +88,11 @@ procSuite "Waku v2 JSON-RPC API - Relay":
   asyncTest "get latest messages":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(60300))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(60302))
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(0))
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(60303), some(extIp), some(port))
+      node3 = WakuNode.new(nodeKey3, bindIp, Port(0), some(extIp), some(port))
       pubSubTopic = "polling"
       contentTopic = DefaultContentTopic
       payload1 = @[byte 9]
@@ -179,11 +179,11 @@ procSuite "Waku v2 JSON-RPC API - Relay":
   asyncTest "generate asymmetric keys and encrypt/decrypt communication":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(62001))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(62002))
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(0))
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(62003), some(extIp), some(port))
+      node3 = WakuNode.new(nodeKey3, bindIp, Port(0), some(extIp), some(port))
       pubSubTopic = "polling"
       contentTopic = DefaultContentTopic
       payload = @[byte 9]
@@ -270,11 +270,11 @@ procSuite "Waku v2 JSON-RPC API - Relay":
   asyncTest "generate symmetric keys and encrypt/decrypt communication":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(62100))
+      node1 = WakuNode.new(nodeKey1, bindIp, Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(62102))
+      node2 = WakuNode.new(nodeKey2, bindIp, Port(0))
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(62103), some(extIp), some(port))
+      node3 = WakuNode.new(nodeKey3, bindIp, Port(0), some(extIp), some(port))
       pubSubTopic = "polling"
       contentTopic = DefaultContentTopic
       payload = @[byte 9]

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
@@ -36,7 +36,7 @@ procSuite "Waku v2 JSON-RPC API - Store":
     privkey = generateSecp256k1Key()
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")
-    port = Port(9000)
+    port = Port(0)
     node = WakuNode.new(privkey, bindIp, port, some(extIp), some(port))
 
   asyncTest "query a node and retrieve historical messages":


### PR DESCRIPTION
This PR should help mitigate the _"LPError: Address already in use"_ issues reported in #1357.

From [this](https://discord.com/channels/864066763682218004/865466680129880074/1052594544400678983) conversation at discord: 
> FWIW. The issue could be solved by allowing the Waku node/switch to be configured with a `/ip4/0.0.0.0/tcp/0` (then it would look for a free TCP/UDP port and bind to it). Then each test case would use its own TCP port, avoiding the "port reuse".