### PR TITLE
feat(postgresql): 1st commit to async sql (waku_archive/driver...)

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -552,7 +552,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
       await node.mountFilterClient()
       node.peerManager.addServicePeer(peerInfo.value, WakuFilterCodec)
 
-      proc filterHandler(pubsubTopic: PubsubTopic, msg: WakuMessage) {.gcsafe.} =
+      proc filterHandler(pubsubTopic: PubsubTopic, msg: WakuMessage) {.async, gcsafe, closure.} =
         trace "Hit filter handler", contentTopic=msg.contentTopic
         chat.printReceivedMessage(msg)
 

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -54,7 +54,7 @@ suite "Waku Filter":
     let serverAddr = serverSwitch.peerInfo.toRemotePeerInfo()
 
     let pushHandlerFuture = newFuture[(string, WakuMessage)]()
-    proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.} =
+    proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.async, gcsafe, closure.} =
       pushHandlerFuture.complete((pubsubTopic, message))
 
     let
@@ -97,7 +97,7 @@ suite "Waku Filter":
     let serverAddr = serverSwitch.peerInfo.toRemotePeerInfo()
 
     var pushHandlerFuture = newFuture[void]()
-    proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.} =
+    proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.async, gcsafe, closure.} =
       pushHandlerFuture.complete()
 
     let
@@ -149,7 +149,7 @@ suite "Waku Filter":
     let serverAddr = serverSwitch.peerInfo.toRemotePeerInfo()
 
     var pushHandlerFuture = newFuture[void]()
-    proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.} =
+    proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.async, gcsafe, closure.} =
       pushHandlerFuture.complete()
 
     let
@@ -214,7 +214,7 @@ suite "Waku Filter":
     let serverAddr = serverSwitch.peerInfo.toRemotePeerInfo()
 
     var pushHandlerFuture = newFuture[void]()
-    proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.} =
+    proc pushHandler(pubsubTopic: PubsubTopic, message: WakuMessage) {.async, gcsafe, closure.} =
       pushHandlerFuture.complete()
 
     let

--- a/tests/v2/test_wakunode_filter.nim
+++ b/tests/v2/test_wakunode_filter.nim
@@ -39,7 +39,7 @@ suite "WakuNode - Filter":
       message = fakeWakuMessage(contentTopic=contentTopic)
 
     var filterPushHandlerFut = newFuture[(PubsubTopic, WakuMessage)]()
-    proc filterPushHandler(pubsubTopic: PubsubTopic, msg: WakuMessage) {.gcsafe, closure.} =
+    proc filterPushHandler(pubsubTopic: PubsubTopic, msg: WakuMessage) {.async, gcsafe, closure.} =
       filterPushHandlerFut.complete((pubsubTopic, msg))
 
     ## When

--- a/tests/v2/test_wakunode_filter.nim
+++ b/tests/v2/test_wakunode_filter.nim
@@ -25,10 +25,10 @@ suite "WakuNode - Filter":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
-    await allFutures(server.start(), client.start())
+    waitFor allFutures(server.start(), client.start())
 
-    await server.mountFilter()
-    await client.mountFilterClient()
+    waitFor server.mountFilter()
+    waitFor client.mountFilterClient()
 
     ## Given
     let serverPeerInfo = server.peerInfo.toRemotePeerInfo()
@@ -46,11 +46,11 @@ suite "WakuNode - Filter":
     await client.filterSubscribe(pubsubTopic, contentTopic, filterPushHandler, peer=serverPeerInfo)
 
     # Wait for subscription to take effect
-    await sleepAsync(100.millis)
+    waitFor sleepAsync(100.millis)
 
-    await server.filterHandleMessage(pubSubTopic, message)
+    waitFor server.filterHandleMessage(pubSubTopic, message)
 
-    require await filterPushHandlerFut.withTimeout(5.seconds)
+    require waitFor filterPushHandlerFut.withTimeout(5.seconds)
 
     ## Then
     check filterPushHandlerFut.completed()
@@ -60,4 +60,4 @@ suite "WakuNode - Filter":
       filterMessage == message
 
     ## Cleanup
-    await allFutures(client.stop(), server.stop())
+    waitFor allFutures(client.stop(), server.stop())

--- a/tests/v2/waku_archive/test_driver_queue_query.nim
+++ b/tests/v2/waku_archive/test_driver_queue_query.nim
@@ -35,7 +35,7 @@ proc computeTestCursor(pubsubTopic: PubsubTopic, message: WakuMessage): ArchiveC
 
 suite "Queue driver - query by content topic":
 
-  asyncTest "no content topic":
+  test "no content topic":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -58,11 +58,11 @@ suite "Queue driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       maxPageSize=5,
       ascendingOrder=true
     )
@@ -76,9 +76,9 @@ suite "Queue driver - query by content topic":
       filteredMessages == expected[0..4]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "single content topic":
+  test "single content topic":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -102,11 +102,11 @@ suite "Queue driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       maxPageSize=2,
       ascendingOrder=true
@@ -121,9 +121,9 @@ suite "Queue driver - query by content topic":
       filteredMessages == expected[2..3]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "single content topic - descending order":
+  test "single content topic - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -147,11 +147,11 @@ suite "Queue driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       maxPageSize=2,
       ascendingOrder=false
@@ -166,9 +166,9 @@ suite "Queue driver - query by content topic":
       filteredMessages == expected[6..7].reversed()
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "multiple content topic":
+  test "multiple content topic":
     ## Given
     const contentTopic1 = "test-content-topic-1"
     const contentTopic2 = "test-content-topic-2"
@@ -194,11 +194,11 @@ suite "Queue driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic1, contentTopic2],
       maxPageSize=2,
       ascendingOrder=true
@@ -213,9 +213,9 @@ suite "Queue driver - query by content topic":
       filteredMessages == expected[2..3]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "single content topic - no results":
+  test "single content topic - no results":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -234,11 +234,11 @@ suite "Queue driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       maxPageSize=2,
       ascendingOrder=true
@@ -253,9 +253,9 @@ suite "Queue driver - query by content topic":
       filteredMessages.len == 0
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "content topic and max page size - not enough messages stored":
+  test "content topic and max page size - not enough messages stored":
     ## Given
     const pageSize: uint = 50
 
@@ -263,11 +263,11 @@ suite "Queue driver - query by content topic":
 
     for t in 0..<40:
       let msg = fakeWakuMessage(@[byte t], DefaultContentTopic, ts=ts(t))
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[DefaultContentTopic],
       maxPageSize=pageSize,
       ascendingOrder=true
@@ -282,12 +282,12 @@ suite "Queue driver - query by content topic":
       filteredMessages.len == 40
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
 
 suite "SQLite driver - query by pubsub topic":
 
-  asyncTest "pubsub topic":
+  test "pubsub topic":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -312,11 +312,11 @@ suite "SQLite driver - query by pubsub topic":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       pubsubTopic=some(pubsubTopic),
       maxPageSize=2,
       ascendingOrder=true
@@ -332,9 +332,9 @@ suite "SQLite driver - query by pubsub topic":
       filteredMessages == expectedMessages[4..5]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "no pubsub topic":
+  test "no pubsub topic":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -359,11 +359,11 @@ suite "SQLite driver - query by pubsub topic":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       maxPageSize=2,
       ascendingOrder=true
     )
@@ -378,9 +378,9 @@ suite "SQLite driver - query by pubsub topic":
       filteredMessages == expectedMessages[0..1]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "content topic and pubsub topic":
+  test "content topic and pubsub topic":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -406,11 +406,11 @@ suite "SQLite driver - query by pubsub topic":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       maxPageSize=2,
@@ -427,12 +427,12 @@ suite "SQLite driver - query by pubsub topic":
       filteredMessages == expectedMessages[4..5]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
 
 suite "Queue driver - query by cursor":
 
-  asyncTest "only cursor":
+  test "only cursor":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -456,13 +456,13 @@ suite "Queue driver - query by cursor":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[4])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       cursor=some(cursor),
       maxPageSize=2,
       ascendingOrder=true
@@ -477,9 +477,9 @@ suite "Queue driver - query by cursor":
       filteredMessages == expected[5..6]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "only cursor - descending order":
+  test "only cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -503,13 +503,13 @@ suite "Queue driver - query by cursor":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[4])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       cursor=some(cursor),
       maxPageSize=2,
       ascendingOrder=false
@@ -524,9 +524,9 @@ suite "Queue driver - query by cursor":
       filteredMessages == expected[2..3].reversed()
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "content topic and cursor":
+  test "content topic and cursor":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -548,13 +548,13 @@ suite "Queue driver - query by cursor":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[4])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       cursor=some(cursor),
       maxPageSize=10,
