### PR TITLE
refactor(wakunode2): added peer storage app setup proc and tests (pt. 2)

### DIFF
--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -122,4 +122,4 @@ jobs:
           key: ${{ runner.os }}-zerokit-${{ steps.submodules.outputs.zerokit-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG test2
+        run: make V=1 LOG_LEVEL=DEBUG testcommon test2 testwakunode2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG test2
+        run: make V=1 LOG_LEVEL=DEBUG testcommon test2 testwakunode2
 
 
   build-legacy:
@@ -180,4 +180,4 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG test1
+        run: make V=1 LOG_LEVEL=DEBUG testcommon test1

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ testcommon: | build deps
 #############
 .PHONY: test2 wakunode2 testwakunode2 example2 sim2 scripts2 wakubridge testbridge chat2 chat2bridge
 
-test2: | build deps librln testcommon
+test2: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
@@ -210,11 +210,11 @@ networkmonitor: | build deps
 #################
 .PHONY: testwhisper test1 wakunode1 example1 sim1
 
-testwhisper: | build deps testcommon
+testwhisper: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim testwhisper $(NIM_PARAMS) waku.nims
 
-test1: | build deps testcommon
+test1: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim test1 $(NIM_PARAMS) waku.nims
 

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -14,7 +14,9 @@ import
   libp2p/protocols/pubsub/gossipsub,
   libp2p/peerid,
   eth/keys,
-  eth/net/nat
+  eth/net/nat,
+  json_rpc/rpcserver,
+  presto
 import
   ../../waku/common/sqlite,
   ../../waku/v2/waku_node,
@@ -64,12 +66,14 @@ type
 
     node: WakuNode
 
+    rpcServer: Option[RpcHttpServer]
+    restServer: Option[RestServerRef]
+
   AppResult*[T] = Result[T, string]
 
 
-# TODO: Uncomment after the refactoring work is done
-# func node*(app: App): WakuNode =
-#   app.node
+func node*(app: App): WakuNode =
+  app.node
 
 func version*(app: App): string =
   app.version
@@ -222,6 +226,41 @@ proc setupWakuArchiveDriver(dbUrl: string, vacuum: bool, migrate: bool): AppResu
     let driver = QueueDriver.new()  # Defaults to a capacity of 25.000 messages
     ok(driver)
 
+proc setupWakuArchive*(app: var App): AppResult[void] =
+  ## Waku archive
+
+  if not app.conf.store:
+    return ok()
+
+  # Message storage
+  let dbUrlValidationRes = validateDbUrl(app.conf.storeMessageDbUrl)
+  if dbUrlValidationRes.isErr():
+    return err("failed to configure the message store database connection: " & dbUrlValidationRes.error)
+
+  let archiveDriverRes = setupWakuArchiveDriver(dbUrlValidationRes.get(),
+                                                vacuum = app.conf.storeMessageDbVacuum,
+                                                migrate = app.conf.storeMessageDbMigration)
+  if archiveDriverRes.isOk():
+    app.archiveDriver = some(archiveDriverRes.get())
+  else:
+    return err("failed to configure archive driver: " & archiveDriverRes.error)
+
+  # Message store retention policy
+  let storeMessageRetentionPolicyRes = validateStoreMessageRetentionPolicy(app.conf.storeMessageRetentionPolicy)
+  if storeMessageRetentionPolicyRes.isErr():
+    return err("failed to configure the message retention policy: " & storeMessageRetentionPolicyRes.error)
+
+  let archiveRetentionPolicyRes = setupWakuArchiveRetentionPolicy(storeMessageRetentionPolicyRes.get())
+  if archiveRetentionPolicyRes.isOk():
+    app.archiveRetentionPolicy = archiveRetentionPolicyRes.get()
+  else:
+    return err("failed to configure the message retention policy: " & archiveRetentionPolicyRes.error)
+
+  # TODO: Move retention policy execution here
+  # if archiveRetentionPolicy.isSome():
+  #   executeMessageRetentionPolicy(node)
+  #   startMessageRetentionPolicyPeriodicTask(node, interval=WakuArchiveDefaultRetentionPolicyInterval)
+
 
 ## Retrieve dynamic bootstrap nodes (DNS discovery)
 
@@ -251,6 +290,17 @@ proc retrieveDynamicBootstrapNodes*(dnsDiscovery: bool, dnsDiscoveryUrl: string,
 
   debug "No method for retrieving dynamic bootstrap nodes specified."
   ok(newSeq[RemotePeerInfo]()) # Return an empty seq by default
+
+proc setupDyamicBootstrapNodes*(app: var App): AppResult[void] =
+  let dynamicBootstrapNodesRes = retrieveDynamicBootstrapNodes(app.conf.dnsDiscovery,
+                                                               app.conf.dnsDiscoveryUrl,
+                                                               app.conf.dnsDiscoveryNameServers)
+  if dynamicBootstrapNodesRes.isOk():
+    app.dynamicBootstrapNodes = dynamicBootstrapNodesRes.get()
+  else:
+    warn "2/7 Retrieving dynamic bootstrap nodes failed. Continuing without dynamic bootstrap nodes.", error=dynamicBootstrapNodesRes.error
+
+  ok()
 
 
 ## Init waku node instance
@@ -448,6 +498,15 @@ proc initNode(conf: WakuNodeConf,
 
   ok(node)
 
+proc setupWakuNode*(app: var App): AppResult[void] =
+  ## Waku node
+  let initNodeRes = initNode(app.conf, app.rng, app.peerStore, app.dynamicBootstrapNodes)
+  if initNodeRes.isErr():
+    return err("failed to init node: " & initNodeRes.error)
+
+  app.node = initNodeRes.get()
+  ok()
+
 
 ## Mount protocols
 
@@ -587,6 +646,14 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
 
   return ok()
 
+proc setupAndMountProtocols*(app: App): Future[AppResult[void]] {.async.} =
+  return await setupProtocols(
+    app.node,
+    app.conf,
+    app.archiveDriver,
+    app.archiveRetentionPolicy
+  )
+
 
 ## Start node
 
@@ -642,6 +709,13 @@ proc startNode(node: WakuNode, conf: WakuNodeConf,
 
   return ok()
 
+proc startNode*(app: App): Future[AppResult[void]] {.async.} =
+  return await startNode(
+    app.node,
+    app.conf,
+    app.dynamicBootstrapNodes
+  )
+
 
 ## Monitoring and external interfaces
 
@@ -652,17 +726,6 @@ import
   ./wakunode2_setup_rpc,
   ./wakunode2_setup_rest
 
-proc startRpcServer(node: WakuNode, address: ValidIpAddress, port: uint16, portsShift: uint16, conf: WakuNodeConf): AppResult[void] =
-  try:
-    startRpcServer(node, address, Port(port + portsShift), conf)
-  except CatchableError:
-    return err("failed to start the json-rpc server: " & getCurrentExceptionMsg())
-
-  ok()
-
-proc startRestServer(node: WakuNode, address: ValidIpAddress, port: uint16, portsShift: uint16, conf: WakuNodeConf): AppResult[void] =
-  startRestServer(node, address, Port(port + portsShift), conf)
-  ok()
 
 proc startMetricsServer(node: WakuNode, address: ValidIpAddress, port: uint16, portsShift: uint16): AppResult[void] =
   startMetricsServer(address, Port(port + portsShift))
@@ -672,9 +735,43 @@ proc startMetricsLogging(): AppResult[void] =
   startMetricsLog()
   ok()
 
+proc setupMonitoringAndExternalInterfaces*(app: var App): AppResult[void] =
+  if app.conf.rpc:
+    let startRpcServerRes = startRpcServer(app.node, app.conf.rpcAddress, app.conf.rpcPort, app.conf.portsShift, app.conf)
+    if startRpcServerRes.isErr():
+      error "6/7 Starting JSON-RPC server failed. Continuing in current state.", error=startRpcServerRes.error
+    else:
+      app.rpcServer = some(startRpcServerRes.value)
+
+  if app.conf.rest:
+    let startRestServerRes = startRestServer(app.node, app.conf.restAddress, app.conf.restPort, app.conf.portsShift, app.conf)
+    if startRestServerRes.isErr():
+      error "6/7 Starting REST server failed. Continuing in current state.", error=startRestServerRes.error
+    else:
+      app.restServer = some(startRestServerRes.value)
+
+
+  if app.conf.metricsServer:
+    let startMetricsServerRes = startMetricsServer(app.node, app.conf.metricsServerAddress, app.conf.metricsServerPort, app.conf.portsShift)
+    if startMetricsServerRes.isErr():
+      error "6/7 Starting metrics server failed. Continuing in current state.", error=startMetricsServerRes.error
+
+  if app.conf.metricsLogging:
+    let startMetricsLoggingRes = startMetricsLogging()
+    if startMetricsLoggingRes.isErr():
+      error "6/7 Starting metrics console logging failed. Continuing in current state.", error=startMetricsLoggingRes.error
+
+  ok()
+
 
 # App shutdown
 
 proc stop*(app: App): Future[void] {.async.} =
+  if app.restServer.isSome():
+    await app.restServer.get().stop()
+
+  if app.rpcServer.isSome():
+    await app.rpcServer.get().stop()
+
   if not app.node.isNil():
     await app.node.stop()

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -136,8 +136,8 @@ when isMainModule:
 
     # TODO: Move retention policy execution here
     # if archiveRetentionPolicy.isSome():
-    #   executeMessageRetentionPolicy(node)
-    #   startMessageRetentionPolicyPeriodicTask(node, interval=WakuArchiveDefaultRetentionPolicyInterval)
+    #   executeMessageRetentionPolicy(nodeInstance)
+    #   startMessageRetentionPolicyPeriodicTask(nodeInstance, interval=WakuArchiveDefaultRetentionPolicyInterval)
 
 
   debug "2/7 Retrieve dynamic bootstrap nodes"
@@ -151,24 +151,24 @@ when isMainModule:
 
   debug "3/7 Initializing node"
 
-  var node: WakuNode  # This is the node we're going to setup using the conf
+  var nodeInstance: WakuNode  # This is the node we're going to setup using the conf
 
   let initNodeRes = initNode(conf, rng, peerStore, dynamicBootstrapNodes)
   if initNodeRes.isok():
-    node = initNodeRes.get()
+    nodeInstance = initNodeRes.get()
   else:
     error "3/7 Initializing node failed. Quitting.", error=initNodeRes.error
     quit(QuitFailure)
 
   debug "4/7 Mounting protocols"
 
-  let setupProtocolsRes = waitFor setupProtocols(node, conf, archiveDriver, archiveRetentionPolicy)
+  let setupProtocolsRes = waitFor setupProtocols(nodeInstance, conf, archiveDriver, archiveRetentionPolicy)
   if setupProtocolsRes.isErr():
     error "4/7 Mounting protocols failed. Continuing in current state.", error=setupProtocolsRes.error
 
   debug "5/7 Starting node and mounted protocols"
 
-  let startNodeRes = waitFor startNode(node, conf, dynamicBootstrapNodes)
+  let startNodeRes = waitFor startNode(nodeInstance, conf, dynamicBootstrapNodes)
   if startNodeRes.isErr():
     error "5/7 Starting node and mounted protocols failed. Continuing in current state.", error=startNodeRes.error
 
@@ -176,17 +176,17 @@ when isMainModule:
   debug "6/7 Starting monitoring and external interfaces"
 
   if conf.rpc:
-    let startRpcServerRes = startRpcServer(node, conf.rpcAddress, conf.rpcPort, conf.portsShift, conf)
+    let startRpcServerRes = startRpcServer(nodeInstance, conf.rpcAddress, conf.rpcPort, conf.portsShift, conf)
     if startRpcServerRes.isErr():
       error "6/7 Starting JSON-RPC server failed. Continuing in current state.", error=startRpcServerRes.error
 
   if conf.rest:
-    let startRestServerRes = startRestServer(node, conf.restAddress, conf.restPort, conf.portsShift, conf)
+    let startRestServerRes = startRestServer(nodeInstance, conf.restAddress, conf.restPort, conf.portsShift, conf)
     if startRestServerRes.isErr():
       error "6/7 Starting REST server failed. Continuing in current state.", error=startRestServerRes.error
 
   if conf.metricsServer:
-    let startMetricsServerRes = startMetricsServer(node, conf.metricsServerAddress, conf.metricsServerPort, conf.portsShift)
+    let startMetricsServerRes = startMetricsServer(nodeInstance, conf.metricsServerAddress, conf.metricsServerPort, conf.portsShift)
     if startMetricsServerRes.isErr():
       error "6/7 Starting metrics server failed. Continuing in current state.", error=startMetricsServerRes.error
 
@@ -200,8 +200,8 @@ when isMainModule:
   ## Setup shutdown hooks for this process.
   ## Stop node gracefully on shutdown.
 
-  proc asyncStopper(node: WakuNode) {.async.} =
-    await node.stop()
+  proc asyncStopper(nodeInstance: WakuNode) {.async.} =
+    await nodeInstance.stop()
     quit(QuitSuccess)
 
   # Handle Ctrl-C SIGINT
@@ -210,7 +210,7 @@ when isMainModule:
       # workaround for https://github.com/nim-lang/Nim/issues/4057
       setupForeignThreadGc()
     notice "Shutting down after receiving SIGINT"
-    asyncSpawn asyncStopper(node)
+    asyncSpawn asyncStopper(nodeInstance)
 
   setControlCHook(handleCtrlC)
 
@@ -218,7 +218,7 @@ when isMainModule:
   when defined(posix):
     proc handleSigterm(signal: cint) {.noconv.} =
       notice "Shutting down after receiving SIGTERM"
-      asyncSpawn asyncStopper(node)
+      asyncSpawn asyncStopper(nodeInstance)
 
     c_signal(ansi_c.SIGTERM, handleSigterm)
 
@@ -231,7 +231,7 @@ when isMainModule:
       # Not available in -d:release mode
       writeStackTrace()
 
-      waitFor node.stop()
+      waitFor nodeInstance.stop()
       quit(QuitFailure)
 
     c_signal(ansi_c.SIGSEGV, handleSigsegv)

--- a/apps/wakunode2/wakunode2_setup_rpc.nim
+++ b/apps/wakunode2/wakunode2_setup_rpc.nim
@@ -4,6 +4,7 @@ else:
   {.push raises: [].}
 
 import
+  stew/results,
   stew/shims/net,
   chronicles,
   json_rpc/rpcserver
@@ -20,13 +21,14 @@ import
 logScope:
   topics = "wakunode jsonrpc"
 
+proc startRpcServer(node: WakuNode, address: ValidIpAddress, port: Port, conf: WakuNodeConf): Result[RpcHttpServer, string] =
+  let ta = initTAddress(address, port)
 
-proc startRpcServer*(node: WakuNode, address: ValidIpAddress, port: Port, conf: WakuNodeConf)
-  {.raises: [CatchableError].} =
-
-  let
-    ta = initTAddress(address, port)
+  var server: RpcHttpServer
+  try:
     server = newRpcHttpServer([ta])
+  except CatchableError:
+    return err("failed to init JSON-RPC server: " & getCurrentExceptionMsg())
 
   installDebugApiHandlers(node, server)
 
@@ -49,3 +51,8 @@ proc startRpcServer*(node: WakuNode, address: ValidIpAddress, port: Port, conf: 
 
   server.start()
   info "RPC Server started", address=ta
+
+  ok(server)
+
+proc startRpcServer*(node: WakuNode, address: ValidIpAddress, port: uint16, portsShift: uint16, conf: WakuNodeConf): Result[RpcHttpServer, string] =
+  return startRpcServer(node, address, Port(port + portsShift), conf)

--- a/waku/v2/node/rest/server.nim
+++ b/waku/v2/node/rest/server.nim
@@ -11,7 +11,7 @@ import
   presto
 
 
-type RestServerResult*[T] = Result[T, cstring]
+type RestServerResult*[T] = Result[T, string]
 
 
 ### Configuration
@@ -84,10 +84,11 @@ proc init*(T: type RestServerRef,
       maxHeadersSize = maxHeadersSize,
       maxRequestBodySize = maxRequestBodySize
     )
-  except CatchableError as ex:
-    return err(cstring(ex.msg))
+  except CatchableError:
+    return err(getCurrentExceptionMsg())
 
-  res
+  # RestResult error type is cstring, so we need to map it to string
+  res.mapErr(proc(err: cstring): string = $err)
 
 proc newRestHttpServer*(ip: ValidIpAddress, port: Port,
                         allowedOrigin=none(string),


### PR DESCRIPTION
This is the second part of the `App` implementation and test cases.

> **Note**
> This PR is not merging into the `master` branch. It is merging into the `wakunode-develop` feature branch.

- [x] Added the setup logic for the JSON-RPC server, the REST server, and the metrics server.
- [x] Added shutdown logic for the JSON-RPC and REST servers.
- [x] Added a smoke test that asserts the correct initialization of the Wakunode2 App instance with the default configuration.
- [x] Enabled the `testwakunode2` tests (a.k.a. Wakunode2 App tests) in the CI pipeline.