### PR TITLE
fix(rln-relay): buildscript bad cp

### DIFF
--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -27,5 +27,5 @@ else
     echo "Failed to download $host_triplet-rln.tar.gz"
     # Build rln instead
     cargo build --release --manifest-path "$build_dir/rln/Cargo.toml"
-    cp "$build_dir/rln/target/release/librln.a" .
+    cp "$build_dir/target/release/librln.a" .
 fi


### PR DESCRIPTION
Copies the binary from the repo/target instead of package/target