@@ -570,9 +570,9 @@ suite "Queue driver - query by cursor":
       filteredMessages == expected[5..6]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "content topic and cursor - descending order":
+  test "content topic and cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -594,13 +594,13 @@ suite "Queue driver - query by cursor":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[6])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       cursor=some(cursor),
       maxPageSize=10,
@@ -616,9 +616,9 @@ suite "Queue driver - query by cursor":
       filteredMessages == expected[2..5].reversed()
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "pubsub topic and cursor":
+  test "pubsub topic and cursor":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -647,13 +647,13 @@ suite "Queue driver - query by cursor":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(expected[5][0], expected[5][1])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
       maxPageSize=10,
@@ -670,9 +670,9 @@ suite "Queue driver - query by cursor":
       filteredMessages == expectedMessages[6..7]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "pubsub topic and cursor - descending order":
+  test "pubsub topic and cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -701,13 +701,13 @@ suite "Queue driver - query by cursor":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(expected[6][0], expected[6][1])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
       maxPageSize=10,
@@ -724,12 +724,12 @@ suite "Queue driver - query by cursor":
       filteredMessages == expectedMessages[4..5].reversed()
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
 
 suite "Queue driver - query by time range":
 
-  asyncTest "start time only":
+  test "start time only":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -752,11 +752,11 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       startTime=some(ts(15, timeOrigin)),
       maxPageSize=10,
       ascendingOrder=true
@@ -771,9 +771,9 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[2..6]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "end time only":
+  test "end time only":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -796,11 +796,11 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       endTime=some(ts(45, timeOrigin)),
       maxPageSize=10,
       ascendingOrder=true
@@ -815,9 +815,9 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[0..4]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "start time and end time":
+  test "start time and end time":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -846,11 +846,11 @@ suite "Queue driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       startTime=some(ts(15, timeOrigin)),
       endTime=some(ts(45, timeOrigin)),
       maxPageSize=10,
@@ -867,9 +867,9 @@ suite "Queue driver - query by time range":
       filteredMessages == expectedMessages[2..4]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "invalid time range - no results":
+  test "invalid time range - no results":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -893,11 +893,11 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       startTime=some(ts(45, timeOrigin)),
       endTime=some(ts(15, timeOrigin)),
@@ -913,7 +913,7 @@ suite "Queue driver - query by time range":
       filteredMessages.len == 0
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
   asynctest "time range start and content topic":
     ## Given
@@ -938,11 +938,11 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       startTime=some(ts(15, timeOrigin)),
       maxPageSize=10,
@@ -957,9 +957,9 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[2..6]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "time range start and content topic - descending order":
+  test "time range start and content topic - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -985,11 +985,11 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       startTime=some(ts(15, timeOrigin)),
       maxPageSize=10,
@@ -1004,7 +1004,7 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[2..6].reversed()
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
   asynctest "time range start, single content topic and cursor":
     ## Given
@@ -1032,13 +1032,13 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[3])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       cursor=some(cursor),
       startTime=some(ts(15, timeOrigin)),
@@ -1054,7 +1054,7 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[4..9]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
   asynctest "time range start, single content topic and cursor - descending order":
     ## Given
@@ -1082,13 +1082,13 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[6])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       cursor=some(cursor),
       startTime=some(ts(15, timeOrigin)),
@@ -1104,9 +1104,9 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[3..4].reversed()
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "time range, content topic, pubsub topic and cursor":
+  test "time range, content topic, pubsub topic and cursor":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -1135,13 +1135,13 @@ suite "Queue driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[1][1])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
@@ -1160,9 +1160,9 @@ suite "Queue driver - query by time range":
       filteredMessages == expectedMessages[3..4]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "time range, content topic, pubsub topic and cursor - descending order":
+  test "time range, content topic, pubsub topic and cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -1191,13 +1191,13 @@ suite "Queue driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(expected[7][0], expected[7][1])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
@@ -1216,9 +1216,9 @@ suite "Queue driver - query by time range":
       filteredMessages == expectedMessages[4..5].reversed()
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "time range, content topic, pubsub topic and cursor - cursor timestamp out of time range":
+  test "time range, content topic, pubsub topic and cursor - cursor timestamp out of time range":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -1247,13 +1247,13 @@ suite "Queue driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(expected[1][0], expected[1][1])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
@@ -1273,9 +1273,9 @@ suite "Queue driver - query by time range":
       filteredMessages == expectedMessages[4..5]
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "time range, content topic, pubsub topic and cursor - cursor timestamp out of time range, descending order":
+  test "time range, content topic, pubsub topic and cursor - cursor timestamp out of time range, descending order":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -1304,13 +1304,13 @@ suite "Queue driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      let retFut = await driver.put(topic, msg, computeDigest(msg), msg.timestamp)
+      let retFut = waitFor driver.put(topic, msg, computeDigest(msg), msg.timestamp)
       require retFut.isOk()
 
     let cursor = computeTestCursor(expected[1][0], expected[1][1])
 
     ## When
-    let res = await driver.getMessages(
+    let res = waitFor driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
@@ -1329,4 +1329,4 @@ suite "Queue driver - query by time range":
       filteredMessages.len == 0
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")

--- a/tests/v2/waku_archive/test_driver_sqlite.nim
+++ b/tests/v2/waku_archive/test_driver_sqlite.nim
@@ -23,7 +23,7 @@ proc newTestSqliteDriver(): ArchiveDriver =
 
 suite "SQLite driver":
 
-  test "init driver and database":
+  asyncTest "init driver and database":
     ## Given
     let database = newTestDatabase()
 
@@ -39,9 +39,9 @@ suite "SQLite driver":
       not driver.isNil()
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "insert a message":
+  asyncTest "insert a message":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -50,13 +50,13 @@ suite "SQLite driver":
     let msg = fakeWakuMessage(contentTopic=contentTopic)
 
     ## When
-    let putRes = driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+    let putRes = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
 
     ## Then
     check:
       putRes.isOk()
 
-    let storedMsg = driver.getAllMessages().tryGet()
+    let storedMsg = (await driver.getAllMessages()).tryGet()
     check:
       storedMsg.len == 1
       storedMsg.all do (item: auto) -> bool:
@@ -65,4 +65,4 @@ suite "SQLite driver":
         pubsubTopic == DefaultPubsubTopic
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")

--- a/tests/v2/waku_archive/test_driver_sqlite.nim
+++ b/tests/v2/waku_archive/test_driver_sqlite.nim
@@ -23,7 +23,7 @@ proc newTestSqliteDriver(): ArchiveDriver =
 
 suite "SQLite driver":
 
-  asyncTest "init driver and database":
+  test "init driver and database":
     ## Given
     let database = newTestDatabase()
 
@@ -39,9 +39,9 @@ suite "SQLite driver":
       not driver.isNil()
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")
 
-  asyncTest "insert a message":
+  test "insert a message":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -50,13 +50,13 @@ suite "SQLite driver":
     let msg = fakeWakuMessage(contentTopic=contentTopic)
 
     ## When
-    let putRes = await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
+    let putRes = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)
 
     ## Then
     check:
       putRes.isOk()
 
-    let storedMsg = (await driver.getAllMessages()).tryGet()
+    let storedMsg = (waitFor driver.getAllMessages()).tryGet()
     check:
       storedMsg.len == 1
       storedMsg.all do (item: auto) -> bool:
@@ -65,4 +65,4 @@ suite "SQLite driver":
         pubsubTopic == DefaultPubsubTopic
 
     ## Cleanup
-    (await driver.close()).expect("driver to close")
+    (waitFor driver.close()).expect("driver to close")

--- a/tests/v2/waku_archive/test_driver_sqlite_query.nim
+++ b/tests/v2/waku_archive/test_driver_sqlite_query.nim
@@ -39,7 +39,7 @@ proc computeTestCursor(pubsubTopic: PubsubTopic, message: WakuMessage): ArchiveC
 
 suite "SQLite driver - query by content topic":
 
-  test "no content topic":
+  asyncTest "no content topic":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -62,10 +62,10 @@ suite "SQLite driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       maxPageSize=5,
       ascendingOrder=true
     )
@@ -79,9 +79,9 @@ suite "SQLite driver - query by content topic":
       filteredMessages == expected[0..4]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "single content topic":
+  asyncTest "single content topic":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -105,10 +105,10 @@ suite "SQLite driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       maxPageSize=2,
       ascendingOrder=true
@@ -123,9 +123,9 @@ suite "SQLite driver - query by content topic":
       filteredMessages == expected[2..3]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "single content topic - descending order":
+  asyncTest "single content topic - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -149,10 +149,10 @@ suite "SQLite driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       maxPageSize=2,
       ascendingOrder=false
