### PR TITLE
refactor(node): remove deprecated constructor and extend testlib with builder

### DIFF
--- a/tests/common/test_enr_builder.nim
+++ b/tests/common/test_enr_builder.nim
@@ -7,7 +7,7 @@ import
   testutils/unittests
 import
   ../../waku/common/enr,
-  ../v2/testlib/waku2
+  ../v2/testlib/wakucore
 
 
 suite "nim-eth ENR - builder and typed record":

--- a/tests/v2/test_message_cache.nim
+++ b/tests/v2/test_message_cache.nim
@@ -8,7 +8,7 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/node/message_cache,
   ./testlib/common,
-  ./testlib/waku2
+  ./testlib/wakucore
 
 
 type TestMessageCache = MessageCache[(PubsubTopic, ContentTopic)]

--- a/tests/v2/test_peer_exchange.nim
+++ b/tests/v2/test_peer_exchange.nim
@@ -12,7 +12,8 @@ import
 import
   ../../waku/v2/waku_node,
   ../../waku/v2/utils/peers,
-  ./testlib/waku2
+  ./testlib/wakucore,
+  ./testlib/wakunode
 
 procSuite "Peer Exchange":
   asyncTest "GossipSub (relay) peer exchange":
@@ -22,11 +23,11 @@ procSuite "Peer Exchange":
     let
       bindIp = ValidIpAddress.init("0.0.0.0")
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(0))
+      node1 = newTestWakuNode(nodeKey1, bindIp, Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(0), sendSignedPeerRecord = true)
+      node2 = newTestWakuNode(nodeKey2, bindIp, Port(0), sendSignedPeerRecord = true)
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(0), sendSignedPeerRecord = true)
+      node3 = newTestWakuNode(nodeKey3, bindIp, Port(0), sendSignedPeerRecord = true)
 
     var
       peerExchangeHandler, emptyHandler: RoutingRecordsHandler

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -29,12 +29,13 @@ import
   ../../waku/v2/protocol/waku_peer_exchange,
   ./testlib/common,
   ./testlib/testutils,
-  ./testlib/waku2
+  ./testlib/wakucore,
+  ./testlib/wakunode
 
 procSuite "Peer Manager":
   asyncTest "connectRelay() works":
     # Create 2 nodes
-    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
+    let nodes = toSeq(0..<2).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
     await allFutures(nodes.mapIt(it.start()))
 
     let connOk = await nodes[0].peerManager.connectRelay(nodes[1].peerInfo.toRemotePeerInfo())
@@ -45,7 +46,7 @@ procSuite "Peer Manager":
 
   asyncTest "dialPeer() works":
     # Create 2 nodes
-    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
+    let nodes = toSeq(0..<2).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
@@ -71,7 +72,7 @@ procSuite "Peer Manager":
 
   asyncTest "dialPeer() fails gracefully":
     # Create 2 nodes and start them
-    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
+    let nodes = toSeq(0..<2).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
 
@@ -91,7 +92,7 @@ procSuite "Peer Manager":
 
   asyncTest "Adding, selecting and filtering peers work":
     let
-      node = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
 
       # Create filter peer
       filterLoc = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet()
@@ -123,7 +124,7 @@ procSuite "Peer Manager":
 
   asyncTest "Peer manager keeps track of connections":
     # Create 2 nodes
-    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
+    let nodes = toSeq(0..<2).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
@@ -159,7 +160,7 @@ procSuite "Peer Manager":
 
   asyncTest "Peer manager updates failed peers correctly":
     # Create 2 nodes
-    let nodes = toSeq(0..<2).mapIt(WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
+    let nodes = toSeq(0..<2).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
@@ -212,8 +213,8 @@ procSuite "Peer Manager":
     let
       database = SqliteDatabase.new(":memory:")[]
       storage = WakuPeerStorage.new(database)[]
-      node1 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
-      node2 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
+      node2 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
       peerInfo2 = node2.switch.peerInfo
 
     await node1.start()
@@ -232,7 +233,7 @@ procSuite "Peer Manager":
 
     # Simulate restart by initialising a new node using the same storage
     let
-      node3 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
+      node3 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
 
     await node3.start()
     check:
@@ -257,8 +258,8 @@ procSuite "Peer Manager":
     let
       database = SqliteDatabase.new(":memory:")[]
       storage = WakuPeerStorage.new(database)[]
-      node1 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
-      node2 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
+      node2 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
       peerInfo2 = node2.switch.peerInfo
       betaCodec = "/vac/waku/relay/2.0.0-beta2"
       stableCodec = "/vac/waku/relay/2.0.0"
@@ -282,7 +283,7 @@ procSuite "Peer Manager":
 
     # Simulate restart by initialising a new node using the same storage
     let
-      node3 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
+      node3 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0), peerStorage = storage)
 
     await node3.mountRelay()
     node3.wakuRelay.codec = stableCodec
