### PR TITLE
feat(cbindings): Nim Waku in NodeJs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ nimbus-build-system.paths
 *.sqlite3-shm
 *.sqlite3-wal
 
+/examples/nodejs/build/

--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,10 @@ cwaku_example: | build libwaku
 		vendor/nim-libbacktrace/libbacktrace_wrapper.o \
 		vendor/nim-libbacktrace/install/usr/lib/libbacktrace.a
 
+nodejswaku: | build deps
+		echo -e $(BUILD_MSG) "build/$@" && \
+		node-gyp build --directory=examples/nodejs/
+
 endif # "variables.mk" was not included
 
 ###################

--- a/examples/nodejs/binding.gyp
+++ b/examples/nodejs/binding.gyp
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "target_name": "waku",
+      "sources": [ "waku_addon.c", "../cbindings/base64.c" ],
+      "libraries": [ "-lwaku", "-L../../../build/" ]
+    }
+  ]
+}

--- a/examples/nodejs/waku.js
+++ b/examples/nodejs/waku.js
@@ -1,0 +1,74 @@
+
+var express = require('express');
+var app = express();
+
+function create_random_string(length) {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  let counter = 0;
+  while (counter < length) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    counter += 1;
+  }
+  return result;
+}
+
+var wakuMod = require('bindings')('waku');
+
+var cfg = `{
+    "host": "0.0.0.0",
+    "port": 60001,
+    "key": "364d111d729a6eb6d3e6113e163f017b5ef03a6f94c9b5b7bb1bb36fa5cb07a9",
+    "relay": true
+}`
+
+function event_handler(event) {
+    console.log("evento NodeJs: " + event)
+}
+
+wakuMod.wakuVersion(function(msg){ console.log("Waku Version: " + msg) })
+
+// Example on how to retrieve a value from the waku library
+var defaultPubsubTopic = ""
+wakuMod.wakuDefaultPubsubTopic(function(msg){ defaultPubsubTopic = msg })
+
+console.log("Setting callback event callback function")
+wakuMod.wakuSetEventCallback(event_handler)
+wakuMod.wakuNew(cfg)
+
+wakuMod.wakuStart()
+
+wakuMod.wakuConnect("/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2HAmVFXtAfSj4EiR7mL2KvL4EE2wztuQgUSBoj2Jx2KeXFLN",
+                    10000,
+                    function onErr(msg) {
+                      console.log("Error connecting node: " + msg)
+                    })
+
+wakuMod.wakuRelaySubscribe(defaultPubsubTopic,
+                           function onErr(msg) {
+                             console.log("Error subscribing: " + msg)
+                           })
+
+app.post('/publish', 
+  function (req, res) {
+    // First read existing users.
+    console.log("Publish event received")
+
+    wakuMod.wakuRelayPublish(defaultPubsubTopic,
+                            "content_topic_name",
+                            create_random_string(10),
+                            10000,
+                            function onError(msg) {
+                              console.log("Error: " + msg)
+                              process.exit(-1)
+                            });
+
+    res.end( JSON.stringify("OK publish"))
+  })
+
+var server = app.listen(8081, function () {
+  var host = server.address().address
+  var port = server.address().port
+  console.log("Example waku listening at http://%s:%s", host, port)
+})

