### PR TITLE
feat(message): added meta attribute to waku message

### DIFF
--- a/waku/v2/protocol/waku_message/message.nim
+++ b/waku/v2/protocol/waku_message/message.nim
@@ -13,6 +13,8 @@ import
   ../../utils/time
 
 const
+  MaxMetaAttrLength* = 32 # 32 bytes
+
   MaxWakuMessageSize* = 1024 * 1024 # 1 Mibytes. Corresponds to PubSub default
 
 
@@ -30,6 +32,8 @@ type WakuMessage* = object
     payload*: seq[byte]
     # String identifier that can be used for content-based filtering.
     contentTopic*: ContentTopic
+    # Application specific metadata.
+    meta*: seq[byte]
     # Number to discriminate different types of payload encryption.
     # Compatibility with Whisper/WakuV1.
     version*: uint32


### PR DESCRIPTION
The current PR introduces support for the `meta` attribute:

- [x] Added the `meta` attribute to the `WakuMessage` type
- [x] Extend the `WakuMessage` codec to support the attribute's serialization, deserialization and length validation.

It depends on the following RFC and Protobuf PRs:

- https://github.com/vacp2p/rfc/pull/573
- https://github.com/vacp2p/waku/pull/13
