### PR TITLE
feat(rln-relay): use new atomic_operation ffi api

### DIFF
--- a/tests/v2/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/v2/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -6,7 +6,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[options, osproc, streams, strutils, tables],
+  std/[options, osproc, streams, strutils],
   stew/[results, byteutils],
   stew/shims/net as stewNet,
   testutils/unittests,
@@ -516,11 +516,8 @@ suite "Onchain group manager":
       manager.validRootBuffer.len() == 1
 
     # We can now simulate a chain reorg by calling backfillRootQueue
-    var blockTable = default(BlockTable)
-    blockTable[1.uint] = @[Membership(idCommitment: credentials[4].idCommitment, index: 4.uint)]
-
     let expectedLastRoot = manager.validRootBuffer[0]
-    await manager.backfillRootQueue(blockTable)
+    await manager.backfillRootQueue(1)
 
     # We should now have 5 roots in the queue, and no partial buffer
     check:

--- a/waku/v2/waku_rln_relay/conversion_utils.nim
+++ b/waku/v2/waku_rln_relay/conversion_utils.nim
@@ -90,6 +90,20 @@ proc serialize*(roots: seq[MerkleNode]): seq[byte] =
     rootsBytes = concat(rootsBytes, @root)
   return rootsBytes
 
+# Serializes a sequence of MembershipIndex's
+proc serialize*(memIndices: seq[MembershipIndex]): seq[byte] =
+  var memIndicesBytes = newSeq[byte]()
+
+  # serialize the memIndices, with its length prefixed
+  let len = toBytes(uint64(memIndices.len), Endianness.littleEndian)
+  memIndicesBytes.add(len)
+
+  for memIndex in memIndices:
+    let memIndexBytes = toBytes(uint64(memIndex), Endianness.littleEndian)
+    memIndicesBytes = concat(memIndicesBytes, @memIndexBytes)
+
+  return memIndicesBytes
+
 proc toEpoch*(t: uint64): Epoch =
   ## converts `t` to `Epoch` in little-endian order
   let bytes = toBytes(t, Endianness.littleEndian)

--- a/waku/v2/waku_rln_relay/group_manager/group_manager_base.nim
+++ b/waku/v2/waku_rln_relay/group_manager/group_manager_base.nim
@@ -83,6 +83,10 @@ method withdraw*(g: GroupManager, identitySecretHash: IdentitySecretHash): Futur
 method withdrawBatch*(g: GroupManager, identitySecretHashes: seq[IdentitySecretHash]): Future[void] {.base,gcsafe.} =
   raise newException(CatchableError, "withdrawBatch proc for " & $g.type & " is not implemented yet")
 
+# This proc is used to insert and remove a set of commitments from the merkle tree
+method atomicBatch*(g: GroupManager, idCommitments: seq[IDCommitment], toRemoveIndices: seq[MembershipIndex]): Future[void] {.base,gcsafe.} =
+  raise newException(CatchableError, "atomicBatch proc for " & $g.type & " is not implemented yet")
+
 # This proc is used to set a callback that will be called when an identity commitment is withdrawn
 # The callback may be called multiple times, and should be used to for any post processing
 method onWithdraw*(g: GroupManager, cb: OnWithdrawCallback) {.base,gcsafe.} =

--- a/waku/v2/waku_rln_relay/group_manager/static/group_manager.nim
+++ b/waku/v2/waku_rln_relay/group_manager/static/group_manager.nim
@@ -52,17 +52,8 @@ method startGroupSync*(g: StaticGroupManager): Future[void] =
 method register*(g: StaticGroupManager, idCommitment: IDCommitment): Future[void] {.async.} =
   initializedGuard(g)
 
-  let memberInserted = g.rlnInstance.insertMember(idCommitment)
-  if not memberInserted:
-    raise newException(ValueError, "Failed to insert member into the merkle tree")
+  await g.registerBatch(@[idCommitment])
 
-  discard g.slideRootQueue()
-
-  g.latestIndex += 1
-
-  if g.registerCb.isSome():
-    await g.registerCb.get()(@[Membership(idCommitment: idCommitment, index: g.latestIndex)])
-  return
 
 method registerBatch*(g: StaticGroupManager, idCommitments: seq[IDCommitment]): Future[void] {.async.} =
   initializedGuard(g)

--- a/waku/v2/waku_rln_relay/group_manager/static/group_manager.nim
+++ b/waku/v2/waku_rln_relay/group_manager/static/group_manager.nim
@@ -65,12 +65,12 @@ method registerBatch*(g: StaticGroupManager, idCommitments: seq[IDCommitment]): 
   if g.registerCb.isSome():
     var memberSeq = newSeq[Membership]()
     for i in 0..<idCommitments.len():
-      memberSeq.add(Membership(idCommitment: idCommitments[i], index: g.latestIndex + MembershipIndex(i)))
+      memberSeq.add(Membership(idCommitment: idCommitments[i], index: g.latestIndex + MembershipIndex(i) + 1))
     await g.registerCb.get()(memberSeq)
 
   discard g.slideRootQueue()
 
-  g.latestIndex += MembershipIndex(idCommitments.len() - 1)
+  g.latestIndex += MembershipIndex(idCommitments.len())
 
   return
 

--- a/waku/v2/waku_rln_relay/rln/rln_interface.nim
+++ b/waku/v2/waku_rln_relay/rln/rln_interface.nim
@@ -61,10 +61,12 @@ proc init_tree_with_leaves*(ctx: ptr RLN, input_buffer: ptr Buffer): bool {.impo
 ## leaves are set one after each other starting from index 0
 ## the return bool value indicates the success or failure of the operation
 
-proc set_leaves_from*(ctx: ptr RLN, index: uint, input_buffer: ptr Buffer): bool {.importc: "set_leaves_from".}
-## sets multiple leaves in the tree stored by ctx to the value passed by input_buffer
-## the input_buffer holds a serialized vector of leaves (32 bytes each)
-## the input_buffer size is prefixed by a 8 bytes integer indicating the number of leaves
+proc atomic_write*(ctx: ptr RLN, index: uint, leaves_buffer: ptr Buffer, indices_buffer: ptr Buffer): bool {.importc: "atomic_operation".}
+## sets multiple leaves, and zeroes out indices in the tree stored by ctx to the value passed by input_buffer
+## the leaves_buffer holds a serialized vector of leaves (32 bytes each)
+## the leaves_buffer size is prefixed by a 8 bytes integer indicating the number of leaves
+## the indices_bufffer holds a serialized vector of indices (8 bytes each)
+## the indices_buffer size is prefixed by a 8 bytes integer indicating the number of indices
 ## leaves are set one after each other starting from index `index`
 ## the return bool value indicates the success or failure of the operation
 


### PR DESCRIPTION
- chore(rln-relay): bump zerokit
- feat(rln-relay): use new atomic_operations ffi api


# Description
<!--- Describe your changes to provide context for reviewrs -->
Uses the new `atomic_operation` ffi api from zerokit which allows atomic batching of insertions and removals to the 
merkle tree.

cc: 
- @richard-ramos for the go-waku 
- @weboko for the js-rln 
implementations :)

# Changes

<!-- List of detailed changes -->

- [x] `insertMembers` uses `atomicWrite` 
- [x] `removeMembers` uses `atomicWrite`
- [x] `set_leaves_from` has been removed and replaced with `atomic_write`
- [x] GroupManager implements new method `atomicBatch`, which accepts a list of idCommitments to insert, and indices 
to remove, uses `atomicWrite`

<!--
## How to test

1.
1.
1.

-->

## Issue

closes #1729
