### PR TITLE
fix: wakunode2 config. adding new 'topic' config parameter.

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -549,11 +549,12 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
   if conf.relay:
 
     var pubsubTopics = @[""]
-    if conf.topicsDeprecated != "":
+    if conf.topicsDeprecated != "/waku/2/default-waku/proto":
+      warn "The 'topics' parameter is deprecated. Better use the 'topic' one instead."
       if conf.topics != @["/waku/2/default-waku/proto"]:
         return err("Please don't specify 'topics' and 'topic' simultaneously. Only use the 'topic' parameter")
 
-      # This clause (if conf.topicsDeprecated != "") should disapear in >= v0.18.0
+      # This clause (if conf.topicsDeprecated ) should disapear in >= v0.18.0
       pubsubTopics = conf.topicsDeprecated.split(" ")
     else:
       pubsubTopics = conf.topics

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -547,7 +547,16 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
     peerExchangeHandler = some(handlePeerExchange)
 
   if conf.relay:
-    let pubsubTopics = conf.topics.split(" ")
+
+    var pubsubTopics = @[""]
+    if conf.topicsDeprecated != "":
+      if conf.topics != @["/waku/2/default-waku/proto"]:
+        return err("Please don't specify 'topics' and 'topic' simultaneously. Only use the 'topic' parameter")
+
+      # This clause (if conf.topicsDeprecated != "") should disapear in >= v0.18.0
+      pubsubTopics = conf.topicsDeprecated.split(" ")
+    else:
+      pubsubTopics = conf.topics
     try:
       await mountRelay(node, pubsubTopics, peerExchangeHandler = peerExchangeHandler)
     except CatchableError:

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -42,7 +42,6 @@ type
       defaultValue: newSeq[ProtectedTopic](0)
       name: "protected-topic" .}: seq[ProtectedTopic]
 
-
     ## Log configuration
     logLevel* {.
       desc: "Sets the log level for process. Supported levels: TRACE, DEBUG, INFO, NOTICE, WARN, ERROR or FATAL",
@@ -53,7 +52,6 @@ type
       desc: "Specifies what kind of logs should be written to stdout. Suported formats: TEXT, JSON",
       defaultValue: logging.LogFormat.TEXT,
       name: "log-format" .}: logging.LogFormat
-
 
     ## General node config
     agentString* {.
@@ -207,10 +205,15 @@ type
       defaultValue: false
       name: "keep-alive" }: bool
 
-    topics* {.
-      desc: "Default topics to subscribe to (space separated list)."
-      defaultValue: "/waku/2/default-waku/proto"
+    topicsDeprecated* {.
+      desc: "Default topics to subscribe to (space separated list). DEPRECATED: please use repeated --topic argument instead."
+      defaultValue: ""
       name: "topics" .}: string
+
+    topics* {.
+      desc: "Default topic to subscribe to. Argument may be repeated."
+      defaultValue: @["/waku/2/default-waku/proto"]
+      name: "topic" .}: seq[string]
 
     ## Store and message store config
 

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -207,7 +207,7 @@ type
 
     topicsDeprecated* {.
       desc: "Default topics to subscribe to (space separated list). DEPRECATED: please use repeated --topic argument instead."
-      defaultValue: ""
+      defaultValue: "/waku/2/default-waku/proto"
       name: "topics" .}: string
 
     topics* {.


### PR DESCRIPTION
# Description
Adding a new `topic` parameter can be repeated.
The `topics` parameter becomes deprecated because it is not consistent with the other "repeatable" ones as it expects a space-separated list of pubsub topics.

## How to use the new parameter
When setting different pubsub topics through the CLI, they can be repeated:
`./build/wakunode2 --topic=t1 --topic=t2 --topic=t3 ...`

However, when setting them from within a config file, they should be in an array format within the cfg file:
```
topic = [ "t1" "t2" "t3" ]
```

## Issue
closes #1726
