### PR TITLE
feat: new filter protocol increment - subscribe request handling

### DIFF
--- a/tests/v2/waku_filter_v2/test_waku_filter_v2.nim
+++ b/tests/v2/waku_filter_v2/test_waku_filter_v2.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options,sets,tables],
+  std/[options,sets,strutils,tables],
   testutils/unittests,
   chronos,
   chronicles
@@ -9,6 +9,7 @@ import
   ../../../waku/v2/node/peer_manager,
   ../../../waku/v2/protocol/waku_filter_v2,
   ../../../waku/v2/protocol/waku_filter_v2/rpc,
+  ../../../waku/v2/protocol/waku_message,
   ../testlib/common,
   ../testlib/waku2
 
@@ -22,23 +23,217 @@ proc newTestWakuFilter(switch: Switch): Future[WakuFilter] {.async.} =
 
   return proto
 
+proc generateRequestId(rng: ref HmacDrbgContext): string =
+  var bytes: array[10, byte]
+  hmacDrbgGenerate(rng[], bytes)
+  return toHex(bytes)
+
+proc createRequest(filterSubscribeType: FilterSubscribeType, pubsubTopic = none(PubsubTopic), contentTopics = newSeq[ContentTopic]()): FilterSubscribeRequest =
+  let requestId = generateRequestId(rng)
+
+  return FilterSubscribeRequest(
+    requestId: requestId,
+    filterSubscribeType: filterSubscribeType,
+    pubsubTopic: pubsubTopic,
+    contentTopics: contentTopics
+  )
+
+proc getSubscribedContentTopics(wakuFilter: WakuFilter, peerId: PeerId): seq[ContentTopic] =
+  var contentTopics: seq[ContentTopic]
+  for filterCriterion in wakuFilter.subscriptions[peerId]:
+    contentTopics.add(filterCriterion[1])
+
+  return contentTopics
+
 suite "Waku Filter - handling subscribe requests":
 
-  asyncTest "subscribe request":
+  asyncTest "simple subscribe and unsubscribe request":
+    # Given
     let
       switch = newStandardSwitch()
       wakuFilter = await newTestWakuFilter(switch)
       peerId = PeerId.random().get()
