### PR TITLE
chore(rln-relay): update tree_config

### DIFF
--- a/waku/v2/waku_rln_relay/constants.nim
+++ b/waku/v2/waku_rln_relay/constants.nim
@@ -30,7 +30,15 @@ const
 const
   # The relative folder where the circuit, proving and verification key for RLN can be found
   # Note that resources has to be compiled with respect to the above MerkleTreeDepth
-  RlnConfig* = $(%* { "resources_folder": "tree_height_" & $MerkleTreeDepth & "/" })
+  RlnConfig* = $(%* { 
+    "resources_folder": "tree_height_" & $MerkleTreeDepth & "/", 
+    "tree_config": {
+      "cache_capacity": 15_000, 
+      "mode": "high_throughput", 
+      "compression": false,
+      "flush_interval": 12_000
+    } 
+  })
 
 # temporary variables to test waku-rln-relay performance in the static group mode
 const


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewers -->
Updates the pmtree configuration `tree_config` according to the parameters which work best with ethereum mainnet.

# Changes

- cache_capacity: max_number_of_leaves_inserted_per_block ~ 407 (based on the gas used by the register fn on the smart 
contract, and block gas limit) * leaf_size = ~13_024
- mode: high_throughput
- compression: false
- flush_interval: 12_000 (average block time)
<!--
## How to test

1.
1.
1.

-->



## Issue

closes #1775