@@ -310,7 +311,7 @@ procSuite "Peer Manager":
 
   asyncTest "Peer manager connects to all peers supporting a given protocol":
     # Create 4 nodes
-    let nodes = toSeq(0..<4).mapIt(WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
+    let nodes = toSeq(0..<4).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
     # Start them
     await allFutures(nodes.mapIt(it.start()))
@@ -350,7 +351,7 @@ procSuite "Peer Manager":
 
   asyncTest "Peer store keeps track of incoming connections":
     # Create 4 nodes
-    let nodes = toSeq(0..<4).mapIt(WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
+    let nodes = toSeq(0..<4).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
     # Start them
     await allFutures(nodes.mapIt(it.start()))
@@ -411,7 +412,7 @@ procSuite "Peer Manager":
     let basePeerId = "16Uiu2HAm7QGEZKujdSbbo1aaQyfDPQ6Bw3ybQnj6fruH5Dxwd7D"
 
     let
-      node = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
       peer1 = parseRemotePeerInfo("/ip4/0.0.0.0/tcp/30300/p2p/" & basePeerId & "1")
       peer2 = parseRemotePeerInfo("/ip4/0.0.0.0/tcp/30301/p2p/" & basePeerId & "2")
       peer3 = parseRemotePeerInfo("/ip4/0.0.0.0/tcp/30302/p2p/" & basePeerId & "3")

--- a/tests/v2/test_peer_storage.nim
+++ b/tests/v2/test_peer_storage.nim
@@ -7,7 +7,7 @@ import
   ../../waku/common/sqlite,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/peer_manager/peer_store/waku_peer_storage,
-  ./testlib/waku2
+  ./testlib/wakucore
 
 
 suite "Peer Storage":

--- a/tests/v2/test_peer_store_extended.nim
+++ b/tests/v2/test_peer_store_extended.nim
@@ -12,7 +12,7 @@ import
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/peer_manager/waku_peer_store,
   ../../waku/v2/waku_node,
-  ./testlib/waku2
+  ./testlib/wakucore
 
 
 suite "Extended nim-libp2p Peer Store":

--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -14,7 +14,8 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_discv5,
   ./testlib/common,
-  ./testlib/waku2
+  ./testlib/wakucore,
+  ./testlib/wakunode
 
 procSuite "Waku Discovery v5":
   asyncTest "Waku Discovery v5 end-to-end":
@@ -26,17 +27,17 @@ procSuite "Waku Discovery v5":
       nodeKey1 = generateSecp256k1Key()
       nodeTcpPort1 = Port(61500)
       nodeUdpPort1 = Port(9000)
-      node1 = WakuNode.new(nodeKey1, bindIp, nodeTcpPort1)
+      node1 = newTestWakuNode(nodeKey1, bindIp, nodeTcpPort1)
 
       nodeKey2 = generateSecp256k1Key()
       nodeTcpPort2 = Port(61502)
       nodeUdpPort2 = Port(9002)
-      node2 = WakuNode.new(nodeKey2, bindIp, nodeTcpPort2)
+      node2 = newTestWakuNode(nodeKey2, bindIp, nodeTcpPort2)
 
       nodeKey3 = generateSecp256k1Key()
       nodeTcpPort3 = Port(61504)
       nodeUdpPort3 = Port(9004)
-      node3 = WakuNode.new(nodeKey3, bindIp, nodeTcpPort3)
+      node3 = newTestWakuNode(nodeKey3, bindIp, nodeTcpPort3)
 
       flags = CapabilitiesBitfield.init(
                 lightpush = false,

--- a/tests/v2/test_waku_dnsdisc.nim
+++ b/tests/v2/test_waku_dnsdisc.nim
@@ -15,7 +15,8 @@ import
   ../../waku/v2/waku_node,
   ../../waku/v2/protocol/waku_dnsdisc,
   ./testlib/common,
-  ./testlib/waku2
+  ./testlib/wakucore,
+  ./testlib/wakunode
 
 suite "Waku DNS Discovery":
   asyncTest "Waku DNS Discovery end-to-end":
@@ -26,13 +27,13 @@ suite "Waku DNS Discovery":
     let
       bindIp = ValidIpAddress.init("0.0.0.0")
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(63500))
+      node1 = newTestWakuNode(nodeKey1, bindIp, Port(63500))
       enr1 = node1.enr
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(63502))
+      node2 = newTestWakuNode(nodeKey2, bindIp, Port(63502))
       enr2 = node2.enr
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, bindIp, Port(63503))
+      node3 = newTestWakuNode(nodeKey3, bindIp, Port(63503))
       enr3 = node3.enr
 
     await node1.mountRelay()
