### PR TITLE
chore: add deprecation notice to utils module. move heartbeat to common

### DIFF
--- a/waku/common/nimchronos.nim
+++ b/waku/common/nimchronos.nim
@@ -1,13 +1,19 @@
+## An extension wrapper around nim-chronos
 when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:
   {.push raises: [].}
 
-import sequtils
-import chronos, chronicles
+import
+  chronos,
+  chronicles
+
+export chronos
+
+
+## Extension methods
 
 # Taken from: https://github.com/status-im/nim-libp2p/blob/master/libp2p/utils/heartbeat.nim
-
 template heartbeat*(name: string, interval: Duration, body: untyped): untyped =
   var nextHeartbeat = Moment.now()
   while true:
@@ -19,11 +25,12 @@ template heartbeat*(name: string, interval: Duration, body: untyped): untyped =
       let
         delay = now - nextHeartbeat
         itv = interval
+
       if delay > itv:
-        info "Missed multiple heartbeats", heartbeat = name,
-          delay = delay, hinterval = itv
+        info "Missed multiple heartbeats", heartbeat = name, delay = delay, hinterval = itv
       else:
-        debug "Missed heartbeat", heartbeat = name,
-          delay = delay, hinterval = itv
+        debug "Missed heartbeat", heartbeat = name, delay = delay, hinterval = itv
+
       nextHeartbeat = now + itv
+
     await sleepAsync(nextHeartbeat - now)

--- a/waku/common/utils/DEPRECATION_NOTICE.md
+++ b/waku/common/utils/DEPRECATION_NOTICE.md
@@ -1,0 +1,6 @@
+# :warning: DEPRECATION NOTICE :warning:
+
+The `utils` module has been marked as deprecated.
+This package submodules are planned to be moved to different modules.
+
+**No new sub-modules must be added to this folder.**

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -12,9 +12,9 @@ import
   libp2p/multistream,
   libp2p/muxers/muxer
 import
+  ../../../common/nimchronos,
   ../../waku_relay,
   ../../utils/peers,
-  ../../utils/heartbeat,
   ./peer_store/peer_storage,
   ./waku_peer_store
 


### PR DESCRIPTION
As we discussed many times, the `utils` module has been marked as deprecated. The contained modules will be moved to different packages in future PRs.

- [x] Added `DEPRECATION_NOTICE` to `waku/v2/utils` folder.
- [x] Moved `heartbeat.nim` to `waku/common` as `nimchronos` submodule, given that this file extends the `nim-chronos` functionality in a "waku-opinionated" way. Note that the nim file cannot be called `chronos.nim` since it would conflict with the `nim-chronos` vendor module.