### PR TITLE
chore: pointed all waku node imports to the barrel import

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -29,7 +29,7 @@ import
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_dnsdisc,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/waku_metrics,
   ../../waku/v2/node/peer_manager,
   ../../waku/v2/utils/compat,

--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -15,7 +15,7 @@ import
   libp2p/crypto/crypto,
   libp2p/errors,
   ../../../waku/v2/protocol/waku_message,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/utils/peers,
   ../../../waku/v2/node/peer_manager,
   ../../waku/v2/protocol/waku_filter,

--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -29,7 +29,7 @@ import
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/node/message_cache,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/peer_manager,
   ../../waku/v2/node/jsonrpc/debug/handlers as debug_api,
   ../../waku/v2/node/jsonrpc/filter/handlers as filter_api,

--- a/apps/wakunode2/wakunode2_setup_rest.nim
+++ b/apps/wakunode2/wakunode2_setup_rest.nim
@@ -8,7 +8,7 @@ import
   chronicles,
   presto
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/rest/server,
   ../../waku/v2/node/rest/debug/handlers as debug_api,
   ../../waku/v2/node/rest/relay/handlers as relay_api,

--- a/apps/wakunode2/wakunode2_setup_rpc.nim
+++ b/apps/wakunode2/wakunode2_setup_rpc.nim
@@ -9,7 +9,7 @@ import
   json_rpc/rpcserver
 import
   ../../waku/v2/node/message_cache,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/jsonrpc/admin/handlers as admin_api,
   ../../waku/v2/node/jsonrpc/debug/handlers as debug_api,
   ../../waku/v2/node/jsonrpc/filter/handlers as filter_api,

--- a/examples/v2/publisher.nim
+++ b/examples/v2/publisher.nim
@@ -12,7 +12,7 @@ import
 import
   ../../../waku/common/logging,
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/protocol/waku_enr,
   ../../../waku/v2/protocol/waku_discv5,

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -12,7 +12,7 @@ import
 import
   ../../../waku/common/logging,
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/protocol/waku_enr,
   ../../../waku/v2/protocol/waku_discv5

--- a/tests/v2/test_peer_exchange.nim
+++ b/tests/v2/test_peer_exchange.nim
@@ -10,7 +10,7 @@ import
   libp2p/crypto/crypto,
   libp2p/protocols/pubsub/gossipsub
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/utils/peers,
   ./testlib/waku2
 

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -21,7 +21,7 @@ import
   ../../waku/common/sqlite,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/peer_manager/peer_store/waku_peer_storage,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/protocol/waku_store,
   ../../waku/v2/protocol/waku_filter,

--- a/tests/v2/test_peer_store_extended.nim
+++ b/tests/v2/test_peer_store_extended.nim
@@ -11,7 +11,7 @@ import
 import
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/peer_manager/waku_peer_store,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ./testlib/waku2
 
 

--- a/tests/v2/test_waku_dnsdisc.nim
+++ b/tests/v2/test_waku_dnsdisc.nim
@@ -12,7 +12,7 @@ import
   discovery/dnsdisc/builder
 import
   ../../waku/v2/node/peer_manager,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/protocol/waku_dnsdisc,
   ./testlib/common,
   ./testlib/waku2

--- a/tests/v2/test_waku_keepalive.nim
+++ b/tests/v2/test_waku_keepalive.nim
@@ -12,7 +12,7 @@ import
   libp2p/stream/connection,
   libp2p/crypto/crypto
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/utils/peers,
   ./testlib/waku2
 

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -12,7 +12,7 @@ import
   eth/keys,
   eth/p2p/discoveryv5/enr
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/peer_manager,
   ../../waku/v2/protocol/waku_discv5,
   ../../waku/v2/protocol/waku_peer_exchange,

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -17,7 +17,7 @@ import
   libp2p/nameresolving/mockresolver,
   eth/p2p/discoveryv5/enr
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/peer_manager,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_relay,