@@ -167,9 +167,9 @@ suite "SQLite driver - query by content topic":
       filteredMessages == expected[6..7].reversed()
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "multiple content topic":
+  asyncTest "multiple content topic":
     ## Given
     const contentTopic1 = "test-content-topic-1"
     const contentTopic2 = "test-content-topic-2"
@@ -195,10 +195,10 @@ suite "SQLite driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic1, contentTopic2],
       maxPageSize=2,
       ascendingOrder=true
@@ -213,9 +213,9 @@ suite "SQLite driver - query by content topic":
       filteredMessages == expected[2..3]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "single content topic - no results":
+  asyncTest "single content topic - no results":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -234,10 +234,10 @@ suite "SQLite driver - query by content topic":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       maxPageSize=2,
       ascendingOrder=true
@@ -252,9 +252,9 @@ suite "SQLite driver - query by content topic":
       filteredMessages.len == 0
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "content topic and max page size - not enough messages stored":
+  asyncTest "content topic and max page size - not enough messages stored":
     ## Given
     const pageSize: uint = 50
 
@@ -262,10 +262,10 @@ suite "SQLite driver - query by content topic":
 
     for t in 0..<40:
       let msg = fakeWakuMessage(@[byte t], DefaultContentTopic, ts=ts(t))
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[DefaultContentTopic],
       maxPageSize=pageSize,
       ascendingOrder=true
@@ -280,12 +280,12 @@ suite "SQLite driver - query by content topic":
       filteredMessages.len == 40
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
 
 suite "SQLite driver - query by pubsub topic":
 
-  test "pubsub topic":
+  asyncTest "pubsub topic":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -310,10 +310,10 @@ suite "SQLite driver - query by pubsub topic":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       pubsubTopic=some(pubsubTopic),
       maxPageSize=2,
       ascendingOrder=true
@@ -329,9 +329,9 @@ suite "SQLite driver - query by pubsub topic":
       filteredMessages == expectedMessages[4..5]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "no pubsub topic":
+  asyncTest "no pubsub topic":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -356,10 +356,10 @@ suite "SQLite driver - query by pubsub topic":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       maxPageSize=2,
       ascendingOrder=true
     )
@@ -374,9 +374,9 @@ suite "SQLite driver - query by pubsub topic":
       filteredMessages == expectedMessages[0..1]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "content topic and pubsub topic":
+  asyncTest "content topic and pubsub topic":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -402,10 +402,10 @@ suite "SQLite driver - query by pubsub topic":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       maxPageSize=2,
@@ -422,12 +422,12 @@ suite "SQLite driver - query by pubsub topic":
       filteredMessages == expectedMessages[4..5]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
 
 suite "SQLite driver - query by cursor":
 
-  test "only cursor":
+  asyncTest "only cursor":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -451,12 +451,12 @@ suite "SQLite driver - query by cursor":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[4])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       cursor=some(cursor),
       maxPageSize=2,
       ascendingOrder=true
@@ -471,9 +471,9 @@ suite "SQLite driver - query by cursor":
       filteredMessages == expected[5..6]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "only cursor - descending order":
+  asyncTest "only cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -497,12 +497,12 @@ suite "SQLite driver - query by cursor":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[4])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       cursor=some(cursor),
       maxPageSize=2,
       ascendingOrder=false
@@ -517,9 +517,9 @@ suite "SQLite driver - query by cursor":
       filteredMessages == expected[2..3].reversed()
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "content topic and cursor":
+  asyncTest "content topic and cursor":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -541,12 +541,12 @@ suite "SQLite driver - query by cursor":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[4])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       cursor=some(cursor),
       maxPageSize=10,
@@ -562,9 +562,9 @@ suite "SQLite driver - query by cursor":
       filteredMessages == expected[5..6]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "content topic and cursor - descending order":
+  asyncTest "content topic and cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -586,12 +586,12 @@ suite "SQLite driver - query by cursor":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[6])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       cursor=some(cursor),
       maxPageSize=10,
@@ -607,9 +607,9 @@ suite "SQLite driver - query by cursor":
       filteredMessages == expected[2..5].reversed()
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "pubsub topic and cursor":
+  asyncTest "pubsub topic and cursor":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -638,12 +638,12 @@ suite "SQLite driver - query by cursor":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(expected[5][0], expected[5][1])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
       maxPageSize=10,
@@ -660,9 +660,9 @@ suite "SQLite driver - query by cursor":
       filteredMessages == expectedMessages[6..7]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "pubsub topic and cursor - descending order":
+  asyncTest "pubsub topic and cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -691,12 +691,12 @@ suite "SQLite driver - query by cursor":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(expected[6][0], expected[6][1])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
       maxPageSize=10,
@@ -713,12 +713,12 @@ suite "SQLite driver - query by cursor":
       filteredMessages == expectedMessages[4..5].reversed()
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
 
 suite "SQLite driver - query by time range":
 
-  test "start time only":
+  asyncTest "start time only":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -741,10 +741,10 @@ suite "SQLite driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       startTime=some(ts(15, timeOrigin)),
       maxPageSize=10,
       ascendingOrder=true
@@ -759,9 +759,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expected[2..6]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "end time only":
+  asyncTest "end time only":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -784,10 +784,10 @@ suite "SQLite driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       endTime=some(ts(45, timeOrigin)),
       maxPageSize=10,
       ascendingOrder=true
@@ -802,9 +802,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expected[0..4]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "start time and end time":
+  asyncTest "start time and end time":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -833,10 +833,10 @@ suite "SQLite driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       startTime=some(ts(15, timeOrigin)),
       endTime=some(ts(45, timeOrigin)),
       maxPageSize=10,
@@ -853,9 +853,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expectedMessages[2..4]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "invalid time range - no results":
+  asyncTest "invalid time range - no results":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -879,10 +879,10 @@ suite "SQLite driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       startTime=some(ts(45, timeOrigin)),
       endTime=some(ts(15, timeOrigin)),
@@ -898,9 +898,9 @@ suite "SQLite driver - query by time range":
       filteredMessages.len == 0
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "time range start and content topic":
+  asyncTest "time range start and content topic":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -923,10 +923,10 @@ suite "SQLite driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       startTime=some(ts(15, timeOrigin)),
       maxPageSize=10,
@@ -941,9 +941,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expected[2..6]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "time range start and content topic - descending order":
+  asyncTest "time range start and content topic - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -969,10 +969,10 @@ suite "SQLite driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       startTime=some(ts(15, timeOrigin)),
       maxPageSize=10,
@@ -987,9 +987,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expected[2..6].reversed()
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "time range start, single content topic and cursor":
+  asyncTest "time range start, single content topic and cursor":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -1015,12 +1015,12 @@ suite "SQLite driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[3])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       cursor=some(cursor),
       startTime=some(ts(15, timeOrigin)),
@@ -1036,9 +1036,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expected[4..9]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "time range start, single content topic and cursor - descending order":
+  asyncTest "time range start, single content topic and cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
 
@@ -1064,12 +1064,12 @@ suite "SQLite driver - query by time range":
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
 
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[6])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       cursor=some(cursor),
       startTime=some(ts(15, timeOrigin)),
@@ -1085,9 +1085,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expected[3..4].reversed()
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "time range, content topic, pubsub topic and cursor":
+  asyncTest "time range, content topic, pubsub topic and cursor":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -1116,12 +1116,12 @@ suite "SQLite driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[1][1])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
@@ -1140,9 +1140,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expectedMessages[3..4]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "time range, content topic, pubsub topic and cursor - descending order":
+  asyncTest "time range, content topic, pubsub topic and cursor - descending order":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -1171,12 +1171,12 @@ suite "SQLite driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(expected[7][0], expected[7][1])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
@@ -1195,9 +1195,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expectedMessages[4..5].reversed()
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "time range, content topic, pubsub topic and cursor - cursor timestamp out of time range":
+  asyncTest "time range, content topic, pubsub topic and cursor - cursor timestamp out of time range":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -1226,12 +1226,12 @@ suite "SQLite driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(expected[1][0], expected[1][1])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
@@ -1251,9 +1251,9 @@ suite "SQLite driver - query by time range":
       filteredMessages == expectedMessages[4..5]
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "time range, content topic, pubsub topic and cursor - cursor timestamp out of time range, descending order":
+  asyncTest "time range, content topic, pubsub topic and cursor - cursor timestamp out of time range, descending order":
     ## Given
     const contentTopic = "test-content-topic"
     const pubsubTopic = "test-pubsub-topic"
@@ -1282,12 +1282,12 @@ suite "SQLite driver - query by time range":
 
     for row in messages:
       let (topic, msg) = row
