### PR TITLE
refactor(wakunode2): added peer storage app setup proc and tests (pt. 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ testcommon: | build deps
 #############
 ## Waku v2 ##
 #############
-.PHONY: test2 wakunode2 example2 sim2 scripts2 wakubridge chat2 chat2bridge
+.PHONY: test2 wakunode2 testwakunode2 example2 sim2 scripts2 wakubridge testbridge chat2 chat2bridge
 
 test2: | build deps librln testcommon
 	echo -e $(BUILD_MSG) "build/$@" && \
@@ -153,6 +153,10 @@ test2: | build deps librln testcommon
 wakunode2: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim wakunode2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
+
+testwakunode2: | build deps librln
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim testwakunode2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
 example2: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
@@ -171,6 +175,10 @@ scripts2: | build deps wakunode2
 wakubridge: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim bridge $(NIM_PARAMS) waku.nims
+
+testbridge: | build deps librln
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim testbridge $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
 chat2: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \

--- a/tests/all_tests_wakunode2.nim
+++ b/tests/all_tests_wakunode2.nim
@@ -1,0 +1,4 @@
+## Wakunode2
+
+import
+  ./wakunode2/test_app

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -1,0 +1,55 @@
+{.used.}
+
+import
+  stew/shims/net,
+  testutils/unittests,
+  chronicles,
+  chronos,
+  libp2p/crypto/crypto,
+  libp2p/crypto/secp,
+  libp2p/multiaddress,
+  libp2p/switch
+import
+  ../../apps/wakunode2/config,
+  ../../apps/wakunode2/app,
+  ../v2/testlib/common,
+  ../v2/testlib/wakucore
+
+
+proc dummyTestWakuNodeConf(): WakuNodeConf =
+  WakuNodeConf(
+    listenAddress: ValidIpAddress.init("127.0.0.1"),
+    rpcAddress: ValidIpAddress.init("127.0.0.1"),
+    restAddress: ValidIpAddress.init("127.0.0.1"),
+    metricsServerAddress: ValidIpAddress.init("127.0.0.1"),
+  )
+
+
+suite "Wakunode2 - App":
+  test "compilation version should be reported":
+    ## Given
+    let conf = dummyTestWakuNodeConf()
+
+    var wakunode2 = App.init(rng(), conf)
+
+    ## When
+    let version = wakunode2.version
+
+    ## Then
+    check:
+      version == app.git_version
+
+
+suite "Wakunode2 - App initialization":
+  test "peer persistence setup should be successfully mounted":
+    ## Given
+    var conf = dummyTestWakuNodeConf()
+    conf.peerPersistence = true
+
+    var wakunode2 = App.init(rng(), conf)
+
+    ## When
+    let res = wakunode2.setupPeerPersistence()
+
+    ## Then
+    check res.isOk()

--- a/waku.nimble
+++ b/waku.nimble
@@ -70,13 +70,20 @@ task test1, "Build & run Waku v1 tests":
 
 
 ### Waku v2 tasks
-task wakunode2, "Build Waku v2 (experimental) cli node":
+task wakunode2, "Build Waku v2 cli node":
   let name = "wakunode2"
   buildBinary name, "apps/wakunode2/", "-d:chronicles_log_level=TRACE"
 
 task bridge, "Build Waku v1 - v2 bridge":
   let name = "wakubridge"
   buildBinary name, "apps/wakubridge/", "-d:chronicles_log_level=TRACE"
+
+
+task testwakunode2, "Build & run wakunode2 app tests":
+  test "all_tests_wakunode2"
+
+task testbridge, "Build & run wakubridge tests":
+  test "all_tests_wakubridge"
 
 task test2, "Build & run Waku v2 tests":
   test "all_tests_v2"


### PR DESCRIPTION
As discussed at today's nwaku PM call, I am adding an instance object holding reference to all the parts that compose the `wakunode2` app to support gray-box testing.

- [x] Added `App` type to `wakunonode2/app.nim`.
- [x] Added the `testwakunode2` and `testbridge` make targets.
- [x] Added some test cases covering the Peer storage setup phase of the `wakunode2` app.