### PR TITLE
fix: fix filter v2 proto fields

### DIFF
--- a/waku/v2/waku_filter_v2/rpc_codec.nim
+++ b/waku/v2/waku_filter_v2/rpc_codec.nim
@@ -55,8 +55,8 @@ proc encode*(rpc: FilterSubscribeResponse): ProtoBuffer =
   var pb = initProtoBuffer()
 
   pb.write3(1, rpc.requestId)
-  pb.write3(2, rpc.statusCode)
-  pb.write3(3, rpc.statusDesc)
+  pb.write3(10, rpc.statusCode)
+  pb.write3(11, rpc.statusDesc)
 
   pb
 
@@ -67,11 +67,11 @@ proc decode*(T: type FilterSubscribeResponse, buffer: seq[byte]): ProtobufResult
   if not ?pb.getField(1, rpc.requestId):
     return err(ProtobufError.missingRequiredField("request_id"))
 
-  if not ?pb.getField(2, rpc.statusCode):
+  if not ?pb.getField(10, rpc.statusCode):
     return err(ProtobufError.missingRequiredField("status_code"))
 
   var statusDesc: string
-  if not ?pb.getField(3, statusDesc):
+  if not ?pb.getField(11, statusDesc):
     rpc.statusDesc = none(string)
   else:
     rpc.statusDesc = some(statusDesc)


### PR DESCRIPTION
Fixes the protofield numbering in the nwaku implementation of https://rfc.vac.dev/spec/12/.

The `status_code` and `status_desc` fields were using field numbers `2` and `3`, whereas the specified field numbers are `10` and `11`.

cc @fryorcraken @danisharora099 