@@ -67,7 +68,7 @@ suite "Waku DNS Discovery":
 
     let
       nodeKey4 = generateSecp256k1Key()
-      node4 = WakuNode.new(nodeKey4, bindIp, Port(63504))
+      node4 = newTestWakuNode(nodeKey4, bindIp, Port(63504))
 
     await node4.mountRelay()
     await node4.start()

--- a/tests/v2/test_waku_enr.nim
+++ b/tests/v2/test_waku_enr.nim
@@ -6,7 +6,7 @@ import
   testutils/unittests
 import
   ../../waku/v2/protocol/waku_enr,
-  ./testlib/waku2
+  ./testlib/wakucore
 
 
 suite "Waku ENR -  Capabilities bitfield":

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -12,7 +12,7 @@ import
   ../../waku/v2/protocol/waku_filter,
   ../../waku/v2/protocol/waku_filter/client,
   ./testlib/common,
-  ./testlib/waku2
+  ./testlib/wakucore
 
 
 proc newTestWakuFilterNode(switch: Switch, timeout: Duration = 2.hours): Future[WakuFilter] {.async.} =

--- a/tests/v2/test_waku_keepalive.nim
+++ b/tests/v2/test_waku_keepalive.nim
@@ -14,7 +14,8 @@ import
 import
   ../../waku/v2/waku_node,
   ../../waku/v2/utils/peers,
-  ./testlib/waku2
+  ./testlib/wakucore,
+  ./testlib/wakunode
 
 
 suite "Waku Keepalive":