-      require driver.put(topic, msg, computeDigest(msg), msg.timestamp).isOk()
+      require (await driver.put(topic, msg, computeDigest(msg), msg.timestamp)).isOk()
 
     let cursor = computeTestCursor(expected[1][0], expected[1][1])
 
     ## When
-    let res = driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic= @[contentTopic],
       pubsubTopic=some(pubsubTopic),
       cursor=some(cursor),
@@ -1306,4 +1306,4 @@ suite "SQLite driver - query by time range":
       filteredMessages.len == 0
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")

--- a/tests/v2/waku_archive/test_retention_policy.nim
+++ b/tests/v2/waku_archive/test_retention_policy.nim
@@ -26,7 +26,7 @@ proc newTestArchiveDriver(): ArchiveDriver =
 
 suite "Waku Archive - Retention policy":
 
-  test "capacity retention policy - windowed message deletion":
+  asyncTest "capacity retention policy - windowed message deletion":
     ## Given
     let
       capacity = 100
@@ -40,11 +40,11 @@ suite "Waku Archive - Retention policy":
     for i in 1..capacity+excess:
       let msg = fakeWakuMessage(payload= @[byte i], contentTopic=DefaultContentTopic, ts=Timestamp(i))
 
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
-      require retentionPolicy.execute(driver).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
+      require (await retentionPolicy.execute(driver)).isOk()
 
     ## Then
-    let numMessages = driver.getMessagesCount().tryGet()
+    let numMessages = (await driver.getMessagesCount()).tryGet()
     check:
       # Expected number of messages is 120 because
       # (capacity = 100) + (half of the overflow window = 15) + (5 messages added after after the last delete)
@@ -52,9 +52,9 @@ suite "Waku Archive - Retention policy":
       numMessages == 120
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
-  test "store capacity should be limited":
+  asyncTest "store capacity should be limited":
     ## Given
     const capacity = 5
     const contentTopic = "test-content-topic"
@@ -76,11 +76,11 @@ suite "Waku Archive - Retention policy":
 
     ## When
     for msg in messages:
-      require driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp).isOk()
-      require retentionPolicy.execute(driver).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
+      require (await retentionPolicy.execute(driver)).isOk()
 
     ## Then
-    let storedMsg = driver.getAllMessages().tryGet()
+    let storedMsg = (await driver.getAllMessages()).tryGet()
     check:
       storedMsg.len == capacity
       storedMsg.all do (item: auto) -> bool:
@@ -89,4 +89,4 @@ suite "Waku Archive - Retention policy":
         pubsubTopic == DefaultPubsubTopic
 
     ## Cleanup
-    driver.close().expect("driver to close")
+    (await driver.close()).expect("driver to close")

--- a/tests/v2/waku_store/test_waku_store.nim
+++ b/tests/v2/waku_store/test_waku_store.nim
@@ -14,8 +14,6 @@ import
   ../testlib/common,
   ../testlib/wakucore
 
-
-
 proc newTestWakuStore(switch: Switch, handler: HistoryQueryHandler): Future[WakuStore] {.async.} =
   let
     peerManager = PeerManager.new(switch)
@@ -27,8 +25,7 @@ proc newTestWakuStore(switch: Switch, handler: HistoryQueryHandler): Future[Waku
   return proto
 
 proc newTestWakuStoreClient(switch: Switch): WakuStoreClient =
-  let
-    peerManager = PeerManager.new(switch)
+  let peerManager = PeerManager.new(switch)
   WakuStoreClient.new(peerManager, rng)
 
 
@@ -48,7 +45,8 @@ suite "Waku Store - query handler":
     let msg = fakeWakuMessage(contentTopic=DefaultContentTopic)
 
     var queryHandlerFut = newFuture[(HistoryQuery)]()
-    let queryHandler = proc(req: HistoryQuery): HistoryResult =
+
+    let queryHandler = proc(req: HistoryQuery): Future[HistoryResult] {.async, gcsafe.} =
           queryHandlerFut.complete(req)
           return ok(HistoryResponse(messages: @[msg]))
 
@@ -90,7 +88,7 @@ suite "Waku Store - query handler":
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
 
     var queryHandlerFut = newFuture[(HistoryQuery)]()
-    let queryHandler = proc(req: HistoryQuery): HistoryResult =
+    let queryHandler = proc(req: HistoryQuery): Future[HistoryResult] {.async, gcsafe.} =
           queryHandlerFut.complete(req)
           return err(HistoryError(kind: HistoryErrorKind.BAD_REQUEST))
 

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
@@ -22,7 +22,7 @@ import
   ../../v2/testlib/wakunode
 
 
-proc put(store: ArchiveDriver, pubsubTopic: PubsubTopic, message: WakuMessage): Result[void, string] =
+proc put(store: ArchiveDriver, pubsubTopic: PubsubTopic, message: WakuMessage): Future[Result[void, string]] =
   let
     digest = waku_archive.computeDigest(message)
     receivedTime = if message.timestamp > 0: message.timestamp
@@ -83,7 +83,7 @@ procSuite "Waku v2 JSON-RPC API - Store":
     ]
 
     for msg in msgList:
-      require driver.put(DefaultPubsubTopic, msg).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort, false)
@@ -133,7 +133,7 @@ procSuite "Waku v2 JSON-RPC API - Store":
       fakeWakuMessage(@[byte 9], ts=9)
     ]
     for msg in msgList:
-      require driver.put(DefaultPubsubTopic, msg).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort, false)

--- a/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
+++ b/tests/v2/wakunode_jsonrpc/test_jsonrpc_store.nim
@@ -83,7 +83,7 @@ procSuite "Waku v2 JSON-RPC API - Store":
     ]
 
     for msg in msgList:
-      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort, false)
@@ -133,7 +133,7 @@ procSuite "Waku v2 JSON-RPC API - Store":
       fakeWakuMessage(@[byte 9], ts=9)
     ]
     for msg in msgList:
-      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort, false)

--- a/tests/v2/wakunode_rest/test_rest_store.nim
+++ b/tests/v2/wakunode_rest/test_rest_store.nim
@@ -28,7 +28,7 @@ import
 logScope:
   topics = "waku node rest store_api test"
 
-proc put(store: ArchiveDriver, pubsubTopic: PubsubTopic, message: WakuMessage): Result[void, string] =
+proc put(store: ArchiveDriver, pubsubTopic: PubsubTopic, message: WakuMessage): Future[Result[void, string]] =
   let
     digest = waku_archive.computeDigest(message)
     receivedTime = if message.timestamp > 0: message.timestamp
@@ -107,7 +107,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("c2"), ts=9)
     ]
     for msg in msgList:
-      require driver.put(DefaultPubsubTopic, msg).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -178,7 +178,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 09], ts=ts(90, timeOrigin))
     ]
     for msg in msgList:
-      require driver.put(DefaultPubsubTopic, msg).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -266,7 +266,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("2"), ts=9)
     ]
     for msg in msgList:
-      require driver.put(DefaultPubsubTopic, msg).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -338,7 +338,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("ct2"), ts=9)
     ]
     for msg in msgList:
-      require driver.put(DefaultPubsubTopic, msg).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -427,7 +427,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("ct2"), ts=9)
     ]
     for msg in msgList:
-      require driver.put(DefaultPubsubTopic, msg).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -482,7 +482,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("ct2"), ts=9)
     ]
     for msg in msgList:
-      require driver.put(DefaultPubsubTopic, msg).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 

--- a/tests/v2/wakunode_rest/test_rest_store.nim
+++ b/tests/v2/wakunode_rest/test_rest_store.nim
@@ -107,7 +107,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("c2"), ts=9)
     ]
     for msg in msgList:
-      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -178,7 +178,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 09], ts=ts(90, timeOrigin))
     ]
     for msg in msgList:
-      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -266,7 +266,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("2"), ts=9)
     ]
     for msg in msgList:
-      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -338,7 +338,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("ct2"), ts=9)
     ]
     for msg in msgList:
-      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -427,7 +427,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("ct2"), ts=9)
     ]
     for msg in msgList:
-      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -482,7 +482,7 @@ procSuite "Waku v2 Rest API - Store":
       fakeWakuMessage(@[byte 9], contentTopic=ContentTopic("ct2"), ts=9)
     ]
     for msg in msgList:
-      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 

