### PR TITLE
chore(networking): set and use target outbound connections + prune

### DIFF
--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -456,7 +456,7 @@ procSuite "Peer Manager":
       # but the relay peer is not
       node.peerManager.serviceSlots.hasKey(WakuRelayCodec) == false
 
-  asyncTest "getNumConnections() returns expected number of connections per protocol":
+  asyncTest "connectedPeers() returns expected number of connections per protocol":
     # Create 4 nodes
     let nodes = toSeq(0..<4).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
 
@@ -483,17 +483,29 @@ procSuite "Peer Manager":
 
     # assert physical connections
     check:
-      nodes[0].peerManager.getNumConnections(WakuRelayCodec) == (0, 2)
-      nodes[0].peerManager.getNumConnections(WakuFilterCodec) == (0, 2)
+      nodes[0].peerManager.connectedPeers(WakuRelayCodec)[0].len == 0
+      nodes[0].peerManager.connectedPeers(WakuRelayCodec)[1].len == 2
 
-      nodes[1].peerManager.getNumConnections(WakuRelayCodec) == (1, 1)
-      nodes[1].peerManager.getNumConnections(WakuFilterCodec) == (1, 0)
+      nodes[0].peerManager.connectedPeers(WakuFilterCodec)[0].len == 0
+      nodes[0].peerManager.connectedPeers(WakuFilterCodec)[1].len == 2
 
-      nodes[2].peerManager.getNumConnections(WakuRelayCodec) == (2, 1)
-      nodes[2].peerManager.getNumConnections(WakuFilterCodec) == (1, 1)
+      nodes[1].peerManager.connectedPeers(WakuRelayCodec)[0].len == 1
+      nodes[1].peerManager.connectedPeers(WakuRelayCodec)[1].len == 1
 
-      nodes[3].peerManager.getNumConnections(WakuRelayCodec) == (1, 0)
-      nodes[3].peerManager.getNumConnections(WakuFilterCodec) == (1, 0)
+      nodes[1].peerManager.connectedPeers(WakuFilterCodec)[0].len == 1
+      nodes[1].peerManager.connectedPeers(WakuFilterCodec)[1].len == 0
+
+      nodes[2].peerManager.connectedPeers(WakuRelayCodec)[0].len == 2
+      nodes[2].peerManager.connectedPeers(WakuRelayCodec)[1].len == 1
+
+      nodes[2].peerManager.connectedPeers(WakuFilterCodec)[0].len == 1
+      nodes[2].peerManager.connectedPeers(WakuFilterCodec)[1].len == 1
+
+      nodes[3].peerManager.connectedPeers(WakuRelayCodec)[0].len == 1
+      nodes[3].peerManager.connectedPeers(WakuRelayCodec)[1].len == 0
+
+      nodes[3].peerManager.connectedPeers(WakuFilterCodec)[0].len == 1
+      nodes[3].peerManager.connectedPeers(WakuFilterCodec)[1].len == 0
 
   asyncTest "getNumStreams() returns expected number of connections per protocol":
     # Create 2 nodes


### PR DESCRIPTION
# Description
* Before this PR nwaku nodes constantly tried to create new outcoming relay connections up to max connections. In theory, this could cause a node to only have out connections, which is a selfish behaviour since this takes a lot of incoming slots (of other peers) in the network.
* This PR enforces a given in/out ratio of connections, leaving more incoming slots than outgoing, which is more altruistic with the network, something quite important in the fleets. It archieves so by:
  * prunning exceding inbound connections
  * not attempting mroe out connections if the target was reach. 

closes https://github.com/waku-org/nwaku/issues/1495