### PR TITLE
feat(wakunode2): enable libp2p rendezvous protocol by default

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -526,6 +526,12 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
       notice "routing only signed traffic", protectedTopic=topicKey.topic, publicKey=topicKey.key
       node.wakuRelay.addSignedTopicValidator(Pubsubtopic(topicKey.topic), topicKey.key)
 
+    # Enable Rendezvous Discovery protocol when Relay is enabled
+    try:
+      await mountRendezvous(node)
+    except CatchableError:
+      return err("failed to mount waku rendezvous protocol: " & getCurrentExceptionMsg())
+
   # Keepalive mounted on all nodes
   try:
     await mountLibp2pPing(node)

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -62,6 +62,7 @@ import
   ./v2/test_waku_noise,
   ./v2/test_waku_noise_sessions,
   ./v2/test_waku_switch,
+  ./v2/test_waku_rendezvous,
   # Utils
   ./v2/test_utils_compat
 

--- a/tests/v2/test_waku_rendezvous.nim
+++ b/tests/v2/test_waku_rendezvous.nim
@@ -1,0 +1,59 @@
+{.used.}
+
+import
+  chronos,
+  testutils/unittests,
+  libp2p,
+  libp2p/protocols/rendezvous
+
+import
+  ../../waku/v2/node/waku_switch,
+  ./testlib/common,
+  ./testlib/wakucore
+
+proc newRendezvousClientSwitch(rdv: RendezVous): Switch =
+  SwitchBuilder.new()
+    .withRng(rng())
+    .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
+    .withTcpTransport()
+    .withMplex()
+    .withNoise()
+    .withRendezVous(rdv)
+    .build()
+
+procSuite "Waku Rendezvous":
+  asyncTest "Waku Switch uses Rendezvous":
+    ## Setup
+
+    let
+      wakuClient = RendezVous.new()
+      sourceClient = RendezVous.new()
+      destClient = RendezVous.new()
+      wakuSwitch = newRendezvousClientSwitch(wakuClient) #rendezvous point
+      sourceSwitch = newRendezvousClientSwitch(sourceClient) #client
+      destSwitch = newRendezvousClientSwitch(destClient) #client
+
+    # Setup client rendezvous
+    wakuClient.setup(wakuSwitch)
+    sourceClient.setup(sourceSwitch)
+    destClient.setup(destSwitch)
+
+    await allFutures(wakuSwitch.start(), sourceSwitch.start(), destSwitch.start())
+
+    # Connect clients to the rendezvous point
+    await sourceSwitch.connect(wakuSwitch.peerInfo.peerId, wakuSwitch.peerInfo.addrs)
+    await destSwitch.connect(wakuSwitch.peerInfo.peerId, wakuSwitch.peerInfo.addrs)
+
+    let res0 = await sourceClient.request("empty")
+    check res0.len == 0
+
+    # Check that source client gets peer info of dest client from rendezvous point
+    await sourceClient.advertise("foo")
+    let res1 = await destClient.request("foo")
+    check:
+      res1.len == 1
+      res1[0] == sourceSwitch.peerInfo.signedPeerRecord.data
+    
+    await allFutures(wakuSwitch.stop(), sourceSwitch.stop(), destSwitch.stop())
+
+   

--- a/tests/v2/testlib/wakunode.nim
+++ b/tests/v2/testlib/wakunode.nim
@@ -67,6 +67,7 @@ proc newTestWakuNode*(nodeKey: crypto.PrivateKey,
     secureKey = if secureKey != "": some(secureKey) else: none(string),
     secureCert = if secureCert != "": some(secureCert) else: none(string),
     agentString = agentString,
+    
   )
   builder.withWakuDiscv5(wakuDiscv5.get(nil))
 

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -24,6 +24,8 @@ proc defaultTestWakuNodeConf(): WakuNodeConf =
     metricsServerAddress: ValidIpAddress.init("127.0.0.1"),
     nat: "any",
     maxConnections: 50,
+    topics: @["/waku/2/default-waku/proto"],
+    relay: true
   )
 
 
@@ -77,6 +79,7 @@ suite "Wakunode2 - App initialization":
       node.wakuArchive.isNil()
       node.wakuStore.isNil()
       not node.wakuStoreClient.isNil()
+      not node.rendezvous.isNil()
 
     ## Cleanup
     waitFor wakunode2.stop()

--- a/waku/v2/node/waku_switch.nim
+++ b/waku/v2/node/waku_switch.nim
@@ -10,6 +10,7 @@ import
   eth/keys,
   libp2p/crypto/crypto,
   libp2p/protocols/pubsub/gossipsub,
+  libp2p/protocols/rendezvous,
   libp2p/nameresolving/nameresolver,
   libp2p/builders,
   libp2p/switch,
@@ -78,6 +79,7 @@ proc newWakuSwitch*(
     agentString = none(string),    # defaults to nim-libp2p version
     peerStoreCapacity = none(int), # defaults to 1.25 maxConnections
     services: seq[switch.Service] = @[],
+    rendezvous: RendezVous = nil,
     ): Switch
     {.raises: [Defect, IOError, LPError].} =
 
@@ -118,5 +120,8 @@ proc newWakuSwitch*(
 
     if services.len > 0:
       b = b.withServices(services)
+
+    if not rendezvous.isNil():
+      b = b.withRendezVous(rendezvous)
 
     b.build()


### PR DESCRIPTION
# Description

Rendezvous Discovery protocol allows peers to advertise their addresses at a rendezvous point and other peers to query the rendezvous point to discover new peers.

This will be particularly useful for peers using circuit relay as they can then easily advertise their circuit relay multiaddress and be discovered by other network participants.

This PR uses libp2p Rendezvous implementation and mounts the protocol by default when relay protocol is enabled.

# Changes

- [x] mount Rendezvous protocol when relay is mounted
- [x] add simple test of libp2p rendezvous protocol to waku_switch test suite
- [x] add a check to wakunode2 app tests that rendezvous is enabled along with relay

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #1605
