### PR TITLE
refactor(networking): unify peer data models, remove StoredInfo

### DIFF
--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -105,13 +105,13 @@ procSuite "Peer Manager":
       node.peerManager.peerStore.peers().len == 3
       node.peerManager.peerStore.peers(WakuFilterCodec).allIt(it.peerId == filterPeer.peerId and
                                                               it.addrs.contains(filterLoc) and
-                                                              it.protos.contains(WakuFilterCodec))
+                                                              it.protocols.contains(WakuFilterCodec))
       node.peerManager.peerStore.peers(WakuSwapCodec).allIt(it.peerId == swapPeer.peerId and
                                                             it.addrs.contains(swapLoc) and
-                                                            it.protos.contains(WakuSwapCodec))
+                                                            it.protocols.contains(WakuSwapCodec))
       node.peerManager.peerStore.peers(WakuStoreCodec).allIt(it.peerId == storePeer.peerId and
                                                              it.addrs.contains(storeLoc) and
-                                                             it.protos.contains(WakuStoreCodec))
+                                                             it.protocols.contains(WakuStoreCodec))
 
     await node.stop()
 
@@ -270,7 +270,7 @@ procSuite "Peer Manager":
       # Currently connected to node2
       node1.peerManager.peerStore.peers().len == 1
       node1.peerManager.peerStore.peers().anyIt(it.peerId == peerInfo2.peerId)
-      node1.peerManager.peerStore.peers().anyIt(it.protos.contains(node2.wakuRelay.codec))
+      node1.peerManager.peerStore.peers().anyIt(it.protocols.contains(node2.wakuRelay.codec))
       node1.peerManager.peerStore.connectedness(peerInfo2.peerId) == Connected
 
     # Simulate restart by initialising a new node using the same storage
@@ -286,7 +286,7 @@ procSuite "Peer Manager":
       # Node2 has been loaded after "restart", but we have not yet reconnected
       node3.peerManager.peerStore.peers().len == 1
       node3.peerManager.peerStore.peers().anyIt(it.peerId == peerInfo2.peerId)
-      node3.peerManager.peerStore.peers().anyIt(it.protos.contains(betaCodec))
+      node3.peerManager.peerStore.peers().anyIt(it.protocols.contains(betaCodec))
       node3.peerManager.peerStore.connectedness(peerInfo2.peerId) == NotConnected
 
     await node3.start() # This should trigger a reconnect
@@ -295,8 +295,8 @@ procSuite "Peer Manager":
       # Reconnected to node2 after "restart"
       node3.peerManager.peerStore.peers().len == 1
       node3.peerManager.peerStore.peers().anyIt(it.peerId == peerInfo2.peerId)
-      node3.peerManager.peerStore.peers().anyIt(it.protos.contains(betaCodec))
-      node3.peerManager.peerStore.peers().anyIt(it.protos.contains(stableCodec))
+      node3.peerManager.peerStore.peers().anyIt(it.protocols.contains(betaCodec))
+      node3.peerManager.peerStore.peers().anyIt(it.protocols.contains(stableCodec))
       node3.peerManager.peerStore.connectedness(peerInfo2.peerId) == Connected
 
     await allFutures([node1.stop(), node2.stop(), node3.stop()])

--- a/tests/v2/test_peer_store_extended.nim
+++ b/tests/v2/test_peer_store_extended.nim
@@ -103,37 +103,37 @@ suite "Extended nim-libp2p Peer Store":
 
   test "get() returns the correct StoredInfo for a given PeerId":
     # When
-    let storedInfoPeer1 = peerStore.get(p1)
-    let storedInfoPeer6 = peerStore.get(p6)
+    let peer1 = peerStore.get(p1)
+    let peer6 = peerStore.get(p6)
 
     # Then
     check:
       # regression on nim-libp2p fields
