### PR TITLE
fix(wakunode2): fix main warnings and drop swap support

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -471,9 +471,6 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
   let listenStr = $peerInfo.addrs[0] & "/p2p/" & $peerInfo.peerId
   echo &"Listening on\n {listenStr}"
 
-  if conf.swap:
-    await node.mountSwap()
-
   if (conf.storenode != "") or (conf.store == true):
     await node.mountStore()
 

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -114,13 +114,6 @@ type
       defaultValue: ""
       name: "filternode" }: string
 
-    ## Swap config
-
-    swap* {.
-      desc: "Enable swap protocol: true|false",
-      defaultValue: true
-      name: "swap" }: bool
-
     ## Lightpush config
 
     lightpush* {.

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -256,13 +256,6 @@ type
       defaultValue: 14400 # 4 hours
       name: "filter-timeout" }: int64
 
-    ## Swap config
-
-    swap* {.
-      desc: "Enable swap protocol: true|false",
-      defaultValue: false
-      name: "swap" }: bool
-
     ## Lightpush config
 
     lightpush* {.

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -301,7 +301,7 @@ proc initNode(conf: WakuNodeConf,
       discv5UdpPort = discv5UdpPort,
       wakuFlags = some(wakuFlags),
     ))
-  except:
+  except CatchableError:
     return err("failed to create net config instance: " & getCurrentExceptionMsg())
 
   let netConfig = netConfigOpt.get()
@@ -334,7 +334,7 @@ proc initNode(conf: WakuNodeConf,
         rng = rng,
         discv5Config = discv5Config,
       ))
-    except:
+    except CatchableError:
       return err("failed to create waku discv5 instance: " & getCurrentExceptionMsg())
   try:
     node = WakuNode.new(nodekey = nodekey,
@@ -349,7 +349,7 @@ proc initNode(conf: WakuNodeConf,
                         agentString = some(conf.agentString),
                         peerStoreCapacity = conf.peerStoreCapacity,
                         rng = rng)
-  except:
+  except CatchableError:
     return err("failed to create waku node instance: " & getCurrentExceptionMsg())
 
   ok(node)
@@ -365,7 +365,7 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
   var peerExchangeHandler = none(RoutingRecordsHandler)
   if conf.relayPeerExchange:
     proc handlePeerExchange(peer: PeerId, topic: string,
-                            peers: seq[RoutingRecordsPair]) {.gcsafe, raises: [Defect].} =
+                            peers: seq[RoutingRecordsPair]) {.gcsafe.} =
       ## Handle peers received via gossipsub peer exchange
       # TODO: Only consider peers on pubsub topics we subscribe to
       let exchangedPeers = peers.filterIt(it.record.isSome()) # only peers with populated records
@@ -382,14 +382,14 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
     try:
       let pubsubTopics = conf.topics.split(" ")
       await mountRelay(node, pubsubTopics, peerExchangeHandler = peerExchangeHandler)
-    except:
+    except CatchableError:
       return err("failed to mount waku relay protocol: " & getCurrentExceptionMsg())
 
 
   # Keepalive mounted on all nodes
   try:
     await mountLibp2pPing(node)
-  except:
+  except CatchableError:
     return err("failed to mount libp2p ping protocol: " & getCurrentExceptionMsg())
 
   when defined(rln):
@@ -410,15 +410,8 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
 
       try:
         await node.mountRlnRelay(rlnConf)
-      except:
+      except CatchableError:
         return err("failed to mount waku RLN relay protocol: " & getCurrentExceptionMsg())
-
-  if conf.swap:
-    try:
-      await mountSwap(node)
-      # TODO: Set swap peer, for now should be same as store peer
-    except:
-      return err("failed to mount waku swap protocol: " & getCurrentExceptionMsg())
 
   if conf.store:
     # Archive setup
@@ -428,7 +421,7 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
     # Store setup
     try:
       await mountStore(node)
-    except:
+    except CatchableError:
       return err("failed to mount waku store protocol: " & getCurrentExceptionMsg())
 
     # TODO: Move this to storage setup phase
@@ -441,14 +434,14 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
       mountStoreClient(node)
       let storenode = parseRemotePeerInfo(conf.storenode)
       node.peerManager.addServicePeer(storenode, WakuStoreCodec)
