### PR TITLE
refactor(wakunode2): split setup logic into app module (pt. 4)

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -538,3 +538,57 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
 
   return ok()
 
+
+## Start node
+
+proc startNode(node: WakuNode, conf: WakuNodeConf,
+               dynamicBootstrapNodes: seq[RemotePeerInfo] = @[]): Future[AppResult[void]] {.async.} =
+  ## Start a configured node and all mounted protocols.
+  ## Connect to static nodes and start
+  ## keep-alive, if configured.
+
+  # Start Waku v2 node
+  try:
+    await node.start()
+  except CatchableError:
+    return err("failed to start waku node: " & getCurrentExceptionMsg())
+
+  # Start discv5 and connect to discovered nodes
+  if conf.discv5Discovery:
+    try:
+      if not await node.startDiscv5():
+        error "could not start Discovery v5"
+    except CatchableError:
+      return err("failed to start waku discovery v5: " & getCurrentExceptionMsg())
+
+  # Connect to configured static nodes
+  if conf.staticnodes.len > 0:
+    try:
+      await connectToNodes(node, conf.staticnodes, "static")
+    except CatchableError:
+      return err("failed to connect to static nodes: " & getCurrentExceptionMsg())
+
+  if dynamicBootstrapNodes.len > 0:
+    info "Connecting to dynamic bootstrap peers"
+    try:
+      await connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")
+    except CatchableError:
+      return err("failed to connect to dynamic bootstrap nodes: " & getCurrentExceptionMsg())
+
+  if conf.peerExchange:
+    asyncSpawn runPeerExchangeDiscv5Loop(node.wakuPeerExchange)
+
+  # retrieve px peers and add the to the peer store
+  if conf.peerExchangeNode != "":
+    let desiredOutDegree = node.wakuRelay.parameters.d.uint64()
+    await node.fetchPeerExchangePeers(desiredOutDegree)
+
+  # Start keepalive, if enabled
+  if conf.keepAlive:
+    node.startKeepalive()
+
+  # Maintain relay connections
+  if conf.relay:
+    node.peerManager.start()
+
+  return ok()


### PR DESCRIPTION
This is the third PR of the `refactor(wakunode2): split setup logic into app module` refactoring series.

> **Note**
> This PR is not merging into the `master` branch. It is merging into `wakunode-develop`.

- [x] Moved some of the setup methods from the main file to the app module:
	+ Start node procedure