@@ -22,9 +23,9 @@ suite "Waku Keepalive":
   asyncTest "handle ping keepalives":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node2 = newTestWakuNode(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     var completionFut = newFuture[bool]()
 

--- a/tests/v2/test_waku_lightpush.nim
+++ b/tests/v2/test_waku_lightpush.nim
@@ -11,7 +11,7 @@ import
   ../../waku/v2/protocol/waku_lightpush,
   ../../waku/v2/protocol/waku_lightpush/client,
   ./testlib/common,
-  ./testlib/waku2
+  ./testlib/wakucore
 
 
 proc newTestWakuLightpushNode(switch: Switch, handler: PushMessageHandler): Future[WakuLightPush] {.async.} =

--- a/tests/v2/test_waku_message_digest.nim
+++ b/tests/v2/test_waku_message_digest.nim
@@ -8,7 +8,7 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_message/codec,
   ../../waku/v2/protocol/waku_message/digest,
-  ./testlib/waku2
+  ./testlib/wakucore
 
 suite "Waku Message - Deterministic hashing":
 

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -18,7 +18,8 @@ import
   ../../waku/v2/protocol/waku_peer_exchange,
   ../../waku/v2/protocol/waku_peer_exchange/rpc,
   ../../waku/v2/protocol/waku_peer_exchange/rpc_codec,
-  ./testlib/waku2
+  ./testlib/wakucore,
+  ./testlib/wakunode
 
 
 # TODO: Extend test coverage
@@ -76,17 +77,17 @@ procSuite "Waku Peer Exchange":
       nodeKey1 = generateSecp256k1Key()
       nodeTcpPort1 = Port(64010)
       nodeUdpPort1 = Port(9000)
-      node1 = WakuNode.new(nodeKey1, bindIp, nodeTcpPort1)
+      node1 = newTestWakuNode(nodeKey1, bindIp, nodeTcpPort1)
 
       nodeKey2 = generateSecp256k1Key()
       nodeTcpPort2 = Port(64012)
       nodeUdpPort2 = Port(9002)
-      node2 = WakuNode.new(nodeKey2, bindIp, nodeTcpPort2)
+      node2 = newTestWakuNode(nodeKey2, bindIp, nodeTcpPort2)
 
       nodeKey3 = generateSecp256k1Key()
       nodeTcpPort3 = Port(64014)
       nodeUdpPort3 = Port(9004)
-      node3 = WakuNode.new(nodeKey3, bindIp, nodeTcpPort3)
+      node3 = newTestWakuNode(nodeKey3, bindIp, nodeTcpPort3)
 
       # todo: px flag
       flags = CapabilitiesBitfield.init(
@@ -154,8 +155,8 @@ procSuite "Waku Peer Exchange":
 
   asyncTest "peer exchange request functions returns some discovered peers":
     let
-      node1 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
-      node2 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node2 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
 
     # Start and mount peer exchange
     await allFutures([node1.start(), node2.start()])
@@ -198,8 +199,8 @@ procSuite "Waku Peer Exchange":
 
   asyncTest "peer exchange handler works as expected":
     let
-      node1 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
-      node2 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node2 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
 
     # Start and mount peer exchange
     await allFutures([node1.start(), node2.start()])
@@ -234,8 +235,8 @@ procSuite "Waku Peer Exchange":
 
   asyncTest "peer exchange request fails gracefully":
     let
-      node1 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
-      node2 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      node2 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
 
     # Start and mount peer exchange
     await allFutures([node1.start(), node2.start()])

--- a/tests/v2/test_waku_switch.nim
+++ b/tests/v2/test_waku_switch.nim
@@ -11,7 +11,7 @@ import
 import
   ../../waku/v2/node/waku_switch,
   ./testlib/common,
-  ./testlib/waku2
+  ./testlib/wakucore
 
 proc newCircuitRelayClientSwitch(relayClient: RelayClient): Switch =
   SwitchBuilder.new()

--- a/tests/v2/test_wakunode_filter.nim
+++ b/tests/v2/test_wakunode_filter.nim
@@ -12,7 +12,8 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/utils/peers,
   ./testlib/common,
-  ./testlib/waku2
+  ./testlib/wakucore,
+  ./testlib/wakunode
 
 
 suite "WakuNode - Filter":
@@ -21,9 +22,9 @@ suite "WakuNode - Filter":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      server = newTestWakuNode(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(server.start(), client.start())
 

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -14,7 +14,8 @@ import
   ../../waku/v2/utils/peers,
   ../../waku/v2/waku_node,
   ./testlib/common,
-  ./testlib/waku2
+  ./testlib/wakucore,
+  ./testlib/wakunode
 
 
 suite "WakuNode - Lightpush":
@@ -22,11 +23,11 @@ suite "WakuNode - Lightpush":
     ## Setup
     let
       lightNodeKey = generateSecp256k1Key()
-      lightNode = WakuNode.new(lightNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      lightNode = newTestWakuNode(lightNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       bridgeNodeKey = generateSecp256k1Key()
-      bridgeNode = WakuNode.new(bridgeNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      bridgeNode = newTestWakuNode(bridgeNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       destNodeKey = generateSecp256k1Key()
-      destNode = WakuNode.new(destNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      destNode = newTestWakuNode(destNodeKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(destNode.start(), bridgeNode.start(), lightNode.start())
 

--- a/tests/v2/testlib/wakucore.nim
+++ b/tests/v2/testlib/wakucore.nim
@@ -1,6 +1,8 @@
 import
   std/options,
-  stew/byteutils,
+  stew/[results, byteutils],
+  stew/shims/net,
+  chronos,
   libp2p/switch,
   libp2p/builders,
   libp2p/crypto/crypto as libp2p_keys,

--- a/tests/v2/testlib/wakunode.nim
+++ b/tests/v2/testlib/wakunode.nim
@@ -1,0 +1,73 @@
+import
+  std/options,
+  stew/results,
+  stew/shims/net,
+  chronos,
+  libp2p/switch,
+  libp2p/builders,
+  libp2p/nameresolving/nameresolver,
+  libp2p/crypto/crypto as libp2p_keys,
+  eth/keys as eth_keys
+import
+  ../../../waku/v2/waku_node,
+  ../../../waku/v2/node/peer_manager,
+  ../../../waku/v2/protocol/waku_enr,
+  ../../../waku/v2/protocol/waku_discv5,
+  ./common
+
+
+# Waku node
+
+proc newTestWakuNode*(nodeKey: crypto.PrivateKey,
+                      bindIp: ValidIpAddress,
+                      bindPort: Port,
+                      extIp = none(ValidIpAddress),
+                      extPort = none(Port),
+                      extMultiAddrs = newSeq[MultiAddress](),
+                      peerStorage: PeerStorage = nil,
+                      maxConnections = builders.MaxConnections,
+                      wsBindPort: Port = (Port)8000,
+                      wsEnabled: bool = false,
+                      wssEnabled: bool = false,
+                      secureKey: string = "",
+                      secureCert: string = "",
+                      wakuFlags = none(CapabilitiesBitfield),
+                      nameResolver: NameResolver = nil,
+                      sendSignedPeerRecord = false,
+                      dns4DomainName = none(string),
+                      discv5UdpPort = none(Port),
+                      wakuDiscv5 = none(WakuDiscoveryV5),
+                      agentString = none(string),
+                      peerStoreCapacity = none(int)): WakuNode =
+  let netConfigRes = NetConfig.init(
+    bindIp = bindIp,
+    bindPort = bindPort,
+    extIp = extIp,
+    extPort = extPort,
+    extMultiAddrs = extMultiAddrs,
+    wsBindPort = wsBindPort,
+    wsEnabled = wsEnabled,
+    wssEnabled = wssEnabled,
+    wakuFlags = wakuFlags,
+    dns4DomainName = dns4DomainName,
+    discv5UdpPort = discv5UdpPort,
+  )
+  if netConfigRes.isErr:
+    raise newException(Defect, "Invalid network configuration")
+
+  var builder = WakuNodeBuilder.init()
+  builder.withRng(rng())
+  builder.withNodeKey(nodeKey)
+  builder.withNetworkConfiguration(netConfigRes.get())
+  builder.withPeerStorage(peerStorage, capacity = peerStoreCapacity)
+  builder.withSwitchConfiguration(
+    maxConnections = some(maxConnections),
+    nameResolver = nameResolver,
+    sendSignedPeerRecord = sendSignedPeerRecord,
+    secureKey = if secureKey != "": some(secureKey) else: none(string),
+    secureCert = if secureCert != "": some(secureCert) else: none(string),
+    agentString = agentString,
+  )
+  builder.withWakuDiscv5(wakuDiscv5.get(nil))
+
+  return builder.build().get()

--- a/tests/v2/waku_archive/test_driver_queue_pagination.nim
+++ b/tests/v2/waku_archive/test_driver_queue_pagination.nim
@@ -11,7 +11,7 @@ import
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/utils/time,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 
 proc getTestQueueDriver(numMessages: int): QueueDriver =

--- a/tests/v2/waku_archive/test_driver_queue_query.nim
+++ b/tests/v2/waku_archive/test_driver_queue_query.nim
@@ -10,7 +10,7 @@ import
   ../../../waku/v2/protocol/waku_archive/driver/queue_driver,
   ../../../waku/v2/protocol/waku_message,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 
 logScope:

--- a/tests/v2/waku_archive/test_driver_sqlite.nim
+++ b/tests/v2/waku_archive/test_driver_sqlite.nim
@@ -10,7 +10,7 @@ import
   ../../../waku/v2/protocol/waku_archive/driver/sqlite_driver,
   ../../../waku/v2/protocol/waku_message,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 
 proc newTestDatabase(): SqliteDatabase =

--- a/tests/v2/waku_archive/test_driver_sqlite_query.nim
+++ b/tests/v2/waku_archive/test_driver_sqlite_query.nim
@@ -11,7 +11,7 @@ import
   ../../../waku/v2/protocol/waku_archive/driver/sqlite_driver,
   ../../../waku/v2/protocol/waku_message,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 logScope:
   topics = "test archive _driver"

--- a/tests/v2/waku_archive/test_retention_policy.nim
+++ b/tests/v2/waku_archive/test_retention_policy.nim
@@ -14,7 +14,7 @@ import
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/utils/time,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 
 proc newTestDatabase(): SqliteDatabase =

--- a/tests/v2/waku_archive/test_waku_archive.nim
+++ b/tests/v2/waku_archive/test_waku_archive.nim
@@ -12,7 +12,7 @@ import
   ../../../waku/v2/protocol/waku_archive,
   ../../../waku/v2/utils/time,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 
 proc newTestDatabase(): SqliteDatabase =

--- a/tests/v2/waku_filter_v2/test_waku_filter.nim
+++ b/tests/v2/waku_filter_v2/test_waku_filter.nim
@@ -13,7 +13,7 @@ import
   ../../../waku/v2/protocol/waku_filter_v2/rpc,
   ../../../waku/v2/protocol/waku_message,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 proc newTestWakuFilter(switch: Switch): Future[WakuFilter] {.async.} =
   let

--- a/tests/v2/waku_filter_v2/test_waku_filter_protocol.nim
+++ b/tests/v2/waku_filter_v2/test_waku_filter_protocol.nim
@@ -12,7 +12,7 @@ import
   ../../../waku/v2/protocol/waku_filter_v2/rpc,
   ../../../waku/v2/protocol/waku_message,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 proc newTestWakuFilter(switch: Switch): WakuFilter =
   let

--- a/tests/v2/waku_relay/test_waku_relay.nim
+++ b/tests/v2/waku_relay/test_waku_relay.nim
@@ -13,7 +13,7 @@ import
   ../../../waku/v2/protocol/waku_message,
   ../../../waku/v2/protocol/waku_relay,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 
 proc noopRawHandler(): PubsubRawHandler =

--- a/tests/v2/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/v2/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -19,7 +19,8 @@ import
   ../../../waku/v2/protocol/waku_rln_relay,
   ../../../waku/v2/protocol/waku_keystore,
   ../../../waku/v2/utils/peers,
-  ../testlib/waku2
+  ../testlib/wakucore,
+  ../testlib/wakunode
 
 from std/times import epochTime
 
@@ -32,13 +33,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Relay node
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node2 = newTestWakuNode(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Subscriber
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node3 = newTestWakuNode(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")
@@ -120,13 +121,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Relay node
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node2 = newTestWakuNode(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Subscriber
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node3 = newTestWakuNode(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")
@@ -225,13 +226,13 @@ procSuite "WakuNode - RLN relay":
     let
       # publisher node
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node1 = newTestWakuNode(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Relay node
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node2 = newTestWakuNode(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(0))
       # Subscriber
       nodeKey3 = generateSecp256k1Key()
-      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
+      node3 = newTestWakuNode(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(0))
 
       rlnRelayPubSubTopic = RlnRelayPubsubTopic
       contentTopic = ContentTopic("/waku/2/default-content/proto")

--- a/tests/v2/waku_store/test_resume.nim
+++ b/tests/v2/waku_store/test_resume.nim
@@ -214,9 +214,9 @@ suite "WakuNode - waku store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      server = newTestWakuNode(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start())
 
@@ -248,9 +248,9 @@ suite "WakuNode - waku store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      server = newTestWakuNode(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(server.start(), client.start())
     await server.mountStore(store=StoreQueueRef.new())

--- a/tests/v2/waku_store/test_rpc_codec.nim
+++ b/tests/v2/waku_store/test_rpc_codec.nim
@@ -10,7 +10,7 @@ import
   ../../../waku/v2/protocol/waku_store/rpc_codec,
   ../../../waku/v2/utils/time,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 
 

--- a/tests/v2/waku_store/test_waku_store.nim
+++ b/tests/v2/waku_store/test_waku_store.nim
@@ -12,7 +12,7 @@ import
   ../../../waku/v2/protocol/waku_store,
   ../../../waku/v2/protocol/waku_store/client,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore
 
 
 

--- a/tests/v2/waku_store/test_wakunode_store.nim
+++ b/tests/v2/waku_store/test_wakunode_store.nim
@@ -23,7 +23,8 @@ import
   ../../../waku/v2/utils/peers,
   ../../../waku/v2/waku_node,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore,
+  ../testlib/wakunode
 
 
 proc newTestArchiveDriver(): ArchiveDriver =
@@ -67,9 +68,9 @@ procSuite "WakuNode - Store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      server = newTestWakuNode(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start())
 
@@ -99,9 +100,9 @@ procSuite "WakuNode - Store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      server = newTestWakuNode(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start())
 
@@ -148,9 +149,9 @@ procSuite "WakuNode - Store":
     ## Setup
     let
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      server = newTestWakuNode(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start())
 
@@ -198,11 +199,11 @@ procSuite "WakuNode - Store":
     ## Setup
     let
       filterSourceKey = generateSecp256k1Key()
-      filterSource = WakuNode.new(filterSourceKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      filterSource = newTestWakuNode(filterSourceKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       serverKey = generateSecp256k1Key()
-      server = WakuNode.new(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      server = newTestWakuNode(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
       clientKey = generateSecp256k1Key()
-      client = WakuNode.new(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
+      client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(client.start(), server.start(), filterSource.start())
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_admin.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_admin.nim
@@ -20,7 +20,8 @@ import
   ../../../waku/v2/protocol/waku_store,
   ../../../waku/v2/protocol/waku_filter,
   ../../../waku/v2/utils/peers,
-  ../testlib/waku2
+  ../testlib/wakucore,
+  ../testlib/wakunode
 
 
 procSuite "Waku v2 JSON-RPC API - Admin":
@@ -30,10 +31,10 @@ procSuite "Waku v2 JSON-RPC API - Admin":
   asyncTest "connect to ad-hoc peers":
     # Create a couple of nodes
     let
-      node1 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60600))
-      node2 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60602))
+      node1 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60600))
+      node2 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60602))
       peerInfo2 = node2.switch.peerInfo
-      node3 = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60604))
+      node3 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60604))
       peerInfo3 = node3.switch.peerInfo
 
     await allFutures([node1.start(), node2.start(), node3.start()])
@@ -89,7 +90,7 @@ procSuite "Waku v2 JSON-RPC API - Admin":
 
   asyncTest "get managed peer information":
     # Create 3 nodes and start them with relay
-    let nodes = toSeq(0..<3).mapIt(WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60220+it*2)))
+    let nodes = toSeq(0..<3).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60220+it*2)))
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
 
@@ -136,7 +137,7 @@ procSuite "Waku v2 JSON-RPC API - Admin":
     await allFutures(nodes.mapIt(it.stop()))
 
   asyncTest "get unmanaged peer information":
-    let node = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60523))
+    let node = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60523))
 
     await node.start()
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_debug.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_debug.nim
@@ -13,7 +13,9 @@ import
   ../../../waku/v2/waku_node,
   ../../../waku/v2/node/jsonrpc/debug/handlers as debug_api,
   ../../../waku/v2/node/jsonrpc/debug/client as debug_api_client,