-      filterSubscribeRequest = FilterSubscribeRequest(
-        requestId: "1",
-        filterSubscribeType: FilterSubscribeType.SUBSCRIBE,
-        pubsubTopic: some("test-topic"),
-        contentTopics: @["test-topic"]
+      filterSubscribeRequest = createRequest(
+        filterSubscribeType = FilterSubscribeType.SUBSCRIBE,
+        pubsubTopic = some(DefaultPubsubTopic),
+        contentTopics = @[DefaultContentTopic]
+      )
+      filterUnsubscribeRequest = createRequest(
+        filterSubscribeType = FilterSubscribeType.UNSUBSCRIBE,
+        pubsubTopic = filterSubscribeRequest.pubsubTopic,
+        contentTopics = filterSubscribeRequest.contentTopics
       )
 
+    # When
     let response = wakuFilter.handleSubscribeRequest(peerId, filterSubscribeRequest)
 
+    # Then
     check:
       wakuFilter.subscriptions.len == 1
       wakuFilter.subscriptions[peerId].len == 1
       response.requestId == filterSubscribeRequest.requestId
+      response.statusCode == 200
+      response.statusDesc.get() == "OK"
+
+    # When
+    let response2 = wakuFilter.handleSubscribeRequest(peerId, filterUnsubscribeRequest)
+
+    # Then
+    check:
+      wakuFilter.subscriptions.len == 0 # peerId is removed from subscriptions
+      response2.requestId == filterUnsubscribeRequest.requestId
+      response2.statusCode == 200
+      response2.statusDesc.get() == "OK"
+
+  asyncTest "simple subscribe and unsubscribe all for multiple content topics":
+    # Given
+    let
+      switch = newStandardSwitch()
+      wakuFilter = await newTestWakuFilter(switch)
+      peerId = PeerId.random().get()
+      nonDefaultContentTopic = ContentTopic("/waku/2/non-default-waku/proto")
+      filterSubscribeRequest = createRequest(
+        filterSubscribeType = FilterSubscribeType.SUBSCRIBE,
+        pubsubTopic = some(DefaultPubsubTopic),
+        contentTopics = @[DefaultContentTopic, nonDefaultContentTopic]
+      )
+      filterUnsubscribeAllRequest = createRequest(
+        filterSubscribeType = FilterSubscribeType.UNSUBSCRIBE_ALL
+      )
+
+    # When
+    let response = wakuFilter.handleSubscribeRequest(peerId, filterSubscribeRequest)
+
+    # Then
+    check:
+      wakuFilter.subscriptions.len == 1
+      wakuFilter.subscriptions[peerId].len == 2
+      wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest.contentTopics
+      response.requestId == filterSubscribeRequest.requestId
+      response.statusCode == 200
+      response.statusDesc.get() == "OK"
+
+    # When
+    let response2 = wakuFilter.handleSubscribeRequest(peerId, filterUnsubscribeAllRequest)
+
+    # Then
+    check:
+      wakuFilter.subscriptions.len == 0 # peerId is removed from subscriptions
+      response2.requestId == filterUnsubscribeAllRequest.requestId
+      response2.statusCode == 200
+      response2.statusDesc.get() == "OK"
+
+  asyncTest "subscribe and unsubscribe to multiple content topics":
+    # Given
+    let
+      switch = newStandardSwitch()
+      wakuFilter = await newTestWakuFilter(switch)
+      peerId = PeerId.random().get()
+      nonDefaultContentTopic = ContentTopic("/waku/2/non-default-waku/proto")
+      filterSubscribeRequest1 = createRequest(
+        filterSubscribeType = FilterSubscribeType.SUBSCRIBE,
+        pubsubTopic = some(DefaultPubsubTopic),
+        contentTopics = @[DefaultContentTopic]
+      )
+      filterSubscribeRequest2 = createRequest(
+        filterSubscribeType = FilterSubscribeType.SUBSCRIBE,
+        pubsubTopic = filterSubscribeRequest1.pubsubTopic,
+        contentTopics = @[nonDefaultContentTopic]
+      )
+      filterUnsubscribeRequest1 = createRequest(
+        filterSubscribeType = FilterSubscribeType.UNSUBSCRIBE,
+        pubsubTopic = filterSubscribeRequest1.pubsubTopic,
+        contentTopics = filterSubscribeRequest1.contentTopics
+      )
+      filterUnsubscribeRequest2 = createRequest(
+        filterSubscribeType = FilterSubscribeType.UNSUBSCRIBE,
+        pubsubTopic = filterSubscribeRequest2.pubsubTopic,
+        contentTopics = filterSubscribeRequest2.contentTopics
+      )
+
+    # When
+    let response1 = wakuFilter.handleSubscribeRequest(peerId, filterSubscribeRequest1)
+
+    # Then
+    check:
+      wakuFilter.subscriptions.len == 1
+      wakuFilter.subscriptions[peerId].len == 1
+      wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest1.contentTopics
+      response1.requestId == filterSubscribeRequest1.requestId
+      response1.statusCode == 200
+      response1.statusDesc.get() == "OK"
+
+    # When
+    let response2 = wakuFilter.handleSubscribeRequest(peerId, filterSubscribeRequest2)
+
+    # Then
+    check:
+      wakuFilter.subscriptions.len == 1
+      wakuFilter.subscriptions[peerId].len == 2
+      wakuFilter.getSubscribedContentTopics(peerId) ==
+        filterSubscribeRequest1.contentTopics &
+        filterSubscribeRequest2.contentTopics
+      response2.requestId == filterSubscribeRequest2.requestId
+      response2.statusCode == 200
+      response2.statusDesc.get() == "OK"
+
+    # When
+    let response3 = wakuFilter.handleSubscribeRequest(peerId, filterUnsubscribeRequest1)
+
+    # Then
+    check:
+      wakuFilter.subscriptions.len == 1
+      wakuFilter.subscriptions[peerId].len == 1
+      wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest2.contentTopics
+      response3.requestId == filterUnsubscribeRequest1.requestId
+      response3.statusCode == 200
+      response3.statusDesc.get() == "OK"
+
+    # When
+    let response4 = wakuFilter.handleSubscribeRequest(peerId, filterUnsubscribeRequest2)
+
+    # Then
+    check:
+      wakuFilter.subscriptions.len == 0 # peerId is removed from subscriptions
+      response4.requestId == filterUnsubscribeRequest2.requestId
+      response4.statusCode == 200
+      response4.statusDesc.get() == "OK"
+
+  asyncTest "ping subscriber":
+    # Given
+    let
+      switch = newStandardSwitch()
+      wakuFilter = await newTestWakuFilter(switch)
+      peerId = PeerId.random().get()
+      pingRequest = createRequest(
+        filterSubscribeType = FilterSubscribeType.SUBSCRIBER_PING
+      )
+      filterSubscribeRequest = createRequest(
+        filterSubscribeType = FilterSubscribeType.SUBSCRIBE,
+        pubsubTopic = some(DefaultPubsubTopic),
+        contentTopics = @[DefaultContentTopic]
+      )
+
+    # When
+    let response1 = wakuFilter.handleSubscribeRequest(peerId, pingRequest)
+
+    # Then
+    check:
+      response1.requestId == pingRequest.requestId
+      response1.statusCode == FilterSubscribeErrorKind.NOT_FOUND.uint32
+      response1.statusDesc.get().contains("peer has no subscriptions")
+
+    # When
+    let
+      response2 = wakuFilter.handleSubscribeRequest(peerId, filterSubscribeRequest)
+      response3 = wakuFilter.handleSubscribeRequest(peerId, pingRequest)
+
+    # Then
+    check:
+      response2.requestId == filterSubscribeRequest.requestId
+      response2.statusCode == 200
+      response2.statusDesc.get() == "OK"
+      response3.requestId == pingRequest.requestId
+      response3.statusCode == 200
+      response3.statusDesc.get() == "OK"
+

--- a/tests/v2/waku_filter_v2/test_waku_filter_v2.nim
+++ b/tests/v2/waku_filter_v2/test_waku_filter_v2.nim
@@ -1,0 +1,44 @@
+{.used.}
+
+import
+  std/[options,sets,tables],
+  testutils/unittests,
+  chronos,
+  chronicles
+import
+  ../../../waku/v2/node/peer_manager,
+  ../../../waku/v2/protocol/waku_filter_v2,
+  ../../../waku/v2/protocol/waku_filter_v2/rpc,
+  ../testlib/common,
+  ../testlib/waku2
+
+proc newTestWakuFilter(switch: Switch): Future[WakuFilter] {.async.} =
+  let
+    peerManager = PeerManager.new(switch)
+    proto = WakuFilter.new(peerManager)
+
+  await proto.start()
+  switch.mount(proto)
+
+  return proto
+
+suite "Waku Filter - handling subscribe requests":
+
+  asyncTest "subscribe request":
+    let
+      switch = newStandardSwitch()
+      wakuFilter = await newTestWakuFilter(switch)
+      peerId = PeerId.random().get()
+      filterSubscribeRequest = FilterSubscribeRequest(
+        requestId: "1",
+        filterSubscribeType: FilterSubscribeType.SUBSCRIBE,
+        pubsubTopic: some("test-topic"),
+        contentTopics: @["test-topic"]
+      )
+
+    let response = wakuFilter.handleSubscribeRequest(peerId, filterSubscribeRequest)
+
+    check:
+      wakuFilter.subscriptions.len == 1
+      wakuFilter.subscriptions[peerId].len == 1
+      response.requestId == filterSubscribeRequest.requestId

--- a/waku/v2/protocol/waku_filter_v2.nim
+++ b/waku/v2/protocol/waku_filter_v2.nim
@@ -1,0 +1,5 @@
+import
+  ./waku_filter_v2/protocol
+
+export
+  protocol

--- a/waku/v2/protocol/waku_filter_v2.nim
+++ b/waku/v2/protocol/waku_filter_v2.nim
@@ -1,5 +1,7 @@
 import
+  ./waku_filter_v2/common,
   ./waku_filter_v2/protocol
 
 export
+  common,
   protocol

--- a/waku/v2/protocol/waku_filter_v2/common.nim
+++ b/waku/v2/protocol/waku_filter_v2/common.nim
@@ -1,0 +1,29 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+const
+  WakuFilterSubscribeCodec* = "/vac/waku/filter-subscribe/2.0.0-beta1"
+  WakuFilterPushCodec* = "/vac/waku/filter-push/2.0.0-beta1"
+
+type
+  FilterSubscribeErrorKind* {.pure.} = enum
+    UNKNOWN = uint32(000)
+    BAD_REQUEST = uint32(400)
+    NOT_FOUND = uint32(404)
+
+  FilterSubscribeError* = object
+    kind*: FilterSubscribeErrorKind
+    cause*: string
+
+  FilterSubscribeResult* = Result[void, FilterSubscribeError]
+
+proc `$`*(err: FilterSubscribeError): string =
+  case err.kind:
+  of FilterSubscribeErrorKind.BAD_REQUEST:
+    "BAD_REQUEST: " & err.cause
+  of FilterSubscribeErrorKind.NOT_FOUND:
+    "NOT_FOUND: " & err.cause
+  of FilterSubscribeErrorKind.UNKNOWN:
+    "UNKNOWN"

--- a/waku/v2/protocol/waku_filter_v2/common.nim
+++ b/waku/v2/protocol/waku_filter_v2/common.nim
@@ -23,6 +23,23 @@ type
 
   FilterSubscribeResult* = Result[void, FilterSubscribeError]
 
+# Convenience functions
+
+proc badRequest*(T: type FilterSubscribeError, cause = "bad request"): FilterSubscribeError =
+  FilterSubscribeError(
+    kind: FilterSubscribeErrorKind.BAD_REQUEST,
+    cause: cause)
+
+proc notFound*(T: type FilterSubscribeError, cause = "peer has no subscriptions"): FilterSubscribeError =
+  FilterSubscribeError(
+    kind: FilterSubscribeErrorKind.NOT_FOUND,
+    cause: cause)
+
+proc serviceUnavailable*(T: type FilterSubscribeError, cause = "service unavailable"): FilterSubscribeError =
+  FilterSubscribeError(
+    kind: FilterSubscribeErrorKind.SERVICE_UNAVAILABLE,
+    cause: cause)
+
 proc `$`*(err: FilterSubscribeError): string =
   case err.kind:
   of FilterSubscribeErrorKind.BAD_REQUEST:

--- a/waku/v2/protocol/waku_filter_v2/common.nim
+++ b/waku/v2/protocol/waku_filter_v2/common.nim
@@ -3,6 +3,9 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
+import
+  stew/results
+
 const
   WakuFilterSubscribeCodec* = "/vac/waku/filter-subscribe/2.0.0-beta1"
   WakuFilterPushCodec* = "/vac/waku/filter-push/2.0.0-beta1"
@@ -12,6 +15,7 @@ type
     UNKNOWN = uint32(000)
     BAD_REQUEST = uint32(400)
     NOT_FOUND = uint32(404)
+    SERVICE_UNAVAILABLE = uint32(503)
 
   FilterSubscribeError* = object
     kind*: FilterSubscribeErrorKind
@@ -25,5 +29,7 @@ proc `$`*(err: FilterSubscribeError): string =
     "BAD_REQUEST: " & err.cause
   of FilterSubscribeErrorKind.NOT_FOUND:
     "NOT_FOUND: " & err.cause
+  of FilterSubscribeErrorKind.SERVICE_UNAVAILABLE:
+    "SERVICE_UNAVAILABLE: " & err.cause
   of FilterSubscribeErrorKind.UNKNOWN:
     "UNKNOWN"

--- a/waku/v2/protocol/waku_filter_v2/protocol.nim
+++ b/waku/v2/protocol/waku_filter_v2/protocol.nim
@@ -159,7 +159,7 @@ proc initProtocolHandler(wf: WakuFilter) =
     let buf = await conn.readLp(MaxSubscribeSize)
 
     let decodeRes = FilterSubscribeRequest.decode(buf)
-    if decodeRes.isErr:
+    if decodeRes.isErr():
       error "Failed to decode filter subscribe request", peerId=conn.peerId
       waku_filter_errors.inc(labelValues = [decodeRpcFailure])
       return

--- a/waku/v2/protocol/waku_filter_v2/protocol.nim
+++ b/waku/v2/protocol/waku_filter_v2/protocol.nim
@@ -1,0 +1,159 @@
+## Waku Filter protocol for subscribing and filtering messages
+
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/[sets,tables],
+  libp2p/peerid
+import
+  ../../node/peer_manager,
+  ../waku_message,
+  ./common,
+  ./codec
+
+const
+  MaxSubscriptions* = 1000 # TODO make configurable
+  MaxCriteriaPerSubscription = 1000
+
+type
+  FilterCriterion* = (PubsubTopic, ContentTopic) # a single filter criterion is fully defined by a pubsub topic and content topic
+  FilterCriteria* = HashSet[FilterCriterion] # a sequence of filter criteria
+
+  WakuFilter* = object
+    subscriptions*: Table[PeerID, FilterCriteria] # a mapping of peer ids to a sequence of filter criteria
+    peerManager: PeerManager
+
+proc pingSubscriber(wf: WakuFilter, peerId: PeerID): FilterSubscribeResult =
+  if peerId notin wf.subscriptions:
+    return err(FilterSubscribeError(
+      kind: FilterSubscribeErrorKind.NOT_FOUND,
+      cause: "NOT_FOUND: peer has no subscriptions"
+    ))
+
+  ok()
+
+proc subscribe(wf: WakuFilter, peerId: PeerID, pubsubTopic: Option[PubsubTopic], contentTopics: seq[ContentTopic]): FilterSubscribeResult =
+  if pubsubTopic.isNone() or contentTopics.isEmpty():
+    return err(FilterSubscribeError(
+      kind: FilterSubscribeErrorKind.BAD_REQUEST,
+      cause: "BAD_REQUEST: pubsubTopic and contentTopics must be specified"
+    ))
+
+  let filterCriteria = toHashSet(contentTopics.mapIt((pubsubTopic.get(), it)))
+
+  if peerId in wf.subscriptions:
+    let peerSubscription = wf.subscriptions[peerId]
+    if peerSubscription.len() + filterCriteria.length >= MaxCriteriaPerSubscription:
+      return err(FilterSubscribeError(
+        kind: FilterSubscribeErrorKind.BAD_REQUEST,
+        cause: "BAD_REQUEST: peer has reached maximum number of filter criteria"
+      ))
+
+    wf.subscriptions[peerId].incl(filterCriteria)
+  else:
+    if wf.subscriptions.len() >= MaxSubscriptions:
+      return err(FilterSubscribeError(
+        kind: FilterSubscribeErrorKind.BAD_REQUEST,
+        cause: "BAD_REQUEST: node has reached maximum number of subscriptions"
+      ))
+    wf.subscriptions[peerId] = filterCriteria
+
+  ok()
+
+proc unsubscribe(wf: WakuFilter, peerId: PeerID, pubsubTopic: Option[PubsubTopic], contentTopics: seq[ContentTopic]): FilterSubscribeResult =
+  if pubsubTopic.isNone() or contentTopics.isEmpty():
+    return err(FilterSubscribeError(
+      kind: FilterSubscribeErrorKind.BAD_REQUEST,
+      cause: "BAD_REQUEST: pubsubTopic and contentTopics must be specified"
+    ))
+
+  let filterCriteria = toHashSet(contentTopics.mapIt((pubsubTopic.get(), it)))
+
+  if peerId notin wf.subscriptions:
+    return err(FilterSubscribeError(
+      kind: FilterSubscribeErrorKind.NOT_FOUND,
+      cause: "NOT_FOUND: peer has no subscriptions"
+    ))
+
+  let peerSubscription = wf.subscriptions[peerId]
+  # TODO: consider error response if filter criteria does not exist
+  wf.subscriptions[peerId].excl(filterCriteria)
+
+  ok()
+
+proc unsubscribeAll(wf: WakuFilter, peerId: PeerID): FilterSubscribeResult =
+  if peerId notin wf.subscriptions:
+    return err(FilterSubscribeError(
+      kind: FilterSubscribeErrorKind.NOT_FOUND,
+      cause: "NOT_FOUND: peer has no subscriptions"
+    ))
+
+  wf.subscriptions.del(peerId)
+
+  ok()
+
+
+proc handleSubscribeRequest*(wf: WakuFilter, request: FilterSubscribeRequest): FilterSubscribeResponse =
+  var subscribeResult: FilterSubscribeResult
+
+  case request.filterSubscribeType
+  of SubscribeType.SUBSCRIBER_PING:
+    subscribeResult = wf.pingSubscriber(request.peerId)
+  of SubscribeType.SUBSCRIBE:
+    subscribeResult = wf.subscribe(request.peerId, request.pubsubTopic, request.contentTopics)
+  of SubscribeType.UNSUBSCRIBE:
+    subscribeResult = wf.unsubscribe(request.peerId, request.pubsubTopic, request.contentTopics)
+  of SubscribeType.UNSUBSCRIBE_ALL:
+    subscribeResult = wf.unsubscribeAll(request.peerId)
+
+  if subscribeResult.isErr():
+    return FilterSubscribeResponse(
+      requestId: requestId,
+      statusCode: subscribeResult.error.kind,
+      statusMessage: some($subscribeResult.error)
+    )
+  else:
+    return FilterSubscribeResponse(
+      requestId: requestId,
+      statusCode: 200,
+      statusMessage: some("OK")
+    )
+
+proc handleMessage*(wf: WakuFilter, message: WakuMessage) =
+  raiseAssert "Unimplemented"
+
+proc initProtocolHandler(wf: WakuFilter) =
+
+  proc handler(conn: Connection, proto: string) {.async.} =
+    let buf = await conn.readLp(MaxSubscribeSize)
+
+    let decodeRes = FilterSubscribeRequest.decode(buf)
+    if decodeRes.isErr:
+      error "Failed to decode filter subscribe request", peerId = $conn.peerId
+      waku_filter_errors.inc[labelValues = decodeRpcFailure]
+      return
+
+    let request = decodeRes.value #TODO: toAPI() split here
+
+    info "received filter subscribe request", peerId=$conn.peerId, request = request
+    waku_filter_requests.inc()
+
+    let response = wf.handleSubscribeRequest(request)
+
+    await conn.writeLp(response.encode()) #TODO: toRPC() separation here
+    return
+
+  ws.handler = handler
+  ws.codec = WakuFilterSubscribeCodec
+
+proc new*(T: type WakuFilter,
+          peerManager: PeerManager): T =
+
+  let ws = WakuFilter(
+    peerManager: peerManager
+  )
+  ws.initProtocolHandler()
+  ws

--- a/waku/v2/protocol/waku_filter_v2/protocol.nim
+++ b/waku/v2/protocol/waku_filter_v2/protocol.nim
@@ -66,6 +66,7 @@ proc subscribe(wf: WakuFilter, peerId: PeerID, pubsubTopic: Option[PubsubTopic],
       ))
 
     peerSubscription.incl(filterCriteria)
