### PR TITLE
chore(core): move utils time module to waku_core

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -34,7 +34,6 @@ import
   ../../waku/v2/node/peer_manager,
   ../../waku/v2/utils/compat,
   ../../waku/v2/utils/peers,
-  ../../waku/v2/utils/time,
   ../../waku/common/utils/nat,
   ./config_chat2
 

--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -24,7 +24,6 @@ import
   # Waku v2 imports
   libp2p/crypto/crypto,
   libp2p/nameresolving/nameresolver,
-  ../../waku/v2/utils/time,
   ../../waku/v2/waku_core,
   ../../waku/v2/waku_store,
   ../../waku/v2/waku_filter,

--- a/examples/v2/publisher.nim
+++ b/examples/v2/publisher.nim
@@ -12,11 +12,10 @@ import
 import
   ../../../waku/common/logging,
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/waku_node,
   ../../../waku/v2/waku_core,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/waku_enr,
-  ../../../waku/v2/waku_discv5,
-  ../../../waku/v2/utils/time
+  ../../../waku/v2/waku_discv5
 
 proc now*(): Timestamp =
   getNanosecondTime(getTime().toUnixFloat())

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -12,8 +12,8 @@ import
 import
   ../../../waku/common/logging,
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/waku_node,
   ../../../waku/v2/waku_core,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/waku_enr,
   ../../../waku/v2/waku_discv5
 

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -3,7 +3,9 @@
 # Waku core test suite
 import
   ./v2/waku_core/test_namespaced_topics,
+  ./v2/waku_core/test_time,
   ./v2/waku_core/test_message_digest
+
 
 # Waku archive test suite
 import

--- a/tests/v2/test_utils_compat.nim
+++ b/tests/v2/test_utils_compat.nim
@@ -5,7 +5,6 @@ import
 import
   ../../waku/v2/waku_core,
   ../../waku/v2/utils/compat,
-  ../../waku/v2/utils/time,
   ./testlib/common
 
 suite "Waku Payload":

--- a/tests/v2/testlib/common.nim
+++ b/tests/v2/testlib/common.nim
@@ -2,17 +2,6 @@ import
   std/[times, random],
   bearssl/rand,
   libp2p/crypto/crypto
-import
-  ../../../waku/v2/utils/time
-
-
-# Time
-
-proc now*(): Timestamp =
-  getNanosecondTime(getTime().toUnixFloat())
-
-proc ts*(offset=0, origin=now()): Timestamp =
-  origin + getNanosecondTime(offset)
 
 
 ## Randomization

--- a/tests/v2/testlib/wakucore.nim
+++ b/tests/v2/testlib/wakucore.nim
@@ -1,5 +1,5 @@
 import
-  std/options,
+  std/[options, times],
   stew/[results, byteutils],
   stew/shims/net,
   chronos,
@@ -12,6 +12,15 @@ import
   ./common
 
 export switch
+
+
+# Time
+
+proc now*(): Timestamp =
+  getNanosecondTime(getTime().toUnixFloat())
+
+proc ts*(offset=0, origin=now()): Timestamp =
+  origin + getNanosecondTime(offset)
 
 
 # Switch

--- a/tests/v2/waku_archive/test_driver_queue.nim
+++ b/tests/v2/waku_archive/test_driver_queue.nim
@@ -8,8 +8,7 @@ import
   ../../../waku/v2/waku_archive,
   ../../../waku/v2/waku_archive/driver/queue_driver/queue_driver {.all.},
   ../../../waku/v2/waku_archive/driver/queue_driver/index,
-  ../../../waku/v2/waku_core,
-  ../../../waku/v2/utils/time
+  ../../../waku/v2/waku_core
 
 
 # Helper functions

--- a/tests/v2/waku_archive/test_driver_queue_index.nim
+++ b/tests/v2/waku_archive/test_driver_queue_index.nim
@@ -7,8 +7,7 @@ import
   nimcrypto
 import
   ../../../waku/v2/waku_core,
