### PR TITLE
refactoring: Adding parsePeerInfo and deprecating 'parseRemotePeerInfo'

### DIFF
--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -286,12 +286,18 @@ when isMainModule:
     waitFor connectToNodes(bridge.nodev2, conf.staticnodes)
 
   if conf.storenode != "":
-    let storePeer = parseRemotePeerInfo(conf.storenode)
-    bridge.nodev2.peerManager.addServicePeer(storePeer, WakuStoreCodec)
+    let storePeer = parsePeerInfo(conf.storenode)
+    if storePeer.isOk():
+      bridge.nodev2.peerManager.addServicePeer(storePeer.value, WakuStoreCodec)
+    else:
+      error "Error parsing conf.storenode", error = storePeer.error
 
   if conf.filternode != "":
-    let filterPeer = parseRemotePeerInfo(conf.filternode)
-    bridge.nodev2.peerManager.addServicePeer(filterPeer, WakuFilterCodec)
+    let filterPeer = parsePeerInfo(conf.filternode)
+    if filterPeer.isOk():
+      bridge.nodev2.peerManager.addServicePeer(filterPeer.value, WakuFilterCodec)
+    else:
+      error "Error parsing conf.filternode", error = filterPeer.error
 
   if conf.rpc:
     let ta = initTAddress(conf.rpcAddress,

--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -431,13 +431,19 @@ when isMainModule:
 
   if conf.storenode != "":
     mountStoreClient(bridge.nodev2)
-    let storeNode = parseRemotePeerInfo(conf.storenode)
-    bridge.nodev2.peerManager.addServicePeer(storeNode, WakuStoreCodec)
+    let storeNode = parsePeerInfo(conf.storenode)
+    if storeNode.isOk():
+      bridge.nodev2.peerManager.addServicePeer(storeNode.value, WakuStoreCodec)
+    else:
+      error "Couldn't parse conf.storenode", error = storeNode.error
 
   if conf.filternode != "":
     waitFor mountFilterClient(bridge.nodev2)
-    let filterNode = parseRemotePeerInfo(conf.filternode)
-    bridge.nodev2.peerManager.addServicePeer(filterNode, WakuFilterCodec)
+    let filterNode = parsePeerInfo(conf.filternode)
+    if filterNode.isOk():
+      bridge.nodev2.peerManager.addServicePeer(filterNode.value, WakuFilterCodec)
+    else:
+      error "Couldn't parse conf.filternode", error = filterNode.error
 
   if conf.rpc:
     let ta = initTAddress(conf.rpcAddress,

--- a/tests/v2/test_utils_peers.nim
+++ b/tests/v2/test_utils_peers.nim
@@ -16,8 +16,11 @@ suite "Utils - Peers":
     let address = "/ip4/127.0.0.1/tcp/65002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
       
     ## When
-    let remotePeerInfo = parseRemotePeerInfo(address)
-    
+    let remotePeerInfoRes = parsePeerInfo(address)
+    require remotePeerInfoRes.isOk()
+
+    let remotePeerInfo = remotePeerInfoRes.value
+
     ## Then
     check:
       $(remotePeerInfo.peerId) == "16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
@@ -29,7 +32,10 @@ suite "Utils - Peers":
     let address = "/dns/localhost/tcp/65012/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
 
     ## When
-    let dnsPeer = parseRemotePeerInfo(address)
+    let dnsPeerRes = parsePeerInfo(address)
+    require dnsPeerRes.isOk()
+
+    let dnsPeer = dnsPeerRes.value
 
     ## Then
     check:
@@ -42,7 +48,10 @@ suite "Utils - Peers":
     let address = "/dnsaddr/localhost/tcp/65022/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
     
     ## When
-    let dnsAddrPeer = parseRemotePeerInfo(address)
+    let dnsAddrPeerRes = parsePeerInfo(address)
+    require dnsAddrPeerRes.isOk()
+
+    let dnsAddrPeer = dnsAddrPeerRes.value
 
     ## Then
     check:
@@ -55,7 +64,10 @@ suite "Utils - Peers":
     let address = "/dns4/localhost/tcp/65032/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
 
     ## When
-    let dns4Peer = parseRemotePeerInfo(address)
+    let dns4PeerRes = parsePeerInfo(address)
+    require dns4PeerRes.isOk()
+
+    let dns4Peer = dns4PeerRes.value
 
     # Then
     check:
@@ -68,7 +80,10 @@ suite "Utils - Peers":
     let address = "/dns6/localhost/tcp/65042/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
 
     ## When
-    let dns6Peer = parseRemotePeerInfo(address)
+    let dns6PeerRes = parsePeerInfo(address)
+    require dns6PeerRes.isOk()
+
+    let dns6Peer = dns6PeerRes.value
 
     ## Then
     check:
@@ -81,46 +96,46 @@ suite "Utils - Peers":
     let address = "/p2p/$UCH GIBBER!SH"
 
     ## Then
-    expect LPError:
-      discard parseRemotePeerInfo(address)
+    check:
+      parsePeerInfo(address).isErr()
 
   test "Multiaddr parsing should fail with leading whitespace":
     ## Given
     let address = " /ip4/127.0.0.1/tcp/65062/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
-    
+
     ## Then
-    expect LPError:
-      discard parseRemotePeerInfo(address)
+    check:
+      parsePeerInfo(address).isErr()
 
   test "Multiaddr parsing should fail with trailing whitespace":
     ## Given
     let address = "/ip4/127.0.0.1/tcp/65072/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc "
     
     ## Then
-    expect LPError:
-      discard parseRemotePeerInfo(address)
+    check:
+      parsePeerInfo(address).isErr()
 
   test "Multiaddress parsing should fail with invalid IP address":
     ## Given
     let address = "/ip4/127.0.0.0.1/tcp/65082/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
     
     ## Then
-    expect LPError:
-      discard parseRemotePeerInfo(address)
+    check:
+      parsePeerInfo(address).isErr()
 
   test "Multiaddress parsing should fail with no peer ID":
     ## Given
     let address = "/ip4/127.0.0.1/tcp/65092"
     
     # Then
-    expect LPError:
-      discard parseRemotePeerInfo(address)
+    check:
+      parsePeerInfo(address).isErr()
 
   test "Multiaddress parsing should fail with unsupported transport":
     ## Given
     let address = "/ip4/127.0.0.1/udp/65102/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
     
     ## Then
-    expect ValueError:
-      discard parseRemotePeerInfo(address)
+    check:
+      parsePeerInfo(address).isErr()
 

--- a/tests/v2/wakunode_rest/test_rest_store.nim
+++ b/tests/v2/wakunode_rest/test_rest_store.nim
@@ -391,7 +391,7 @@ procSuite "Waku v2 Rest API - Store":
       $response.contentType == $MIMETYPE_TEXT
       response.data.messages.len == 0
       response.data.error_message.get ==
-        "Failed parsing remote peer info [multiaddress: Invalid MultiAddress, must start with `/`]"
+        "Failed parsing remote peer info [MultiAddress.init [multiaddress: Invalid MultiAddress, must start with `/`]]"
 
     await restServer.stop()
     await restServer.closeWait()

--- a/tools/wakucanary/wakucanary.nim
+++ b/tools/wakucanary/wakucanary.nim
@@ -108,8 +108,14 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
     protocols=conf.protocols,
     logLevel=conf.logLevel
 
+  let peerRes = parsePeerInfo(conf.address)
+  if peerRes.isErr():
+    error "Couldn't parse 'conf.address'", error = peerRes.error
+    return 1
+
+  let peer = peerRes.value
+
   let
-    peer: RemotePeerInfo = parseRemotePeerInfo(conf.address)
     nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
     bindIp = ValidIpAddress.init("0.0.0.0")
     nodeTcpPort = Port(conf.nodePort)

--- a/waku/v2/node/jsonrpc/admin/handlers.nim
+++ b/waku/v2/node/jsonrpc/admin/handlers.nim
@@ -45,7 +45,11 @@ proc installAdminApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     debug "post_waku_v2_admin_v1_peers"
 
     for i, peer in peers:
-      let connOk = await node.peerManager.connectRelay(parseRemotePeerInfo(peer), source="rpc")
+      let peerInfo = parsePeerInfo(peer)
+      if peerInfo.isErr():
+        raise newException(ValueError, "Couldn't parse remote peer info: " & peerInfo.error)
+
+      let connOk = await node.peerManager.connectRelay(peerInfo.value, source="rpc")
       if not connOk:
         raise newException(ValueError, "Failed to connect to peer at index: " & $i & " " & $peer)
 

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -411,9 +411,11 @@ proc connectToNodes*(pm: PeerManager,
 
   var futConns: seq[Future[bool]]
   for node in nodes:
-    let node = when node is string: parseRemotePeerInfo(node)
-               else: node
-    futConns.add(pm.connectRelay(node))
+    let node = parsePeerInfo(node)
+    if node.isOk():
+      futConns.add(pm.connectRelay(node.value))
+    else:
+      error "Couldn't parse node info", error = node.error
 
   await allFutures(futConns)
   let successfulConns = futConns.mapIt(it.read()).countIt(true)


### PR DESCRIPTION
As per @LNSD's recommendation, we are adding a 'parseRemotePeerInfo'-equivalent function that doesn't raises any expection but deals with Restult[...] which is a better approach to handle errors.