+    wf.subscriptions[peerId] = peerSubscription
   else:
     if wf.subscriptions.len() >= MaxSubscriptions:
       return err(FilterSubscribeError(
@@ -102,6 +103,8 @@ proc unsubscribe(wf: WakuFilter, peerId: PeerID, pubsubTopic: Option[PubsubTopic
   if peerSubscription.len() == 0:
     debug "peer has no more subscriptions, removing subscription", peerId=peerId
     wf.subscriptions.del(peerId)
+  else:
+    wf.subscriptions[peerId] = peerSubscription
 
   ok()
 

--- a/waku/v2/protocol/waku_filter_v2/protocol_metrics.nim
+++ b/waku/v2/protocol/waku_filter_v2/protocol_metrics.nim
@@ -1,0 +1,15 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import metrics
+
+export metrics
+
+declarePublicGauge waku_filter_errors, "number of filter protocol errors", ["type"]
+declarePublicGauge waku_filter_requests, "number of filter subscribe requests received", ["type"]
+
+# Error types (metric label values)
+const
+  decodeRpcFailure* = "decode_rpc_failure"

--- a/waku/v2/protocol/waku_filter_v2/rpc.nim
+++ b/waku/v2/protocol/waku_filter_v2/rpc.nim
@@ -33,4 +33,3 @@ type
     # Message pushed from service node to client
     wakuMessage*: WakuMessage
     pubsubTopic*: Option[string]
-

--- a/waku/v2/protocol/waku_filter_v2/rpc.nim
+++ b/waku/v2/protocol/waku_filter_v2/rpc.nim
@@ -1,0 +1,36 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/options
+import
+  ../waku_message
+
+type
+  FilterSubscribeType* {.pure.} = enum
+    # Indicates the type of request from client to service node
+    SUBSCRIBER_PING = uint32(0)
+    SUBSCRIBE = uint32(1)
+    UNSUBSCRIBE = uint32(2)
+    UNSUBSCRIBE_ALL = uint32(3)
+
+  FilterSubscribeRequest* = object
+    # Request from client to service node
+    requestId*: string
+    filterSubscribeType*: FilterSubscribeType
+    pubsubTopic*: Option[PubsubTopic]
+    contentTopics*: seq[ContentTopic]
+
+  FilterSubscribeResponse* = object
+    # Response from service node to client
+    requestId*: string
+    statusCode*: uint32
+    statusDesc*: Option[string]
+
+  MessagePush* = object
+    # Message pushed from service node to client
+    wakuMessage*: WakuMessage
+    pubsubTopic*: Option[string]
+

--- a/waku/v2/protocol/waku_filter_v2/rpc.nim
+++ b/waku/v2/protocol/waku_filter_v2/rpc.nim
@@ -33,3 +33,12 @@ type
     # Message pushed from service node to client
     wakuMessage*: WakuMessage
     pubsubTopic*: Option[string]
+
+# Convenience functions
+
+proc ok*(T: type FilterSubscribeResponse, requestId: string, desc = "OK"): T =
+  FilterSubscribeResponse(
+    requestId: requestId,
+    statusCode: 200,
+    statusDesc: some(desc)
+  )

--- a/waku/v2/protocol/waku_filter_v2/rpc_codec.nim
+++ b/waku/v2/protocol/waku_filter_v2/rpc_codec.nim
@@ -1,0 +1,71 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  ../../../common/protobuf,
+  ./rpc
+
+const
+  MaxSubscribeSize* = 10 * MaxWakuMessageSize + 64*1024 # We add a 64kB safety buffer for protocol overhead
+  MaxPushSize* = 10 * MaxWakuMessageSize + 64*1024 # We add a 64kB safety buffer for protocol overhead
+
+proc encode*(rpc: FilterSubscribeRequest): ProtoBuffer =
+  var pb = initProtoBuffer()
+
+  pb.write3(1, rpc.requestId)
+  pb.write3(2, uint32(ord(rpc.filterSubscribeType)))
+
+  pb.write3(10, rpc.pubsubTopic)
+
+  for contentTopic in rpc.contentTopics:
+    pb.write3(11, contentTopic)
+
+  pb
+
+proc decode*(T: type FilterSubscribeRequest, buffer: seq[byte]): ProtoResult[T] =
+  let pb = initProtoBuffer(buffer)
+  var rpc = FilterSubscribeRequest()
+
+  if not ?pb.getField(1, rpc.requestId):
+    return err(ProtobufError.missingRequiredField("request_id"))
+
+  if not ?pb.getField(2, rpc.filterSubscribeType):
+    return err(ProtobufError.missingRequiredField("filter_subscribe_type"))
+
+  var pubsubTopic: PubsubTopic
+  if not ?pb.getField(10, rpc.pubsubTopic):
+    rpc.pubsubTopic = none(PubsubTopic)
+  else:
+    rpc.pubsubTopic = some(pubsubTopic)
+
+  pb.getRepeatedField(11, rpc.contentTopics)
+
+  ok(rpc)
+
+proc encode*(rpc: FilterSubscribeResponse): ProtoBuffer =
+  var pb = initProtoBuffer()
+
+  pb.write3(1, rpc.requestId)
+  pb.write3(2, rpc.statusCode)
+  pb.write3(3, rpc.statusDesc)
+
+  pb
+
+proc decode*(T: type FilterSubscribeResponse, buffer: seq[byte]): ProtoResult[T] =
+  let pb = initProtoBuffer(buffer)
+  var rpc = FilterSubscribeResponse()
+
+  if not ?pb.getField(1, rpc.requestId):
+    return err(ProtobufError.missingRequiredField("request_id"))
+
+  if not ?pb.getField(2, rpc.statusCode):
+    return err(ProtobufError.missingRequiredField("status_code"))
+
+  if not ?pb.getField(3, rpc.statusDesc):
+    rpc.statusDesc = none(string)
+  else:
+    rpc.statusDesc = some(rpc.statusDesc.get())
+
+  ok(rpc)

--- a/waku/v2/protocol/waku_filter_v2/rpc_codec.nim
+++ b/waku/v2/protocol/waku_filter_v2/rpc_codec.nim
@@ -4,7 +4,10 @@ else:
   {.push raises: [].}
 
 import
+  std/options
+import
   ../../../common/protobuf,
+  ../waku_message,
   ./rpc
 
 const
@@ -24,23 +27,26 @@ proc encode*(rpc: FilterSubscribeRequest): ProtoBuffer =
 
   pb
 
-proc decode*(T: type FilterSubscribeRequest, buffer: seq[byte]): ProtoResult[T] =
+proc decode*(T: type FilterSubscribeRequest, buffer: seq[byte]): ProtobufResult[T] =
   let pb = initProtoBuffer(buffer)
   var rpc = FilterSubscribeRequest()
 
   if not ?pb.getField(1, rpc.requestId):
     return err(ProtobufError.missingRequiredField("request_id"))
 
-  if not ?pb.getField(2, rpc.filterSubscribeType):
+  var filterSubscribeType: uint32
+  if not ?pb.getField(2, filterSubscribeType):
     return err(ProtobufError.missingRequiredField("filter_subscribe_type"))
+  else:
+    rpc.filterSubscribeType = FilterSubscribeType(filterSubscribeType)
 
   var pubsubTopic: PubsubTopic
-  if not ?pb.getField(10, rpc.pubsubTopic):
+  if not ?pb.getField(10, pubsubTopic):
     rpc.pubsubTopic = none(PubsubTopic)
   else:
     rpc.pubsubTopic = some(pubsubTopic)
 
-  pb.getRepeatedField(11, rpc.contentTopics)
+  discard ?pb.getRepeatedField(11, rpc.contentTopics)
 
   ok(rpc)
 
@@ -53,7 +59,7 @@ proc encode*(rpc: FilterSubscribeResponse): ProtoBuffer =
 
   pb
 
-proc decode*(T: type FilterSubscribeResponse, buffer: seq[byte]): ProtoResult[T] =
+proc decode*(T: type FilterSubscribeResponse, buffer: seq[byte]): ProtobufResult[T] =
   let pb = initProtoBuffer(buffer)
   var rpc = FilterSubscribeResponse()
 


### PR DESCRIPTION
## Background

This is a first increment towards the server-side implementation of the filter protocol changes proposed in https://github.com/vacp2p/rfc/pull/562 with wire protocol in https://github.com/vacp2p/waku/pull/16.

It only covers basic subscriber request handling.

Note that this is still an incomplete feature and isolated in code. Once feature-complete, the old `filter` implementation will be removed and replaced by this one (with simultaneous merging of the RFC). Test cases are also still mainly focused on happy-path cases, to keep this increment as simple as possible.

The major outstanding features are:
- [ ] message handling within the filter service node
- [ ] a client implementation

Dogfooding can likely start without a client implementation in nwaku, as nwaku is most often configured as a service node only.


### Next steps

Further steps, roughly in order:
- [ ] message handling within filter service node
- [ ] a subscriptions sweeper to handle subscription maintenance (e.g. removing stale subscriptions, managing capacity, etc.)
- [ ] test cases that cover error and boundary conditions
- [ ] improved metrics and logging
- [ ] client implementation