### PR TITLE
feat(networking): integrate gossipsub scoring

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -564,16 +564,11 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
 
   # Subscribe to a topic, if relay is mounted
   if conf.relay:
-    proc handler(topic: Topic, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
       trace "Hit subscribe handler", topic
 
-      let decoded = WakuMessage.decode(data)
-
-      if decoded.isOk():
-        if decoded.get().contentTopic == chat.contentTopic:
-          chat.printReceivedMessage(decoded.get())
-      else:
-        trace "Invalid encoded WakuMessage", error = decoded.error
+      if msg.contentTopic == chat.contentTopic:
+        chat.printReceivedMessage(msg)
 
     let topic = DefaultPubsubTopic
     node.subscribe(topic, handler)

--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -264,7 +264,7 @@ proc start*(bridge: WakuBridge) {.async.} =
 
   # Always mount relay for bridge.
   # `triggerSelf` is false on a `bridge` to avoid duplicates
-  await bridge.nodev2.mountRelay(triggerSelf = false)
+  await bridge.nodev2.mountRelay()
 
   # Bridging
   # Handle messages on Waku v1 and bridge to Waku v2

--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -275,12 +275,11 @@ proc start*(bridge: WakuBridge) {.async.} =
   bridge.nodev1.registerEnvReceivedHandler(handleEnvReceived)
 
   # Handle messages on Waku v2 and bridge to Waku v1
-  proc relayHandler(pubsubTopic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
-    let msg = WakuMessage.decode(data)
-    if msg.isOk() and msg.get().isBridgeable():
+  proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+    if msg.isBridgeable():
       try:
-        trace "Bridging message from V2 to V1", msg=msg.tryGet()
-        bridge.toWakuV1(msg.tryGet())
+        trace "Bridging message from V2 to V1", msg=msg
+        bridge.toWakuV1(msg)
       except ValueError:
         trace "Failed to convert message to Waku v1. Check content-topic format.", msg=msg
         waku_bridge_dropped.inc(labelValues = ["value_error"])

--- a/apps/wakubridge/wakubridge.nim
+++ b/apps/wakubridge/wakubridge.nim
@@ -265,6 +265,7 @@ proc start*(bridge: WakuBridge) {.async.} =
   # Always mount relay for bridge.
   # `triggerSelf` is false on a `bridge` to avoid duplicates
   await bridge.nodev2.mountRelay()
+  bridge.nodev2.wakuRelay.triggerSelf = false
 
   # Bridging
   # Handle messages on Waku v1 and bridge to Waku v2

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -81,14 +81,13 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
     # any content topic can be chosen. make sure it matches the publisher
     let contentTopic = ContentTopic("/examples/1/pubsub-example/proto")
 
-    proc handler(pubsubTopic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
-      let message = WakuMessage.decode(data).value
-      let payloadStr = string.fromBytes(message.payload)
-      if message.contentTopic == contentTopic:
+    proc handler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      let payloadStr = string.fromBytes(msg.payload)
+      if msg.contentTopic == contentTopic:
         notice "message received", payload=payloadStr,
                                    pubsubTopic=pubsubTopic,
-                                   contentTopic=message.contentTopic,
-                                   timestamp=message.timestamp
+                                   contentTopic=msg.contentTopic,
+                                   timestamp=msg.timestamp
     node.subscribe(pubSubTopic, handler)
 
 when isMainModule:

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -60,14 +60,11 @@ suite "WakuNode":
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      check:
+        topic == pubSubTopic
+        msg.contentTopic == contentTopic
+        msg.payload == payload
       completionFut.complete(true)
 
     node2.subscribe(pubSubTopic, relayHandler)

--- a/tests/v2/test_wakunode_lightpush.nim
+++ b/tests/v2/test_wakunode_lightpush.nim
@@ -43,10 +43,9 @@ suite "WakuNode - Lightpush":
     let message = fakeWakuMessage()
 
     var completionFutRelay = newFuture[bool]()
-    proc relayHandler(pubsubTopic: PubsubTopic, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data).get()
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
       check:
-        pubsubTopic == DefaultPubsubTopic
+        topic == DefaultPubsubTopic
         msg == message
       completionFutRelay.complete(true)
     destNode.subscribe(DefaultPubsubTopic, relayHandler)

--- a/tests/v2/waku_relay/test_waku_relay.nim
+++ b/tests/v2/waku_relay/test_waku_relay.nim
@@ -16,14 +16,14 @@ import
   ../testlib/wakucore
 
 
-proc noopRawHandler(): PubsubRawHandler =
-    var handler: PubsubRawHandler
-    handler = proc(pubsubTopic: PubsubTopic, data: seq[byte]): Future[void] {.gcsafe, noSideEffect.} = discard
+proc noopRawHandler(): WakuRelayHandler =
+    var handler: WakuRelayHandler
+    handler = proc(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} = discard
     handler
 
 
-proc newTestWakuRelay(switch = newTestSwitch(), self = true): Future[WakuRelay] {.async.} =
-  let proto = WakuRelay.new(switch, triggerSelf = self).tryGet()
+proc newTestWakuRelay(switch = newTestSwitch()): Future[WakuRelay] {.async.} =
+  let proto = WakuRelay.new(switch).tryGet()
   await proto.start()
 
   let protocolMatcher = proc(proto: string): bool {.gcsafe.} =

--- a/tests/v2/waku_relay/test_waku_relay.nim
+++ b/tests/v2/waku_relay/test_waku_relay.nim
@@ -85,7 +85,7 @@ suite "Waku Relay":
       topics.contains(networkC)
 
     ## When
-    nodeA.unsubscribeAll(networkA)
+    nodeA.unsubscribe(networkA)
 
     ## Then
     check:

--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -483,7 +483,7 @@ suite "WakuNode - Relay":
     # all nodes lower the score of nodes[0] (will change if gossipsub params or amount of msg changes)
     for i in 1..<5:
       check:
-        nodes[1].wakuRelay.peerStats[nodes[0].switch.peerInfo.peerId].score == -25009.0
+        nodes[1].wakuRelay.peerStats[nodes[0].switch.peerInfo.peerId].score == -250004.9
 
     # nodes[0] was blacklisted from all other peers, no connections
     check:

--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -483,7 +483,7 @@ suite "WakuNode - Relay":
     # all nodes lower the score of nodes[0] (will change if gossipsub params or amount of msg changes)
     for i in 1..<5:
       check:
-        nodes[1].wakuRelay.peerStats[nodes[0].switch.peerInfo.peerId].score == -250004.9
+        nodes[i].wakuRelay.peerStats[nodes[0].switch.peerInfo.peerId].score == -250004.9
 
     # nodes[0] was blacklisted from all other peers, no connections
     check:

--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -483,7 +483,7 @@ suite "WakuNode - Relay":
     # all nodes lower the score of nodes[0] (will change if gossipsub params or amount of msg changes)
     for i in 1..<5:
       check:
-        nodes[i].wakuRelay.peerStats[nodes[0].switch.peerInfo.peerId].score == -250004.9
+        nodes[i].wakuRelay.peerStats[nodes[0].switch.peerInfo.peerId].score == -249999.9
 
     # nodes[0] was blacklisted from all other peers, no connections
     check:

--- a/tests/v2/waku_relay/test_wakunode_relay.nim
+++ b/tests/v2/waku_relay/test_wakunode_relay.nim
@@ -94,14 +94,11 @@ suite "WakuNode - Relay":
     )
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      check:
+        topic == pubSubTopic
+        msg.contentTopic == contentTopic
+        msg.payload == payload
       completionFut.complete(true)
 
     node3.subscribe(pubSubTopic, relayHandler)
@@ -182,18 +179,13 @@ suite "WakuNode - Relay":
     node2.wakuRelay.addValidator(pubSubTopic, validator)
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      debug "relayed pubsub topic:", topic
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          # check that only messages with contentTopic1 is relayed (but not contentTopic2)
-          val.contentTopic == contentTopic1
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      check:
+        topic == pubSubTopic
+        # check that only messages with contentTopic1 is relayed (but not contentTopic2)
+        msg.contentTopic == contentTopic1
       # relay handler is called
       completionFut.complete(true)
-
 
     node3.subscribe(pubSubTopic, relayHandler)
     await sleepAsync(500.millis)
@@ -269,14 +261,11 @@ suite "WakuNode - Relay":
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      check:
+        topic == pubSubTopic
+        msg.contentTopic == contentTopic
+        msg.payload == payload
       completionFut.complete(true)
 
     node1.subscribe(pubSubTopic, relayHandler)
@@ -313,14 +302,11 @@ suite "WakuNode - Relay":
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      check:
+        topic == pubSubTopic
+        msg.contentTopic == contentTopic
+        msg.payload == payload
       completionFut.complete(true)
 
     node1.subscribe(pubSubTopic, relayHandler)
@@ -361,14 +347,11 @@ suite "WakuNode - Relay":
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      check:
+        topic == pubSubTopic
+        msg.contentTopic == contentTopic
+        msg.payload == payload
       completionFut.complete(true)
 
     node1.subscribe(pubSubTopic, relayHandler)
@@ -404,14 +387,11 @@ suite "WakuNode - Relay":
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      check:
+        topic == pubSubTopic
+        msg.contentTopic == contentTopic
+        msg.payload == payload
       completionFut.complete(true)
 
     node1.subscribe(pubSubTopic, relayHandler)
@@ -447,14 +427,11 @@ suite "WakuNode - Relay":
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let val = msg.value()
-        check:
-          topic == pubSubTopic
-          val.contentTopic == contentTopic
-          val.payload == payload
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      check:
+        topic == pubSubTopic
+        msg.contentTopic == contentTopic
+        msg.payload == payload
       completionFut.complete(true)
 
     node1.subscribe(pubSubTopic, relayHandler)
@@ -468,3 +445,54 @@ suite "WakuNode - Relay":
       (await completionFut.withTimeout(5.seconds)) == true
     await node1.stop()
     await node2.stop()
+
+  asyncTest "Bad peers with low reputation are disconnected":
+    # Create 5 nodes
+    let nodes = toSeq(0..<5).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0)))
+    await allFutures(nodes.mapIt(it.start()))
+    await allFutures(nodes.mapIt(it.mountRelay()))
+
+    # subscribe all nodes to a topic
+    let topic = "topic"
+    for node in nodes: node.wakuRelay.subscribe(topic, nil)
+    await sleepAsync(500.millis)
+
+    # connect nodes in full mesh
+    for i in 0..<5:
+      for j in 0..<5:
+        if i == j:
+          continue
+        let connOk = await nodes[i].peerManager.connectRelay(nodes[j].switch.peerInfo.toRemotePeerInfo())
+        require connOk
+
+    # connection triggers different actions, wait for them
+    await sleepAsync(1.seconds)
+
+    # all peers are connected in a mesh, 4 conns each
+    for i in 0..<5:
+      check:
+        nodes[i].peerManager.switch.connManager.getConnections().len == 4
+
+    # node[0] publishes wrong messages (random bytes not decoding into WakuMessage)
+    for j in 0..<50:
+      discard await nodes[0].wakuRelay.publish(topic, urandom(1*(10^3)))
+
+    # long wait, must be higher than the configured decayInterval (how often score is updated)
+    await sleepAsync(20.seconds)
+
+    # all nodes lower the score of nodes[0] (will change if gossipsub params or amount of msg changes)
+    for i in 1..<5:
+      check:
+        nodes[1].wakuRelay.peerStats[nodes[0].switch.peerInfo.peerId].score == -25009.0
+
+    # nodes[0] was blacklisted from all other peers, no connections
+    check:
+      nodes[0].peerManager.switch.connManager.getConnections().len == 0
+
+    # the rest of the nodes now have 1 conn less (kicked nodes[0] out)
+    for i in 1..<5:
+      check:
+        nodes[i].peerManager.switch.connManager.getConnections().len == 3
+
+    # Stop all nodes
+    await allFutures(nodes.mapIt(it.stop()))

