### PR TITLE
build: decouple test2 target from testcommon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,14 @@ else # "variables.mk" was included. Business as usual until the end of this file
 ##########
 ## Main ##
 ##########
-.PHONY: all test update clean v1 v2
+.PHONY: all test update clean v1 v2 test1 test2
 
 # default target, because it's the first one that doesn't start with '.'
 all: | v1 v2
 
 test: | test1 test2
+test1: | testcommon testwhisper testwaku1
+test2: | testcommon testwaku2
 
 v1: | wakunode1 example1 sim1
 v2: | wakunode2 example2 wakubridge chat2 chat2bridge
@@ -144,9 +146,9 @@ testcommon: | build deps
 #############
 ## Waku v2 ##
 #############
-.PHONY: test2 wakunode2 example2 sim2 scripts2 wakubridge chat2 chat2bridge
+.PHONY: testwaku2 wakunode2 example2 sim2 scripts2 wakubridge chat2 chat2bridge
 
-test2: | build deps librln testcommon
+testwaku2: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
@@ -200,13 +202,13 @@ networkmonitor: | build deps
 #################
 ## Waku legacy ##
 #################
-.PHONY: testwhisper test1 wakunode1 example1 sim1
+.PHONY: testwhisper testwaku1 wakunode1 example1 sim1
 
-testwhisper: | build deps testcommon
+testwhisper: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim testwhisper $(NIM_PARAMS) waku.nims
 
-test1: | build deps testcommon
+testwaku1: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim test1 $(NIM_PARAMS) waku.nims
 


### PR DESCRIPTION
Running `make test2` implied running the `testcommon` target. Sometimes this could be more convenient. This PR decouples both Makefile targets:

- [x] Added `testwaku1` and `testwaku2` targets to decuple the Waku v1/v2 tests from the `testcommon` tests.
- [x] Modified `test2` to run `testcommon` and `testwaku2`.
- [x] Modified `test1` to run `testwhisper` and `testwaku1`. 