### PR TITLE
fix: Dockerfile - forcing the use of alpine:3.16 when building the heaptrackapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ CMD ["--help"]
 # DEBUG IMAGE ------------------------------------------------------------------
 
 # Build debug tools: heaptrack
-FROM alpine:edge AS heaptrack-build
+FROM alpine:3.16 AS heaptrack-build
 
 RUN apk update
 RUN apk add -- gdb git g++ make cmake zlib-dev boost-dev libunwind-dev


### PR DESCRIPTION
# Description
We came across compilation issues when building a docker image with heaptrack support.
`sudo make docker-image  DOCKER_IMAGE_NAME=nwaku:gc HEAPTRACKER=1`

# Further details

The use of `alpine:edge` make the heaptrack build to start failing.

```
#0 1.755 In file included from /heaptrack/src/analyze/suppressions.cpp:7:
#0 1.755 /heaptrack/src/analyze/suppressions.h:20:5: error: 'int64_t' does not name a type
#0 1.755    20 |     int64_t matches = 0;
#0 1.755       |     ^~~~~~~
#0 1.755 /heaptrack/src/analyze/suppressions.h:12:1: note: 'int64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
#0 1.755    11 | #include <vector>
#0 1.755   +++ |+#include <cstdint>
#0 1.755    12 | 
#0 1.755 /heaptrack/src/analyze/suppressions.h:21:5: error: 'int64_t' does not name a type
#0 1.755    21 |     int64_t leaked = 0;
#0 1.755       |     ^~~~~~~
#0 1.755 /heaptrack/src/analyze/suppressions.h:21:5: note: 'int64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
#0 1.784 [ 76%] Linking C static library libbacktrace.a
#0 1.817 [ 76%] Built target backtrace
#0 1.836 [ 80%] Building CXX object src/interpret/CMakeFiles/heaptrack_interpret.dir/heaptrack_interpret.cpp.o
#0 2.084 /heaptrack/src/analyze/suppressions.cpp: In function 'std::vector<Suppression> builtinSuppressions()':
#0 2.084 /heaptrack/src/analyze/suppressions.cpp:132:5: error: could not convert '{{"__nss_module_allocate", 0, 0}, {"__gconv_read_conf", 0, 0}, {"__new_exitfn", 0, 0}, {"tzset_internal", 0, 0}, {"dl_open_worker", 0, 0}, {"g_main_context_new", 0, 0}, {"g_main_context_new", 0, 0}, {"g_thread_self", 0, 0}}' from '<brace-enclosed initializer list>' to 'std::vector<Suppression>'
#0 2.084   132 |     };
#0 2.084       |     ^
#0 2.084       |     |

```