--- a/tests/v2/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/v2/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -83,12 +83,10 @@ procSuite "WakuNode - RLN relay":
     await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        debug "The received topic:", topic
-        if topic == rlnRelayPubSubTopic:
-          completionFut.complete(true)
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      debug "The received topic:", topic
+      if topic == rlnRelayPubSubTopic:
+        completionFut.complete(true)
 
     # mount the relay handler
     node3.subscribe(rlnRelayPubSubTopic, relayHandler)
@@ -172,12 +170,10 @@ procSuite "WakuNode - RLN relay":
 
     # define a custom relay handler
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        debug "The received topic:", topic
-        if topic == rlnRelayPubSubTopic:
-          completionFut.complete(true)
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      debug "The received topic:", topic
+      if topic == rlnRelayPubSubTopic:
+        completionFut.complete(true)
 
     # mount the relay handler
     node3.subscribe(rlnRelayPubSubTopic, relayHandler)
@@ -302,20 +298,17 @@ procSuite "WakuNode - RLN relay":
     var completionFut2 = newFuture[bool]()
     var completionFut3 = newFuture[bool]()
     var completionFut4 = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-      if msg.isOk():
-        let wm = msg.value()
-        debug "The received topic:", topic
-        if topic == rlnRelayPubSubTopic:
-          if wm == wm1:
-            completionFut1.complete(true)
-          if wm == wm2:
-            completionFut2.complete(true)
-          if wm == wm3:
-            completionFut3.complete(true)
-          if wm == wm4:
-            completionFut4.complete(true)
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      debug "The received topic:", topic
+      if topic == rlnRelayPubSubTopic:
+        if msg == wm1:
+          completionFut1.complete(true)
+        if msg == wm2:
+          completionFut2.complete(true)
+        if msg == wm3:
+          completionFut3.complete(true)
+        if msg == wm4:
+          completionFut4.complete(true)
 
 
     # mount the relay handler for node3

