### PR TITLE
fix: clean and normalize module imports

### DIFF
--- a/waku/v2/node/jsonrpc/admin/handlers.nim
+++ b/waku/v2/node/jsonrpc/admin/handlers.nim
@@ -9,11 +9,11 @@ import
   json_rpc/rpcserver,
   libp2p/[peerinfo, switch]
 import
-  ../../../../waku/v2/protocol/waku_store,
-  ../../../../waku/v2/protocol/waku_filter,
-  ../../../../waku/v2/protocol/waku_relay,
-  ../../../../waku/v2/node/peer_manager,
-  ../../../../waku/v2/node/waku_node,
+  ../../../protocol/waku_store,
+  ../../../protocol/waku_filter,
+  ../../../protocol/waku_relay,
+  ../../peer_manager,
+  ../../waku_node,
   ./types
 
 

--- a/waku/v2/node/jsonrpc/debug/client.nim
+++ b/waku/v2/node/jsonrpc/debug/client.nim
@@ -7,7 +7,7 @@ import
   std/[os, strutils],
   json_rpc/rpcclient
 import
-  ../../../../waku/v2/node/waku_node
+  ../../waku_node
 
 template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
 

--- a/waku/v2/node/jsonrpc/debug/handlers.nim
+++ b/waku/v2/node/jsonrpc/debug/handlers.nim
@@ -7,7 +7,7 @@ import
   chronicles,
   json_rpc/rpcserver
 import
-  ../../../../waku/v2/node/waku_node
+  ../../waku_node
 
 logScope:
   topics = "waku node jsonrpc debug_api"

--- a/waku/v2/node/jsonrpc/filter/client.nim
+++ b/waku/v2/node/jsonrpc/filter/client.nim
@@ -7,8 +7,8 @@ import
   std/[os, strutils],
   json_rpc/rpcclient
 import
-  ../../../../waku/v2/protocol/waku_message,
-  ../../../../waku/v2/protocol/waku_filter/rpc
+  ../../../protocol/waku_message,
+  ../../../protocol/waku_filter/rpc
 
 template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
 

--- a/waku/v2/node/jsonrpc/filter/handlers.nim
+++ b/waku/v2/node/jsonrpc/filter/handlers.nim
@@ -8,13 +8,13 @@ import
   chronicles,
   json_rpc/rpcserver
 import
-  ../../../../waku/v2/protocol/waku_message,
-  ../../../../waku/v2/protocol/waku_filter,
-  ../../../../waku/v2/protocol/waku_filter/rpc,
-  ../../../../waku/v2/protocol/waku_filter/client,
-  ../../../../waku/v2/node/message_cache,
-  ../../../../waku/v2/node/peer_manager,
-  ../../../../waku/v2/node/waku_node
+  ../../../protocol/waku_message,
+  ../../../protocol/waku_filter,
+  ../../../protocol/waku_filter/rpc,
+  ../../../protocol/waku_filter/client,
+  ../../message_cache,
+  ../../peer_manager,
+  ../../waku_node
 
 
 logScope:

--- a/waku/v2/node/jsonrpc/message.nim
+++ b/waku/v2/node/jsonrpc/message.nim
@@ -3,9 +3,9 @@ import
   json,
   json_rpc/rpcserver
 import
-  ../../../waku/common/base64,
-  ../../../waku/v2/protocol/waku_message,
-  ../../../waku/v2/utils/time
+  ../../../common/base64,
+  ../../protocol/waku_message,
+  ../../utils/time
 
 
 type

--- a/waku/v2/node/jsonrpc/relay/client.nim
+++ b/waku/v2/node/jsonrpc/relay/client.nim
@@ -7,8 +7,8 @@ import
   std/[os, strutils],
   json_rpc/rpcclient
 import
-  ../../../../waku/v2/protocol/waku_message,
-  ../../../../waku/v2/utils/compat,
+  ../../../protocol/waku_message,
+  ../../../utils/compat,
   ./types
 
 export types

--- a/waku/v2/node/jsonrpc/relay/handlers.nim
+++ b/waku/v2/node/jsonrpc/relay/handlers.nim
@@ -10,13 +10,13 @@ import
   eth/keys,
   nimcrypto/sysrand
 import
-  ../../../../waku/common/base64,
-  ../../../../waku/v2/protocol/waku_message,
-  ../../../../waku/v2/protocol/waku_relay,
-  ../../../../waku/v2/node/waku_node,
-  ../../../../waku/v2/node/message_cache,
-  ../../../../waku/v2/utils/compat,
-  ../../../../waku/v2/utils/time,
+  ../../../../common/base64,
+  ../../../protocol/waku_message,
+  ../../../protocol/waku_relay,
+  ../../../utils/compat,
+  ../../../utils/time,
+  ../../waku_node,
+  ../../message_cache,
   ./types
 
 

--- a/waku/v2/node/jsonrpc/store/client.nim
+++ b/waku/v2/node/jsonrpc/store/client.nim
@@ -7,8 +7,8 @@ import
   std/[os, strutils],
   json_rpc/rpcclient
 import