-  ../../../waku/v2/waku_archive/driver/queue_driver/index,
-  ../../../waku/v2/utils/time
+  ../../../waku/v2/waku_archive/driver/queue_driver/index
 
 
 ## Helpers

--- a/tests/v2/waku_archive/test_driver_queue_pagination.nim
+++ b/tests/v2/waku_archive/test_driver_queue_pagination.nim
@@ -9,7 +9,6 @@ import
   ../../../waku/v2/waku_archive/driver/queue_driver/queue_driver {.all.},
   ../../../waku/v2/waku_archive/driver/queue_driver/index,
   ../../../waku/v2/waku_core,
-  ../../../waku/v2/utils/time,
   ../testlib/common,
   ../testlib/wakucore
 

--- a/tests/v2/waku_archive/test_retention_policy.nim
+++ b/tests/v2/waku_archive/test_retention_policy.nim
@@ -7,12 +7,11 @@ import
   chronos
 import
   ../../../waku/common/sqlite,
+  ../../../waku/v2/waku_core,
   ../../../waku/v2/waku_archive,
   ../../../waku/v2/waku_archive/driver/sqlite_driver,
   ../../../waku/v2/waku_archive/retention_policy,
   ../../../waku/v2/waku_archive/retention_policy/retention_policy_capacity,
-  ../../../waku/v2/waku_core,
-  ../../../waku/v2/utils/time,
   ../testlib/common,
   ../testlib/wakucore
 

--- a/tests/v2/waku_archive/test_waku_archive.nim
+++ b/tests/v2/waku_archive/test_waku_archive.nim
@@ -10,7 +10,6 @@ import
   ../../../waku/v2/waku_core,
   ../../../waku/v2/waku_archive/driver/sqlite_driver,
   ../../../waku/v2/waku_archive,
-  ../../../waku/v2/utils/time,
   ../testlib/common,
   ../testlib/wakucore
 

--- a/tests/v2/waku_core/test_time.nim
+++ b/tests/v2/waku_core/test_time.nim
@@ -1,12 +1,11 @@
 {.used.}
 
 import
-  stew/results,
   testutils/unittests
 import
-  ../../waku/v2/utils/time
+  ../../waku/v2/waku_core/time
 
-suite "Utils - Time":
+suite "Waku Core - Time":
 
   test "Test timestamp conversion":
     ## Given

--- a/tests/v2/waku_store/test_rpc_codec.nim
+++ b/tests/v2/waku_store/test_rpc_codec.nim
@@ -6,9 +6,9 @@ import
   chronos
 import
   ../../../waku/common/protobuf,
+  ../../../waku/v2/waku_core,
   ../../../waku/v2/waku_store/rpc,
   ../../../waku/v2/waku_store/rpc_codec,
-  ../../../waku/v2/utils/time,
   ../testlib/common,
   ../testlib/wakucore
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
@@ -9,16 +9,15 @@ import
   json_rpc/[rpcserver, rpcclient]
 import
   ../../../waku/v2/node/peer_manager,
+  ../../../waku/v2/waku_core,
   ../../../waku/v2/waku_node,
   ../../../waku/v2/node/jsonrpc/store/handlers as store_api,
   ../../../waku/v2/node/jsonrpc/store/client as store_api_client,
-  ../../../waku/v2/waku_core,
   ../../../waku/v2/waku_archive,
   ../../../waku/v2/waku_archive/driver/queue_driver,
   ../../../waku/v2/waku_store,
   ../../../waku/v2/waku_store/rpc,
   ../../../waku/v2/utils/peers,
-  ../../../waku/v2/utils/time,
   ../../v2/testlib/common,
   ../../v2/testlib/wakucore,
   ../../v2/testlib/wakunode

--- a/tests/v2/wakunode_rest/test_rest_relay.nim
+++ b/tests/v2/wakunode_rest/test_rest_relay.nim
@@ -9,6 +9,7 @@ import
   libp2p/crypto/crypto
 import
   ../../waku/common/base64,
