### PR TITLE
peers.nim: adding more detail in case the p2pPart doesn't contain '/'

### DIFF
--- a/waku/v2/utils/peers.nim
+++ b/waku/v2/utils/peers.nim
@@ -136,7 +136,9 @@ proc parsePeerInfo*(peer: RemotePeerInfo|string):
 
   let p2pPartStr = p2pPart.toString()[]
   if not p2pPartStr.contains("/"):
-    return err("Error in parsePeerInfo: p2p part should contain /")
+    let msg = "Error in parsePeerInfo: p2p part should contain / [" &
+          p2pPartStr & "]"
+    return err(msg)
 
   let peerId = ? PeerID.init(p2pPartStr.split("/")[^1])
                         .mapErr(proc (e:cstring):string = cast[string](e))


### PR DESCRIPTION
Merely adds the content of `p2pPartStr` to the returned error in `parsePeerInfo` if the next error occurs:

` Error in parsePeerInfo: p2p part should contain /` 