--- a/tests/wakubridge/test_wakubridge.nim
+++ b/tests/wakubridge/test_wakubridge.nim
@@ -88,7 +88,8 @@ procSuite "WakuBridge":
     waitFor bridge.start()
 
     waitFor v2Node.start()
-    await v2Node.mountRelay(@[DefaultBridgeTopic], triggerSelf = false)
+    await v2Node.mountRelay(@[DefaultBridgeTopic])
+    v2Node.wakuRelay.triggerSelf = false
 
     discard waitFor v1Node.rlpxConnect(newNode(bridge.nodev1.toENode()))
     waitFor waku_node.connectToNodes(v2Node, @[bridge.nodev2.switch.peerInfo.toRemotePeerInfo()])

--- a/tests/wakubridge/test_wakubridge.nim
+++ b/tests/wakubridge/test_wakubridge.nim
@@ -95,14 +95,12 @@ procSuite "WakuBridge":
 
     var completionFut = newFuture[bool]()
 
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.decode(data)
-
-      if msg.isOk() and msg.value().version == 1:
+    proc relayHandler(topic: PubsubTopic, msg: WakuMessage): Future[void] {.async, gcsafe.} =
+      if msg.version == 1:
         check:
           # Message fields are as expected
-          msg.value().contentTopic == contentTopic # Topic translation worked
-          string.fromBytes(msg.value().payload).contains("from V1")
+          msg.contentTopic == contentTopic # Topic translation worked
+          string.fromBytes(msg.payload).contains("from V1")
 
         completionFut.complete(true)
 

