### PR TITLE
refactor(enr): node capabilities code clean up and reorganization

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -269,10 +269,12 @@ proc initNode(conf: WakuNodeConf,
                     else:
                       @[]
 
-    wakuFlags = initWakuFlags(conf.lightpush,
-                              conf.filter,
-                              conf.store,
-                              conf.relay)
+    wakuFlags = CapabilitiesBitfield.init(
+        lightpush = conf.lightpush,
+        filter = conf.filter,
+        store = conf.store,
+        relay = conf.relay
+      )
 
   var node: WakuNode
 

--- a/examples/v2/publisher.nim
+++ b/examples/v2/publisher.nim
@@ -36,7 +36,7 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
         nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
         ip = ValidIpAddress.init("0.0.0.0")
         node = WakuNode.new(nodeKey, ip, Port(wakuPort))
-        flags = initWakuFlags(lightpush = false, filter = false, store = false, relay = true)
+        flags = CapabilitiesBitfield.init(lightpush = false, filter = false, store = false, relay = true)
 
     # assumes behind a firewall, so not care about being discoverable
     node.wakuDiscv5 = WakuDiscoveryV5.new(

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -32,7 +32,7 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
         nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
         ip = ValidIpAddress.init("0.0.0.0")
         node = WakuNode.new(nodeKey, ip, Port(wakuPort))
-        flags = initWakuFlags(lightpush = false, filter = false, store = false, relay = true)
+        flags = CapabilitiesBitfield.init(lightpush = false, filter = false, store = false, relay = true)
 
     # assumes behind a firewall, so not care about being discoverable
     node.wakuDiscv5 = WakuDiscoveryV5.new(

--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -38,10 +38,12 @@ procSuite "Waku Discovery v5":
       nodeUdpPort3 = Port(9004)
       node3 = WakuNode.new(nodeKey3, bindIp, nodeTcpPort3)
 
-      flags = initWakuFlags(lightpush = false,
-                            filter = false,
-                            store = false,
-                            relay = true)
+      flags = CapabilitiesBitfield.init(
+                lightpush = false,
+                filter = false,
+                store = false,
+                relay = true
+              )
 
       # E2E relay test paramaters
       pubSubTopic = "/waku/2/default-waku/proto"
@@ -128,10 +130,12 @@ procSuite "Waku Discovery v5":
       extIp = ValidIpAddress.init("127.0.0.1")
       expectedMultiAddr = MultiAddress.init("/ip4/200.200.200.200/tcp/9000/wss").tryGet()
 
-      flags = initWakuFlags(lightpush = false,
-                            filter = false,
-                            store = false,
-                            relay = true)
+      flags = CapabilitiesBitfield.init(
+                lightpush = false,
+                filter = false,
+                store = false,
+                relay = true
+              )
 
       nodeTcpPort1 = Port(9010)
       nodeUdpPort1 = Port(9012)

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -89,10 +89,12 @@ procSuite "Waku Peer Exchange":
       node3 = WakuNode.new(nodeKey3, bindIp, nodeTcpPort3)
 
       # todo: px flag
-      flags = initWakuFlags(lightpush = false,
-                            filter = false,
-                            store = false,
-                            relay = true)
+      flags = CapabilitiesBitfield.init(
+                lightpush = false,
+                filter = false,
+                store = false,
+                relay = true
+              )
 
     # Mount discv5
     node1.wakuDiscv5 = WakuDiscoveryV5.new(

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -224,7 +224,7 @@ proc initAndStartNode(conf: NetworkMonitorConf): Result[WakuNode, string] =
     nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
     nodeTcpPort = Port(60000)
     nodeUdpPort = Port(9000)
-    flags = initWakuFlags(lightpush = false, filter = false, store = false, relay = true)
+    flags = CapabilitiesBitfield.init(lightpush = false, filter = false, store = false, relay = true)
 
   try:
     let

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -135,7 +135,7 @@ type NetConfig* = object
   enrIp*: Option[ValidIpAddress]
   enrPort*: Option[Port]
   discv5UdpPort*: Option[Port]
-  wakuFlags*: Option[WakuEnrBitfield]
+  wakuFlags*: Option[CapabilitiesBitfield]
   bindIp*: ValidIpAddress
   bindPort*: Port
 
@@ -151,7 +151,7 @@ proc init*(
   wssEnabled: bool = false,
   dns4DomainName = none(string),
   discv5UdpPort = none(Port),
-  wakuFlags = none(WakuEnrBitfield)
+  wakuFlags = none(CapabilitiesBitfield)
 ): T {.raises: [LPError]} =
   ## Initialize addresses
   let
@@ -230,7 +230,7 @@ proc getEnr*(netConfig: NetConfig,
   if wakuDiscV5.isSome():
     return wakuDiscV5.get().protocol.getRecord()
 
-  return enr.Record.init(nodekey,
+  return enr.Record.init(1, nodekey,
                          netConfig.enrIp,
                          netConfig.enrPort,
                          netConfig.discv5UdpPort,
@@ -275,7 +275,7 @@ proc new*(T: type WakuNode,
           wssEnabled: bool = false,
           secureKey: string = "",
           secureCert: string = "",
-          wakuFlags = none(WakuEnrBitfield),
+          wakuFlags = none(CapabilitiesBitfield),
           nameResolver: NameResolver = nil,
           sendSignedPeerRecord = false,
           dns4DomainName = none(string),

--- a/waku/v2/protocol/waku_discv5.nim
+++ b/waku/v2/protocol/waku_discv5.nim
@@ -72,10 +72,10 @@ proc addBootstrapNode*(bootstrapAddr: string,
           bootstrapAddr, reason = enrRes.error
 
 proc isWakuNode(node: Node): bool =
-  let wakuField = node.record.tryGet(WAKU_ENR_FIELD, uint8)
+  let wakuField = node.record.tryGet(CapabilitiesEnrField, uint8)
 
   if wakuField.isSome():
-    return wakuField.get().WakuEnrBitfield != 0x00 # True if any flag set to true
+    return wakuField.get() != 0x00 # True if any flag set to true
 
   return false
 
@@ -116,14 +116,14 @@ proc new*(T: type WakuDiscoveryV5,
           bootstrapEnrs = newSeq[enr.Record](),
           enrAutoUpdate = false,
           privateKey: keys.PrivateKey,
-          flags: WakuEnrBitfield,
+          flags: CapabilitiesBitfield,
           multiaddrs = newSeq[MultiAddress](),
           rng: ref HmacDrbgContext,
           discv5Config: protocol.DiscoveryConfig = protocol.defaultDiscoveryConfig): T =
   ## TODO: consider loading from a configurable bootstrap file
 
   ## We always add the waku field as specified
-  var enrInitFields = @[(WAKU_ENR_FIELD, @[flags.byte])]
+  var enrInitFields = @[(CapabilitiesEnrField, @[flags.byte])]
 
   ## Add multiaddresses to ENR
   if multiaddrs.len > 0:
@@ -151,7 +151,7 @@ proc new*(T: type WakuDiscoveryV5,
           bootstrapNodes: seq[string],
           enrAutoUpdate = false,
           privateKey: keys.PrivateKey,
-          flags: WakuEnrBitfield,
+          flags: CapabilitiesBitfield,
           multiaddrs = newSeq[MultiAddress](),
           rng: ref HmacDrbgContext,
           discv5Config: protocol.DiscoveryConfig = protocol.defaultDiscoveryConfig): T =


### PR DESCRIPTION
This is part of the ENR and discovery refactoring groundworks for static sharding:

- [x] Refactor the capabilities bitfield and the associated procedures
- [x] Support specifying the ENR sequence number in the extension method
- [x] Updated tests and dependent modules accordingly