-  ../testlib/waku2
+  ../testlib/common,
+  ../testlib/wakucore,
+  ../testlib/wakunode
 
 
 procSuite "Waku v2 JSON-RPC API - Debug":
@@ -22,7 +24,7 @@ procSuite "Waku v2 JSON-RPC API - Debug":
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")
     port = Port(0)
-    node = WakuNode.new(privkey, bindIp, port, some(extIp), some(port))
+    node = newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
   asyncTest "get node info":
     await node.start()

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_filter.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_filter.nim
@@ -18,7 +18,8 @@ import
   ../../../waku/v2/protocol/waku_filter/rpc,
   ../../../waku/v2/protocol/waku_filter/client,
   ../../../waku/v2/utils/peers,
-  ../testlib/waku2
+  ../testlib/wakucore,
+  ../testlib/wakunode
 
 
 proc newTestMessageCache(): filter_api.MessageCache =
@@ -32,9 +33,9 @@ procSuite "Waku v2 JSON-RPC API - Filter":
   asyncTest "subscribe and unsubscribe":
     let
       nodeKey1 = generateSecp256k1Key()
-      node1 = WakuNode.new(nodeKey1, bindIp, Port(0))
+      node1 = newTestWakuNode(nodeKey1, bindIp, Port(0))
       nodeKey2 = generateSecp256k1Key()
