### PR TITLE
fix: change message ID provider to match go-waku

### DIFF
--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -8,7 +8,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[tables, sequtils, hashes],
+  std/[tables, sequtils],
   stew/results,
   chronos,
   chronicles,
@@ -80,11 +80,8 @@ method initPubSub(w: WakuRelay) {.raises: [InitializationError].} =
 proc new*(T: type WakuRelay, switch: Switch, triggerSelf: bool = true): WakuRelayResult[T] =
 
   proc msgIdProvider(msg: messages.Message): Result[MessageID, ValidationResult] =
-    let hash = MultiHash.digest("sha2-256", msg.data)
-    if hash.isErr():
-      ok(toBytes($hashes.hash(msg.data)))
-    else:
-      ok(hash.value.data.buffer)
+    let hash = sha256.digest(msg.data)
+    ok(toSeq(hash.data))
 
   var wr: WakuRelay
   try:


### PR DESCRIPTION
The existing `messageIdProvider` in nwaku uses `Multihash` format, while in go-waku straightforward `sha256` hashes are used. This implies that message IDs (e.g. in the seen cache, in control messages, etc.) do not match between go-waku and nwaku, resulting in a lot of duplication and unnecessary control messages.

Since nwaku is more easily upgraded than go-waku, this quickfix changes nwaku message IDs to match those of go-waku.

A longer term solution is to specify a hashing scheme in an RFC.