-  ../../../../waku/v2/protocol/waku_store/rpc,
-  ../../../../waku/v2/utils/time,
+  ../../../protocol/waku_store/rpc,
+  ../../../utils/time,
   ./types
 
 export types

--- a/waku/v2/node/jsonrpc/store/handlers.nim
+++ b/waku/v2/node/jsonrpc/store/handlers.nim
@@ -8,11 +8,11 @@ import
   chronicles,
   json_rpc/rpcserver
 import
-  ../../../../../waku/v2/protocol/waku_store,
-  ../../../../../waku/v2/protocol/waku_store/rpc,
-  ../../../../../waku/v2/utils/time,
-  ../../../../waku/v2/node/waku_node,
-  ../../../../waku/v2/node/peer_manager,
+  ../../../protocol/waku_store,
+  ../../../protocol/waku_store/rpc,
+  ../../../utils/time,
+  ../../waku_node,
+  ../../peer_manager,
   ./types
 
 

--- a/waku/v2/node/jsonrpc/store/types.nim
+++ b/waku/v2/node/jsonrpc/store/types.nim
@@ -6,7 +6,7 @@ else:
 import
   std/options
 import
-  ../../../../waku/v2/protocol/waku_store/rpc,
+  ../../../protocol/waku_store/rpc,
   ../message
 
 export message

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -11,8 +11,8 @@ import
   metrics,
   libp2p/multistream
 import
+  ../../protocol/waku_relay,
   ../../utils/peers,
-  ../../waku/v2/protocol/waku_relay,
   ./peer_store/peer_storage,
   ./waku_peer_store
 

--- a/waku/v2/node/rest/debug/handlers.nim
+++ b/waku/v2/node/rest/debug/handlers.nim
@@ -8,7 +8,7 @@ import
   json_serialization,
   presto/route
 import
-  ../../../../waku/v2/node/waku_node,
+  ../../waku_node,
   ../responses,
   ../serdes,
   ./types

--- a/waku/v2/node/rest/debug/types.nim
+++ b/waku/v2/node/rest/debug/types.nim
@@ -8,7 +8,7 @@ import
   json_serialization,
   json_serialization/std/options
 import
-  ../../../../waku/v2/node/waku_node,
+  ../../waku_node,
   ../serdes
 
 #### Types

--- a/waku/v2/node/rest/relay/client.nim
+++ b/waku/v2/node/rest/relay/client.nim
@@ -11,7 +11,7 @@ import
   json_serialization/std/options,
   presto/[route, client, common]
 import
-  ../../../../waku/v2/protocol/waku_message,
+  ../../../protocol/waku_message,
   ../serdes,
   ../responses,
   ./types

--- a/waku/v2/node/rest/relay/handlers.nim
+++ b/waku/v2/node/rest/relay/handlers.nim
@@ -12,7 +12,7 @@ import
   presto/route,
   presto/common
 import
-  ../../../../waku/v2/node/waku_node,
+  ../../waku_node,
   ../serdes,
   ../responses,
   ./types,

--- a/waku/v2/node/rest/relay/topic_cache.nim
+++ b/waku/v2/node/rest/relay/topic_cache.nim
@@ -7,9 +7,9 @@ import
   chronos,
   chronicles
 import
-  ../../../../waku/v2/protocol/waku_relay,
-  ../../../../waku/v2/protocol/waku_message,
-  ../../../../waku/v2/node/message_cache
+  ../../../protocol/waku_relay,
+  ../../../protocol/waku_message,
+  ../../message_cache
 
 export message_cache
 

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -37,16 +37,20 @@ else:
 
 import
   std/[tables, options, json],
+  stew/results,
+  chronos,
+  chronicles,
+  metrics,
   bearssl/rand,
-  chronos, chronicles, metrics, stew/results,
   libp2p/crypto/crypto,
   libp2p/protocols/protocol,
   libp2p/protobuf/minprotobuf,
-  libp2p/stream/connection,
-  ../../node/peer_manager,
-  ./waku_swap_types,
+  libp2p/stream/connection
+import
   ../../../common/protobuf,
-  ../../waku/v2/protocol/waku_swap/waku_swap_contracts
+  ../../node/peer_manager,
+  ./waku_swap_contracts,
+  ./waku_swap_types
 
 export waku_swap_types
 


### PR DESCRIPTION
From discord (@arnetheduck):

> hm, looks like some waku imports are a bit off - take for example https://github.com/waku-org/nwaku/blob/master/waku/v2/node/peer_manager/peer_manager.nim#L15 - the ../.. works because of an unfortunate quirk in Nim when compiling a top-level project in a suitable folder, but the file is actually not available in that location - instead, it actually resides in ../../../../waku/v2/protocol/waku_relay (or simply ../protocol/waku_relay) preventing the use of the module from "outside", ie when importing waku in a stand-alone application - I think this might be the leftover of some refactoring? cc @LNSD 

This PR aims to fix this issue.