--- a/tests/v2/test_wakunode_filter.nim
+++ b/tests/v2/test_wakunode_filter.nim
@@ -8,7 +8,7 @@ import
   libp2p/crypto/crypto
 import
   ../../waku/v2/node/peer_manager,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/utils/peers,
   ./testlib/common,

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -12,7 +12,7 @@ import
   ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/node/peer_manager,
   ../../waku/v2/utils/peers,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ./testlib/common,
   ./testlib/waku2
 

--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -21,7 +21,7 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/peer_manager,
   ../../waku/v2/utils/peers,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/protocol/waku_relay/validators,
   ../testlib/testutils,

--- a/tests/v2/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/v2/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -14,7 +14,7 @@ import
   libp2p/protocols/pubsub/pubsub,
   eth/keys
 import
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/protocol/waku_rln_relay,
   ../../../waku/v2/protocol/waku_keystore,

--- a/tests/v2/waku_store/test_wakunode_store.nim
+++ b/tests/v2/waku_store/test_wakunode_store.nim
@@ -21,7 +21,7 @@ import
   ../../../waku/v2/protocol/waku_store,
   ../../../waku/v2/protocol/waku_filter,
   ../../../waku/v2/utils/peers,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../testlib/common,
   ../testlib/waku2
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_admin.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_admin.nim
@@ -11,7 +11,7 @@ import
   json_rpc/[rpcserver, rpcclient]
 import
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/node/jsonrpc/admin/handlers as admin_api,
   ../../../waku/v2/node/jsonrpc/admin/client as admin_api_client,
   ../../../waku/v2/protocol/waku_relay,

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_debug.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_debug.nim
@@ -10,7 +10,7 @@ import
   json_rpc/[rpcserver, rpcclient]
 import
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/node/jsonrpc/debug/handlers as debug_api,
   ../../../waku/v2/node/jsonrpc/debug/client as debug_api_client,
   ../testlib/waku2

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_filter.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_filter.nim
@@ -9,7 +9,7 @@ import
   json_rpc/[rpcserver, rpcclient]
 import
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/node/message_cache,
   ../../../waku/v2/node/jsonrpc/filter/handlers as filter_api,
   ../../../waku/v2/node/jsonrpc/filter/client as filter_api_client,

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -11,7 +11,7 @@ import
   ../../../waku/common/base64,
   ../../../waku/v2/node/peer_manager,
   ../../../waku/v2/node/message_cache,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/node/jsonrpc/relay/handlers as relay_api,
   ../../../waku/v2/node/jsonrpc/relay/client as relay_api_client,
   ../../../waku/v2/protocol/waku_message,

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
@@ -10,7 +10,7 @@ import
   json_rpc/[rpcserver, rpcclient]
 import
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/node/waku_node,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/node/jsonrpc/store/handlers as store_api,
   ../../../waku/v2/node/jsonrpc/store/client as store_api_client,
   ../../../waku/v2/protocol/waku_message,

--- a/tests/v2/wakunode_rest/test_rest_debug.nim
+++ b/tests/v2/wakunode_rest/test_rest_debug.nim
@@ -9,7 +9,7 @@ import
   libp2p/multiaddress,
   libp2p/crypto/crypto
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/rest/server,
   ../../waku/v2/node/rest/client,
   ../../waku/v2/node/rest/responses,

--- a/tests/v2/wakunode_rest/test_rest_relay.nim
+++ b/tests/v2/wakunode_rest/test_rest_relay.nim
@@ -9,7 +9,7 @@ import
   libp2p/crypto/crypto
 import
   ../../waku/common/base64,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/rest/server,
   ../../waku/v2/node/rest/client,
   ../../waku/v2/node/rest/responses,

--- a/tests/wakubridge/test_wakubridge.nim
+++ b/tests/wakubridge/test_wakubridge.nim
@@ -18,7 +18,7 @@ import
 import
   ../../waku/v1/protocol/waku_protocol,
   ../../waku/v2/protocol/waku_message,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/utils/compat,
   ../../waku/v2/utils/peers,
   ../test_helpers