--- a/waku/v2/node/jsonrpc/filter/handlers.nim
+++ b/waku/v2/node/jsonrpc/filter/handlers.nim
@@ -44,7 +44,7 @@ proc installFilterApiHandlers*(node: WakuNode, server: RpcServer, cache: Message
       pubsubTopic: PubsubTopic = topic.get(DefaultPubsubTopic)
       contentTopics: seq[ContentTopic] = contentFilters.mapIt(it.contentTopic)
 
-    let handler: FilterPushHandler = proc(pubsubTopic: PubsubTopic, msg: WakuMessage) {.gcsafe, closure.} =
+    let handler: FilterPushHandler = proc(pubsubTopic: PubsubTopic, msg: WakuMessage) {.async, gcsafe, closure.} =
         cache.addMessage(msg.contentTopic, msg)
 
     let subFut = node.filterSubscribe(pubsubTopic, contentTopics, handler, peerOpt.get())

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -264,7 +264,7 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
     if node.wakuArchive.isNil():
       return
 
-    node.wakuArchive.handleMessage(topic, msg)
+    await node.wakuArchive.handleMessage(topic, msg)
 
 
   let defaultHandler = proc(topic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
@@ -455,11 +455,11 @@ proc filterSubscribe*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopics: C
 
   # Add handler wrapper to store the message when pushed, when relay is disabled and filter enabled
   # TODO: Move this logic to wakunode2 app
-  let handlerWrapper: FilterPushHandler = proc(pubsubTopic: string, message: WakuMessage) {.raises: [Exception].} =
+  let handlerWrapper: FilterPushHandler = proc(pubsubTopic: string, message: WakuMessage) {.async, gcsafe, closure.} =
       if node.wakuRelay.isNil() and not node.wakuStore.isNil():
-        node.wakuArchive.handleMessage(pubSubTopic, message)
+        await node.wakuArchive.handleMessage(pubSubTopic, message)
 
-      handler(pubsubTopic, message)
+      await handler(pubsubTopic, message)
 
   let subRes = await node.wakuFilterClientLegacy.subscribe(pubsubTopic, contentTopics, handlerWrapper, peer=remotePeer)
   if subRes.isOk():
@@ -521,7 +521,6 @@ proc unsubscribe*(node: WakuNode, pubsubTopic: PubsubTopic, contentTopics: Conte
 
   await node.filterUnsubscribe(pubsubTopic, contentTopics, peer=peerOpt.get())
 
-
 ## Waku archive
 
 proc mountArchive*(node: WakuNode,
@@ -544,8 +543,8 @@ proc executeMessageRetentionPolicy*(node: WakuNode) =
 
   debug "executing message retention policy"
 
-  node.wakuArchive.executeMessageRetentionPolicy()
-  node.wakuArchive.reportStoredMessagesMetric()
+  asyncSpawn node.wakuArchive.executeMessageRetentionPolicy()
+  asyncSpawn node.wakuArchive.reportStoredMessagesMetric()
 
 proc startMessageRetentionPolicyPeriodicTask*(node: WakuNode, interval: Duration) =
   if node.wakuArchive.isNil():
@@ -602,13 +601,12 @@ proc mountStore*(node: WakuNode) {.async, raises: [Defect, LPError].} =
     return
 
   # TODO: Review this handler logic. Maybe, move it to the appplication code
-  let queryHandler: HistoryQueryHandler = proc(request: HistoryQuery): HistoryResult =
+  let queryHandler: HistoryQueryHandler = proc(request: HistoryQuery): Future[HistoryResult] {.async.} =
       let request = request.toArchiveQuery()
-      let response = node.wakuArchive.findMessages(request)
-      response.toHistoryResult()
+      let response = await node.wakuArchive.findMessages(request)
+      return response.toHistoryResult()
 
   node.wakuStore = WakuStore.new(node.peerManager, node.rng, queryHandler)
-
 
   if node.started:
     # Node has started already. Let's start store too.

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -543,8 +543,11 @@ proc executeMessageRetentionPolicy*(node: WakuNode) =
 
   debug "executing message retention policy"
 
-  asyncSpawn node.wakuArchive.executeMessageRetentionPolicy()
-  asyncSpawn node.wakuArchive.reportStoredMessagesMetric()
+  try:
+    waitFor node.wakuArchive.executeMessageRetentionPolicy()
+    waitFor node.wakuArchive.reportStoredMessagesMetric()
+  except CatchableError:
+    debug "Error executing retention policy " & getCurrentExceptionMsg()
 
 proc startMessageRetentionPolicyPeriodicTask*(node: WakuNode, interval: Duration) =
   if node.wakuArchive.isNil():

--- a/waku/v2/waku_archive/driver.nim
+++ b/waku/v2/waku_archive/driver.nim
@@ -26,10 +26,10 @@ method put*(driver: ArchiveDriver,
             message: WakuMessage,
             digest: MessageDigest,
             receivedTime: Timestamp):
-            Future[ArchiveDriverResult[void]] {.base.} = discard
+            Future[ArchiveDriverResult[void]] {.base, async.} = discard
 
 method getAllMessages*(driver: ArchiveDriver):
-                       Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base.} = discard
+                       Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async.} = discard
 
 method getMessages*(driver: ArchiveDriver,
                     contentTopic: seq[ContentTopic] = @[],
@@ -39,24 +39,24 @@ method getMessages*(driver: ArchiveDriver,
                     endTime = none(Timestamp),
                     maxPageSize = DefaultPageSize,
                     ascendingOrder = true):
-                    Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base.} = discard
+                    Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async.} = discard
 
 method getMessagesCount*(driver: ArchiveDriver):
-                         Future[ArchiveDriverResult[int64]] {.base.} = discard
+                         Future[ArchiveDriverResult[int64]] {.base, async.} = discard
 
 method getOldestMessageTimestamp*(driver: ArchiveDriver):
-                                  Future[ArchiveDriverResult[Timestamp]] {.base.} = discard
+                                  Future[ArchiveDriverResult[Timestamp]] {.base, async.} = discard
 
 method getNewestMessageTimestamp*(driver: ArchiveDriver):
-                                  Future[ArchiveDriverResult[Timestamp]] {.base.} = discard
+                                  Future[ArchiveDriverResult[Timestamp]] {.base, async.} = discard
 
 method deleteMessagesOlderThanTimestamp*(driver: ArchiveDriver,
                                          ts: Timestamp):
-                                         Future[ArchiveDriverResult[void]] {.base.} = discard
+                                         Future[ArchiveDriverResult[void]] {.base, async.} = discard
 
 method deleteOldestMessagesNotWithinLimit*(driver: ArchiveDriver,
                                            limit: int):
-                                           Future[ArchiveDriverResult[void]] {.base.} = discard
+                                           Future[ArchiveDriverResult[void]] {.base, async.} = discard
 
 method close*(driver: ArchiveDriver):
-              Future[ArchiveDriverResult[void]] {.base.} = discard
+              Future[ArchiveDriverResult[void]] {.base, async.} = discard

--- a/waku/v2/waku_archive/driver.nim
+++ b/waku/v2/waku_archive/driver.nim
@@ -5,53 +5,58 @@ else:
 
 import
   std/options,
-  stew/results
+  stew/results,
+  chronos
 import
   ../waku_core,
   ./common
 
-
 const DefaultPageSize*: uint = 25
-
 
 type
   ArchiveDriverResult*[T] = Result[T, string]
-
   ArchiveDriver* = ref object of RootObj
 
 type ArchiveRow* = (PubsubTopic, WakuMessage, seq[byte], Timestamp)
 
-
 # ArchiveDriver interface
 
-method put*(driver: ArchiveDriver, pubsubTopic: PubsubTopic, message: WakuMessage, digest: MessageDigest, receivedTime: Timestamp): ArchiveDriverResult[void] {.base.} = discard
+method put*(driver: ArchiveDriver,
+            pubsubTopic: PubsubTopic,
+            message: WakuMessage,
+            digest: MessageDigest,
+            receivedTime: Timestamp):
+            Future[ArchiveDriverResult[void]] {.base.} = discard
 
+method getAllMessages*(driver: ArchiveDriver):
+                       Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base.} = discard
 
-method getAllMessages*(driver: ArchiveDriver): ArchiveDriverResult[seq[ArchiveRow]] {.base.} = discard
+method getMessages*(driver: ArchiveDriver,
+                    contentTopic: seq[ContentTopic] = @[],
+                    pubsubTopic = none(PubsubTopic),
+                    cursor = none(ArchiveCursor),
+                    startTime = none(Timestamp),
+                    endTime = none(Timestamp),
+                    maxPageSize = DefaultPageSize,
+                    ascendingOrder = true):
+                    Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base.} = discard
 
-method getMessages*(
-  driver: ArchiveDriver,
-  contentTopic: seq[ContentTopic] = @[],
-  pubsubTopic = none(PubsubTopic),
-  cursor = none(ArchiveCursor),
-  startTime = none(Timestamp),
-  endTime = none(Timestamp),
-  maxPageSize = DefaultPageSize,
-  ascendingOrder = true
-): ArchiveDriverResult[seq[ArchiveRow]] {.base.} = discard
+method getMessagesCount*(driver: ArchiveDriver):
+                         Future[ArchiveDriverResult[int64]] {.base.} = discard
 
