### PR TITLE
chore(rln-relay): use new config for ffi

### DIFF
--- a/waku/v2/waku_rln_relay/constants.nim
+++ b/waku/v2/waku_rln_relay/constants.nim
@@ -1,8 +1,10 @@
 import
+  std/json
   stint
 
 import
   ../waku_keystore
+
 
 # Acceptable roots for merkle root validation of incoming messages
 const AcceptableRootWindowSize* = 5
@@ -28,7 +30,7 @@ const
 const
   # The relative folder where the circuit, proving and verification key for RLN can be found
   # Note that resources has to be compiled with respect to the above MerkleTreeDepth
-  RlnResourceFolder* = "tree_height_" & $MerkleTreeDepth & "/"
+  RlnConfig* = $(%* { "resources_folder": "tree_height_" & $MerkleTreeDepth & "/" })
 
 # temporary variables to test waku-rln-relay performance in the static group mode
 const

--- a/waku/v2/waku_rln_relay/constants.nim
+++ b/waku/v2/waku_rln_relay/constants.nim
@@ -1,5 +1,5 @@
 import
-  std/json
+  std/json,
   stint
 
 import

--- a/waku/v2/waku_rln_relay/rln/wrappers.nim
+++ b/waku/v2/waku_rln_relay/rln/wrappers.nim
@@ -59,7 +59,7 @@ proc createRLNInstanceLocal*(d: int = MerkleTreeDepth): RLNResult =
   var
     rlnInstance: ptr RLN
     merkleDepth: csize_t = uint(d)
-    resourcesPathBuffer = RlnResourceFolder.toOpenArrayByte(0, RlnResourceFolder.high).toBuffer()
+    resourcesPathBuffer = RlnConfig.toOpenArrayByte(0, RlnConfig.high).toBuffer()
 
   # create an instance of RLN
   let res = new_circuit(merkleDepth, addr resourcesPathBuffer, addr rlnInstance)


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Since we pass in a json string to the ffi for additional configs, this pr updates nwaku to do the same

# Changes

<!-- List of detailed changes -->

- [x] https://github.com/vacp2p/zerokit/pull/150

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
