### PR TITLE
fix(networking): fix flaky peerstore test

### DIFF
--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -529,7 +529,7 @@ procSuite "Peer Manager":
     pm.peerStore[ConnectionBook][peers[10].peerId] = Connected
     pm.peerStore[ConnectionBook][peers[12].peerId] = Connected
 
-    # Prune the peerstore
+    # Prune the peerstore (current=15, target=5)
     pm.prunePeerStore()
 
     check:

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -405,7 +405,9 @@ proc prunePeerStore*(pm: PeerManager) =
 
   # prune peers with too many failed attempts
   var pruned = 0
-  for peerId in pm.peerStore[NumberFailedConnBook].book.keys:
+  # copy to avoid modifying the book while iterating
+  let peerKeys = toSeq(pm.peerStore[NumberFailedConnBook].book.keys)
+  for peerId in peerKeys:
     if peersToPrune - pruned == 0:
       break
     if pm.peerStore[NumberFailedConnBook][peerId] >= pm.maxFailedAttempts:


### PR DESCRIPTION
* Fixes flaky test in peer manager reported by @LNSD.
* Was removing an element from a table while iterating it.
* Before the issue showed up every 20 runs.
* With the fix, after 100 runs I couldn't reproduce it, should be solved.