+method getOldestMessageTimestamp*(driver: ArchiveDriver):
+                                  Future[ArchiveDriverResult[Timestamp]] {.base.} = discard
 
-method getMessagesCount*(driver: ArchiveDriver): ArchiveDriverResult[int64] {.base.} = discard
+method getNewestMessageTimestamp*(driver: ArchiveDriver):
+                                  Future[ArchiveDriverResult[Timestamp]] {.base.} = discard
 
-method getOldestMessageTimestamp*(driver: ArchiveDriver): ArchiveDriverResult[Timestamp] {.base.} = discard
+method deleteMessagesOlderThanTimestamp*(driver: ArchiveDriver,
+                                         ts: Timestamp):
+                                         Future[ArchiveDriverResult[void]] {.base.} = discard
 
-method getNewestMessageTimestamp*(driver: ArchiveDriver): ArchiveDriverResult[Timestamp]  {.base.} = discard
+method deleteOldestMessagesNotWithinLimit*(driver: ArchiveDriver,
+                                           limit: int):
+                                           Future[ArchiveDriverResult[void]] {.base.} = discard
 
-
-method deleteMessagesOlderThanTimestamp*(driver: ArchiveDriver, ts: Timestamp): ArchiveDriverResult[void] {.base.} = discard
-
-method deleteOldestMessagesNotWithinLimit*(driver: ArchiveDriver, limit: int): ArchiveDriverResult[void] {.base.} = discard
-
-
-method close*(driver: ArchiveDriver): ArchiveDriverResult[void] {.base.} =
-  ok()
+method close*(driver: ArchiveDriver):
+              Future[ArchiveDriverResult[void]] {.base.} = discard

--- a/waku/v2/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/v2/waku_archive/driver/queue_driver/queue_driver.nim
@@ -273,8 +273,8 @@ method getMessages*(driver: QueueDriver,
 
   if pageRes.isErr():
     return err($pageRes.error)
-  else:
-    return ok(pageRes.value)
+
+  return ok(pageRes.value)
 
 method getMessagesCount*(driver: QueueDriver):
                          Future[ArchiveDriverResult[int64]] {.async} =

--- a/waku/v2/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/v2/waku_archive/driver/queue_driver/queue_driver.nim
@@ -7,20 +7,18 @@ import
   std/options,
   stew/results,
   stew/sorted_set,
-  chronicles
+  chronicles,
+  chronos
 import
   ../../../waku_core,
   ../../common,
   ../../driver,
   ./index
 
-
 logScope:
   topics = "waku archive queue_store"
 
-
 const QueueDriverDefaultMaxCapacity* = 25_000
-
 
 type
   IndexedWakuMessage = object
@@ -43,7 +41,6 @@ proc `$`(error: QueueDriverErrorKind): string =
   of INVALID_CURSOR:
     "invalid_cursor"
 
-
 type QueueDriver* = ref object of ArchiveDriver
     ## Bounded repository for indexed messages
     ##
@@ -58,7 +55,6 @@ type QueueDriver* = ref object of ArchiveDriver
     ## TODO: we don't need to store the Index twice (as key and in the value)
     items: SortedSet[Index, IndexedWakuMessage] # sorted set of stored messages
     capacity: int # Maximum amount of messages to keep
-
 
 ### Helpers
 
@@ -82,13 +78,11 @@ proc walkToCursor(w: SortedSetWalkRef[Index, IndexedWakuMessage],
 
   return nextItem
 
-
 #### API
 
 proc new*(T: type QueueDriver, capacity: int = QueueDriverDefaultMaxCapacity): T =
   var items = SortedSet[Index, IndexedWakuMessage].init()
   return QueueDriver(items: items, capacity: capacity)
-
 
 proc contains*(driver: QueueDriver, index: Index): bool =
   ## Return `true` if the store queue already contains the `index`, `false` otherwise.
@@ -202,7 +196,6 @@ proc last*(driver: QueueDriver): ArchiveDriverResult[IndexedWakuMessage] =
 
   return ok(res.value.data)
 
-
 ## --- Queue API ---
 
 proc add*(driver: QueueDriver, msg: IndexedWakuMessage): ArchiveDriverResult[void] =
@@ -231,27 +224,30 @@ proc add*(driver: QueueDriver, msg: IndexedWakuMessage): ArchiveDriverResult[voi
 
   return ok()
 
-
-method put*(driver: QueueDriver, pubsubTopic: PubsubTopic, message: WakuMessage, digest: MessageDigest, receivedTime: Timestamp): ArchiveDriverResult[void] =
+method put*(driver: QueueDriver,
+            pubsubTopic: PubsubTopic,
+            message: WakuMessage,
+            digest: MessageDigest,
+            receivedTime: Timestamp):
+            Future[ArchiveDriverResult[void]] {.async.} =
   let index = Index(pubsubTopic: pubsubTopic, senderTime: message.timestamp, receiverTime: receivedTime, digest: digest)
   let message = IndexedWakuMessage(msg: message, index: index, pubsubTopic: pubsubTopic)
-  driver.add(message)
+  return driver.add(message)
 
-
-method getAllMessages*(driver: QueueDriver): ArchiveDriverResult[seq[ArchiveRow]] =
+method getAllMessages*(driver: QueueDriver):
+                       Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   # TODO: Implement this message_store method
-  err("interface method not implemented")
+  return err("interface method not implemented")
 
-method getMessages*(
-  driver: QueueDriver,
-  contentTopic: seq[ContentTopic] = @[],
-  pubsubTopic = none(PubsubTopic),
-  cursor = none(ArchiveCursor),
-  startTime = none(Timestamp),
-  endTime = none(Timestamp),
-  maxPageSize = DefaultPageSize,
-  ascendingOrder = true
-): ArchiveDriverResult[seq[ArchiveRow]] =
+method getMessages*(driver: QueueDriver,
+                    contentTopic: seq[ContentTopic] = @[],
+                    pubsubTopic = none(PubsubTopic),
+                    cursor = none(ArchiveCursor),
+                    startTime = none(Timestamp),
+                    endTime = none(Timestamp),
+                    maxPageSize = DefaultPageSize,
+                    ascendingOrder = true):
+                    Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.}=
   let cursor = cursor.map(toIndex)
 
   let matchesQuery: QueryFilterMatcher = func(row: IndexedWakuMessage): bool =
@@ -272,29 +268,38 @@ method getMessages*(
   var pageRes: QueueDriverGetPageResult
   try:
     pageRes = driver.getPage(maxPageSize, ascendingOrder, cursor, matchesQuery)
-  except:  # TODO: Fix "BareExcept" warning
+  except CatchableError, Exception:
     return err(getCurrentExceptionMsg())
 
   if pageRes.isErr():
     return err($pageRes.error)
+  else:
+    return ok(pageRes.value)
 
-  ok(pageRes.value)
+method getMessagesCount*(driver: QueueDriver):
+                         Future[ArchiveDriverResult[int64]] {.async} =
+  return ok(int64(driver.len()))
 
+method getOldestMessageTimestamp*(driver: QueueDriver):
+                                  Future[ArchiveDriverResult[Timestamp]] {.async.} =
+  return driver.first().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)
 
-method getMessagesCount*(driver: QueueDriver): ArchiveDriverResult[int64] =
-  ok(int64(driver.len()))
+method getNewestMessageTimestamp*(driver: QueueDriver):
+                                  Future[ArchiveDriverResult[Timestamp]] {.async.} =
+  return driver.last().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)
 
-method getOldestMessageTimestamp*(driver: QueueDriver): ArchiveDriverResult[Timestamp] =
-  driver.first().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)
-
-method getNewestMessageTimestamp*(driver: QueueDriver): ArchiveDriverResult[Timestamp] =
-  driver.last().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)
-
-
-method deleteMessagesOlderThanTimestamp*(driver: QueueDriver, ts: Timestamp): ArchiveDriverResult[void] =
+method deleteMessagesOlderThanTimestamp*(driver: QueueDriver,
+                                         ts: Timestamp):
+                                         Future[ArchiveDriverResult[void]] {.async.} =
   # TODO: Implement this message_store method
-  err("interface method not implemented")
+  return err("interface method not implemented")
 
-method deleteOldestMessagesNotWithinLimit*(driver: QueueDriver, limit: int): ArchiveDriverResult[void] =
+method deleteOldestMessagesNotWithinLimit*(driver: QueueDriver,
+                                           limit: int):
+                                           Future[ArchiveDriverResult[void]] {.async.} =
   # TODO: Implement this message_store method
-  err("interface method not implemented")
+  return err("interface method not implemented")
+
+method close*(driver: QueueDriver):
+              Future[ArchiveDriverResult[void]] {.async.} =
+  return ok()

