### PR TITLE
fix: allow higher resolution timestamps

### DIFF
--- a/tests/v2/test_utils_time.nim
+++ b/tests/v2/test_utils_time.nim
@@ -1,0 +1,35 @@
+{.used.}
+
+import
+  stew/results,
+  testutils/unittests
+import
+  ../../waku/v2/utils/time
+
+suite "Utils - Time":
+
+  test "Test timestamp conversion":
+    ## Given
+    let
+      nanoseconds = 1676562429123456789.int64
+      secondsPart = nanoseconds div 1_000_000_000
+      nanosecondsPart = nanoseconds mod 1_000_000_000
+      secondsFloat = secondsPart.float64 + (nanosecondsPart.float64 / 1_000_000_000.float64)
+      lowResTimestamp = Timestamp(secondsPart.int64 * 1_000_000_000.int64) # 1676562429000000000
+      highResTimestamp = Timestamp(secondsFloat * 1_000_000_000.float64) # 1676562429123456789
+
+    require highResTimestamp > lowResTimestamp # Sanity check
+
+    ## When
+    let
+      timeInSecondsInt = secondsPart.int
+      timeInSecondsInt64 = secondsPart.int64
+      timeInSecondsFloat = float(secondsFloat)
+      timeInSecondsFloat64 = float64(secondsFloat)
+
+    ## Then
+    check:
+      getNanosecondTime(timeInSecondsInt) == lowResTimestamp
+      getNanosecondTime(timeInSecondsInt64) == lowResTimestamp
+      getNanosecondTime(timeInSecondsFloat) == highResTimestamp
+      getNanosecondTime(timeInSecondsFloat64) == highResTimestamp

--- a/waku/v2/utils/time.nim
+++ b/waku/v2/utils/time.nim
@@ -8,19 +8,11 @@ import
   std/times,
   metrics
 
-type Timestamp* = int64
+type Timestamp* = int64 # A nanosecond precision timestamp
 
-proc getNanosecondTime*[T](timeInSeconds: T): Timestamp =
-  var ns = Timestamp(timeInSeconds.int64 * 1000_000_000.int64)
+proc getNanosecondTime*[T: SomeNumber](timeInSeconds: T): Timestamp =
+  var ns = Timestamp(timeInSeconds * 1_000_000_000.T)
   return ns
-
-proc getMicrosecondTime*[T](timeInSeconds: T): Timestamp =
-  var us = Timestamp(timeInSeconds.int64 * 1000_000.int64)
-  return us
-
-proc getMillisecondTime*[T](timeInSeconds: T): Timestamp =
-  var ms = Timestamp(timeInSeconds.int64 * 1000.int64)
-  return ms
 
 proc nowInUnixFloat(): float =
   return getTime().toUnixFloat()


### PR DESCRIPTION
This fix allows higher precision `Timestamp`s

Wakurtosis reported that all timestamps logged by nwaku were in second resolution (no fractional seconds), which is too imprecise for testing latency, identifying messages etc.

It turns out that our `Timestamp` construction converted the more precise `float`seconds (with fraction) to `int64` before multiplying, resulting in the fractional part always being truncated

I've also:
- removed the unused util functions for micro- and milliseconds. I believe a nwaku `Timestamp` should always be nanoseconds.
- made the generic generation function more strict in requiring `SomeNumber` types in input.
- added basic test suite