### PR TITLE
fix(logs): fix log reporting wrong ok connected peers

### DIFF
--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -422,7 +422,7 @@ proc connectToNodes*(pm: PeerManager,
       error "Couldn't parse node info", error = node.error
 
   await allFutures(futConns)
-  let successfulConns = futConns.mapIt(it.read()).countIt(true)
+  let successfulConns = futConns.mapIt(it.read()).countIt(it == true)
 
   info "Finished dialing multiple peers", successfulConns=successfulConns, attempted=nodes.len
 


### PR DESCRIPTION
* Fix log reporting wrong ok connected peers
* `countIt(true)` != `countIt(it == true)` 🤦 