### PR TITLE
chore(rln-relay): bump zerokit and update ffi

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -117,7 +117,7 @@ proc toString*(message: Chat2Message): string =
 
 # Similarly as Status public chats now.
 proc generateSymKey(contentTopic: ContentTopic): SymKey =
-  var ctx: HMAC[sha256]
+  var ctx: HMAC[pbkdf2.sha256]
   var symKey: SymKey
   if pbkdf2(ctx, contentTopic.toBytes(), "", 65356, symKey) != sizeof(SymKey):
     raise (ref Defect)(msg: "Should not occur as array is properly sized")

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -403,8 +403,8 @@ suite "Waku rln relay":
     # prepare other inputs to the hash function
     let outputBuffer = default(Buffer)
 
-    let hashSuccess = hash(rlnInstance.get(), unsafeAddr hashInputBuffer,
-        unsafeAddr outputBuffer)
+    let hashSuccess = sha256(unsafeAddr hashInputBuffer,
+                             unsafeAddr outputBuffer)
     require:
       hashSuccess
     let outputArr = cast[ptr array[32, byte]](outputBuffer.`ptr`)[]
@@ -429,7 +429,7 @@ suite "Waku rln relay":
     # prepare the input
     let msg = "Hello".toBytes()
 
-    let hash = rln.hash(msg)
+    let hash = sha256(msg)
 
     check:
       "1e32b3ab545c07c8b4a7ab1ca4f46bc31e4fdc29ac3b240ef1d54b4017a26e4c" ==

--- a/waku/v2/protocol/waku_rln_relay/rln/rln_interface.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln/rln_interface.nim
@@ -151,11 +151,20 @@ proc new_circuit_from_data*(tree_height: uint, circom_buffer: ptr Buffer, zkey_b
 ## ctx holds the final created rln object
 ## the return bool value indicates the success or failure of the operation
 
-proc hash*(ctx: ptr RLN,
-           input_buffer: ptr Buffer,
-           output_buffer: ptr Buffer): bool {.importc: "hash".}
+#-------------------------------- Hashing utils -------------------------------------------
+
+proc sha256*(input_buffer: ptr Buffer,
+             output_buffer: ptr Buffer): bool {.importc: "hash".}
 ## it hashes (sha256) the plain text supplied in inputs_buffer and then maps it to a field element
 ## this proc is used to map arbitrary signals to field element for the sake of proof generation
+## inputs_buffer holds the hash input as a byte seq
+## the hash output is generated and populated inside output_buffer
+## the output_buffer contains 32 bytes hash output
+
+proc poseidon*(input_buffer: ptr Buffer,
+               output_buffer: ptr Buffer): bool {.importc: "poseidon_hash".}
+## it hashes (poseidon) the plain text supplied in inputs_buffer
+## this proc is used to compute the identity secret hash, and external nullifier
 ## inputs_buffer holds the hash input as a byte seq
 ## the hash output is generated and populated inside output_buffer
 ## the output_buffer contains 32 bytes hash output

--- a/waku/v2/protocol/waku_rln_relay/rln/wrappers.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln/wrappers.nim
@@ -78,21 +78,21 @@ proc createRLNInstance*(d: int = MerkleTreeDepth): RLNResult =
     res = createRLNInstanceLocal(d)
   return res
 
-proc hash*(rlnInstance: ptr RLN, data: openArray[byte]): MerkleNode =
-  ## a thin layer on top of the Nim wrapper of the Poseidon hasher
-  debug "hash input", hashhex = data.toHex()
+proc sha256*(data: openArray[byte]): MerkleNode =
+  ## a thin layer on top of the Nim wrapper of the sha256 hasher
+  debug "sha256 hash input", hashhex = data.toHex()
   var lenPrefData = appendLength(data)
   var
     hashInputBuffer = lenPrefData.toBuffer()
     outputBuffer: Buffer # will holds the hash output
 
-  debug "hash input buffer length", bufflen = hashInputBuffer.len
+  debug "sha256 hash input buffer length", bufflen = hashInputBuffer.len
   let
-    hashSuccess = hash(rlnInstance, addr hashInputBuffer, addr outputBuffer)
+    hashSuccess = sha256(addr hashInputBuffer, addr outputBuffer)
 
   # check whether the hash call is done successfully
   if not hashSuccess:
-    debug "error in hash"
+    debug "error in sha256 hash"
     return default(MerkleNode)
 
   let


### PR DESCRIPTION
Changes and optimizations included in zerokit's bump - https://github.com/vacp2p/zerokit/compare/005393d...master

This included ffi changes -
```diff
-proc hash*(ctx: ptr RLN,
-           input_buffer: ptr Buffer,
-           output_buffer: ptr Buffer): bool {.importc: "hash".}
+#-------------------------------- Hashing utils -------------------------------------------
+
+proc sha256*(input_buffer: ptr Buffer,
+             output_buffer: ptr Buffer): bool {.importc: "hash".}
 ## it hashes (sha256) the plain text supplied in inputs_buffer and then maps it to a field element
 ## this proc is used to map arbitrary signals to field element for the sake of proof generation
 ## inputs_buffer holds the hash input as a byte seq
 ## the hash output is generated and populated inside output_buffer
 ## the output_buffer contains 32 bytes hash output
+
+proc poseidon*(input_buffer: ptr Buffer,
+               output_buffer: ptr Buffer): bool {.importc: "poseidon_hash".}
+## it hashes (poseidon) the plain text supplied in inputs_buffer
+## this proc is used to compute the identity secret hash, and external nullifier
+## inputs_buffer holds the hash input as a byte seq
+## the hash output is generated and populated inside output_buffer
+## the output_buffer contains 32 bytes hash output
```

Note that we've changed the proc name since it conflicted with hash() generated in `hashcommon.nim` (stdlib), and since it is more indicative of the underlying hash function.
