### PR TITLE
fix(rln-relay): handle invalid deletes

### DIFF
--- a/tests/v2/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/v2/waku_rln_relay/test_waku_rln_relay.nim
@@ -152,10 +152,16 @@ suite "Waku rln relay":
     let rlnInstance = createRLNInstance()
     require:
       rlnInstance.isOk()
+    # generate an identity credential
+    let rln = rlnInstance.get()
+    let idCredentialRes = rln.membershipKeyGen()
+    require:
+      idCredentialRes.isOk()
+      rln.insertMember(idCredentialRes.get().idCommitment)
 
     # delete the first member
     let deletedMemberIndex = MembershipIndex(0)
-    let deletionSuccess = deleteMember(rlnInstance.get(), deletedMemberIndex)
+    let deletionSuccess = rln.deleteMember(deletedMemberIndex)
     check:
       deletionSuccess
 
@@ -191,6 +197,11 @@ suite "Waku rln relay":
     require:
       rlnInstance.isOk()
     let rln = rlnInstance.get()
+
+    let idCredentialRes = rln.membershipKeyGen()
+    require:
+      idCredentialRes.isOk()
+      rln.insertMember(idCredentialRes.get().idCommitment)
     check:
       rln.removeMember(MembershipIndex(0))
 


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
After deletion behaviour in zerokit's master was changed, it caused ci errors in nwaku. This PR addresses that change in behaviour. 

# Changes

<!-- List of detailed changes -->

- [x] Updated tests to include a valid deletion operation

<!--
## How to test

1.
1.
1.

-->


