### PR TITLE
fix(discv5): add multiaddrs only if len > 0

### DIFF
--- a/waku/v2/node/discv5/waku_discv5.nim
+++ b/waku/v2/node/discv5/waku_discv5.nim
@@ -125,7 +125,8 @@ proc new*(T: type WakuDiscoveryV5,
   var enrInitFields = @[(WAKU_ENR_FIELD, @[flags.byte])]
 
   ## Add multiaddresses to ENR
-  enrInitFields.add((MULTIADDR_ENR_FIELD, multiaddrs.getRawField()))
+  if multiaddrs.len > 0:
+    enrInitFields.add((MULTIADDR_ENR_FIELD, multiaddrs.getRawField()))
 
   let protocol = newProtocol(
     privateKey,


### PR DESCRIPTION
This PR addresses a regression introduced in #1512 where custom multiaddresses could be advertised.

The underlying lib (nim-eth/p2p/discoveryv5) does not check if the FieldPair passed in has a valid value, thereby allowing empty values to be set. (This may be according to spec, not sure)

Due to this, enrs like 
```
enr:-J64QM_U8FdESjHoSFcKFoprAGGTwNub1dikCq0YHYSOoP6LbC8flLIy57oOSlPNqh9GI_tU7INptPTMs2OQKeKrgM0BgmlkgnY0gmlwhGRA5CWKbXVsdGlhZGRyc4CJc2VjcDI1NmsxoQIsexkCjCPHfJzB54SyfD_gMLeGl4YSDpFMl9MeyiQBZIN0Y3CC6mCDdWRwgiMohXdha3UyAQ
```
were produced in the edge case where a node has discv5 enabled, without dns4/ws/wss.The enrs have a `multiaddrs` key, but only 0x as the value.

The code now adds multiaddrs only if the seq has elements in it, produces enrs like 
```
enr:-JK4QLJz4uLfh6DIHLFpsL7JXoG2V-7zjTNn0vqrHOpOZinXa8gjdJjwEhdeV1m1AkEtivjmvmfSNx0nX93_3w7WwHcBgmlkgnY0gmlwhGRA5CWJc2VjcDI1NmsxoQJWvwv28MaqUGDI2_wXjTBan_-LbeWfHZQLvkjN-nbhf4N0Y3CC6mCDdWRwgiMohXdha3UyAQ
```

![image](https://user-images.githubusercontent.com/43716372/218534194-6270b33f-f060-40ce-bb7d-ea3d1df12f4b.png)

Note: Trying to test if the `multiaddrs` key is set using `contains()`/`tryGet()` from the enr lib leads to an `UnpackDefect` error (not sure how to test this behaviour)

cc: @richard-ramos 

