### PR TITLE
chore(ci): properly set os and architecture for nightly and release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         experimental: [true, false]
+        arch: [amd64]
+        include:
+        - os: macos-latest
+          experimental: false
+          arch: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -34,20 +39,18 @@ jobs:
           path: |
             vendor/
             .git/modules
-          key: ${{ runner.os }}-vendor-modules-${{ steps.submodules.outputs.hash }}
+          key: ${{ runner.os }}-${{matrix.arch}}-submodules-${{ steps.submodules.outputs.hash }}
 
 
       - name: prep variables
         id: vars
         run: |
-          ARCH=$(uname -m) 
           EXPERIMENTAL=$([[ "${{ matrix.experimental }}" == "true" ]] && echo "-experimental" || echo "")
 
-          echo "arch=${ARCH}" >> $GITHUB_OUTPUT
           echo "experimental=${EXPERIMENTAL}" >> $GITHUB_OUTPUT
 
-          NWAKU_ARTIFACT_NAME=$(echo "nwaku${EXPERIMENTAL}-${ARCH}-${{runner.os}}.tar.gz" | tr "[:upper:]" "[:lower:]")
-          NWAKU_TOOLS_ARTIFACT_NAME=$(echo "nwaku-tools${EXPERIMENTAL}-${ARCH}-${{runner.os}}.tar.gz" | tr "[:upper:]" "[:lower:]")
+          NWAKU_ARTIFACT_NAME=$(echo "nwaku${EXPERIMENTAL}-${{matrix.arch}}-${{runner.os}}.tar.gz" | tr "[:upper:]" "[:lower:]")
+          NWAKU_TOOLS_ARTIFACT_NAME=$(echo "nwaku-tools${EXPERIMENTAL}-${{matrix.arch}}-${{runner.os}}.tar.gz" | tr "[:upper:]" "[:lower:]")
 
           echo "nwaku=${NWAKU_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
           echo "nwakutools=${NWAKU_TOOLS_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
@@ -55,7 +58,9 @@ jobs:
       - name: build artifacts
         id: build
         run: |
-          make QUICK_AND_DIRTY_COMPILER=1 V=1 CI=false EXPERIMENTAL=${{matrix.experimental}} wakunode2 tools
+          OS=$([[ "${{runner.os}}" == "macOS" ]] && echo "macosx" || echo "linux")
+
+          make QUICK_AND_DIRTY_COMPILER=1 V=1 CI=false EXPERIMENTAL=${{matrix.experimental}} NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" wakunode2 tools
 
           tar -cvzf ${{steps.vars.outputs.nwaku}} ./build/wakunode2
           tar -cvzf ${{steps.vars.outputs.nwakutools}} ./build/wakucanary ./build/networkmonitor

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -13,12 +13,17 @@ jobs:
       matrix:
         env:
           - { NPROC: 2 }
-        platform: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.platform }}
+        os: [ubuntu-latest, macos-latest]
+        arch: [amd64]
+        include:
+        - os: macos-latest
+          experimental: false
+          arch: arm64
+    runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}
     timeout-minutes: 60
 
-    name: ${{ matrix.platform }} - ${{ matrix.env.NPROC }} processes
+    name: ${{ matrix.os }} - ${{ matrix.env.NPROC }} processes
 
     steps:
       - name: Checkout code
@@ -35,19 +40,28 @@ jobs:
           path: |
             vendor/
             .git/modules
-          key: ${{ runner.os }}-vendor-modules-${{ steps.submodules.outputs.hash }}
+          key: ${{ runner.os }}-${{matrix.arch}}-submodules-${{ steps.submodules.outputs.hash }}
+
+      - name: prep variables
+        id: vars
+        run: |
+          NWAKU_ARTIFACT_NAME=$(echo "nwaku${EXPERIMENTAL}-${{matrix.arch}}-${{runner.os}}.tar.gz" | tr "[:upper:]" "[:lower:]")
+
+          echo "nwaku=${NWAKU_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
         run: |
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update 
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" CI=false wakunode1
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" CI=false wakunode2
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" CI=false chat2
-          tar -cvzf nim-waku-${{ matrix.platform }}.tar.gz ./build/
+          OS=$([[ "${{runner.os}}" == "macOS" ]] && echo "macosx" || echo "linux")
+
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" V=1 update
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" CI=false wakunode1
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" CI=false wakunode2
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" CI=false chat2
+          tar -cvzf ${{steps.vars.outputs.nwaku}} ./build/
 
       - name: Upload asset
         uses: actions/upload-artifact@v2.2.3
         with:
-          name: nim-waku-${{ matrix.platform }}.tar.gz
-          path: nim-waku-${{ matrix.platform }}.tar.gz
+          name: ${{steps.vars.outputs.nwaku}}
+          path: ${{steps.vars.outputs.nwaku}}
           if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,6 @@ TARGET ?= prod
 GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
 NIM_PARAMS := $(NIM_PARAMS) -d:git_version=\"$(GIT_VERSION)\"
 
-## Pass CPU architecture to C compiler, use basic x86-64 instruction set by default
-ARCHITECTURE ?= "x86-64"
-NIM_PARAMS := $(NIM_PARAMS) --passC:\"-march=$(ARCHITECTURE)\"
-
 ## Heaptracker options
 HEAPTRACKER ?= 0
 HEAPTRACKER_INJECT ?= 0


### PR DESCRIPTION
# Description
This PR updates `config.nims` according to findings by Nimbus about various CPU archs and options (https://github.com/status-im/nimbus-eth2/blob/stable/config.nims#L94). It also updates release workflows (Nightly and actual releases) to leverage these options.

Next, it adds `arm64` architecture for Mac OSX system to make the released assets run on Apple M1 hardware (cc @alrevuelta)

This also reverts #1759 which was an interim solution to enable compatibility between various CPU architectures.

Lastly, it changes the name of the uploaded binary artifacts to 

```
nwaku-${{matrix.arch}}-${{runner.os}}.tar.gz
```

i.e.

```
nwaku-arm64-macos.tar.gz
nwaku-amd64-linux.tar.gz
```

See the example nightly release here: https://github.com/nwaku-test-org/nwaku/releases/tag/nightly

# Changes

<!-- List of detailed changes -->

- [x] Add `arm64` architecture for Mac OSX system in the build matrix
- [x] Update the CPU configuration when `native` architecture is disabled (according to Nimbus)
- [x] Remove the default `-march=x86_64` from `Makefile`
- [x] Rename binary release artifact tarball from  `nim-waku-${OS}-latest.tar.gz` to `nwaku-${{arch}}-${{os}}.tar.gz`


<!--
## How to test

1.
1.
1.

-->



## Issue

closes #1760 
