### PR TITLE
fix(ci): enforce basic CPU instruction set to prevent execution problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ TARGET ?= prod
 GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
 NIM_PARAMS := $(NIM_PARAMS) -d:git_version=\"$(GIT_VERSION)\"
 
+## Pass CPU architecture to C compiler, use basic x86-64 instruction set by default
+ARCHITECTURE ?= "x86-64"
+NIM_PARAMS := $(NIM_PARAMS) --passC:\"-march=$(ARCHITECTURE)\"
+
 ## Heaptracker options
 HEAPTRACKER ?= 0
 HEAPTRACKER_INJECT ?= 0


### PR DESCRIPTION
# Description
It seems Github Action runners started using new machines with new fancy CPUs which include AVX512 instructions. These are not widely available in non-server / older HW (it seems), which result in unusable binaries built in GH Actions.

We can pass explicit architecture / CPU instruction set to build for to C compiler through Nim using `--passC:"-march=..."`

The list of supported architectures: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html

I am choosing basic instruction set `x86-64` for this PR. This may potentially influence speed of some crypto algorithms (which would otherwise leverage AVX instructions), so we should consider doing some benchmarking in the future to asses the impact and consider some newer architecture(s), but to have current builds working and as general as possible, x86-64 seems to be a reasonable choice.

A variable `ARCHITECTURE` is added for cases where operators would prefer to rebuild with newer architecture or `native` option (which leverages all available instructions on the build machine) to benefit from AVX and other "fancy" instructions.

# Changes

- [x] added `-march` option to `Makefile` to make binaries use limited set of CPU instructions


<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->