### PR TITLE
feat: add metrics with msg size histogram

### DIFF
--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -48,7 +48,8 @@ when defined(rln):
     ../waku_rln_relay
 
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]
-declarePublicHistogram waku_histogram_message_size, "message size histogram in kB", buckets = [0.0, 5.0, 15.0, 50.0, 100.0, 300.0, 700.0, 1000.0]
+declarePublicHistogram waku_histogram_message_size, "message size histogram in kB",
+  buckets = [0.0, 5.0, 15.0, 50.0, 100.0, 300.0, 700.0, 1000.0, Inf]
 
 declarePublicGauge waku_version, "Waku version info (in git describe format)", ["version"]
 declarePublicGauge waku_node_errors, "number of wakunode errors", ["type"]

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -47,8 +47,10 @@ when defined(rln):
   import
     ../waku_rln_relay
 
-declarePublicGauge waku_version, "Waku version info (in git describe format)", ["version"]
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]
+declarePublicHistogram waku_histogram_message_size, "message size histogram in kB", buckets = [0.0, 5.0, 15.0, 50.0, 100.0, 300.0, 700.0, 1000.0]
+
+declarePublicGauge waku_version, "Waku version info (in git describe format)", ["version"]
 declarePublicGauge waku_node_errors, "number of wakunode errors", ["type"]
 declarePublicGauge waku_lightpush_peers, "number of lightpush peers"
 declarePublicGauge waku_filter_peers, "number of filter peers"
@@ -240,7 +242,10 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
       hash=topic.digest(msg).to0xHex(),
       receivedTime=getNowInNanosecondTime()
 
+    let msgSizeKB = msg.payload.len/1000
+
     waku_node_messages.inc(labelValues = ["relay"])
+    waku_histogram_message_size.observe(msgSizeKB)
 
   proc filterHandler(topic: PubsubTopic, msg: WakuMessage) {.async, gcsafe.} =
     if node.wakuFilter.isNil():


### PR DESCRIPTION
closes #1626 

* Add a new metric `waku_histogram_message_size` containing the message size histogram.
* This allows to have better observability on the message distribution size.

Suggested usage:

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/8811422/233333160-447c9577-34c4-4fa6-ab43-c504ae59e516.png">

* 98% of the messages are between 5 and 15 kBytes
* 0.7% of the messages are between 50 and 100 kBytes.
* 99% of the messages are lower than 37.6 kBytes.
