### PR TITLE
feat: cbindings - allowing libwaku.so (dynamic) library

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -34,17 +34,17 @@ proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
     extra_params &= " " & paramStr(i)
   exec "nim " & lang & " --out:build/" & name & " " & extra_params & " " & srcDir & name & ".nim"
 
-proc buildLibrary(name: string, srcDir = "./", params = "", lang = "c", isStatic = true) =
+proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
   if not dirExists "build":
     mkDir "build"
   # allow something like "nim nimbus --verbosity:0 --hints:off nimbus.nims"
   var extra_params = params
   for i in 2..<paramCount():
     extra_params &= " " & paramStr(i)
-  if isStatic:
-    exec "nim " & lang & " --out:build/" & name & ".a  --app:staticlib --opt:size --noMain --header " & extra_params & " " & srcDir & name & ".nim"
+  if `type` == "static":
+    exec "nim c" & " --out:build/" & name & ".a  --app:staticlib --opt:size --noMain --header " & extra_params & " " & srcDir & name & ".nim"
   else:
-    exec "nim " & lang & " --out:build/" & name & ".a  --app:lib --opt:size --noMain --header " & extra_params & " " & srcDir & name & ".nim"
+    exec "nim c" & " --out:build/" & name & ".so  --app:lib --opt:size --noMain --header " & extra_params & " " & srcDir & name & ".nim"
 
 proc test(name: string, params = "-d:chronicles_log_level=DEBUG", lang = "c") =
   # XXX: When running `> NIM_PARAMS="-d:chronicles_log_level=INFO" make test2`
@@ -100,9 +100,13 @@ task chat2bridge, "Build chat2bridge":
   buildBinary name, "apps/chat2bridge/", "-d:chronicles_log_level=TRACE"
 
 ### C Bindings
-task libwaku, "Build the cbindings waku node library":
+task libwakuStatic, "Build the cbindings waku node library":
   let name = "libwaku"
-  buildLibrary name, "library/", "-d:chronicles_log_level=ERROR"
+  buildLibrary name, "library/", "-d:chronicles_log_level=ERROR", "static"
+
+task libwakuDynamic, "Build the cbindings waku node library":
+  let name = "libwaku"
+  buildLibrary name, "library/", "-d:chronicles_log_level=ERROR", "dynamic"
 
 ### Legacy: Whisper & Waku v1 tasks
 task testwhisper, "Build & run Whisper tests":


### PR DESCRIPTION
# Description
This PR aims for adding the option to create a dynamic linking library (libwaku.so.)

To change the type of library just pass `STATIC=true` to the Makefile command, and it will generate a libwaku.a. If nothing is passed, it builds dynamic library by default.

## How to use it
### Create cwaku_example
1. To generate a static library (libwaku.a) and cwaku_example binary with the libwaku embbeded into it:
   `make cwaku_example STATIC=true -j8`
2. To generate a dynamic library (libwaku.so) and cwaku_example binary with the libwaku embbeded into it:
   `make cwaku_example -j8`

### Generate the library itself:
1. dynamic library: `make libwaku -j8`.
    `-> produces: build/libwaku.so
2. static library: `make libwaku STATIC=true -j8`
    `-> produces: build/libwaku.a

## Issue
https://github.com/waku-org/nwaku/issues/1632
