### PR TITLE
fix: remove unused imports

### DIFF
--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[os, tables, hashes, sequtils],
+  std/[tables, hashes, sequtils],
   stew/byteutils,
   stew/shims/net as stewNet, json_rpc/rpcserver,
   chronicles,
@@ -24,7 +24,6 @@ import
   # Waku v2 imports
   libp2p/crypto/crypto,
   libp2p/nameresolving/nameresolver,
-  ../../waku/v2/utils/namespacing,
   ../../waku/v2/utils/time,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/message_cache,
@@ -313,6 +312,7 @@ proc setupV2Rpc(node: WakuNode, rpcServer: RpcHttpServer, conf: WakuBridgeConf) 
 {.pop.} # @TODO confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError
 when isMainModule:
   import
+    std/os,
     libp2p/nameresolving/dnsresolver
   import
     ../../waku/common/logging,

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -41,7 +41,6 @@ import
   ../../waku/v2/protocol/waku_archive/retention_policy/retention_policy_capacity,
   ../../waku/v2/protocol/waku_archive/retention_policy/retention_policy_time,
   ../../waku/v2/protocol/waku_store,
-  ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/protocol/waku_peer_exchange,

--- a/apps/wakunode2/wakunode2_setup_rpc.nim
+++ b/apps/wakunode2/wakunode2_setup_rpc.nim
@@ -4,12 +4,10 @@ else:
   {.push raises: [].}
 
 import
-  std/tables,
   stew/shims/net,
   chronicles,
   json_rpc/rpcserver
 import
-  ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/message_cache,
   ../../waku/v2/node/waku_node,
   ../../waku/v2/node/jsonrpc/admin/handlers as admin_api,

--- a/tests/v2/test_waku_keepalive.nim
+++ b/tests/v2/test_waku_keepalive.nim
@@ -7,7 +7,6 @@ import
   chronos,
   chronicles,
   libp2p/switch,
-  libp2p/protobuf/minprotobuf,
   libp2p/protocols/ping,
   libp2p/stream/bufferstream,
   libp2p/stream/connection,

--- a/tests/v2/waku_relay/test_waku_relay.nim
+++ b/tests/v2/waku_relay/test_waku_relay.nim
@@ -2,7 +2,6 @@
 
 import
   std/[options, sequtils, strutils],
-  stew/byteutils,
   stew/shims/net as stewNet,
   testutils/unittests,
   chronicles,

--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[os,sysrand,sequtils,tables,math],
+  std/os,
   stew/byteutils,
   stew/shims/net as stewNet,
   testutils/unittests,

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_debug.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_debug.nim
@@ -6,7 +6,6 @@ import
   testutils/unittests,
   chronicles,
   chronos,
-  eth/keys,
   libp2p/crypto/crypto,
   json_rpc/[rpcserver, rpcclient]
 import

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_filter.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_filter.nim
@@ -5,7 +5,6 @@ import
   stew/shims/net as stewNet,
   testutils/unittests,
   chronicles,
-  eth/keys,
   libp2p/crypto/crypto,
   json_rpc/[rpcserver, rpcclient]
 import

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -5,7 +5,6 @@ import
   stew/shims/net as stewNet,
   testutils/unittests,
   chronicles,
-  eth/keys,
   libp2p/crypto/crypto,
   json_rpc/[rpcserver, rpcclient]
 import

--- a/waku/v2/node/jsonrpc/filter/handlers.nim
+++ b/waku/v2/node/jsonrpc/filter/handlers.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[tables, sequtils],
+  std/sequtils,
   chronicles,
   json_rpc/rpcserver
 import

--- a/waku/v2/node/jsonrpc/store/handlers.nim
+++ b/waku/v2/node/jsonrpc/store/handlers.nim
@@ -8,7 +8,6 @@ import
   chronicles,
   json_rpc/rpcserver
 import
-  ../../../../../waku/v2/protocol/waku_message,
   ../../../../../waku/v2/protocol/waku_store,
   ../../../../../waku/v2/protocol/waku_store/rpc,
   ../../../../../waku/v2/utils/time,

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -5,7 +5,7 @@ else:
 
 
 import
-  std/[options, sets, sequtils, times, random],
+  std/[options, sets, sequtils, times],
   chronos,
   chronicles,
   metrics,

--- a/waku/v2/protocol/waku_peer_exchange/protocol.nim
+++ b/waku/v2/protocol/waku_peer_exchange/protocol.nim
@@ -1,5 +1,5 @@
 import
-  std/[options, sets, tables, sequtils, random],
+  std/[options, sequtils, random],
   stew/results,
   chronicles,
   chronos,
@@ -11,7 +11,6 @@ import
   ../../node/peer_manager,
   ../../node/discv5/waku_discv5,
   ../waku_message,
-  ../waku_relay,
   ./rpc,
   ./rpc_codec
 

--- a/waku/v2/protocol/waku_store/client.nim
+++ b/waku/v2/protocol/waku_store/client.nim
@@ -13,8 +13,6 @@ import
 import
   ../../node/peer_manager,
   ../../utils/requests,
-  ../../utils/time,
-  ../waku_message,
   ./protocol_metrics,
   ./common,
   ./rpc,

--- a/waku/v2/protocol/waku_store/protocol.nim
+++ b/waku/v2/protocol/waku_store/protocol.nim
@@ -20,7 +20,6 @@ import
 import
   ../../node/peer_manager,
   ../../utils/time,
-  ../waku_message,
   ./common,
   ./rpc,
   ./rpc_codec,


### PR DESCRIPTION
Another 🪴 PR. Removed the unused import warnings (except the `chronicles` one).