### PR TITLE
refactor: use QUICK_AND_DIRTY_COMPILER flag for CI

### DIFF
--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -84,7 +84,7 @@ jobs:
           key: ${{ runner.os }}-zerokit-${{ steps.submodules.outputs.zerokit-hash }}
 
       - name: Build binaries
-        run: make V=1 LOG_LEVEL=DEBUG v2
+        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 v2
 
   test-v2:
     needs: changes
@@ -122,4 +122,4 @@ jobs:
           key: ${{ runner.os }}-zerokit-${{ steps.submodules.outputs.zerokit-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG test2 testwakunode2
+        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Build binaries
-        run: make V=1 LOG_LEVEL=DEBUG v2 tools
+        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 v2 tools
 
   test-v2:
     needs: changes
@@ -117,7 +117,7 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG test2 testwakunode2
+        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2
 
 
   build-legacy:
@@ -149,7 +149,7 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Build binaries
-        run: make V=1 LOG_LEVEL=DEBUG v1
+        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 v1
 
   test-legacy:
     needs: changes
@@ -180,4 +180,4 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG test1
+        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test1


### PR DESCRIPTION
# Description
Nimbus uses `QUICK_AND_DIRTY_COMPILER` flag in their [ci](https://github.com/status-im/nimbus-eth2/blob/stable/.github/workflows/ci.yml#L135) and [release](https://github.com/status-im/nimbus-eth2/blob/stable/docker/dist/entry_point.sh#L197) actions. This skips some verification checks for Nim correctness , hence speeds up the build process see for actual usage in `build_nim.sh` - https://github.com/status-im/nimbus-build-system/blob/master/scripts/build_nim.sh#L185

# Changes

<!-- List of detailed changes -->

- [x] enable the `QUICK_AND_DIRTY_COMPILER` for all CI jobs

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->