### PR TITLE
test: set LOG_LEVEL to 'ERROR' in order to have less logs in ci jobs

### DIFF
--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -84,7 +84,7 @@ jobs:
           key: ${{ runner.os }}-zerokit-${{ steps.submodules.outputs.zerokit-hash }}
 
       - name: Build binaries
-        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 v2
+        run: make V=1 LOG_LEVEL=ERROR QUICK_AND_DIRTY_COMPILER=1 v2
 
   test-v2:
     needs: changes
@@ -122,4 +122,4 @@ jobs:
           key: ${{ runner.os }}-zerokit-${{ steps.submodules.outputs.zerokit-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2
+        run: make V=1 LOG_LEVEL=ERROR QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Build binaries
-        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 v2 tools
+        run: make V=1 LOG_LEVEL=ERROR QUICK_AND_DIRTY_COMPILER=1 v2 tools
 
   test-v2:
     needs: changes
@@ -117,7 +117,7 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2
+        run: make V=1 LOG_LEVEL=ERROR QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2
 
 
   build-legacy:
@@ -149,7 +149,7 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Build binaries
-        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 v1
+        run: make V=1 LOG_LEVEL=ERROR QUICK_AND_DIRTY_COMPILER=1 v1
 
   test-legacy:
     needs: changes
@@ -180,4 +180,4 @@ jobs:
           key: ${{ runner.os }}-nim-${{ steps.submodules.outputs.nim-hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test1
+        run: make V=1 LOG_LEVEL=ERROR QUICK_AND_DIRTY_COMPILER=1 test1


### PR DESCRIPTION
# Description
When a job fails I find it awkward to look for what has happened exactly. This change seeks for making it easier.

Therefore, if I need to debug I would do it locally.