--- a/waku/v2/node/jsonrpc/relay/handlers.nim
+++ b/waku/v2/node/jsonrpc/relay/handlers.nim
@@ -66,7 +66,7 @@ proc installRelayApiHandlers*(node: WakuNode, server: RpcServer, cache: MessageC
 
     # Unsubscribe all handlers from requested topics
     for topic in topics:
-      node.unsubscribeAll(topic)
+      node.unsubscribe(topic)
       cache.unsubscribe(topic)
 
     return true

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -359,7 +359,7 @@ proc new*(T: type PeerManager,
                        storage: storage,
                        initialBackoffInSec: initialBackoffInSec,
                        backoffFactor: backoffFactor,
-                       outPeersTarget: max(maxConnections div 10, 10),
+                       outPeersTarget: max(maxConnections div 2, 10),
                        maxFailedAttempts: maxFailedAttempts,
                        colocationLimit: colocationLimit)
 

--- a/waku/v2/node/rest/relay/handlers.nim
+++ b/waku/v2/node/rest/relay/handlers.nim
@@ -88,7 +88,7 @@ proc installRelayDeleteSubscriptionsV1Handler*(router: var RestRouter, node: Wak
 
     # Unsubscribe all handlers from requested topics
     for topic in req:
-      node.unsubscribeAll(string(topic))
+      node.unsubscribe(string(topic))
       cache.unsubscribe(string(topic))
 
     # Successfully unsubscribed from all requested topics

--- a/waku/v2/node/rest/relay/topic_cache.nim
+++ b/waku/v2/node/rest/relay/topic_cache.nim
@@ -23,7 +23,7 @@ type TopicCache* = MessageCache[PubSubTopic]
 
 ##### Message handler
 
-type TopicCacheMessageHandler* = SubscriptionHandler
+type TopicCacheMessageHandler* = WakuRelayHandler
 
 proc messageHandler*(cache: TopicCache): TopicCacheMessageHandler =
 

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -366,7 +366,6 @@ proc startRelay*(node: WakuNode) {.async.} =
 
 proc mountRelay*(node: WakuNode,
                  topics: seq[string] = @[],
-                 triggerSelf = true,
                  peerExchangeHandler = none(RoutingRecordsHandler)) {.async, gcsafe.} =
   if not node.wakuRelay.isNil():
     error "wakuRelay already mounted, skipping"
@@ -375,10 +374,7 @@ proc mountRelay*(node: WakuNode,
   ## The default relay topics is the union of all configured topics plus default PubsubTopic(s)
   info "mounting relay protocol"
 
-  let initRes = WakuRelay.new(
-    node.switch,
-    triggerSelf = triggerSelf
-  )
+  let initRes = WakuRelay.new(node.switch)
   if initRes.isErr():
     error "failed mounting relay protocol", error=initRes.error
     return

--- a/waku/v2/node/waku_node.nim
+++ b/waku/v2/node/waku_node.nim
@@ -298,27 +298,16 @@ proc subscribe*(node: WakuNode, topic: PubsubTopic, handler: WakuRelayHandler) =
   node.registerRelayDefaultHandler(topic)
   node.wakuRelay.subscribe(topic, handler)
 
-proc unsubscribe*(node: WakuNode, topic: PubsubTopic, handler: WakuRelayHandler) =
-  ## Unsubscribes a handler from a PubSub topic.
+proc unsubscribe*(node: WakuNode, topic: PubsubTopic) =
+  ## Unsubscribes from a specific PubSub topic.
+
   if node.wakuRelay.isNil():
     error "Invalid API call to `unsubscribe`. WakuRelay not mounted."
     return
 
-  debug "unsubscribe", pubsubTopic=topic
+  info "unsubscribe", pubsubTopic=topic
 
-  let wakuRelay = node.wakuRelay
-  wakuRelay.unsubscribe(topic)
-
-proc unsubscribeAll*(node: WakuNode, topic: PubsubTopic) =
-  ## Unsubscribes all handlers registered on a specific PubSub topic.
-
-  if node.wakuRelay.isNil():
-    error "Invalid API call to `unsubscribeAll`. WakuRelay not mounted."
-    return
-
-  info "unsubscribeAll", pubsubTopic=topic
-
-  node.wakuRelay.unsubscribeAll(topic)
+  node.wakuRelay.unsubscribe(topic)
 
 
 proc publish*(node: WakuNode, topic: PubsubTopic, message: WakuMessage) {.async, gcsafe.} =

--- a/waku/v2/waku_relay/protocol.nim
+++ b/waku/v2/waku_relay/protocol.nim
@@ -106,13 +106,6 @@ proc initProtocolHandler(w: WakuRelay) =
   w.handler = handler
   w.codec = WakuRelayCodec
 
-proc debugPrintRemove(w: WakuRelay) {.async.} =
-  while true:
-    for k, v in w.peerStats.mpairs:
-      echo "---peerStats: peer: ", k, " ", v.score, " ", v.appScore, " ", v.behaviourPenalty
-    await sleepAsync(5000)
-  #nodes[1].wakuRelay.peerStats[p0Id].topicInfos[spamProtectedTopic].invalidMessageDeliveries == 100.0
-
 proc new*(T: type WakuRelay, switch: Switch, triggerSelf: bool = true): WakuRelayResult[T] =
 
   var wr: WakuRelay
@@ -130,8 +123,6 @@ proc new*(T: type WakuRelay, switch: Switch, triggerSelf: bool = true): WakuRela
 
   except InitializationError:
     return err("initialization error: " & getCurrentExceptionMsg())
-
-  asyncSpawn debugPrintRemove(wr)
 
   ok(wr)
 


### PR DESCRIPTION
closes #1756 

Changes:

- [x] Only allow handling messages containing a valid `WakuMessage`. Just one type of handler. No more handling `seq[byte]` and parsing. Waku relay message handler takes directly a `WakuMesssage`.
- [x] Add a default validator to all subscribed topics, which enforces being able to decode the message into a valid `WakuMessage`. If ok the message is accepted, otherwise rejected. With this, "upper layers" now always get a `WakuMessage`.
- [x] Integrate gossipsub scoring + trigger dissconnections from bad peers.
- [x] Set some default safe parameters for gossipsub scoring to use.
- [x] Write some tests to ensure the feature is integrated ok, where disconnections based on score are triggered.
- [x] Change the in/out peer relation, enforcing 50/50%. 10% of outgoing peers seems to have some issues in simulations, *to be continued*.
- [x] Test in sandbox machine with 200 nodes.