--- a/tools/networkmonitor/networkmonitor.nim
+++ b/tools/networkmonitor/networkmonitor.nim
@@ -21,7 +21,7 @@ import
 import
   ../../apps/wakunode2/wakunode2,
   ../../waku/v2/node/peer_manager,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_enr,
   ../../waku/v2/protocol/waku_discv5,

--- a/tools/scripts/rpc_info.nim
+++ b/tools/scripts/rpc_info.nim
@@ -6,7 +6,7 @@ import
   system,
   options
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/waku_payload,
   ../../waku/v2/node/jsonrpc/jsonrpc_types,
   ../../waku/v2/protocol/waku_filter,

--- a/tools/scripts/rpc_publish.nim
+++ b/tools/scripts/rpc_publish.nim
@@ -6,7 +6,7 @@ import
   system,
   options
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/waku_payload,
   ../../waku/v2/node/jsonrpc/jsonrpc_types,
   ../../waku/v2/protocol/waku_filter,

--- a/tools/scripts/rpc_query.nim
+++ b/tools/scripts/rpc_query.nim
@@ -6,7 +6,7 @@ import
   system,
   options
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/waku_payload,
   ../../waku/v2/node/jsonrpc/jsonrpc_types,
   ../../waku/v2/protocol/waku_filter,

--- a/tools/scripts/rpc_subscribe.nim
+++ b/tools/scripts/rpc_subscribe.nim
@@ -5,7 +5,7 @@ import
   system,
   options
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/waku_payload,
   ../../waku/v2/node/jsonrpc/jsonrpc_types,
   ../../waku/v2/protocol/waku_filter,

--- a/tools/scripts/rpc_subscribe_filter.nim
+++ b/tools/scripts/rpc_subscribe_filter.nim
@@ -6,7 +6,7 @@ import
   system,
   options
 import
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/waku_payload,
   ../../waku/v2/node/jsonrpc/jsonrpc_types,
   ../../waku/v2/protocol/waku_filter,

--- a/tools/simulation/quicksim2.nim
+++ b/tools/simulation/quicksim2.nim
@@ -1,7 +1,7 @@
 import
   std/[os, strutils, times, options], #options as what # TODO: Huh? Redefinition?
-  chronicles, 
-  eth/common as eth_common, 
+  chronicles,
+  eth/common as eth_common,
   eth/keys,
   json_rpc/[rpcclient, rpcserver],
   libp2p/protobuf/minprotobuf
@@ -10,10 +10,10 @@ import
   ../../waku/v2/protocol/waku_store/rpc,
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/utils/time,
-  ../../waku/v2/node/waku_node, 
+  ../../waku/v2/waku_node,
   ../../waku/v2/node/waku_payload,
   ../../waku/v2/node/jsonrpc/[jsonrpc_types,jsonrpc_utils]
-  
+
 
 from strutils import rsplit
 template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]

--- a/tools/wakucanary/wakucanary.nim
+++ b/tools/wakucanary/wakucanary.nim
@@ -10,7 +10,7 @@ import
   libp2p/nameresolving/dnsresolver
 import
   ../../waku/v2/node/peer_manager,
-  ../../waku/v2/node/waku_node,
+  ../../waku/v2/waku_node,
   ../../waku/v2/utils/peers
 
 # protocols and their tag

--- a/waku/waku.nim
+++ b/waku/waku.nim
@@ -5,6 +5,6 @@
 # - APACHEv2 ([LICENSE-APACHEv2](../LICENSE-APACHEv2) or https://www.apache.org/licenses/LICENSE-2.0)
 
 ## An implementation of the [Waku v1](https://specs.vac.dev/specs/waku/waku.html) and [Waku v2](https://specs.vac.dev/specs/waku/v2/waku-v2.html) in nim.
-import v2/node/waku_node as wakunode2, v1/node/wakunode1
+import v2/waku_node as wakunode2, v1/node/wakunode1
 export wakunode2
 export wakunode1


### PR DESCRIPTION
This PR is a gardening follow-up PR of #1646 🪴 

- [x] Updated all imports so we import the barrel import and not `waku/v2/node/waku_node`.