### PR TITLE
fix(ci): make experimental default to true in fleet deployment

### DIFF
--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -39,7 +39,7 @@ pipeline {
     booleanParam(
       name: 'EXPERIMENTAL',
       description: 'Enable experimental features.',
-      defaultValue: false
+      defaultValue: true
     )
     booleanParam(
       name: 'DEBUG',


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
During the period of rln-relay testnet 3, we will make the experimental flag default to true for all fleet deployments.

# Changes

<!-- List of detailed changes -->

- [x] Updated `Jenkinsfile.release` to make `EXPERIMENTAL` default
- [ ] ...

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
