### PR TITLE
feat(rln-relay): fetch release from zerokit ci, or build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ node_modules/
 # RLN / keystore
 rlnCredentials.txt
 rlnKeystore.json
+*.tar.gz
 
 # Nimbus Build System
 nimbus-build-system.paths

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ endif
 
 $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE):
 	echo -e $(BUILD_MSG) "$@" && \
-		./build_rln.sh $(LIBRLN_BUILDDIR)
+		./scripts/build_rln.sh $(LIBRLN_BUILDDIR)
 
 ifneq ($(RLN), true)
 librln: ; # noop

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ endif
 
 ### RLN
 
-LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit/target/release
+LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit
 
 ifeq ($(OS),Windows_NT)
 LIBRLN_FILE := rln.lib
@@ -115,12 +115,12 @@ endif
 
 $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE):
 	echo -e $(BUILD_MSG) "$@" && \
-		cargo build --manifest-path vendor/zerokit/rln/Cargo.toml --release
+		./build_rln.sh $(LIBRLN_BUILDDIR)
 
 ifneq ($(RLN), true)
 librln: ; # noop
 else
-EXPERIMENTAL_PARAMS += -d:rln --passL:$(LIBRLN_BUILDDIR)/$(LIBRLN_FILE) --passL:-lm
+EXPERIMENTAL_PARAMS += -d:rln --passL:$(LIBRLN_FILE) --passL:-lm
 librln: $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE)
 endif
 

--- a/build_rln.sh
+++ b/build_rln.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# This script is used to build the rln library for the current platform, or download it from the
+# release page if it is available.
+
+set -e
+
+# first argument is the build directory
+build_dir=$1
+
+if [ -z "$build_dir" ]; then
+    echo "No build directory specified"
+    exit 1
+fi
+
+# Get the host triplet
+host_triplet=$(rustup show | grep "Default host: " | cut -d' ' -f3)
+
+# Download the prebuilt rln library if it is available
+if wget https://github.com/vacp2p/zerokit/releases/download/nightly/$host_triplet-rln.tar.gz
+then
+    echo "Downloaded $host_triplet-rln.tar.gz"
+    tar -xzf $host_triplet-rln.tar.gz
+    mv release/librln.a .
+    rm -rf $host_triplet-rln.tar.gz release
+else
+    echo "Failed to download $host_triplet-rln.tar.gz"
+    # Build rln instead
+    cargo build --release --manifest-path $build_dir/rln/Cargo.toml
+    cp $build_dir/rln/target/release/librln.a .
+fi

--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -8,7 +8,7 @@ set -e
 # first argument is the build directory
 build_dir=$1
 
-if [ -z "$build_dir" ]; then
+if [[ -z "$build_dir" ]]; then
     echo "No build directory specified"
     exit 1
 fi
@@ -17,15 +17,15 @@ fi
 host_triplet=$(rustup show | grep "Default host: " | cut -d' ' -f3)
 
 # Download the prebuilt rln library if it is available
-if wget https://github.com/vacp2p/zerokit/releases/download/nightly/$host_triplet-rln.tar.gz
+if curl --silent --fail-with-body -L "https://github.com/vacp2p/zerokit/releases/download/nightly/$host_triplet-rln.tar.gz" >> "$host_triplet-rln.tar.gz"
 then
     echo "Downloaded $host_triplet-rln.tar.gz"
-    tar -xzf $host_triplet-rln.tar.gz
+    tar -xzf "$host_triplet-rln.tar.gz"
     mv release/librln.a .
-    rm -rf $host_triplet-rln.tar.gz release
+    rm -rf "$host_triplet-rln.tar.gz" release
 else
     echo "Failed to download $host_triplet-rln.tar.gz"
     # Build rln instead
-    cargo build --release --manifest-path $build_dir/rln/Cargo.toml
-    cp $build_dir/rln/target/release/librln.a .
+    cargo build --release --manifest-path "$build_dir/rln/Cargo.toml"
+    cp "$build_dir/rln/target/release/librln.a" .
 fi


### PR DESCRIPTION
This PR introduces a script, `build_rln.sh` that extracts the host triple, checks if a zerokit release asset exists for it, and if not, builds zerokit from scratch.

Zerokit supports 6 target architectures at the moment, and it is possible that some users will need to build it manually when compiling nwaku with experimental features enabled. I propose that we continue to use zerokit as a submodule for this reason.

