### PR TITLE
fix(rest): change rest server result error type to string

### DIFF
--- a/waku/v2/node/rest/server.nim
+++ b/waku/v2/node/rest/server.nim
@@ -11,7 +11,7 @@ import
   presto
 
 
-type RestServerResult*[T] = Result[T, cstring]
+type RestServerResult*[T] = Result[T, string]
 
 
 ### Configuration
@@ -84,10 +84,11 @@ proc init*(T: type RestServerRef,
       maxHeadersSize = maxHeadersSize,
       maxRequestBodySize = maxRequestBodySize
     )
-  except CatchableError as ex:
-    return err(cstring(ex.msg))
+  except CatchableError:
+    return err(getCurrentExceptionMsg())
 
-  res
+  # RestResult error type is cstring, so we need to map it to string
+  res.mapErr(proc(err: cstring): string = $err)
 
 proc newRestHttpServer*(ip: ValidIpAddress, port: Port,
                         allowedOrigin=none(string),


### PR DESCRIPTION
This is a small refactoring PR 🪴

We are using extensively `string` as the project's standard error type.

- [x] Change the REST server's result error type to `string`.