--- a/examples/nodejs/waku_addon.c
+++ b/examples/nodejs/waku_addon.c
@@ -1,0 +1,576 @@
+#include <assert.h>
+#include <node_api.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "../cbindings/base64.h"
+#include "../../library/libwaku.h"
+
+// Reference to the NodeJs function to be called when a waku event occurs.
+// static napi_ref ref_event_callback = NULL;
+static napi_ref ref_version_callback = NULL;
+static napi_ref ref_def_pubsub_topic_callback = NULL;
+static napi_ref ref_on_error_callback = NULL;
+static napi_threadsafe_function thsafe_fn = NULL;
+
+// As a convenience, wrap N-API calls such that they cause Node.js to abort
+// when they are unsuccessful.
+#define NAPI_CALL(call)                                                    \
+do {                                                                       \
+  napi_status status = call;                                               \
+  if (status != napi_ok) {                                                 \
+    napi_fatal_error(#call, NAPI_AUTO_LENGTH, "failed", NAPI_AUTO_LENGTH); \
+  }                                                                        \
+} while (0)
+
+#define WAKU_CALL(call)                                                        \
+do {                                                                           \
+  int ret = call;                                                              \
+  if (ret != 0) {                                                              \
+    char msg[128];                                                             \
+    snprintf(msg, 128, "WAKU_CALL failed with code %d", ret);                  \
+    napi_fatal_error(#call, NAPI_AUTO_LENGTH, "failed", NAPI_AUTO_LENGTH);     \
+  }                                                                            \
+} while (0)
+
+static napi_env my_env;
+
+// This function is responsible for converting data coming in from the worker
+// thread to napi_value items that can be passed into JavaScript, and for
+// calling the JavaScript function.
+static void CallJs(napi_env env, napi_value js_cb, void* context, void* data) {
+
+  // This parameter is not used.
+  (void) context;
+  // napi_status status;
+
+  // Retrieve the message item created by the worker thread.
+  char* msg = (char*) data;
+
+  // env and js_cb may both be NULL if Node.js is in its cleanup phase, and
+  // items are left over from earlier thread-safe calls from the worker thread.
+  // When env is NULL, we simply skip over the call into Javascript and free the
+  // items.
+  if (env != NULL) {
+    napi_value undefined;
+
+    // Convert the integer to a napi_value.
+    napi_value napi_msg;
+    NAPI_CALL(napi_create_string_utf8(my_env,
+                                      msg,
+                                      NAPI_AUTO_LENGTH,
+                                      &napi_msg));
+
+    // Retrieve the JavaScript `undefined` value so we can use it as the `this`
+    // value of the JavaScript function call.
+    NAPI_CALL(napi_get_undefined(env, &undefined));
+
+    // Call the JavaScript function and pass it the message generated in the 
+    // working thread.
+    NAPI_CALL(napi_call_function(env,
+                                 undefined,
+                                 js_cb,
+                                 1,
+                                 &napi_msg,
+                                 NULL));
+  }
+
+  // Free the item created by the worker thread.
+  free(data);
+}
+
+void handle_waku_version(const char* msg, size_t len) {
+  if (ref_version_callback == NULL) {
+    napi_throw_type_error(my_env, NULL, "ERROR in event_handler. ref_version_callback == NULL");
+  }
+
+  napi_value callback;
+  NAPI_CALL(napi_get_reference_value(my_env, ref_version_callback, &callback));
+
+  size_t argc = 2;
+  napi_value napi_msg;
+  NAPI_CALL(napi_create_string_utf8(my_env,
+                                    msg,
+                                    NAPI_AUTO_LENGTH,
+                                    &napi_msg));
+  napi_value napi_len;
+  NAPI_CALL(napi_create_int32(my_env,
+                              len,
+                              &napi_len));
+
+  napi_value global;
+  NAPI_CALL(napi_get_global(my_env, &global));
+  NAPI_CALL(napi_call_function(my_env, global, callback, argc, &napi_msg, NULL));
+}
+
+// This function is directly passed as a callback to the libwaku and it
+// calls a NodeJs function if it has been set.
+void event_handler(const char* msg, size_t len) {
+  if (thsafe_fn == NULL) {
+  // if (ref_event_callback == NULL) {
+    napi_throw_type_error(my_env, NULL, "ERROR in event_handler. ref_event_callback == NULL");
+  }
+
+  char* allocated_msg = malloc(len + 1);
+  strcpy(allocated_msg, msg);
+
+  NAPI_CALL(napi_call_threadsafe_function(thsafe_fn, allocated_msg, napi_tsfn_nonblocking));
+}
+
+void handle_error(const char* msg, size_t len) {
+  if (ref_on_error_callback == NULL) {
+    napi_throw_type_error(my_env, NULL, "ERROR in event_handler. ref_on_error_callback == NULL");
+  }
+
+  napi_value callback;
+  NAPI_CALL(napi_get_reference_value(my_env,
+                                     ref_on_error_callback,
+                                     &callback));
+  size_t argc = 2;
+  napi_value napi_msg;
+  NAPI_CALL(napi_create_string_utf8(my_env,
+                                    msg,
+                                    NAPI_AUTO_LENGTH,
+                                    &napi_msg));
+  napi_value global;
+  NAPI_CALL(napi_get_global(my_env, &global));
+  NAPI_CALL(napi_call_function(my_env, global, callback, argc, &napi_msg, NULL));
+}
+
+char* contentTopic = NULL;
+void handle_content_topic(const char* msg, size_t len) {
+    if (contentTopic != NULL) {
+        free(contentTopic);
+    }
+
+    contentTopic = malloc(len * sizeof(char) + 1);
+    strcpy(contentTopic, msg);
+}
+
+void handle_default_pubsub_topic(const char* msg, size_t len) {
+  if (ref_def_pubsub_topic_callback == NULL) {
+    napi_throw_type_error(my_env, NULL,
+           "ERROR in event_handler. ref_def_pubsub_topic_callback == NULL");
+  }
+
+  napi_value callback;
+  NAPI_CALL(napi_get_reference_value(my_env,
+                                     ref_def_pubsub_topic_callback,
+                                     &callback));
+  size_t argc = 2;
+  napi_value napi_msg;
+  NAPI_CALL(napi_create_string_utf8(my_env,
+                                    msg,
+                                    NAPI_AUTO_LENGTH,
+                                    &napi_msg));
+  napi_value napi_len;
+  NAPI_CALL(napi_create_int32(my_env,
+                              len,
+                              &napi_len));
+
+  napi_value global;
+  NAPI_CALL(napi_get_global(my_env, &global));
+  NAPI_CALL(napi_call_function(my_env, global, callback, argc, &napi_msg, NULL));
+}
+
+// The next should be called always, at the beginning
+static napi_value WakuNew(napi_env env, napi_callback_info info) {
+
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  if (argc < 1) {
+    napi_throw_type_error(env, NULL, "Wrong number of arguments");
+    return NULL;
+  }
+
+  size_t str_size;
+  size_t str_size_read;
+  napi_get_value_string_utf8(env, args[0], NULL, 0, &str_size);
+  char* jsonConfig;
+  jsonConfig = malloc(str_size + 1);
+  str_size = str_size + 1;
+  napi_get_value_string_utf8(env, args[0], jsonConfig, str_size, &str_size_read);
+
+  WAKU_CALL( waku_new(jsonConfig, event_handler) );
+
+  free(jsonConfig);
+
+  return NULL;
+}
+
+static napi_value WakuVersion(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  if (argc < 1) {
+    napi_throw_type_error(env, NULL, "Wrong number of arguments");
+    return NULL;
+  }
+
+  napi_value cb = args[0];
+
+  napi_valuetype valueType;
+  NAPI_CALL(napi_typeof(env, cb, &valueType));
+
+  if (valueType != napi_function) {
+    napi_throw_type_error(env, NULL, "The argument should be a napi_function");
+    return NULL;
+  }
+
+  my_env = env;
+  if(ref_version_callback != NULL) {
+    NAPI_CALL(napi_delete_reference(env, ref_version_callback));
+  }
+
+  NAPI_CALL(napi_create_reference(env, cb, 1, &ref_version_callback));
+
+  WAKU_CALL( waku_version( handle_waku_version ) );
+
+  return NULL;
+}
+
+static napi_value WakuSetEventCallback(napi_env env, napi_callback_info info) {
+
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  if (argc < 1) {
+    napi_throw_type_error(env, NULL, "Wrong number of arguments");
+    return NULL;
+  }
+
+  napi_value cb = args[0];
+
+  napi_valuetype valueType;
+  NAPI_CALL(napi_typeof(env, cb, &valueType));
+
+  if (valueType != napi_function) {
+    napi_throw_type_error(env, NULL, "The argument should be a napi_function");
+    return NULL;
+  }
+
+  my_env = env;
+
+  napi_value work_name;
+  NAPI_CALL(napi_create_string_utf8(env,
+                                    "worker_name",
+                                    NAPI_AUTO_LENGTH,
+                                    &work_name));
+
+  NAPI_CALL(
+    napi_create_threadsafe_function(env,
+                                    cb,
+                                    NULL,
+                                    work_name,
+                                    0,
+                                    1,
+                                    NULL,
+                                    NULL,
+                                    NULL,
+                                    CallJs, // the C/C++ callback function
+      // out: the asynchronous thread-safe JavaScript function
+                                    &thsafe_fn));
+
+  // Inside 'event_handler', the event will be dispatched to the NodeJs
+  // if there is a proper napi_function (ref_event_callback) being set.
+  waku_set_event_callback(event_handler);
+
+  return NULL;
+}
+
+static napi_value WakuStart(napi_env env, napi_callback_info info) {
+  waku_start();
+  return NULL;
+}
+
+static napi_value WakuConnect(napi_env env, napi_callback_info info) {
+  size_t argc = 3;
+  napi_value args[3];
+  NAPI_CALL(napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  if (argc < 3) {
+    napi_throw_type_error(env, NULL, "Wrong number of arguments");
+    return NULL;
+  }
+
+  // Getting the peers param
+  napi_value napiPeers = args[0];
+  napi_valuetype valueType;
+  NAPI_CALL(napi_typeof(env, napiPeers, &valueType));
+
+  if (valueType != napi_string) {
+    napi_throw_type_error(env, NULL, "The peers attribute should be a string");
+    return NULL;
+  }
+
+  size_t str_size;
+  size_t str_size_read;
+  napi_get_value_string_utf8(env, napiPeers, NULL, 0, &str_size);
+  char* peers;
+  peers = malloc(str_size + 1);
+  str_size = str_size + 1;
+  napi_get_value_string_utf8(env, napiPeers, peers, str_size, &str_size_read);
+
+  // Getting the timeout param
+  napi_value napiTimeout = args[1];
+  NAPI_CALL(napi_typeof(env, napiTimeout, &valueType));
+
+  if (valueType != napi_number) {
+    napi_throw_type_error(env, NULL, "The timeout attribute should be a number");
+    return NULL;
+  }
+
+  int32_t timeoutMs;
+  NAPI_CALL(napi_get_value_int32(env, napiTimeout, &timeoutMs));
+
+  // Getting the 'onError' callback
+  napi_value cb = args[2];
+
+  NAPI_CALL(napi_typeof(env, cb, &valueType));
+
+  if (valueType != napi_function) {
+    napi_throw_type_error(env, NULL, "The argument should be a napi_function");
+    return NULL;
+  }
+
+  my_env = env;
+  NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
+
+  WAKU_CALL(waku_connect(peers, timeoutMs, handle_error));
+
+  // Free allocated memory
+  free(peers);
+
+  return NULL;
+}
+
+static napi_value WakuRelayPublish(napi_env env, napi_callback_info info) {
+  size_t argc = 5;
+  napi_value args[5];
+  NAPI_CALL(napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  if (argc < 5) {
+    napi_throw_type_error(env, NULL, "Wrong number of arguments");
+    return NULL;
+  }
+
+  // pubsubtopic
+  napi_value napiPubsubTopic = args[0];
+  napi_valuetype valueType;
+  NAPI_CALL(napi_typeof(env, napiPubsubTopic, &valueType));
+
+  if (valueType != napi_string) {
+    napi_throw_type_error(env, NULL, "The napiPubsubTopic attribute should be a string");
+    return NULL;
+  }
+
+  size_t str_size;
+  size_t str_size_read;
+  napi_get_value_string_utf8(env, napiPubsubTopic, NULL, 0, &str_size);
+  char* pubsub_topic;
+  pubsub_topic = malloc(str_size + 1);
+  str_size = str_size + 1;
+  napi_get_value_string_utf8(env, napiPubsubTopic, pubsub_topic, str_size, &str_size_read);
+
+  // content topic
+  napi_value napiContentTopic = args[1];
+  NAPI_CALL(napi_typeof(env, napiContentTopic, &valueType));
+
+  if (valueType != napi_string) {
+    napi_throw_type_error(env, NULL, "The content topic attribute should be a string");
+    return NULL;
+  }
+
+  napi_get_value_string_utf8(env, napiContentTopic, NULL, 0, &str_size);
+  char* content_topic_name = malloc(str_size + 1);
+  str_size = str_size + 1;
+  napi_get_value_string_utf8(env, napiContentTopic, content_topic_name, str_size, &str_size_read);
+
+  // message
+  napi_value napiMessage = args[2];
+  NAPI_CALL(napi_typeof(env, napiMessage, &valueType));
+
+  if (valueType != napi_string) {
+    napi_throw_type_error(env, NULL, "The message attribute should be a string");
+    return NULL;
+  }
+
+  char msg[2048];
+  // TODO: check the correct message size limit
+  size_t lengthMsg;
+  NAPI_CALL(napi_get_value_string_utf8(env,
+                                       napiMessage,
+                                       msg,
+                                       2048,
+                                       &lengthMsg));
+  char jsonWakuMsg[1024];
+  char *msgPayload = b64_encode((unsigned char*) msg, strlen(msg));
+
+  // TODO: move all the 'waku_content_topic' logic inside the libwaku
+  WAKU_CALL( waku_content_topic("appName",
+                                1,
+                                content_topic_name,
+                                "encoding",
+                                handle_content_topic) );
+  snprintf(jsonWakuMsg,
+           1024,
+           "{\"payload\":\"%s\",\"content_topic\":\"%s\"}",
+           msgPayload, contentTopic);
+  free(msgPayload);
+
+  // Getting the timeout parameter
+  unsigned int timeoutMs;
+  napi_value timeout = args[3];
+
+  NAPI_CALL(napi_typeof(env, timeout, &valueType));
+
+  if (valueType != napi_number) {
+    napi_throw_type_error(env, NULL, "The argument should be a napi_number");
+    return NULL;
+  }
+
+  NAPI_CALL(napi_get_value_int64(env, timeout, (int64_t *) &timeoutMs)); 
+
+  // Getting the 'onError' callback
+  napi_value cb = args[4];
+
+  NAPI_CALL(napi_typeof(env, cb, &valueType));
+
+  if (valueType != napi_function) {
+    napi_throw_type_error(env, NULL, "The argument should be a napi_function");
+    return NULL;
+  }
+
+  NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
+
+  // Perform the actual 'publish'
+  WAKU_CALL( waku_relay_publish(pubsub_topic,
+                                jsonWakuMsg,
+                                timeoutMs,
+                                handle_error) );
+  free(pubsub_topic);
+  free(content_topic_name);
+
+  return NULL;
+}
+
+static napi_value WakuDefaultPubsubTopic(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  if (argc < 1) {
+    napi_throw_type_error(env, NULL, "Wrong number of arguments");
+    return NULL;
+  }
+
+  napi_value cb = args[0];
+
+  napi_valuetype valueType;
+  NAPI_CALL(napi_typeof(env, cb, &valueType));
+
+  if (valueType != napi_function) {
+    napi_throw_type_error(env, NULL, "The argument should be a napi_function");
+    return NULL;
+  }
+
+  my_env = env;
+  if(ref_def_pubsub_topic_callback != NULL) {
+    NAPI_CALL(napi_delete_reference(env, ref_def_pubsub_topic_callback));
+  }
+
+  NAPI_CALL(napi_create_reference(env, cb, 1, &ref_def_pubsub_topic_callback));
+
+  WAKU_CALL( waku_default_pubsub_topic(handle_default_pubsub_topic) );
+
+  return NULL;
+}
+
+static napi_value WakuRelaySubscribe(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  NAPI_CALL(napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  if (argc < 2) {
+    napi_throw_type_error(env, NULL, "Wrong number of arguments");
+    return NULL;
+  }
+
+  // Getting the pubsub topic param
+  napi_value topic = args[0];
+  napi_valuetype valueType;
+  NAPI_CALL(napi_typeof(env, topic, &valueType));
+
+  if (valueType != napi_string) {
+    napi_throw_type_error(env, NULL, "The topic attribute should be a string");
+    return NULL;
+  }
+
+  size_t str_size;
+  size_t str_size_read;
+  napi_get_value_string_utf8(env, topic, NULL, 0, &str_size);
+  char* pubsub_topic;
+  pubsub_topic = malloc(str_size + 1);
+  str_size = str_size + 1;
+  napi_get_value_string_utf8(env, topic, pubsub_topic, str_size, &str_size_read);
+
+  // Getting the 'onError' callback
+  napi_value cb = args[1];
+
+  NAPI_CALL(napi_typeof(env, cb, &valueType));
+
+  if (valueType != napi_function) {
+    napi_throw_type_error(env, NULL, "The argument should be a napi_function");
+    return NULL;
+  }
+
+  my_env = env;
+  NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
+
+  // Calling the actual 'subscribe' waku function
+  WAKU_CALL( waku_relay_subscribe(pubsub_topic, handle_error) );
+
+  free(pubsub_topic);
+
+  return NULL;
+}
+
+#define DECLARE_NAPI_METHOD(name, func)                                        \
+  { name, 0, func, 0, 0, 0, napi_default, 0 }
+
+static napi_value Init(napi_env env, napi_value exports) {
+  // DECLARE_NAPI_METHOD("<function_name_in_NodeJs>", <function_name_in_waku_wrapper.c>);
+
+  napi_property_descriptor wakuVersion = DECLARE_NAPI_METHOD("wakuVersion", WakuVersion);
+  NAPI_CALL(napi_define_properties(env, exports, 1, &wakuVersion));
+
+  napi_property_descriptor wakuNew = DECLARE_NAPI_METHOD("wakuNew", WakuNew);
+  NAPI_CALL(napi_define_properties(env, exports, 1, &wakuNew));
+
+  napi_property_descriptor wakuStart = DECLARE_NAPI_METHOD("wakuStart", WakuStart);
+  NAPI_CALL(napi_define_properties(env, exports, 1, &wakuStart));
+
+  napi_property_descriptor wakuSetEventCallback = DECLARE_NAPI_METHOD("wakuSetEventCallback", WakuSetEventCallback);
+  NAPI_CALL(napi_define_properties(env, exports, 1, &wakuSetEventCallback));
+
+  napi_property_descriptor wakuDefaultPubsubTopic = DECLARE_NAPI_METHOD("wakuDefaultPubsubTopic", WakuDefaultPubsubTopic);
+  NAPI_CALL(napi_define_properties(env, exports, 1, &wakuDefaultPubsubTopic));
+
+  napi_property_descriptor wakuRelaySubscribe = DECLARE_NAPI_METHOD("wakuRelaySubscribe", WakuRelaySubscribe);
+  NAPI_CALL(napi_define_properties(env, exports, 1, &wakuRelaySubscribe));
+
+  napi_property_descriptor wakuConnect = DECLARE_NAPI_METHOD("wakuConnect", WakuConnect);
+  NAPI_CALL(napi_define_properties(env, exports, 1, &wakuConnect));
+
+  napi_property_descriptor wakuRelayPublish = DECLARE_NAPI_METHOD("wakuRelayPublish", WakuRelayPublish);
+  NAPI_CALL(napi_define_properties(env, exports, 1, &wakuRelayPublish));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -39,7 +39,6 @@ int waku_default_pubsub_topic(WakuCallBack onOkCb);
 int waku_relay_publish(const char* pubSubTopic,
                        const char* jsonWakuMessage,
                        unsigned int timeoutMs,
-                       WakuCallBack onOkCb,
                        WakuCallBack onErrCb);
 
 int waku_relay_subscribe(const char* pubSubTopic,

--- a/waku.nimble
+++ b/waku.nimble
@@ -42,9 +42,9 @@ proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
   for i in 2..<paramCount():
     extra_params &= " " & paramStr(i)
   if `type` == "static":
-    exec "nim c" & " --out:build/" & name & ".a  --app:staticlib --opt:size --noMain --header " & extra_params & " " & srcDir & name & ".nim"
+    exec "nim c" & " --out:build/" & name & ".a --threads:on --app:staticlib --opt:size --noMain --header " & extra_params & " " & srcDir & name & ".nim"
   else:
-    exec "nim c" & " --out:build/" & name & ".so  --app:lib --opt:size --noMain --header " & extra_params & " " & srcDir & name & ".nim"
+    exec "nim c" & " --out:build/" & name & ".so --threads:on --app:lib --opt:size --noMain --header " & extra_params & " " & srcDir & name & ".nim"
 
 proc test(name: string, params = "-d:chronicles_log_level=DEBUG", lang = "c") =
   # XXX: When running `> NIM_PARAMS="-d:chronicles_log_level=INFO" make test2`


### PR DESCRIPTION
# Summary
As part of the C-bindings tasks for nwaku, this PR is the starting point of having a nwaku node as a NodeJs module.

# Further details
This PR adds a nwaku client wrapped as a NodeJs addon (waku_addon.c), which is implemented using the [`Node-API C API`](https://nodejs.org/api/n-api.html).

The `libwaku.so` (dynamic) library should be generated beforehand (`make libwaku`.).

( Edited: the next error is not happening now. It happened because both the NodeJs and Nim runtimes where running in the same thread. Making Nim runtime to run in a separate thread made it to work correctly )
Showstopper :snail:  : there is not a good interoperability between NodeJs GC and the Nim GC, i.e. the waku node runs properly in NodeJs but after a little while, it crashes because a memory region handled by the Nim's GC, had been invalidated by the NodeJs GC. 
  The majority of the crashes happen at this [line](https://github.com/status-im/Nim/blob/b1a0467ffd656f7ec5c2c18677a7efcb989d4600/lib/system/alloc.nim#L735):

```
c.freeList = c.freeList.next
```
And, analysing the generated coredump with `gdb` we have:
```
(gdb) print c
$1 = (tyObject_SmallChunk__tXn60W2f8h3jgAYdEmy5NQ *) 0x7f314a836000
(gdb) print c.freeList
$2 = (tyObject_FreeCell__u6M5LHprqzkn9axr04yg9bGQ *) 0xfffffffffffffff8
(gdb) print c.freeList.next
Cannot access memory at address 0xfffffffffffffff8
```

# Changes

- [x] Add new Makefile entry, `nodejswaku`.
- [x] Add the implementation of the nwaku NodeJs addon, `examples/nodejs/waku_addon.c`.
- [x] Add Javascript example to show how to use the new module: `examples/nodejs/waku.js`.

# How to test
1. Run NodeJs waku node.
   - Open one terminal from the nwaku root folder.
   - Build the libwaku.so library.

      ```code
      make libwaku
      ```

   - Build the NodeJs addon.

       Notice that for this point to work properly, the NodeJs runtime should be properly installed (e.g. v18.16.0). And `npm install -g node-gyp` plus `npm install bindings` should have been run.

      ```code
      make nodejswaku
      ```

   - Run the waku.js example. This runs a waku node which subscribes to the default pubsub topic and tries to connect to a hard-coded node, which will be started in a separate terminal.

      `export LD_LIBRARY_PATH=build`

      ```code
      node examples/nodejs/waku.js
      ```

2. Run Nim wakunode2.
   - Open one terminal from the nwaku root folder.
   - Start a waku node with the next configuration. This will establish a connection with the node started in point 1.
      ```code
      ./build/wakunode2 --config-file=cfg_node_b.txt
      ```

[cfg_node_b.txt](https://github.com/waku-org/nwaku/files/11530302/cfg_node_b.txt)

3. Send messages to the node started in 2.
   - Open a third terminal and start sending messages 
   ```code
   while [ true ]; do curl -d "{\"jsonrpc\":\"2.0\",\"id\":"$(date +%s)",\"method\":\"post_waku_v2_relay_v1_message\", \"params\":[\"/waku/2/default-waku/proto\", {\"timestamp\":"$(date +%s)", \"payload\":\"VGhpcyBpcyBhIG1lc3NhZ2UK\"}]}" --header "Content-Type: application/json" http://localhost:8546; done
   ```

# Issue
closes https://github.com/waku-org/nwaku/issues/1632