+  ../../waku/v2/waku_core,
   ../../waku/v2/waku_node,
   ../../waku/v2/node/rest/server,
   ../../waku/v2/node/rest/client,
@@ -17,9 +18,7 @@ import
   ../../waku/v2/node/rest/relay/handlers as relay_api,
   ../../waku/v2/node/rest/relay/client as relay_api_client,
   ../../waku/v2/node/rest/relay/topic_cache,
-  ../../waku/v2/waku_core,
   ../../waku/v2/waku_relay,
-  ../../waku/v2/utils/time,
   ../testlib/wakucore,
   ../testlib/wakunode
 

--- a/tests/v2/wakunode_rest/test_rest_store.nim
+++ b/tests/v2/wakunode_rest/test_rest_store.nim
@@ -9,20 +9,19 @@ import
   presto, presto/client as presto_client,
   libp2p/crypto/crypto
 import
+  ../../../waku/v2/waku_core,
+  ../../../waku/v2/waku_node,
   ../../../waku/v2/node/peer_manager,
-  ../../../waku/v2/node/waku_node,
-  ../../waku/v2/node/rest/server,
-  ../../waku/v2/node/rest/client,
-  ../../waku/v2/node/rest/responses,
+  ../../../waku/v2/node/rest/server,
+  ../../../waku/v2/node/rest/client,
+  ../../../waku/v2/node/rest/responses,
   ../../../waku/v2/node/rest/store/handlers as store_api,
   ../../../waku/v2/node/rest/store/client as store_api_client,
   ../../../waku/v2/node/rest/store/types,
-  ../../../waku/v2/waku_core,
   ../../../waku/v2/waku_archive,
   ../../../waku/v2/waku_archive/driver/queue_driver,
   ../../../waku/v2/waku_store as waku_store,
   ../../../waku/v2/utils/peers,
-  ../../../waku/v2/utils/time,
   ../../v2/testlib/common,
   ../../v2/testlib/wakucore,
   ../../v2/testlib/wakunode
@@ -166,7 +165,7 @@ procSuite "Waku v2 Rest API - Store":
     peerSwitch.mount(node.wakuStore)
 
     # Now prime it with some history before tests
