### PR TITLE
chore: log node peer ID with relay trace logging

### DIFF
--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -373,6 +373,9 @@ proc new*(T: type WakuNode,
 proc peerInfo*(node: WakuNode): PeerInfo =
   node.switch.peerInfo
 
+proc peerId*(node: WakuNode): PeerId =
+  node.peerInfo.peerId
+
 # TODO: Extend with more relevant info: topics, peers, memory usage, online time, etc
 proc info*(node: WakuNode): WakuInfo =
   ## Returns information about the Node, such as what multiaddress it can be reached at.
@@ -401,7 +404,7 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
 
   proc traceHandler(topic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
     trace "waku.relay received",
-      peerId=node.switch.peerInfo.peerId,
+      peerId=node.peerId,
       pubsubTopic=topic,
       hash=MultiHash.digest("sha2-256", data).expect("valid hash").data.buffer.to0xHex(), # TODO: this could be replaced by a message UID
       receivedTime=getNowInNanosecondTime()
@@ -490,7 +493,7 @@ proc publish*(node: WakuNode, topic: PubsubTopic, message: WakuMessage) {.async,
   discard await node.wakuRelay.publish(topic, message)
 
   trace "waku.relay published",
-    peerId=node.switch.peerInfo.peerId,
+    peerId=node.peerId,
     pubsubTopic=topic,
     hash=MultiHash.digest("sha2-256", message.encode().buffer).expect("valid hash").data.buffer.to0xHex(), # TODO: this could be replaced by a message UID
     publishTime=getNowInNanosecondTime()

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -401,6 +401,7 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
 
   proc traceHandler(topic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
     trace "waku.relay received",
+      peerId=node.switch.peerInfo.peerId,
       pubsubTopic=topic,
       hash=MultiHash.digest("sha2-256", data).expect("valid hash").data.buffer.to0xHex(), # TODO: this could be replaced by a message UID
       receivedTime=getNowInNanosecondTime()
@@ -489,6 +490,7 @@ proc publish*(node: WakuNode, topic: PubsubTopic, message: WakuMessage) {.async,
   discard await node.wakuRelay.publish(topic, message)
 
   trace "waku.relay published",
+    peerId=node.switch.peerInfo.peerId,
     pubsubTopic=topic,
     hash=MultiHash.digest("sha2-256", message.encode().buffer).expect("valid hash").data.buffer.to0xHex(), # TODO: this could be replaced by a message UID
     publishTime=getNowInNanosecondTime()


### PR DESCRIPTION
Logs the peer ID when trace logging relay messages.

Requested by Wakurtosis as a requirement/improvement when scraping logs.