### PR TITLE
chore(rln-relay): msg validation according to new circuit

### DIFF
--- a/waku/v2/protocol/waku_rln_relay/conversion_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/conversion_utils.nim
@@ -19,7 +19,8 @@ export
   web3,
   chronicles,
   stint,
-  constants
+  constants,
+  endians2
 
 logScope:
     topics = "waku rln_relay conversion_utils"

--- a/waku/v2/protocol/waku_rln_relay/protocol_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/protocol_types.nim
@@ -56,6 +56,7 @@ type ProofMetadata* = object
   nullifier*: Nullifier
   shareX*: MerkleNode
   shareY*: MerkleNode
+  externalNullifier*: Nullifier
 
 type
   MessageValidationResult* {.pure.} = enum


### PR DESCRIPTION
This PR fixes https://github.com/waku-org/nwaku/issues/1451

Functional changes in rln-relay:
- instead of using the `epoch` as the key, we now use the `external_nullifier`, which is a combination of the `epoch`, and the `rlnIdentifier`. This fixes the case when rln-relay was erroneously storing messages from multiple rln apps (linked to rlnIdentifiers) (which run on the same content topic/pubsub topic combination) which had the same epoch