-    let timeOrigin = common.now()
+    let timeOrigin = wakucore.now()
     let msgList = @[
       fakeWakuMessage(@[byte 00], ts=ts(00, timeOrigin)),
       fakeWakuMessage(@[byte 01], ts=ts(10, timeOrigin)),

--- a/tools/simulation/quicksim2.nim
+++ b/tools/simulation/quicksim2.nim
@@ -9,7 +9,6 @@ import
   ../../waku/v2/waku_filter/rpc,
   ../../waku/v2/waku_store/rpc,
   ../../waku/v2/waku_core,
-  ../../waku/v2/utils/time,
   ../../waku/v2/waku_node,
   ../../waku/v2/node/waku_payload,
   ../../waku/v2/node/jsonrpc/[jsonrpc_types,jsonrpc_utils]

--- a/waku/v2/node/jsonrpc/message.nim
+++ b/waku/v2/node/jsonrpc/message.nim
@@ -4,8 +4,7 @@ import
   json_rpc/rpcserver
 import
   ../../../common/base64,
-  ../../waku_core,
-  ../../utils/time
+  ../../waku_core
 
 
 type

--- a/waku/v2/node/jsonrpc/relay/handlers.nim
+++ b/waku/v2/node/jsonrpc/relay/handlers.nim
@@ -14,7 +14,6 @@ import
   ../../../waku_core,
   ../../../waku_relay,
   ../../../utils/compat,
-  ../../../utils/time,
   ../../waku_node,
   ../../message_cache,
   ./types

--- a/waku/v2/node/jsonrpc/store/client.nim
+++ b/waku/v2/node/jsonrpc/store/client.nim
@@ -7,8 +7,8 @@ import
   std/[os, strutils],
   json_rpc/rpcclient
 import
+  ../../../waku_core,
   ../../../waku_store/rpc,
-  ../../../utils/time,
   ./types
 
 export types

--- a/waku/v2/node/jsonrpc/store/handlers.nim
+++ b/waku/v2/node/jsonrpc/store/handlers.nim
@@ -8,9 +8,9 @@ import
   chronicles,
   json_rpc/rpcserver
 import
+  ../../../waku_core,
   ../../../waku_store,
   ../../../waku_store/rpc,
-  ../../../utils/time,
   ../../waku_node,
   ../../peer_manager,
   ./types

--- a/waku/v2/node/rest/store/handlers.nim
+++ b/waku/v2/node/rest/store/handlers.nim
@@ -13,7 +13,6 @@ import
   ../../../../common/base64,
   ../../../waku_core,
   ../../../waku_store/common,
-  ../../../utils/time,
   ../../waku_node,
   ../../peer_manager,
   ../responses,

--- a/waku/v2/node/rest/store/types.nim
+++ b/waku/v2/node/rest/store/types.nim
@@ -13,7 +13,6 @@ import
 import
   ../../../waku_store/common as waku_store_common,
   ../../../../common/base64,
-  ../../../utils/time,
   ../../../waku_core,
   ../serdes
 

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -39,7 +39,6 @@ import
   ../waku_discv5,
   ../waku_peer_exchange,
   ../utils/peers,
-  ../utils/time,
   ./config,
   ./peer_manager,
   ./waku_switch

--- a/waku/v2/waku_archive/archive.nim
+++ b/waku/v2/waku_archive/archive.nim
@@ -11,7 +11,6 @@ import
   chronos,
   metrics
 import
-  ../utils/time,
   ../waku_core,
   ./common,
   ./archive_metrics,

--- a/waku/v2/waku_archive/common.nim
+++ b/waku/v2/waku_archive/common.nim
@@ -9,7 +9,6 @@ import
   stew/byteutils,
   nimcrypto/sha2
 import
-  ../utils/time,
   ../waku_core
 
 

--- a/waku/v2/waku_archive/driver.nim
+++ b/waku/v2/waku_archive/driver.nim
@@ -7,7 +7,6 @@ import
   std/options,
   stew/results
 import
-  ../utils/time,
   ../waku_core,
   ./common
 

--- a/waku/v2/waku_archive/driver/queue_driver/index.nim
+++ b/waku/v2/waku_archive/driver/queue_driver/index.nim
@@ -8,7 +8,6 @@ import
   nimcrypto/sha2
 import
   ../../../waku_core,
-  ../../../utils/time,
   ../../common
 
 

--- a/waku/v2/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/v2/waku_archive/driver/queue_driver/queue_driver.nim
@@ -10,7 +10,6 @@ import
   chronicles
 import
   ../../../waku_core,
-  ../../../utils/time,
   ../../common,
   ../../driver,
   ./index

--- a/waku/v2/waku_archive/driver/sqlite_driver/cursor.nim
+++ b/waku/v2/waku_archive/driver/sqlite_driver/cursor.nim
@@ -6,7 +6,6 @@ else:
 
 import
   ../../../waku_core,
-  ../../../utils/time,
   ../../common
 
 type DbCursor* = (Timestamp, seq[byte], PubsubTopic)

--- a/waku/v2/waku_archive/driver/sqlite_driver/queries.nim
+++ b/waku/v2/waku_archive/driver/sqlite_driver/queries.nim
@@ -11,7 +11,6 @@ import
 import
   ../../../../common/sqlite,
   ../../../waku_core,
-  ../../../utils/time,
   ./cursor
 
 

--- a/waku/v2/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/v2/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -12,7 +12,6 @@ import
 import
   ../../../../common/sqlite,
   ../../../waku_core,
-  ../../../utils/time,
   ../../common,
   ../../driver,
   ./cursor,

--- a/waku/v2/waku_archive/retention_policy/retention_policy_time.nim
+++ b/waku/v2/waku_archive/retention_policy/retention_policy_time.nim
@@ -9,7 +9,7 @@ import
   chronicles,
   chronos
 import
-  ../../utils/time,
+  ../../waku_core,
   ../driver,
   ../retention_policy
 

--- a/waku/v2/waku_core.nim
+++ b/waku/v2/waku_core.nim
@@ -1,7 +1,9 @@
 import
   ./waku_core/topics,
+  ./waku_core/time,
   ./waku_core/message
 
 export
   topics,
+  time,
   message

--- a/waku/v2/waku_core/message/codec.nim
+++ b/waku/v2/waku_core/message/codec.nim
@@ -10,8 +10,8 @@ else:
 
 import
   ../../../common/protobuf,
-  ../../utils/time,
   ../topics,
+  ../time,
   ./message
 
 

--- a/waku/v2/waku_core/message/message.nim
+++ b/waku/v2/waku_core/message/message.nim
@@ -10,8 +10,8 @@ else:
 
 
 import
-  ../../utils/time,
-  ../topics
+  ../topics,
+  ../time
 
 const
   MaxMetaAttrLength* = 64 # 64 bytes

--- a/waku/v2/waku_core/time.nim
+++ b/waku/v2/waku_core/time.nim
@@ -1,4 +1,3 @@
-## Contains types and utilities for timestamps.
 when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:

--- a/waku/v2/waku_rln_relay/rln/wrappers.nim
+++ b/waku/v2/waku_rln_relay/rln/wrappers.nim
@@ -10,8 +10,8 @@ import
   ../protocol_types,
   ../protocol_metrics
 import
-  ../../waku_keystore,
-  ../../utils/time
+  ../../waku_core,
+  ../../waku_keystore
 
 logScope:
   topics = "waku rln_relay ffi"

--- a/waku/v2/waku_rln_relay/rln_relay.nim
+++ b/waku/v2/waku_rln_relay/rln_relay.nim
@@ -22,7 +22,7 @@ import
   ./protocol_types,
   ./protocol_metrics
 import
-  ../utils/time,
+  ../waku_core,
   ../waku_keystore
 
 logScope:

--- a/waku/v2/waku_store/common.nim
+++ b/waku/v2/waku_store/common.nim
@@ -9,7 +9,6 @@ import
   stew/byteutils,
   nimcrypto/sha2
 import
-  ../utils/time,
   ../waku_core
 
 

--- a/waku/v2/waku_store/protocol.nim
+++ b/waku/v2/waku_store/protocol.nim
@@ -18,8 +18,8 @@ import
   libp2p/stream/connection,
   metrics
 import
+  ../waku_core,
   ../node/peer_manager,
-  ../utils/time,
   ./common,
   ./rpc,
   ./rpc_codec,

--- a/waku/v2/waku_store/rpc.nim
+++ b/waku/v2/waku_store/rpc.nim
@@ -7,7 +7,6 @@ import
   std/[options, sequtils],
   stew/results
 import
-  ../utils/time,
   ../waku_core,
   ./common
 


### PR DESCRIPTION
Following my motto, _One tech debt PR a day keeps the debugger away 🪴_, bring the subsequent project structure changes.

- [x] Move `utils/time` under `waku_core` module.
- [x] Moved time-related logic from `testlib/common` to `testlib/wakucore`. 
- [x] Updated all imports accordingly. 


There are a few pending tasks that I am leaving out of this PR to reduce the overall cognitive load:

- [ ] Move `utils/peers` under `waku_core` module.
- [ ] Unify key types (libp2p and eth) under a WakuKey type (at `waku_core/keys`).
- [ ] Unify the _Peer_ types under a `WakuPeer` type (at `waku_core/peers`).