### PR TITLE
chore: removed unused submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,11 +88,6 @@
 	url = https://github.com/status-im/nim-http-utils.git
 	ignore = dirty
 	branch = master
-[submodule "vendor/news"]
-	path = vendor/news
-	url = https://github.com/tormund/news.git
-	ignore = dirty
-	branch = master
 [submodule "vendor/nim-bearssl"]
 	path = vendor/nim-bearssl
 	url = https://github.com/status-im/nim-bearssl.git


### PR DESCRIPTION
Remove unused submodule `news`. This was an old "Nim Easy Websockets" library, which has since been replaced by `nim-websock`