### PR TITLE
feat(enr): added enr builder waku capabilities extension

### DIFF
--- a/tests/common/test_enr_builder.nim
+++ b/tests/common/test_enr_builder.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/options ,
+  std/options,
   stew/results,
   stew/shims/net,
   testutils/unittests


### PR DESCRIPTION
This PR introduces the Waku ENR capabilities field extension to the `EnrBuilder` type.

- [x] Added the `EnrBuilder` Waku node capabilities extension.
- [x] Added tests covering this functionality.