-      storedInfoPeer1.peerId == p1
-      storedInfoPeer1.addrs == @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
-      storedInfoPeer1.protos == @["/vac/waku/relay/2.0.0-beta1", "/vac/waku/store/2.0.0"]
-      storedInfoPeer1.agent == "nwaku"
-      storedInfoPeer1.protoVersion == "protoVersion1"
+      peer1.peerId == p1
+      peer1.addrs == @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
+      peer1.protocols == @["/vac/waku/relay/2.0.0-beta1", "/vac/waku/store/2.0.0"]
+      peer1.agent == "nwaku"
+      peer1.protoVersion == "protoVersion1"
 
       # our extended fields
-      storedInfoPeer1.connectedness == Connected
-      storedInfoPeer1.disconnectTime == 0
-      storedInfoPeer1.origin == Discv5
-      storedInfoPeer1.numberFailedConn == 1
-      storedInfoPeer1.lastFailedConn == Moment.init(1001, Second)
+      peer1.connectedness == Connected
+      peer1.disconnectTime == 0
+      peer1.origin == Discv5
+      peer1.numberFailedConn == 1
+      peer1.lastFailedConn == Moment.init(1001, Second)
 
     check:
       # fields are empty, not part of the peerstore
-      storedInfoPeer6.peerId == p6
-      storedInfoPeer6.addrs.len == 0
-      storedInfoPeer6.protos.len == 0
-      storedInfoPeer6.agent == default(string)
-      storedInfoPeer6.protoVersion == default(string)
-      storedInfoPeer6.connectedness == default(Connectedness)
-      storedInfoPeer6.disconnectTime == default(int)
-      storedInfoPeer6.origin == default(PeerOrigin)
-      storedInfoPeer6.numberFailedConn == default(int)
-      storedInfoPeer6.lastFailedConn == default(Moment)
+      peer6.peerId == p6
+      peer6.addrs.len == 0
+      peer6.protocols.len == 0
+      peer6.agent == default(string)
+      peer6.protoVersion == default(string)
+      peer6.connectedness == default(Connectedness)
+      peer6.disconnectTime == default(int)
+      peer6.origin == default(PeerOrigin)
+      peer6.numberFailedConn == default(int)
+      peer6.lastFailedConn == default(Moment)
 
   test "peers() returns all StoredInfo of the PeerStore":
     # When
@@ -153,7 +153,7 @@ suite "Extended nim-libp2p Peer Store":
     check:
       # regression on nim-libp2p fields
       p3.addrs == @[MultiAddress.init("/ip4/127.0.0.1/tcp/3").tryGet()]
-      p3.protos == @["/vac/waku/lightpush/2.0.0", "/vac/waku/store/2.0.0-beta1"]
+      p3.protocols == @["/vac/waku/lightpush/2.0.0", "/vac/waku/store/2.0.0-beta1"]
       p3.agent == "gowaku"
       p3.protoVersion == "protoVersion3"
 
@@ -180,7 +180,7 @@ suite "Extended nim-libp2p Peer Store":
       # Only p3 supports that protocol
       lpPeers.len == 1
       lpPeers.anyIt(it.peerId == p3)
-      lpPeers[0].protos == @["/vac/waku/lightpush/2.0.0", "/vac/waku/store/2.0.0-beta1"]
+      lpPeers[0].protocols == @["/vac/waku/lightpush/2.0.0", "/vac/waku/store/2.0.0-beta1"]
 
   test "peers() returns all StoredInfo matching a given protocolMatcher":
     # When
@@ -197,28 +197,25 @@ suite "Extended nim-libp2p Peer Store":
       pMatcherStorePeers.anyIt(it.peerId == p5)
 
     check:
-      pMatcherStorePeers.filterIt(it.peerId == p1)[0].protos == @["/vac/waku/relay/2.0.0-beta1", "/vac/waku/store/2.0.0"]
-      pMatcherStorePeers.filterIt(it.peerId == p2)[0].protos == @["/vac/waku/relay/2.0.0", "/vac/waku/store/2.0.0"]
-      pMatcherStorePeers.filterIt(it.peerId == p3)[0].protos == @["/vac/waku/lightpush/2.0.0", "/vac/waku/store/2.0.0-beta1"]
-      pMatcherStorePeers.filterIt(it.peerId == p5)[0].protos == @["/vac/waku/swap/2.0.0", "/vac/waku/store/2.0.0-beta2"]
+      pMatcherStorePeers.filterIt(it.peerId == p1)[0].protocols == @["/vac/waku/relay/2.0.0-beta1", "/vac/waku/store/2.0.0"]
+      pMatcherStorePeers.filterIt(it.peerId == p2)[0].protocols == @["/vac/waku/relay/2.0.0", "/vac/waku/store/2.0.0"]
+      pMatcherStorePeers.filterIt(it.peerId == p3)[0].protocols == @["/vac/waku/lightpush/2.0.0", "/vac/waku/store/2.0.0-beta1"]
+      pMatcherStorePeers.filterIt(it.peerId == p5)[0].protocols == @["/vac/waku/swap/2.0.0", "/vac/waku/store/2.0.0-beta2"]
 
     check:
       pMatcherSwapPeers.len == 1
       pMatcherSwapPeers.anyIt(it.peerId == p5)
-      pMatcherSwapPeers[0].protos == @["/vac/waku/swap/2.0.0", "/vac/waku/store/2.0.0-beta2"]
+      pMatcherSwapPeers[0].protocols == @["/vac/waku/swap/2.0.0", "/vac/waku/store/2.0.0-beta2"]
 
   test "toRemotePeerInfo() converts a StoredInfo to a RemotePeerInfo":
     # Given
-    let storedInfoPeer1 = peerStore.get(p1)
-
-    # When
-    let remotePeerInfo1 = storedInfoPeer1.toRemotePeerInfo()
+    let peer1 = peerStore.get(p1)
 
     # Then
     check:
-      remotePeerInfo1.peerId == p1
-      remotePeerInfo1.addrs == @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
-      remotePeerInfo1.protocols == @["/vac/waku/relay/2.0.0-beta1", "/vac/waku/store/2.0.0"]
+      peer1.peerId == p1
+      peer1.addrs == @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
+      peer1.protocols == @["/vac/waku/relay/2.0.0-beta1", "/vac/waku/store/2.0.0"]
 
   test "connectedness() returns the connection status of a given PeerId":
     check:

--- a/waku/v2/node/jsonrpc/admin/handlers.nim
+++ b/waku/v2/node/jsonrpc/admin/handlers.nim
@@ -38,13 +38,6 @@ proc constructMultiaddrStr*(remotePeerInfo: RemotePeerInfo): string =
     return ""
   constructMultiaddrStr(remotePeerInfo.addrs[0], remotePeerInfo.peerId)
 
-proc constructMultiaddrStr*(storedInfo: StoredInfo): string =
-  # Constructs a multiaddress with both location (wire) address and p2p identity
-  if storedInfo.addrs.len == 0:
-    return ""
-  constructMultiaddrStr(storedInfo.addrs[0], storedInfo.peerId)
-
-
 proc installAdminApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   rpcsrv.rpc("post_waku_v2_admin_v1_peers") do (peers: seq[string]) -> bool:

--- a/waku/v2/node/peer_manager/peer_store/peer_storage.nim
+++ b/waku/v2/node/peer_manager/peer_store/peer_storage.nim
@@ -7,14 +7,15 @@ else:
 import
   stew/results
 import
-  ../waku_peer_store
+  ../waku_peer_store,
+  ../../../utils/peers
 
 ## This module defines a peer storage interface. Implementations of
 ## PeerStorage are used to store and retrieve peers
 
 type
   PeerStorage* = ref object of RootObj
