### PR TITLE
fix(wakunode2): made setup nat return errors

### DIFF
--- a/waku/common/utils/nat.nim
+++ b/waku/common/utils/nat.nim
@@ -14,14 +14,15 @@ logScope:
 proc setupNat*(natConf, clientId: string, tcpPort, udpPort: Port):
     tuple[ip: Option[ValidIpAddress],
           tcpPort: Option[Port],
-          udpPort: Option[Port]] {.gcsafe.} =
+          udpPort: Option[Port]] {.gcsafe, deprecated:
+  "Unsafe: this proc quits the app if something is not ok".} =
 
   var
     endpoint: tuple[ip: Option[ValidIpAddress],
                     tcpPort: Option[Port],
                     udpPort: Option[Port]]
     nat: NatStrategy
-  
+
   case natConf.toLowerAscii:
     of "any":
       nat = NatAny
@@ -65,5 +66,5 @@ proc setupNat*(natConf, clientId: string, tcpPort, udpPort: Port):
         let (extTcpPort, extUdpPort) = extPorts.get()
         endpoint.tcpPort = some(extTcpPort)
         endpoint.udpPort = some(extUdpPort)
-  
+
   return endpoint


### PR DESCRIPTION
The `setupNat` method from `waku/common/utils/nat` module is unsuitable for production. Instead of returning an error, it quits the application with return code `1`.

- [x] Deprecated the `waku/common/nat#setupNat()` method.
- [x] Added an error returning version of `setupNat` to `wakunode2` module (as a temporary solution).

This has been discovered during the refactoring process of the WakuNode and the Wakunode2 app.