--- a/waku/v2/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/v2/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -8,7 +8,8 @@ else:
 import
   std/options,
   stew/[byteutils, results],
-  chronicles
+  chronicles,
+  chronos
 import
   ../../../../common/sqlite,
   ../../../waku_core,
@@ -19,8 +20,6 @@ import
 
 logScope:
   topics = "waku archive sqlite"
-
-
 
 proc init(db: SqliteDatabase): ArchiveDriverResult[void] =
   ## Misconfiguration can lead to nil DB
@@ -43,7 +42,6 @@ proc init(db: SqliteDatabase): ArchiveDriverResult[void] =
 
   ok()
 
-
 type SqliteDriver* = ref object of ArchiveDriver
     db: SqliteDatabase
     insertStmt: SqliteStmt[InsertMessageParams, void]
@@ -59,22 +57,14 @@ proc new*(T: type SqliteDriver, db: SqliteDatabase): ArchiveDriverResult[T] =
   let insertStmt = db.prepareInsertMessageStmt()
   ok(SqliteDriver(db: db, insertStmt: insertStmt))
 
-method close*(s: SqliteDriver): ArchiveDriverResult[void] =
-  ## Close the database connection
-
-  # Dispose statements
-  s.insertStmt.dispose()
-
-  # Close connection
-  s.db.close()
-
-  ok()
-
-
-method put*(s: SqliteDriver, pubsubTopic: PubsubTopic, message: WakuMessage, digest: MessageDigest, receivedTime: Timestamp): ArchiveDriverResult[void] =
+method put*(s: SqliteDriver,
+            pubsubTopic: PubsubTopic,
+            message: WakuMessage,
+            digest: MessageDigest,
+            receivedTime: Timestamp):
+            Future[ArchiveDriverResult[void]] {.async.} =
   ## Inserts a message into the store