-  
+
   PeerStorageResult*[T] = Result[T, string]
 
   DataProc* = proc(peerId: PeerID, storedInfo: StoredInfo,

--- a/waku/v2/node/peer_manager/peer_store/peer_storage.nim
+++ b/waku/v2/node/peer_manager/peer_store/peer_storage.nim
@@ -18,13 +18,13 @@ type
 
   PeerStorageResult*[T] = Result[T, string]
 
-  DataProc* = proc(peerId: PeerID, storedInfo: StoredInfo,
+  DataProc* = proc(peerId: PeerID, remotePeerInfo: RemotePeerInfo,
                    connectedness: Connectedness, disconnectTime: int64) {.closure, raises: [Defect].}
 
 # PeerStorage interface
 method put*(db: PeerStorage,
             peerId: PeerID,
-            storedInfo: StoredInfo,
+            remotePeerInfo: RemotePeerInfo,
             connectedness: Connectedness,
             disconnectTime: int64): PeerStorageResult[void] {.base.} = discard
 

--- a/waku/v2/node/peer_manager/peer_store/waku_peer_storage.nim
+++ b/waku/v2/node/peer_manager/peer_store/waku_peer_storage.nim
@@ -34,31 +34,31 @@ proc init*(T: type RemotePeerInfo, buffer: seq[byte]): ProtoResult[T] =
 
   var pb = initProtoBuffer(buffer)
 
-  #discard ? pb.getField(1, storedInfo.peerId)
-  #discard ? pb.getRepeatedField(2, multiaddrSeq)
-  #discard ? pb.getRepeatedField(3, protoSeq)
-  #discard ? pb.getField(4, storedInfo.publicKey)
+  discard ? pb.getField(1, storedInfo.peerId)
+  discard ? pb.getRepeatedField(2, multiaddrSeq)
+  discard ? pb.getRepeatedField(3, protoSeq)
+  discard ? pb.getField(4, storedInfo.publicKey)
 
-  #storedInfo.addrs = multiaddrSeq
-  #storedInfo.protos = protoSeq
+  storedInfo.addrs = multiaddrSeq
+  storedInfo.protocols = protoSeq
 
   ok(storedInfo)
 
 proc encode*(remotePeerInfo: RemotePeerInfo): PeerStorageResult[ProtoBuffer] =
   var pb = initProtoBuffer()
 
-  #pb.write(1, storedInfo.peerId)
+  pb.write(1, remotePeerInfo.peerId)
 
-  #for multiaddr in storedInfo.addrs.items:
-  #  pb.write(2, multiaddr)
+  for multiaddr in remotePeerInfo.addrs.items:
+    pb.write(2, multiaddr)
 
-  #for proto in storedInfo.protos.items:
-  #  pb.write(3, proto)
+  for proto in remotePeerInfo.protocols.items:
+    pb.write(3, proto)
 
-  #try:
-  #  pb.write(4, storedInfo.publicKey)
-  #except ResultError[CryptoError] as e:
-  #  return err("Failed to encode public key")
+  try:
+    pb.write(4, remotePeerInfo.publicKey)
+  except ResultError[CryptoError] as e:
+    return err("Failed to encode public key")
 
   ok(pb)
 

--- a/waku/v2/node/peer_manager/peer_store/waku_peer_storage.nim
+++ b/waku/v2/node/peer_manager/peer_store/waku_peer_storage.nim
@@ -39,6 +39,8 @@ proc init*(T: type RemotePeerInfo, buffer: seq[byte]): ProtoResult[T] =
   discard ? pb.getRepeatedField(3, protoSeq)
   discard ? pb.getField(4, storedInfo.publicKey)
 
+  # TODO: Store the rest of parameters such as connectedness and disconnectTime
+
   storedInfo.addrs = multiaddrSeq
   storedInfo.protocols = protoSeq
 
@@ -77,6 +79,8 @@ proc new*(T: type WakuPeerStorage, db: SqliteDatabase): PeerStorageResult[T] =
   ##  - stored info (serialised protobuf), stored as a blob
   ##  - last known enumerated connectedness state, stored as an integer
   ##  - disconnect time in epoch seconds, if applicable
+
+  # TODO: connectedness and disconnectTime are now stored in the storedInfo type
   let
     createStmt = db.prepareStmt("""
       CREATE TABLE IF NOT EXISTS Peer (

--- a/waku/v2/node/peer_manager/peer_store/waku_peer_storage.nim
+++ b/waku/v2/node/peer_manager/peer_store/waku_peer_storage.nim
@@ -26,39 +26,39 @@ type
 # Protobuf Serialisation #
 ##########################
 
-proc init*(T: type StoredInfo, buffer: seq[byte]): ProtoResult[T] =
+proc init*(T: type RemotePeerInfo, buffer: seq[byte]): ProtoResult[T] =
   var
     multiaddrSeq: seq[MultiAddress]
     protoSeq: seq[string]
-    storedInfo = StoredInfo()
+    storedInfo = RemotePeerInfo()
 
   var pb = initProtoBuffer(buffer)
 
-  discard ? pb.getField(1, storedInfo.peerId)
-  discard ? pb.getRepeatedField(2, multiaddrSeq)
-  discard ? pb.getRepeatedField(3, protoSeq)
-  discard ? pb.getField(4, storedInfo.publicKey)
+  #discard ? pb.getField(1, storedInfo.peerId)
+  #discard ? pb.getRepeatedField(2, multiaddrSeq)
+  #discard ? pb.getRepeatedField(3, protoSeq)
+  #discard ? pb.getField(4, storedInfo.publicKey)
 
-  storedInfo.addrs = multiaddrSeq
-  storedInfo.protos = protoSeq
+  #storedInfo.addrs = multiaddrSeq
+  #storedInfo.protos = protoSeq
 
   ok(storedInfo)
 
-proc encode*(storedInfo: StoredInfo): PeerStorageResult[ProtoBuffer] =
+proc encode*(remotePeerInfo: RemotePeerInfo): PeerStorageResult[ProtoBuffer] =
   var pb = initProtoBuffer()
 
-  pb.write(1, storedInfo.peerId)
+  #pb.write(1, storedInfo.peerId)
 
-  for multiaddr in storedInfo.addrs.items:
-    pb.write(2, multiaddr)
+  #for multiaddr in storedInfo.addrs.items:
+  #  pb.write(2, multiaddr)
 
-  for proto in storedInfo.protos.items:
-    pb.write(3, proto)
+  #for proto in storedInfo.protos.items:
+  #  pb.write(3, proto)
 
-  try:
-    pb.write(4, storedInfo.publicKey)
-  except ResultError[CryptoError] as e:
-    return err("Failed to encode public key")
+  #try:
+  #  pb.write(4, storedInfo.publicKey)
+  #except ResultError[CryptoError] as e:
+  #  return err("Failed to encode public key")
 
   ok(pb)
 
@@ -110,12 +110,12 @@ proc new*(T: type WakuPeerStorage, db: SqliteDatabase): PeerStorageResult[T] =
 
 method put*(db: WakuPeerStorage,
             peerId: PeerID,
-            storedInfo: StoredInfo,
+            remotePeerInfo: RemotePeerInfo,
             connectedness: Connectedness,
             disconnectTime: int64): PeerStorageResult[void] =
 
   ## Adds a peer to storage or replaces existing entry if it already exists
-  let encoded = storedInfo.encode()
+  let encoded = remotePeerInfo.encode()
 
   if encoded.isErr:
     return err("failed to encode: " & encoded.error())
@@ -140,7 +140,7 @@ method getAll*(db: WakuPeerStorage, onData: peer_storage.DataProc): PeerStorageR
       # Stored Info
       sTo = cast[ptr UncheckedArray[byte]](sqlite3_column_blob(s, 1))
       sToL = sqlite3_column_bytes(s, 1)
-      storedInfo = StoredInfo.init(@(toOpenArray(sTo, 0, sToL - 1))).tryGet()
+      storedInfo = RemotePeerInfo.init(@(toOpenArray(sTo, 0, sToL - 1))).tryGet()
       # Connectedness
       connectedness = Connectedness(sqlite3_column_int(s, 2))
       # DisconnectTime

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -15,45 +15,6 @@ import
 export peerstore, builders
 
 type
-  Connectedness* = enum
-    # NotConnected: default state for a new peer. No connection and no further information on connectedness.
-    NotConnected,
-    # CannotConnect: attempted to connect to peer, but failed.
-    CannotConnect,
-    # CanConnect: was recently connected to peer and disconnected gracefully.
-    CanConnect,
-    # Connected: actively connected to peer.
-    Connected
-
-  PeerOrigin* = enum
-    UnknownOrigin,
-    Discv5,
-    Static,
-    Dns
-
-  PeerDirection* = enum
-    UnknownDirection,
-    Inbound,
-    Outbound
-
-  # Keeps track of the Connectedness state of a peer
-  ConnectionBook* = ref object of PeerBook[Connectedness]
-
-  # Last failed connection attemp timestamp
-  LastFailedConnBook* = ref object of PeerBook[Moment]
-
-  # Failed connection attempts
-  NumberFailedConnBook* = ref object of PeerBook[int]
-
-  # Keeps track of when peers were disconnected in Unix timestamps
-  DisconnectBook* = ref object of PeerBook[int64]
-
-  # Keeps track of the origin of a peer
-  SourceBook* = ref object of PeerBook[PeerOrigin]
-
-  # Direction
-  DirectionBook* = ref object of PeerBook[PeerDirection]
-
   StoredInfo* = object
     # Taken from nim-libp2
     peerId*: PeerId

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -49,21 +49,21 @@ proc get*(peerStore: PeerStore,
           peerId: PeerID): RemotePeerInfo =
   ## Get the stored information of a given peer.
   RemotePeerInfo(
-    # Taken from nim-libp2
-    #peerId: peerId,
-    #addrs: peerStore[AddressBook][peerId],
-    #protos: peerStore[ProtoBook][peerId],
-    #publicKey: peerStore[KeyBook][peerId],
-    #agent: peerStore[AgentBook][peerId],
-    #protoVersion: peerStore[ProtoVersionBook][peerId],
+    peerId: peerId,
+    addrs: peerStore[AddressBook][peerId],
+    #enr*: Option[enr.Record]  #TODO
+    protocols: peerStore[ProtoBook][peerId],
+    agent: peerStore[AgentBook][peerId],
+    protoVersion: peerStore[ProtoVersionBook][peerId],
+    publicKey: peerStore[KeyBook][peerId],
 
     # Extended custom fields
-    #connectedness: peerStore[ConnectionBook][peerId],
-    #disconnectTime: peerStore[DisconnectBook][peerId],
-    #origin: peerStore[SourceBook][peerId],
-    #direction: peerStore[DirectionBook][peerId],
-    #lastFailedConn: peerStore[LastFailedConnBook][peerId],
-    #numberFailedConn: peerStore[NumberFailedConnBook][peerId]
+    connectedness: peerStore[ConnectionBook][peerId],
+    disconnectTime: peerStore[DisconnectBook][peerId],
+    origin: peerStore[SourceBook][peerId],
+    direction: peerStore[DirectionBook][peerId],
+    lastFailedConn: peerStore[LastFailedConnBook][peerId],
+    numberFailedConn: peerStore[NumberFailedConnBook][peerId]
   )
 
 # TODO: Rename peers() to getPeersByProtocol()

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -6,6 +6,7 @@ else:
 import
   std/[tables, sequtils, sets, options, times, math],
   chronos,
+  eth/p2p/discoveryv5/enr,
   libp2p/builders,
   libp2p/peerstore
 
@@ -51,7 +52,7 @@ proc get*(peerStore: PeerStore,
   RemotePeerInfo(
     peerId: peerId,
     addrs: peerStore[AddressBook][peerId],
-    #enr*: Option[enr.Record]  #TODO
+    enr: if peerStore[ENRBook][peerId] != default(enr.Record): some(peerStore[ENRBook][peerId]) else: none(enr.Record),
     protocols: peerStore[ProtoBook][peerId],
     agent: peerStore[AgentBook][peerId],
     protoVersion: peerStore[ProtoVersionBook][peerId],

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -15,6 +15,29 @@ import
 
 export peerstore, builders
 
+type
+
+  # Keeps track of the Connectedness state of a peer
+  ConnectionBook* = ref object of PeerBook[Connectedness]
+
+  # Last failed connection attemp timestamp
+  LastFailedConnBook* = ref object of PeerBook[Moment]
+
+  # Failed connection attempts
+  NumberFailedConnBook* = ref object of PeerBook[int]
+
+  # Keeps track of when peers were disconnected in Unix timestamps
+  DisconnectBook* = ref object of PeerBook[int64]
+
+  # Keeps track of the origin of a peer
+  SourceBook* = ref object of PeerBook[PeerOrigin]
+
+  # Direction
+  DirectionBook* = ref object of PeerBook[PeerDirection]
+
+  # ENR Book
+  ENRBook* = ref object of PeerBook[enr.Record]
+
 ##################
 # Peer Store API #
 ##################

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -980,7 +980,6 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
     # First get a list of connected peer infos
     let peers = node.peerManager.peerStore.peers()
                                 .filterIt(it.connectedness == Connected)
-                                .mapIt(it.toRemotePeerInfo())
 
     for peer in peers:
       try:

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -585,7 +585,7 @@ proc filterSubscribe*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopics: C
   let remotePeer = when peer is string: parseRemotePeerInfo(peer)
                    else: peer
 
-  info "registering filter subscription to content", pubsubTopic=pubsubTopic, contentTopics=contentTopics, peer=remotePeer
+  info "registering filter subscription to content", pubsubTopic=pubsubTopic, contentTopics=contentTopics, peer=remotePeer.peerId
 
   # Add handler wrapper to store the message when pushed, when relay is disabled and filter enabled
   # TODO: Move this logic to wakunode2 app
@@ -612,7 +612,7 @@ proc filterUnsubscribe*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopics:
   let remotePeer = when peer is string: parseRemotePeerInfo(peer)
                    else: peer
 
-  info "deregistering filter subscription to content", pubsubTopic=pubsubTopic, contentTopics=contentTopics, peer=remotePeer
+  info "deregistering filter subscription to content", pubsubTopic=pubsubTopic, contentTopics=contentTopics, peer=remotePeer.peerId
 
   let unsubRes = await node.wakuFilterClient.unsubscribe(pubsubTopic, contentTopics, peer=remotePeer)
   if unsubRes.isOk():
@@ -854,7 +854,7 @@ proc lightpushPublish*(node: WakuNode, pubsubTopic: PubsubTopic, message: WakuMe
   if node.wakuLightpushClient.isNil():
     return err("waku lightpush client is nil")
 
-  debug "publishing message with lightpush", pubsubTopic=pubsubTopic, contentTopic=message.contentTopic, peer=peer
+  debug "publishing message with lightpush", pubsubTopic=pubsubTopic, contentTopic=message.contentTopic, peer=peer.peerId
 
   return await node.wakuLightpushClient.publish(pubsubTopic, message, peer)
 

--- a/waku/v2/utils/peers.nim
+++ b/waku/v2/utils/peers.nim
@@ -17,7 +17,6 @@ import
           multicodec,
           peerid,
           peerinfo,
-          peerstore,
           routing_record]
 
 #import
@@ -45,27 +44,6 @@ type
     UnknownDirection,
     Inbound,
     Outbound
-
-  # Keeps track of the Connectedness state of a peer
-  ConnectionBook* = ref object of PeerBook[Connectedness]
-
-  # Last failed connection attemp timestamp
-  LastFailedConnBook* = ref object of PeerBook[Moment]
-
-  # Failed connection attempts
-  NumberFailedConnBook* = ref object of PeerBook[int]
-
-  # Keeps track of when peers were disconnected in Unix timestamps
-  DisconnectBook* = ref object of PeerBook[int64]
-
-  # Keeps track of the origin of a peer
-  SourceBook* = ref object of PeerBook[PeerOrigin]
-
-  # Direction
-  DirectionBook* = ref object of PeerBook[PeerDirection]
-
-  # ENR Book
-  ENRBook* = ref object of PeerBook[enr.Record]
 
 type
   RemotePeerInfo* = ref object of RootObj

--- a/waku/v2/utils/peers.nim
+++ b/waku/v2/utils/peers.nim
@@ -64,6 +64,9 @@ type
   # Direction
   DirectionBook* = ref object of PeerBook[PeerDirection]
 
+  # ENR Book
+  ENRBook* = ref object of PeerBook[enr.Record]
+
 type
   RemotePeerInfo* = ref object of RootObj
     peerId*: PeerID

--- a/waku/v2/utils/peers.nim
+++ b/waku/v2/utils/peers.nim
@@ -5,7 +5,8 @@ else:
 
 # Collection of utilities related to Waku peers
 import
-  std/[options, sequtils, strutils],
+  std/[options, sequtils, strutils, times],
+  chronos,
   stew/results,
   stew/shims/net,
   eth/keys,
@@ -16,7 +17,52 @@ import
           multicodec,
           peerid,
           peerinfo,
+          peerstore,
           routing_record]
+
+#import
+#  ../node/peer_manager/waku_peer_store
+# todo organize this
+
+type
+  Connectedness* = enum
+    # NotConnected: default state for a new peer. No connection and no further information on connectedness.
+    NotConnected,
+    # CannotConnect: attempted to connect to peer, but failed.
+    CannotConnect,
+    # CanConnect: was recently connected to peer and disconnected gracefully.
+    CanConnect,
+    # Connected: actively connected to peer.
+    Connected
+
+  PeerOrigin* = enum
+    UnknownOrigin,
+    Discv5,
+    Static,
+    Dns
+
+  PeerDirection* = enum
+    UnknownDirection,
+    Inbound,
+    Outbound
+
+  # Keeps track of the Connectedness state of a peer
+  ConnectionBook* = ref object of PeerBook[Connectedness]
+
+  # Last failed connection attemp timestamp
+  LastFailedConnBook* = ref object of PeerBook[Moment]
+
+  # Failed connection attempts
+  NumberFailedConnBook* = ref object of PeerBook[int]
+
+  # Keeps track of when peers were disconnected in Unix timestamps
+  DisconnectBook* = ref object of PeerBook[int64]
+
+  # Keeps track of the origin of a peer
+  SourceBook* = ref object of PeerBook[PeerOrigin]
+
+  # Direction
+  DirectionBook* = ref object of PeerBook[PeerDirection]
 
 type
   RemotePeerInfo* = ref object of RootObj
@@ -24,6 +70,16 @@ type
     addrs*: seq[MultiAddress]
     enr*: Option[enr.Record]
     protocols*: seq[string]
+
+    agent*: string
+    protoVersion*: string
+    publicKey*: crypto.PublicKey
+    connectedness*: Connectedness
+    disconnectTime*: int64
+    origin*: PeerOrigin
+    direction*: PeerDirection
+    lastFailedConn*: Moment
+    numberFailedConn*: int
 
 func `$`*(remotePeerInfo: RemotePeerInfo): string =
   $remotePeerInfo.peerId


### PR DESCRIPTION
Summary:
* `RemotePeerInfo` and `StoredInfo` store very similar content, being totally redundant.
* Back and forth conversions between both types are all over the codebase.
* This PR unifies `RemotePeerInfo` and `StoredInfo`, removing the later leaving only `RemotePeerInfo`.