-      node2 = WakuNode.new(nodeKey2, bindIp, Port(0))
+      node2 = newTestWakuNode(nodeKey2, bindIp, Port(0))
 
     await allFutures(node1.start(), node2.start())
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -19,7 +19,8 @@ import
   ../../../waku/v2/utils/compat,
   ../../../waku/v2/utils/peers,
   ../testlib/common,
-  ../testlib/waku2
+  ../testlib/wakucore,
+  ../testlib/wakunode
 
 
 proc newTestMessageCache(): relay_api.MessageCache =
@@ -30,7 +31,7 @@ suite "Waku v2 JSON-RPC API - Relay":
 
   asyncTest "subscribe and unsubscribe from topics":
     ## Setup
-    let node = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+    let node = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await node.start()
     await node.mountRelay(topics = @[DefaultPubsubTopic])
@@ -92,8 +93,8 @@ suite "Waku v2 JSON-RPC API - Relay":
 
     # Relay nodes setup
     let
-      srcNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
-      dstNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      srcNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      dstNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(srcNode.start(), dstNode.start())
 
@@ -158,8 +159,8 @@ suite "Waku v2 JSON-RPC API - Relay":
 
     # Relay nodes setup
     let
-      srcNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
-      dstNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      srcNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
+      dstNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
 
     await allFutures(srcNode.start(), dstNode.start())
 
