### PR TITLE
chore: refactor flaky test with while

### DIFF
--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -281,6 +281,9 @@ suite "WakuNode - Relay":
         let connOk = await nodes[i].peerManager.connectRelay(nodes[j].switch.peerInfo.toRemotePeerInfo())
         require connOk
 
+    # Connection triggers different actions, wait for them
+    await sleepAsync(500.millis)
+
     var msgReceived = 0
     proc handler(pubsubTopic: PubsubTopic, data: WakuMessage) {.async, gcsafe.} =
       msgReceived += 1
@@ -302,7 +305,7 @@ suite "WakuNode - Relay":
         await nodes[i].publish(spamProtectedTopic, msg)
 
     # Wait for gossip
-    await sleepAsync(1.seconds)
+    await sleepAsync(2.seconds)
 
     # 50 messages were sent to 5 peers = 250 messages
     check:
@@ -354,6 +357,9 @@ suite "WakuNode - Relay":
     proc handler(pubsubTopic: PubsubTopic, msg: WakuMessage) {.async, gcsafe.} =
       msgReceived += 1
 
+    # Connection triggers different actions, wait for them
+    await sleepAsync(500.millis)
+
     # Subscribe all nodes to the same topic/handler
     for node in nodes: node.wakuRelay.subscribe(spamProtectedTopic, handler)
     await sleepAsync(500.millis)
@@ -379,7 +385,7 @@ suite "WakuNode - Relay":
         await nodes[i].publish(spamProtectedTopic, unsignedMessage)
 
     # Wait for gossip
-    await sleepAsync(1.seconds)
+    await sleepAsync(2.seconds)
 
     # Since we have a full mesh with 5 nodes and each one publishes 50+50 msgs
     # there are 500 messages being sent.
@@ -443,6 +449,7 @@ suite "WakuNode - Relay":
         let connOk2 = await nodes[i].peerManager.connectRelay(nodes[j].switch.peerInfo.toRemotePeerInfo())
         require connOk2
 
+    # Connection triggers different actions, wait for them
     await sleepAsync(500.millis)
 
     # nodes[0] spams 50 non signed messages (nodes[0] just knows of nodes[1])
@@ -462,7 +469,7 @@ suite "WakuNode - Relay":
       await nodes[0].publish(spamProtectedTopic, msg)
 
     # Wait for gossip
-    await sleepAsync(1.seconds)
+    await sleepAsync(2.seconds)
 
     # only 100 messages are received (50 + 50) which demonstrate
     # nodes[1] doest gossip invalid messages.


### PR DESCRIPTION
Aims to fix couple of flaky tests by:
* Increasing the time we wait before the assert.
* Running a while loop with a max number of attempts. So instead of waiting a fixed amount of time, we set a maximum number of attempts before it fails. If the tests succeedes before, it shorten execution time.