### PR TITLE
refactor(enr): move waku enr multiaddr to typedrecod and builder extensions

### DIFF
--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -18,7 +18,12 @@ import
   ../../../waku/v2/protocol/waku_discv5
 
 # An accesible bootstrap node. See wakuv2.prod fleets.status.im
-const bootstrapNodes = @["enr:-Nm4QOdTOKZJKTUUZ4O_W932CXIET-M9NamewDnL78P5u9DOGnZlK0JFZ4k0inkfe6iY-0JAaJVovZXc575VV3njeiABgmlkgnY0gmlwhAjS3ueKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuYWMtY24taG9uZ2tvbmctYy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGhAo0C-VvfgHiXrxZi3umDiooXMGY9FvYj5_d1Q4EeS7eyg3RjcIJ2X4N1ZHCCIyiFd2FrdTIP"]
+const bootstrapNode = "enr:-Nm4QOdTOKZJKTUUZ4O_W932CXIET-M9NamewDnL78P5u9DOGnZl" &
+                      "K0JFZ4k0inkfe6iY-0JAaJVovZXc575VV3njeiABgmlkgnY0gmlwhAjS" &
+                      "3ueKbXVsdGlhZGRyc7g6ADg2MW5vZGUtMDEuYWMtY24taG9uZ2tvbmct" &
+                      "Yy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGH0DeA4lzZWNwMjU2azGh" &
+                      "Ao0C-VvfgHiXrxZi3umDiooXMGY9FvYj5_d1Q4EeS7eyg3RjcIJ2X4N1" &
+                      "ZHCCIyiFd2FrdTIP"
 
 # careful if running pub and sub in the same machine
 const wakuPort = 50000
@@ -34,6 +39,9 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
         node = WakuNode.new(nodeKey, ip, Port(wakuPort))
         flags = CapabilitiesBitfield.init(lightpush = false, filter = false, store = false, relay = true)
 
+    var bootstrapNodeEnr: enr.Record
+    discard bootstrapNodeEnr.fromURI(bootstrapNode)
+
     # assumes behind a firewall, so not care about being discoverable
     node.wakuDiscv5 = WakuDiscoveryV5.new(
         extIp= none(ValidIpAddress),
@@ -41,7 +49,7 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
         extUdpPort = none(Port),
         bindIP = ip,
         discv5UdpPort = Port(discv5Port),
-        bootstrapNodes = bootstrapNodes,
+        bootstrapEnrs = @[bootstrapNodeEnr],
         privateKey = keys.PrivateKey(nodeKey.skkey),
         flags = flags,
         rng = node.rng)

--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -56,7 +56,7 @@ procSuite "Waku Discovery v5":
         some(extIp), some(nodeTcpPort1), some(nodeUdpPort1),
         bindIp,
         nodeUdpPort1,
-        newSeq[string](),
+        newSeq[enr.Record](),
         false,
         keys.PrivateKey(nodeKey1.skkey),
         flags,
@@ -68,7 +68,7 @@ procSuite "Waku Discovery v5":
         some(extIp), some(nodeTcpPort2), some(nodeUdpPort2),
         bindIp,
         nodeUdpPort2,
-        @[node1.wakuDiscv5.protocol.localNode.record.toURI()], # Bootstrap with node1
+        @[node1.wakuDiscv5.protocol.localNode.record], # Bootstrap with node1
         false,
         keys.PrivateKey(nodeKey2.skkey),
         flags,
@@ -80,7 +80,7 @@ procSuite "Waku Discovery v5":
         some(extIp), some(nodeTcpPort3), some(nodeUdpPort3),
         bindIp,
         nodeUdpPort3,
-        @[node2.wakuDiscv5.protocol.localNode.record.toURI()], # Bootstrap with node2
+        @[node2.wakuDiscv5.protocol.localNode.record], # Bootstrap with node2
         false,
         keys.PrivateKey(nodeKey3.skkey),
         flags,
@@ -191,7 +191,7 @@ procSuite "Waku Discovery v5":
     await sleepAsync(3000.millis) # Give the algorithm some time to work its magic
 
     let node1Enr = node2.wakuDiscv5.protocol.routingTable.buckets[0].nodes[0].record
-    let multiaddrs = node1Enr.get(MULTIADDR_ENR_FIELD, seq[byte])[].toMultiAddresses()
+    let multiaddrs = node1Enr.toTyped().get().multiaddrs.get()
 
     check:
       node1.wakuDiscv5.protocol.nodesDiscovered > 0

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -101,7 +101,7 @@ procSuite "Waku Peer Exchange":
         some(extIp), some(nodeTcpPort1), some(nodeUdpPort1),
         bindIp,
         nodeUdpPort1,
-        newSeq[string](),
+        newSeq[enr.Record](),
         false,
         keys.PrivateKey(nodeKey1.skkey),
         flags,
@@ -113,7 +113,7 @@ procSuite "Waku Peer Exchange":
         some(extIp), some(nodeTcpPort2), some(nodeUdpPort2),
         bindIp,
         nodeUdpPort2,
-        @[node1.wakuDiscv5.protocol.localNode.record.toURI()], # Bootstrap with node1
+        @[node1.wakuDiscv5.protocol.localNode.record], # Bootstrap with node1
         false,
         keys.PrivateKey(nodeKey2.skkey),
         flags,


### PR DESCRIPTION
This PR ports the waku multiaddress ENR field from the old non-extensible approach to the new builder/typed record extensible approach:

- [x] Added the `multiaddrs` ENR builder extension.
- [x] Added a `multiaddrs` typed record getter.
- [x] Updated all tests and protocols accordingly.

> **Note**
> Removal of the deprecated `Record.init()` method will be part of a follow-up PR.