### PR TITLE
feat: add release-notes target

### DIFF
--- a/.sv4git.yml
+++ b/.sv4git.yml
@@ -1,0 +1,21 @@
+version: "1.1" #config version
+
+tag:
+    pattern: "v%d.%d.%d"
+
+release-notes:
+    sections: # Array with each section of release note. Check template section for more information.
+        - name: Features # Name used on section.
+          section-type: commits # Type of the section, supported types: commits, breaking-changes.
+          commit-types: [feat] # Commit types for commit section-type, one commit type cannot be in more than one section.
+        - name: Bug Fixes
+          section-type: commits
+          commit-types: [fix, bug]
+        - name: Changes
+          section-type: commits
+          commit-types: [chore, docs, build, refactor, docker]
+
+commit-message:
+
+    issue:
+      regex: '#[0-9]+' # Regex for issue id.

--- a/.sv4git/templates/releasenotes-md.tpl
+++ b/.sv4git/templates/releasenotes-md.tpl
@@ -1,0 +1,8 @@
+## {{if .Release}}{{.Release}}{{end}}{{if and (not .Date.IsZero) .Release}} ({{end}}{{timefmt .Date "2006-01-02"}}{{if and (not .Date.IsZero) .Release}}){{end}}
+{{- range $section := .Sections }}
+{{- if (eq $section.SectionType "commits") }}
+{{- template "rn-md-section-commits.tpl" $section }}
+{{- else if (eq $section.SectionType "breaking-changes")}}
+{{- template "rn-md-section-breaking-changes.tpl" $section }}
+{{- end}}
+{{- end}}

--- a/.sv4git/templates/rn-md-section-commits.tpl
+++ b/.sv4git/templates/rn-md-section-commits.tpl
@@ -1,0 +1,7 @@
+{{- if .}}{{- if ne .SectionName ""}}
+
+### {{.SectionName}}
+{{range $k,$v := .Items}}
+- {{if $v.Message.Scope}}**{{$v.Message.Scope}}:** {{end}}{{$v.Message.Description}} ([{{$v.Hash}}](https://github.com/waku-org/nwaku/commit/{{$v.Hash}})){{if $v.Message.Metadata.issue}} ([https://github.com/waku-org/nwaku/issues/{{$v.Message.Metadata.issue}}]({{$v.Message.Metadata.issue}})){{end}}
+{{- end}}
+{{- end}}{{- end}}

--- a/Makefile
+++ b/Makefile
@@ -308,3 +308,19 @@ cwaku_example: | build cbindings
 		vendor/nim-libbacktrace/install/usr/lib/libbacktrace.a
 
 endif # "variables.mk" was not included
+
+###################
+# Release Targets #
+###################
+
+release-notes:
+	docker run \
+		-it \
+		--rm \
+		-v $${PWD}:/opt/sv4git/repo:z \
+		-u $(shell id -u) \
+		quay.io/vpavlin0/sv4git:latest \
+			release-notes |\
+			sed -E 's@#([0-9]+)@[#\1](https://github.com/waku-org/nwaku/issues/\1)@g'
+# I could not get the tool to replace issue ids with links, so using sed for now,
+# asked here: https://github.com/bvieira/sv4git/discussions/101

--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ release-notes:
 		--rm \
 		-v $${PWD}:/opt/sv4git/repo:z \
 		-u $(shell id -u) \
-		quay.io/vpavlin0/sv4git:latest \
+		docker.io/wakuorg/sv4git:latest \
 			release-notes |\
 			sed -E 's@#([0-9]+)@[#\1](https://github.com/waku-org/nwaku/issues/\1)@g'
 # I could not get the tool to replace issue ids with links, so using sed for now,


### PR DESCRIPTION
# Description
Adds a make target to generate release notes based on commit messages.

# Changes

- [x] new target added to Makefile


Example:

```
$ make release-notes 
## v0.17.0 (2023-05-16)

### Features

- add release-notes target ([ec9b222e](https://github.com/waku-org/nwaku/commit/ec9b222e))
- **cbindings:** first commit - waku relay ([#1632](https://github.com/waku-org/nwaku/issues/1632)) ([#1714](https://github.com/waku-org/nwaku/issues/1714)) ([2defbd23](https://github.com/waku-org/nwaku/commit/2defbd23))
- example using filter and lightpush ([#1720](https://github.com/waku-org/nwaku/issues/1720)) ([8987d4a3](https://github.com/waku-org/nwaku/commit/8987d4a3))
- configure protected topics via cli ([#1696](https://github.com/waku-org/nwaku/issues/1696)) ([16b44523](https://github.com/waku-org/nwaku/commit/16b44523))
- **mem-analysis:** Adding Dockerfile_with_heaptrack ([#1681](https://github.com/waku-org/nwaku/issues/1681)) ([9b9172ab](https://github.com/waku-org/nwaku/commit/9b9172ab))
- add metrics with msg size histogram ([#1697](https://github.com/waku-org/nwaku/issues/1697)) ([67e96ba8](https://github.com/waku-org/nwaku/commit/67e96ba8))
...
```

$ make release-notes 
## v0.17.0 (2023-05-16)

### Features

- add release-notes target ([ec9b222e](https://github.com/waku-org/nwaku/commit/ec9b222e))
- **cbindings:** first commit - waku relay ([#1632](https://github.com/waku-org/nwaku/issues/1632)) ([#1714](https://github.com/waku-org/nwaku/issues/1714)) ([2defbd23](https://github.com/waku-org/nwaku/commit/2defbd23))
- example using filter and lightpush ([#1720](https://github.com/waku-org/nwaku/issues/1720)) ([8987d4a3](https://github.com/waku-org/nwaku/commit/8987d4a3))
- configure protected topics via cli ([#1696](https://github.com/waku-org/nwaku/issues/1696)) ([16b44523](https://github.com/waku-org/nwaku/commit/16b44523))
- **mem-analysis:** Adding Dockerfile_with_heaptrack ([#1681](https://github.com/waku-org/nwaku/issues/1681)) ([9b9172ab](https://github.com/waku-org/nwaku/commit/9b9172ab))
- add metrics with msg size histogram ([#1697](https://github.com/waku-org/nwaku/issues/1697)) ([67e96ba8](https://github.com/waku-org/nwaku/commit/67e96ba8))
...



<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->