### PR TITLE
chore: allow to call store api endpoints without a storenode (#1575)

### DIFF
--- a/apps/wakunode2/wakunode2_setup_rpc.nim
+++ b/apps/wakunode2/wakunode2_setup_rpc.nim
@@ -42,9 +42,7 @@ proc startRpcServer*(node: WakuNode, address: ValidIpAddress, port: Port, conf: 
     let filterMessageCache = filter_api.MessageCache.init(capacity=30)
     installFilterApiHandlers(node, server, filterMessageCache)
 
-  # TODO: Move to setup protocols proc
-  if conf.storenode != "":
-    installStoreApiHandlers(node, server)
+  installStoreApiHandlers(node, server)
 
   if conf.rpcAdmin:
     installAdminApiHandlers(node, server)

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
@@ -1,9 +1,8 @@
 {.used.}
 
 import
-  std/[options, times],
+  std/[options, times, json],
   stew/shims/net as stewNet,
-  chronicles,
   testutils/unittests,
   eth/keys,
   libp2p/crypto/crypto,
@@ -34,17 +33,16 @@ proc put(store: ArchiveDriver, pubsubTopic: PubsubTopic, message: WakuMessage): 
   store.put(pubsubTopic, message, digest, receivedTime)
 
 procSuite "Waku v2 JSON-RPC API - Store":
-  let
-    privkey = generateSecp256k1Key()
-    bindIp = ValidIpAddress.init("0.0.0.0")
-    extIp = ValidIpAddress.init("127.0.0.1")
-    port = Port(0)
-    node = newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
   asyncTest "query a node and retrieve historical messages":
-    await node.start()
+    let
+      privkey = generateSecp256k1Key()
+      bindIp = ValidIpAddress.init("0.0.0.0")
+      extIp = ValidIpAddress.init("127.0.0.1")
+      port = Port(0)
+      node = newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
-    await node.mountRelay()
+    await node.start()
 
     # RPC server setup
     let
@@ -70,7 +68,6 @@ procSuite "Waku v2 JSON-RPC API - Store":
 
     node.peerManager.addServicePeer(listenSwitch.peerInfo.toRemotePeerInfo(), WakuStoreCodec)
 
-    listenSwitch.mount(node.wakuRelay)
     listenSwitch.mount(node.wakuStore)
 
     # Now prime it with some history before tests
@@ -93,12 +90,97 @@ procSuite "Waku v2 JSON-RPC API - Store":
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort, false)
 
-    let response = await client.get_waku_v2_store_v1_messages(some(DefaultPubsubTopic), some(@[HistoryContentFilterRPC(contentTopic: DefaultContentTopic)]), some(Timestamp(0)), some(Timestamp(9)), some(StorePagingOptions()))
+    let response = await client.get_waku_v2_store_v1_messages(
+                                some(DefaultPubsubTopic),
+                                some(@[HistoryContentFilterRPC(contentTopic: DefaultContentTopic)]),
+                                some(Timestamp(0)),
+                                some(Timestamp(9)),
+                                some(StorePagingOptions()))
     check:
-      response.messages.len() == 8
+      response.messages.len == 8
       response.pagingOptions.isNone()
 
     await server.stop()
     await server.closeWait()
-
     await node.stop()
+    await listenSwitch.stop()
+
+  asyncTest "check error response when peer-store-node is not available":
+    let
+      privkey = generateSecp256k1Key()
+      bindIp = ValidIpAddress.init("0.0.0.0")
+      extIp = ValidIpAddress.init("127.0.0.1")
+      port = Port(0)
+      node = newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
+
+    await node.start()
+
+    # RPC server setup
+    let
+      rpcPort = Port(8549)
+      ta = initTAddress(bindIp, rpcPort)
+      server = newRpcHttpServer([ta])
+
+    installStoreApiHandlers(node, server)
+    server.start()
+
+    let driver: ArchiveDriver = QueueDriver.new()
+    node.mountArchive(some(driver), none(MessageValidator), none(RetentionPolicy))
+    await node.mountStore()
+    node.mountStoreClient()
+
+    # Now prime it with some history before tests
+    let msgList = @[
+      fakeWakuMessage(@[byte 0], ts=0),
+      fakeWakuMessage(@[byte 9], ts=9)
+    ]
+    for msg in msgList:
+      require driver.put(DefaultPubsubTopic, msg).isOk()
+
+    let client = newRpcHttpClient()
+    await client.connect("127.0.0.1", rpcPort, false)
+
+    var response:StoreResponse
+    var jsonError:JsonNode
+    try:
+      response = await client.get_waku_v2_store_v1_messages(
+                                  some(DefaultPubsubTopic),
+                                  some(@[HistoryContentFilterRPC(contentTopic: DefaultContentTopic)]),
+                                  some(Timestamp(0)),
+                                  some(Timestamp(9)),
+                                  some(StorePagingOptions()))
+    except ValueError:
+      jsonError = parseJson(getCurrentExceptionMsg())
+
+    check:
+      $jsonError["code"] == "-32000"
+      jsonError["message"].getStr() == "get_waku_v2_store_v1_messages raised an exception"
+      jsonError["data"].getStr() == "no suitable remote store peers"
+
+    # Now configure a store-peer
+    let
+      key = generateEcdsaKey()
+      peer = PeerInfo.new(key)
+
+    var listenSwitch = newStandardSwitch(some(key))
+    await listenSwitch.start()
+
+    listenSwitch.mount(node.wakuStore)
+
+    node.peerManager.addServicePeer(listenSwitch.peerInfo.toRemotePeerInfo(),
+                                    WakuStoreCodec)
+
+    response = await client.get_waku_v2_store_v1_messages(
+                                some(DefaultPubsubTopic),
+                                some(@[HistoryContentFilterRPC(contentTopic: DefaultContentTopic)]),
+                                some(Timestamp(0)),
+                                some(Timestamp(9)),
+                                some(StorePagingOptions()))
+    check:
+      response.messages.len == 2
+      response.pagingOptions.isNone()
+
+    await server.stop()
+    await server.closeWait()
+    await node.stop()
+    await listenSwitch.stop()


### PR DESCRIPTION
## Chore
https://github.com/waku-org/nwaku/issues/1575

## Comment
Separated change to always enable the store-rpc handler even though the 'storenode' param is not passed.

## Additional info for new members
The storenode param is described ain:
https://github.com/waku-org/nwaku/blob/0627b4f8f2c83d34ece6baeaa64b2d8b9244937b/apps/wakunode2/config.nim#L212