@@ -220,9 +221,9 @@ suite "Waku v2 JSON-RPC API - Relay (Private)":
       contentTopic = "test-relay-content-topic"
 
     let
-      srcNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
-      relNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
-      dstNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
+      srcNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
+      relNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
+      dstNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
 
     await allFutures(srcNode.start(), relNode.start(), dstNode.start())
 
@@ -309,9 +310,9 @@ suite "Waku v2 JSON-RPC API - Relay (Private)":
       contentTopic = "test-relay-content-topic"
 
     let
-      srcNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
-      relNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
-      dstNode = WakuNode.new(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
+      srcNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
+      relNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
+      dstNode = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(0))
 
     await allFutures(srcNode.start(), relNode.start(), dstNode.start())
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
@@ -21,7 +21,8 @@ import
   ../../../waku/v2/utils/peers,
   ../../../waku/v2/utils/time,
   ../../v2/testlib/common,
-  ../../v2/testlib/waku2
+  ../../v2/testlib/wakucore,
+  ../../v2/testlib/wakunode
 
 
 proc put(store: ArchiveDriver, pubsubTopic: PubsubTopic, message: WakuMessage): Result[void, string] =
@@ -38,7 +39,7 @@ procSuite "Waku v2 JSON-RPC API - Store":
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")
     port = Port(0)
