### PR TITLE
feat(ci): add nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,97 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: 13 3 * * *
+  workflow_dispatch:
+
+env:
+  RELEASE_NAME: nightly
+
+  NPROC: 2
+  MAKEFLAGS: "-j${NPROC}"
+  NIMFLAGS: "--parallelBuild:${NPROC}"
+
+jobs:
+  build-and-publish:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get submodules hash
+        id: submodules
+        run: |
+          echo "hash=$(git submodule status | awk '{print $1}' | sort | shasum -a 256 | sed 's/[ -]*//g')" >> $GITHUB_OUTPUT
+
+      - name: Cache submodules
+        uses: actions/cache@v3
+        with:
+          path: |
+            vendor/
+            .git/modules
+          key: ${{ runner.os }}-vendor-modules-${{ steps.submodules.outputs.hash }}
+
+
+      - name: build artifacts
+        id: build
+        run: |
+          ARCH=$(uname -m) 
+          echo "arch=${ARCH}" >> $GITHUB_OUTPUT
+          make QUICK_AND_DIRTY_COMPILER=1 V=1 CI=false wakunode2 tools
+
+          tar -cvzf nwaku-${ARCH}-${{runner.os}}.tar.gz ./build/wakunode2
+          tar -cvzf nwaku-tools-${ARCH}-${{runner.os}}.tar.gz ./build/wakucanary ./build/networkmonitor
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: wakunode2
+          path: nwaku-${{steps.build.outputs.arch}}-${{runner.os}}.tar.gz
+          retention-days: 2
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: tools
+          path: nwaku-tools-${{steps.build.outputs.arch}}-${{runner.os}}.tar.gz
+          retention-days: 2
+
+  create-release-candidate:
+    runs-on: ubuntu-latest
+    needs: [ build-and-publish ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: master
+      - name: download artifacts
+        uses: actions/download-artifact@v2
+      - name: generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view ${RELEASE_NAME} &>/dev/null &&\
+            gh release delete -y ${RELEASE_NAME} --cleanup-tag &&\
+            git tag -d ${RELEASE_NAME}
+
+          docker run \
+              -t \
+              --rm \
+              -v ${PWD}:/opt/sv4git/repo:z \
+              -u $(id -u) \
+              docker.io/wakuorg/sv4git:latest \
+                release-notes |\
+                sed -E 's@#([0-9]+)@[#\1](https://github.com/waku-org/nwaku/issues/\1)@g' > release_notes.md
+
+          sed -i "s/^## .*/Generated at $(date)/" release_notes.md
+
+          cat release_notes.md
+
+          gh release create ${RELEASE_NAME} --prerelease  --target master \
+            --title ${RELEASE_NAME} --notes-file release_notes.md \
+            wakunode2/* tools/*

--- a/docs/operators/overview.md
+++ b/docs/operators/overview.md
@@ -14,6 +14,9 @@ see our [Docker guide](./docker-quickstart.md).
 
 [Build the nwaku node](./how-to/build.md)
 or download a precompiled binary from our [releases page](https://github.com/waku-org/nwaku/releases).
+
+If you'd like to test latest changes without building the binaries yourself, you can refer to [nightly release](https://github.com/waku-org/nwaku/releases/tag/nightly).
+
 Docker images are published to [statusteam/nim-waku](https://hub.docker.com/r/statusteam/nim-waku/tags) on Docker Hub.
 See our [Docker quickstart guide](./docker-quickstart.md) to run nwaku in a Docker container.
 


### PR DESCRIPTION
# Description
It might be useful to build releasable artifacts nightly and create/update a Github Release with included commits and artifacts.

This gives anyone a place to simply get and test latest binary artifacts and to us a place to experiment with how artifacts are produced and packaged.

The GH Actions job is triggered every night + can be triggered manually, it builds `wakunode2` and tools (`networkmonitor` and `wakucanary`)  and creates or updates the `nightly` tag and release.

See an example here: https://github.com/nwaku-test-org/nwaku/releases/tag/nightly

# Changes


- [x] added a CI job which for nightly builds

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->