### PR TITLE
fix: change filter request default behaviour to subscriber-ping

### DIFF
--- a/waku/v2/waku_filter_v2/protocol.nim
+++ b/waku/v2/waku_filter_v2/protocol.nim
@@ -222,7 +222,7 @@ proc initProtocolHandler(wf: WakuFilter) =
 
     let decodeRes = FilterSubscribeRequest.decode(buf)
     if decodeRes.isErr():
-      error "Failed to decode filter subscribe request", peerId=conn.peerId
+      error "Failed to decode filter subscribe request", peerId=conn.peerId, err=decodeRes.error
       waku_filter_errors.inc(labelValues = [decodeRpcFailure])
       return
 

--- a/waku/v2/waku_filter_v2/rpc_codec.nim
+++ b/waku/v2/waku_filter_v2/rpc_codec.nim
@@ -37,7 +37,8 @@ proc decode*(T: type FilterSubscribeRequest, buffer: seq[byte]): ProtobufResult[
 
   var filterSubscribeType: uint32
   if not ?pb.getField(2, filterSubscribeType):
-    return err(ProtobufError.missingRequiredField("filter_subscribe_type"))
+    # Revert to ping by default if not set
+    rpc.filterSubscribeType = FilterSubscribeType.SUBSCRIBER_PING
   else:
     rpc.filterSubscribeType = FilterSubscribeType(filterSubscribeType)
 


### PR DESCRIPTION
Instead of raising a decoding error, the filter protocol should assume `SUBSCRIBER_PING` as the default request type if the corresponding field is not set. This also matches proto3 requirements for enums to have a `0` value, which do not need to be serialised: https://protobuf.dev/programming-guides/proto3/#default

cc @danisharora099 