### PR TITLE
docker: add dash between target and version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ DOCKER_IMAGE_NIMFLAGS ?= -d:chronicles_colors:none -d:insecure
 
 # build a docker image for the fleet
 docker-image: MAKE_TARGET ?= wakunode2
-docker-image: DOCKER_IMAGE_TAG ?= $(MAKE_TARGET)$(GIT_VERSION)
+docker-image: DOCKER_IMAGE_TAG ?= $(MAKE_TARGET)-$(GIT_VERSION)
 docker-image: DOCKER_IMAGE_NAME ?= statusteam/nim-waku:$(DOCKER_IMAGE_TAG)
 docker-image:
 	docker build \


### PR DESCRIPTION
Instead of ugly:
```
statusteam/nim-waku:wakunode2v0.16.0-1-gb495dd
```
Create better looking:
```
statusteam/nim-waku:wakunode2-v0.16.0-1-gb495dd
```
Annoys me every time I use it.