-    except:
+    except CatchableError:
       return err("failed to set node waku store peer: " & getCurrentExceptionMsg())
 
   # NOTE Must be mounted after relay
   if conf.lightpush:
     try:
       await mountLightPush(node)
-    except:
+    except CatchableError:
       return err("failed to mount waku lightpush protocol: " & getCurrentExceptionMsg())
 
   if conf.lightpushnode != "":
@@ -456,14 +449,14 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
       mountLightPushClient(node)
       let lightpushnode = parseRemotePeerInfo(conf.lightpushnode)
       node.peerManager.addServicePeer(lightpushnode, WakuLightPushCodec)
-    except:
+    except CatchableError:
       return err("failed to set node waku lightpush peer: " & getCurrentExceptionMsg())
 
   # Filter setup. NOTE Must be mounted after relay
   if conf.filter:
     try:
       await mountFilter(node, filterTimeout = chronos.seconds(conf.filterTimeout))
-    except:
+    except CatchableError:
       return err("failed to mount waku filter protocol: " & getCurrentExceptionMsg())
 
   if conf.filternode != "":
@@ -471,21 +464,21 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
       await mountFilterClient(node)
       let filternode = parseRemotePeerInfo(conf.filternode)
       node.peerManager.addServicePeer(filternode, WakuFilterCodec)
-    except:
+    except CatchableError:
       return err("failed to set node waku filter peer: " & getCurrentExceptionMsg())
 
   # waku peer exchange setup
   if (conf.peerExchangeNode != "") or (conf.peerExchange):
     try:
       await mountPeerExchange(node)
-    except:
+    except CatchableError:
       return err("failed to mount waku peer-exchange protocol: " & getCurrentExceptionMsg())
 
     if conf.peerExchangeNode != "":
       try:
         let peerExchangeNode = parseRemotePeerInfo(conf.peerExchangeNode)
         node.peerManager.addServicePeer(peerExchangeNode, WakuPeerExchangeCodec)
-      except:
+      except CatchableError:
         return err("failed to set node waku peer-exchange peer: " & getCurrentExceptionMsg())
 
   return ok()
@@ -499,7 +492,7 @@ proc startNode(node: WakuNode, conf: WakuNodeConf,
   # Start Waku v2 node
   try:
     await node.start()
-  except:
+  except CatchableError:
     return err("failed to start waku node: " & getCurrentExceptionMsg())
 
   # Start discv5 and connect to discovered nodes
@@ -507,21 +500,21 @@ proc startNode(node: WakuNode, conf: WakuNodeConf,
     try:
       if not await node.startDiscv5():
         error "could not start Discovery v5"
-    except:
+    except CatchableError:
       return err("failed to start waku discovery v5: " & getCurrentExceptionMsg())
 
   # Connect to configured static nodes
   if conf.staticnodes.len > 0:
     try:
       await connectToNodes(node, conf.staticnodes, "static")
-    except:
+    except CatchableError:
       return err("failed to connect to static nodes: " & getCurrentExceptionMsg())
 
   if dynamicBootstrapNodes.len > 0:
     info "Connecting to dynamic bootstrap peers"
     try:
       await connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")
-    except:
+    except CatchableError:
       return err("failed to connect to dynamic bootstrap nodes: " & getCurrentExceptionMsg())
 
   if conf.peerExchange:
@@ -551,19 +544,19 @@ when defined(waku_exp_store_resume):
     var remotePeer: RemotePeerInfo
     try:
       remotePeer = parseRemotePeerInfo(address)
-    except:
+    except CatchableError:
       return err("invalid peer multiaddress: " & getCurrentExceptionMsg())
 
     try:
       await node.resume(some(@[remotePeer]))
-    except:
+    except CatchableError:
       return err("failed to resume messages history: " & getCurrentExceptionMsg())
 
 
 proc startRpcServer(node: WakuNode, address: ValidIpAddress, port: uint16, portsShift: uint16, conf: WakuNodeConf): SetupResult[void] =
   try:
     startRpcServer(node, address, Port(port + portsShift), conf)
-  except:
+  except CatchableError:
     return err("failed to start the json-rpc server: " & getCurrentExceptionMsg())
 
   ok()


### PR DESCRIPTION
A spin off PR from #1620:

- [x] Fix several warnings like this: `The bare except clause is deprecated; use ``except CatchableError:`` instead [BareExcept]`.
- [x] Drop apps support for Waku Swap protocol (`wakunode2` and `chat2`).