### PR TITLE
fix: connect instead dial relay peer

### DIFF
--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -138,9 +138,9 @@ suite "WakuNode":
     await node3.start()
     await node3.mountRelay()
 
-    discard await node1.peerManager.dialPeer(node2.switch.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
+    discard await node1.peerManager.connectRelay(node2.switch.peerInfo.toRemotePeerInfo())
     await sleepAsync(3.seconds)
-    discard await node1.peerManager.dialPeer(node3.switch.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
+    discard await node1.peerManager.connectRelay(node3.switch.peerInfo.toRemotePeerInfo())
 
     check:
       # Verify that only the first connection succeeded

--- a/tests/v2/waku_relay/test_waku_relay.nim
+++ b/tests/v2/waku_relay/test_waku_relay.nim
@@ -116,9 +116,9 @@ suite "Waku Relay":
     await allFutures(srcSwitch.start(), dstSwitch.start())
 
     let dstPeerInfo = dstPeerManager.switch.peerInfo.toRemotePeerInfo()
-    let conn = await srcPeerManager.dialPeer(dstPeerInfo, WakuRelayCodec)
+    let connOk = await srcPeerManager.connectRelay(dstPeerInfo)
     require:
-      conn.isSome()
+      connOk == true
 
     ## Given
     let networkTopic = "test-network1"
@@ -174,9 +174,9 @@ suite "Waku Relay":
     await allFutures(srcSwitch.start(), dstSwitch.start())
 
     let dstPeerInfo = dstPeerManager.switch.peerInfo.toRemotePeerInfo()
-    let conn = await srcPeerManager.dialPeer(dstPeerInfo, WakuRelayCodec)
+    let connOk = await srcPeerManager.connectRelay(dstPeerInfo)
     require:
-      conn.isSome()
+      connOk == true
 
     ## Given
     let networkTopic = "test-network1"

--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -221,8 +221,9 @@ suite "WakuNode - Relay":
     await allFutures(nodes.mapIt(it.mountRelay()))
 
     # Connect nodes
-    let conn = await nodes[0].peerManager.dialPeer(nodes[1].switch.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
-    require conn.isSome
+    let connOk = await nodes[0].peerManager.connectRelay(nodes[1].switch.peerInfo.toRemotePeerInfo())
+    require:
+      connOk == true
 
     # Node 1 subscribes to topic
     nodes[1].subscribe(DefaultPubsubTopic)

--- a/waku/v2/node/jsonrpc/admin/handlers.nim
+++ b/waku/v2/node/jsonrpc/admin/handlers.nim
@@ -45,8 +45,8 @@ proc installAdminApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     debug "post_waku_v2_admin_v1_peers"
 
     for i, peer in peers:
-      let conn = await node.peerManager.dialPeer(parseRemotePeerInfo(peer), WakuRelayCodec, source="rpc")
-      if conn.isNone():
+      let connOk = await node.peerManager.connectRelay(parseRemotePeerInfo(peer), source="rpc")
+      if not connOk:
         raise newException(ValueError, "Failed to connect to peer at index: " & $i & " " & $peer)
 
     return true

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -380,8 +380,8 @@ proc info*(node: WakuNode): WakuInfo =
 
 proc connectToNodes*(node: WakuNode, nodes: seq[RemotePeerInfo] | seq[string], source = "api") {.async.} =
   ## `source` indicates source of node addrs (static config, api call, discovery, etc)
-  # NOTE This is dialing on WakuRelay protocol specifically
-  await peer_manager.connectToNodes(node.peerManager, nodes, WakuRelayCodec, source=source)
+  # NOTE Connects to the node without a give protocol, which automatically creates streams for relay
+  await connectToNodes(node.peerManager, nodes, source=source)
 
 
 ## Waku relay


### PR DESCRIPTION
* As detected by @lchenut we were using`dial` for connecting to relay peers.
* Using `dial` creates a stream (that can be used to read and write data)
* However since relay is based on gossipsub, the streams are created under the hood for us by libp2p. And since we just use the protocol, there is no need to create new streams, since we don't write/read data for the relay protocol.
* This PR now enforces usig `connect` when using relay protocol and `dial` for the rest.

As a rule of thumb:
* Use `dial` when a stream to read/write is required (eg all protocols but relay)