-    node = WakuNode.new(privkey, bindIp, port, some(extIp), some(port))
+    node = newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
   asyncTest "query a node and retrieve historical messages":
     await node.start()

--- a/tests/v2/wakunode_rest/test_rest_debug.nim
+++ b/tests/v2/wakunode_rest/test_rest_debug.nim
@@ -10,22 +10,25 @@ import
   libp2p/crypto/crypto
 import
   ../../waku/v2/waku_node,
+  ../../waku/v2/node/waku_node as waku_node2,  # TODO: Remove after moving `git_version` to the app code.
   ../../waku/v2/node/rest/server,
   ../../waku/v2/node/rest/client,
   ../../waku/v2/node/rest/responses,
   ../../waku/v2/node/rest/debug/handlers as debug_api,
-  ../../waku/v2/node/rest/debug/client as debug_api_client
+  ../../waku/v2/node/rest/debug/client as debug_api_client,
+  ../testlib/common,
+  ../testlib/wakucore,
+  ../testlib/wakunode
 
 
 proc testWakuNode(): WakuNode =
   let
-    rng = crypto.newRng()
     privkey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
     bindIp = ValidIpAddress.init("0.0.0.0")
     extIp = ValidIpAddress.init("127.0.0.1")
     port = Port(58000)
 
-  WakuNode.new(privkey, bindIp, port, some(extIp), some(port))
+  newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
 
 suite "Waku v2 REST API - Debug":
@@ -77,7 +80,7 @@ suite "Waku v2 REST API - Debug":
     check:
       response.status == 200
       $response.contentType == $MIMETYPE_TEXT
-      response.data == waku_node.git_version
+      response.data == waku_node2.git_version
 
     await restServer.stop()
     await restServer.closeWait()

--- a/tests/v2/wakunode_rest/test_rest_relay.nim
+++ b/tests/v2/wakunode_rest/test_rest_relay.nim
@@ -20,7 +20,8 @@ import
   ../../waku/v2/protocol/waku_message,
   ../../waku/v2/protocol/waku_relay,
   ../../waku/v2/utils/time,
-  ../testlib/waku2
+  ../testlib/wakucore,
+  ../testlib/wakunode
 
 
 proc testWakuNode(): WakuNode =
@@ -30,7 +31,7 @@ proc testWakuNode(): WakuNode =
     extIp = ValidIpAddress.init("127.0.0.1")
     port = Port(0)
 
-  WakuNode.new(privkey, bindIp, port, some(extIp), some(port))
+  newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
 
 suite "Waku v2 Rest API - Relay":


### PR DESCRIPTION
As most of the test cases depend on the `WakuNode.new()` constructor, it is not easy to refactor and remove the deprecated constructor.

- [x] Added a `testlib/wakunode` submodule. It is not possible to add these methods to the already existing `testlib/waku2` submodule without triggering some cryptic and unrelated compilation errors.
- [x] Renamed `testlib/waku2` to `testlib/wakucore`, for consistency with the `testlib/wakunode` subpackage.
- [x] Added a  shim`newTestWakuNode` method to the `testlib` module that acts as a `WakuNodeBuilder` wrapper.
- [x] Updated all test cases and imports accordingly. 
- [x] Removed the deptercated `WakuNode.new()` method. 
