### PR TITLE
chore: do not mount relay more than once

### DIFF
--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -413,6 +413,10 @@ proc mountRelay*(node: WakuNode,
                  topics: seq[string] = @[],
                  triggerSelf = true,
                  peerExchangeHandler = none(RoutingRecordsHandler)) {.async, gcsafe.} =
+  if not node.wakuRelay.isNil():
+    error "wakuRelay already mounted, skipping"
+    return
+
   ## The default relay topics is the union of all configured topics plus default PubsubTopic(s)
   info "mounting relay protocol"
 


### PR DESCRIPTION
* Prevents the relay from being mounted more than once.
* This prevents mounting more relay protocols in the switch, which created unnecessary streams under the hood.