### PR TITLE
test(postgres): Allow run postgres tests only on ci Linux platforms

### DIFF
--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -47,7 +47,6 @@ jobs:
       common: ${{ steps.filter.outputs.common }}
       v2: ${{ steps.filter.outputs.v2 }}
 
-
   build-v2:
     needs: changes
     if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' }}
@@ -88,6 +87,7 @@ jobs:
     timeout-minutes: 60
 
     name: test-v2-${{ matrix.os }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -106,4 +106,9 @@ jobs:
           key: ${{ runner.os }}-vendor-modules-${{ steps.submodules.outputs.hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2
+        run: |
+          if [ ${{ runner.os }} == "Linux" ]; then
+            sudo docker run --rm -d -e POSTGRES_PASSWORD=test123 -p 5432:5432 postgres:9.6-alpine
+          fi
+
+          make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
       v2: ${{ steps.filter.outputs.v2 }}
       legacy: ${{ steps.filter.outputs.legacy }}
 
-
   build-v2:
     needs: changes
     if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' }}
@@ -115,8 +114,12 @@ jobs:
           key: ${{ runner.os }}-vendor-modules-${{ steps.submodules.outputs.hash }}
 
       - name: Run tests
-        run: make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2
+        run: |
+          if [ ${{ runner.os }} == "Linux" ]; then
+            sudo docker run --rm -d -e POSTGRES_PASSWORD=test123 -p 5432:5432 postgres:9.6-alpine
+          fi
 
+          make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2
 
   build-legacy:
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ testcommon: | build deps
 
 testwaku2: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
+		$(ENV_SCRIPT) nim test2 -d:os=$(shell uname) $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
 wakunode2: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -19,9 +19,12 @@ import
   ./v2/waku_archive/test_retention_policy,
   ./v2/waku_archive/test_waku_archive
 
-# TODO: add the postgres test when we can mock the database.
-# The postgres tests now need a running postgresql database running locally.
-#  ./v2/waku_archive/test_driver_postgres,
+const os* {.strdefine.} = ""
+when os == "Linux":
+  # GitHub only supports container actions on Linux
+  # and we need to start a postgress database in a docker container
+  import
+    ./v2/waku_archive/test_driver_postgres
 
 # Waku store test suite
 import

--- a/tests/postgres-docker-compose.yml
+++ b/tests/postgres-docker-compose.yml
@@ -1,6 +1,5 @@
 version: "3.8"
 
-
 services:
   db:
     image: postgres:9.6-alpine


### PR DESCRIPTION
## Summary
Allowing the execution of postgres unit tests on Linux GitHub runners

## Note
The next file is only left in order to run local tests manually:
tests/postgres-docker-compose.yml

The ci launches its postgres instance with `sudo docker run ...`

## Issue
https://github.com/waku-org/nwaku/issues/1604