-
-  let res = s.insertStmt.exec((
+  return s.insertStmt.exec((
     @(digest.data),                # id
     receivedTime,                  # storedAt
     toBytes(message.contentTopic), # contentTopic
@@ -83,30 +73,25 @@ method put*(s: SqliteDriver, pubsubTopic: PubsubTopic, message: WakuMessage, dig
     int64(message.version),        # version
     message.timestamp              # senderTimestamp
   ))
-  if res.isErr():
-    return err("message insert failed: " & res.error)
 
-  ok()
-
-
-method getAllMessages*(s: SqliteDriver):  ArchiveDriverResult[seq[ArchiveRow]] =
+method getAllMessages*(s: SqliteDriver):
+                       Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   ## Retrieve all messages from the store.
-  s.db.selectAllMessages()
+  return s.db.selectAllMessages()
 
+method getMessages*(s: SqliteDriver,
+                    contentTopic: seq[ContentTopic] = @[],
+                    pubsubTopic = none(PubsubTopic),
+                    cursor = none(ArchiveCursor),
+                    startTime = none(Timestamp),
+                    endTime = none(Timestamp),
+                    maxPageSize = DefaultPageSize,
+                    ascendingOrder = true):
+                    Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
 
-method getMessages*(
-  s: SqliteDriver,
-  contentTopic: seq[ContentTopic] = @[],
-  pubsubTopic = none(PubsubTopic),
-  cursor = none(ArchiveCursor),
-  startTime = none(Timestamp),
-  endTime = none(Timestamp),
-  maxPageSize = DefaultPageSize,
-  ascendingOrder = true
-): ArchiveDriverResult[seq[ArchiveRow]] =
   let cursor = cursor.map(toDbCursor)
 
-  let rows = ?s.db.selectMessagesByHistoryQueryWithLimit(
+  return s.db.selectMessagesByHistoryQueryWithLimit(
     contentTopic,
     pubsubTopic,
     cursor,
@@ -116,21 +101,33 @@ method getMessages*(
     ascending=ascendingOrder
   )
 
-  ok(rows)
+method getMessagesCount*(s: SqliteDriver):
+                         Future[ArchiveDriverResult[int64]] {.async.} =
+  return s.db.getMessageCount()
 
+method getOldestMessageTimestamp*(s: SqliteDriver):
+                                  Future[ArchiveDriverResult[Timestamp]] {.async.} =
+  return s.db.selectOldestReceiverTimestamp()
 
-method getMessagesCount*(s: SqliteDriver): ArchiveDriverResult[int64] =
-  s.db.getMessageCount()
+method getNewestMessageTimestamp*(s: SqliteDriver):
+                                  Future[ArchiveDriverResult[Timestamp]] {.async.} =
+  return s.db.selectnewestReceiverTimestamp()
 
-method getOldestMessageTimestamp*(s: SqliteDriver): ArchiveDriverResult[Timestamp] =
-  s.db.selectOldestReceiverTimestamp()
+method deleteMessagesOlderThanTimestamp*(s: SqliteDriver,
+                                         ts: Timestamp):
+                                         Future[ArchiveDriverResult[void]] {.async.} =
+  return s.db.deleteMessagesOlderThanTimestamp(ts)
 
-method getNewestMessageTimestamp*(s: SqliteDriver): ArchiveDriverResult[Timestamp] =
-  s.db.selectnewestReceiverTimestamp()
+method deleteOldestMessagesNotWithinLimit*(s: SqliteDriver,
+                                           limit: int):
+                                           Future[ArchiveDriverResult[void]] {.async.} =
+  return s.db.deleteOldestMessagesNotWithinLimit(limit)
 
-
-method deleteMessagesOlderThanTimestamp*(s: SqliteDriver, ts: Timestamp): ArchiveDriverResult[void] =
-  s.db.deleteMessagesOlderThanTimestamp(ts)
-
-method deleteOldestMessagesNotWithinLimit*(s: SqliteDriver, limit: int): ArchiveDriverResult[void] =
-  s.db.deleteOldestMessagesNotWithinLimit(limit)
+method close*(s: SqliteDriver):
+              Future[ArchiveDriverResult[void]] {.async.} =
+  ## Close the database connection
+  # Dispose statements
+  s.insertStmt.dispose()
+  # Close connection
+  s.db.close()
+  return ok()

--- a/waku/v2/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/v2/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -64,7 +64,7 @@ method put*(s: SqliteDriver,
             receivedTime: Timestamp):
             Future[ArchiveDriverResult[void]] {.async.} =
   ## Inserts a message into the store
-  return s.insertStmt.exec((
+  let res = s.insertStmt.exec((
     @(digest.data),                # id
     receivedTime,                  # storedAt
     toBytes(message.contentTopic), # contentTopic
@@ -73,6 +73,8 @@ method put*(s: SqliteDriver,
     int64(message.version),        # version
     message.timestamp              # senderTimestamp
   ))
+
+  return res
 
 method getAllMessages*(s: SqliteDriver):
                        Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
@@ -91,7 +93,7 @@ method getMessages*(s: SqliteDriver,
 
   let cursor = cursor.map(toDbCursor)
 
-  return s.db.selectMessagesByHistoryQueryWithLimit(
+  let rowsRes = s.db.selectMessagesByHistoryQueryWithLimit(
     contentTopic,
     pubsubTopic,
     cursor,
@@ -100,6 +102,8 @@ method getMessages*(s: SqliteDriver,
     limit=maxPageSize,
     ascending=ascendingOrder
   )
+
+  return rowsRes
 
 method getMessagesCount*(s: SqliteDriver):
                          Future[ArchiveDriverResult[int64]] {.async.} =

--- a/waku/v2/waku_archive/retention_policy.nim
+++ b/waku/v2/waku_archive/retention_policy.nim
@@ -4,7 +4,8 @@ else:
   {.push raises: [].}
 
 import
-  stew/results
+  stew/results,
+  chronos
 import
   ./driver
 
@@ -12,5 +13,5 @@ type RetentionPolicyResult*[T] = Result[T, string]
 
 type RetentionPolicy* = ref object of RootObj
 
-
-method execute*(p: RetentionPolicy, store: ArchiveDriver): RetentionPolicyResult[void] {.base.} = discard
+method execute*(p: RetentionPolicy, store: ArchiveDriver):
+                Future[Result[void, string]] {.base.} = discard

--- a/waku/v2/waku_archive/retention_policy.nim
+++ b/waku/v2/waku_archive/retention_policy.nim
@@ -14,4 +14,4 @@ type RetentionPolicyResult*[T] = Result[T, string]
 type RetentionPolicy* = ref object of RootObj
 
 method execute*(p: RetentionPolicy, store: ArchiveDriver):
-                Future[Result[void, string]] {.base.} = discard
+                Future[RetentionPolicyResult[void]] {.base, async.} = discard

--- a/waku/v2/waku_archive/retention_policy/retention_policy_capacity.nim
+++ b/waku/v2/waku_archive/retention_policy/retention_policy_capacity.nim
@@ -5,14 +5,14 @@ else:
 
 import
   stew/results,
-  chronicles
+  chronicles,
+  chronos
 import
   ../driver,
   ../retention_policy
 
 logScope:
   topics = "waku archive retention_policy"
-
 
 const DefaultCapacity*: int = 25_000
 
@@ -38,7 +38,6 @@ type
       totalCapacity: int # = capacity * MaxOverflow
       deleteWindow: int # = capacity * (MaxOverflow - 1) / 2; half of the overflow window, the amount of messages deleted when overflow occurs
 
-
 proc calculateTotalCapacity(capacity: int, overflow: float): int =
   int(float(capacity) * overflow)
 
@@ -47,7 +46,6 @@ proc calculateOverflowWindow(capacity: int, overflow: float): int =
 
 proc calculateDeleteWindow(capacity: int, overflow: float): int =
   calculateOverflowWindow(capacity, overflow) div 2
-
 
 proc init*(T: type CapacityRetentionPolicy, capacity=DefaultCapacity): T =
   let
@@ -60,14 +58,21 @@ proc init*(T: type CapacityRetentionPolicy, capacity=DefaultCapacity): T =
     deleteWindow: deleteWindow
   )
 
-method execute*(p: CapacityRetentionPolicy, driver: ArchiveDriver): RetentionPolicyResult[void] =
-  let numMessages = ?driver.getMessagesCount().mapErr(proc(err: string): string = "failed to get messages count: " & err)
+method execute*(p: CapacityRetentionPolicy,
+                driver: ArchiveDriver):
+                Future[Result[void, string]] {.async.} =
+
+  let numMessagesRes = await driver.getMessagesCount()
+  if numMessagesRes.isErr():
+    return err("failed to get messages count: " & numMessagesRes.error)
+
+  let numMessages = numMessagesRes.value
 
   if numMessages < p.totalCapacity:
     return ok()
 
-  let res = driver.deleteOldestMessagesNotWithinLimit(limit=p.capacity + p.deleteWindow)
+  let res = await driver.deleteOldestMessagesNotWithinLimit(limit=p.capacity + p.deleteWindow)
   if res.isErr():
-    return err("deleting oldest messages failed: " & res.error())
-
-  ok()
+    return err("deleting oldest messages failed: " & res.error)
+  else:
+    return ok()

--- a/waku/v2/waku_archive/retention_policy/retention_policy_capacity.nim
+++ b/waku/v2/waku_archive/retention_policy/retention_policy_capacity.nim
@@ -60,7 +60,7 @@ proc init*(T: type CapacityRetentionPolicy, capacity=DefaultCapacity): T =
 
 method execute*(p: CapacityRetentionPolicy,
                 driver: ArchiveDriver):
-                Future[Result[void, string]] {.async.} =
+                Future[RetentionPolicyResult[void]] {.async.} =
 
   let numMessagesRes = await driver.getMessagesCount()
   if numMessagesRes.isErr():
@@ -74,5 +74,5 @@ method execute*(p: CapacityRetentionPolicy,
   let res = await driver.deleteOldestMessagesNotWithinLimit(limit=p.capacity + p.deleteWindow)
   if res.isErr():
     return err("deleting oldest messages failed: " & res.error)
-  else:
-    return ok()
+
+  return ok()

--- a/waku/v2/waku_archive/retention_policy/retention_policy_time.nim
+++ b/waku/v2/waku_archive/retention_policy/retention_policy_time.nim
@@ -29,21 +29,24 @@ proc init*(T: type TimeRetentionPolicy, retentionTime=DefaultRetentionTime): T =
     retentionTime: retentionTime.seconds
   )
 
-
-method execute*(p: TimeRetentionPolicy, driver: ArchiveDriver): RetentionPolicyResult[void] =
+method execute*(p: TimeRetentionPolicy,
+                driver: ArchiveDriver):
+                Future[RetentionPolicyResult[void]] {.async.} =
   ## Delete messages that exceed the retention time by 10% and more (batch delete for efficiency)
 
-  let oldestReceiverTimestamp = ?driver.getOldestMessageTimestamp().mapErr(proc(err: string): string = "failed to get oldest message timestamp: " & err)
+  let omtRes = await driver.getOldestMessageTimestamp()
+  if omtRes.isErr():
+    return err("failed to get oldest message timestamp: " & omtRes.error)
 
   let now = getNanosecondTime(getTime().toUnixFloat())
   let retentionTimestamp = now - p.retentionTime.nanoseconds
   let thresholdTimestamp = retentionTimestamp - p.retentionTime.nanoseconds div 10
 
-  if thresholdTimestamp <= oldestReceiverTimestamp:
+  if thresholdTimestamp <= omtRes.value:
     return ok()
 
-  let res = driver.deleteMessagesOlderThanTimestamp(ts=retentionTimestamp)
+  let res = await driver.deleteMessagesOlderThanTimestamp(ts=retentionTimestamp)
   if res.isErr():
-    return err("failed to delete oldest messages: " & res.error())
-
-  ok()
+    return err("failed to delete oldest messages: " & res.error)
+  else:
+    return ok()

--- a/waku/v2/waku_archive/retention_policy/retention_policy_time.nim
+++ b/waku/v2/waku_archive/retention_policy/retention_policy_time.nim
@@ -48,5 +48,5 @@ method execute*(p: TimeRetentionPolicy,
   let res = await driver.deleteMessagesOlderThanTimestamp(ts=retentionTimestamp)
   if res.isErr():
     return err("failed to delete oldest messages: " & res.error)
-  else:
-    return ok()
+
+  return ok()

--- a/waku/v2/waku_filter/client.nim
+++ b/waku/v2/waku_filter/client.nim
@@ -30,7 +30,7 @@ const Defaultstring = "/waku/2/default-waku/proto"
 
 ### Client, filter subscripton manager
 
-type FilterPushHandler* = proc(pubsubTopic: PubsubTopic, message: WakuMessage) {.gcsafe, closure.}
+type FilterPushHandler* = proc(pubsubTopic: PubsubTopic, message: WakuMessage) {.async, gcsafe, closure.}
 
 
 ## Subscription manager
@@ -59,7 +59,7 @@ proc notifySubscriptionHandler(m: SubscriptionManager, pubsubTopic: PubsubTopic,
 
   try:
     let handler = m.subscriptions[(pubsubTopic, contentTopic)]
-    handler(pubsubTopic, message)
+    asyncSpawn handler(pubsubTopic, message)
   except:  # TODO: Fix "BareExcept" warning
     discard
 

--- a/waku/v2/waku_store/protocol.nim
+++ b/waku/v2/waku_store/protocol.nim
@@ -34,7 +34,7 @@ const
   MaxMessageTimestampVariance* = getNanoSecondTime(20) # 20 seconds maximum allowable sender timestamp "drift"
 
 
-type HistoryQueryHandler* = proc(req: HistoryQuery): HistoryResult {.gcsafe.}
+type HistoryQueryHandler* = proc(req: HistoryQuery): Future[HistoryResult] {.async, gcsafe.}
 
 type
   WakuStore* = ref object of LPProtocol
@@ -74,7 +74,7 @@ proc initProtocolHandler(ws: WakuStore) =
 
     var responseRes: HistoryResult
     try:
-      responseRes = ws.queryHandler(request)
+      responseRes = await ws.queryHandler(request)
     except Exception:
       error "history query failed", peerId= $conn.peerId, requestId=requestId, error=getCurrentExceptionMsg()
 


### PR DESCRIPTION
# Description
This PR is a very first step on getting asynchronous calls to any CRUD `archive` operation.

Important to notice that this PR doesn't allow async calls per se. For example, in `waku/v2/waku_archive/driver/sqlite_driver/sqlite_driver.nim`, the method `getMessages()` will still be sync because the call to `s.db.selectMessagesByHistoryQueryWithLimit(..)` will still be blocking.

Instead, this PR is a reorganization to adopt the asynchronous patterns for `waku archive` and adapt the code for the upcoming PR's where we will aggregate the @LNSD's PR, and therefore, start incorporating the needed to allow async interaction with a PostgreSQL database.

Sorry for the big number of changes. These are the most relevant:
1. waku/v2/waku_archive/driver.nim
2. waku/v2/waku_archive/driver/sqlite_driver/sqlite_driver.nim
3. waku/v2/waku_archive/driver/queue_driver/queue_driver.nim
4.  ( in the next PR's we will have a postgresql driver  )

# Changes
- [x] Make async all the `waku_archive/driver.nim` methods

## Issue
https://github.com/waku-org/nwaku/issues/1604

