### PR TITLE
chore(rln-relay): pass in the path to the tree db

### DIFF
--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -202,7 +202,7 @@ type
       name: "rln-relay-cred-password" }: string
 
     rlnRelayTreePath* {.
-      desc: "Path to the RLN merkle tree db",
+      desc: "Path to the RLN merkle tree sled db (https://github.com/spacejam/sled)",
       defaultValue: ""
       name: "rln-relay-tree-path" }: string
 

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -201,6 +201,11 @@ type
       defaultValue: ""
       name: "rln-relay-cred-password" }: string
 
+    rlnRelayTreePath* {.
+      desc: "Path to the RLN merkle tree db",
+      defaultValue: ""
+      name: "rln-relay-tree-path" }: string
+
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."
       name: "staticnode" }: seq[string]

--- a/waku/v2/waku_rln_relay/constants.nim
+++ b/waku/v2/waku_rln_relay/constants.nim
@@ -28,17 +28,7 @@ const
   HashHexSize* = int(HashBitSize/4)
 
 const
-  # The relative folder where the circuit, proving and verification key for RLN can be found
-  # Note that resources has to be compiled with respect to the above MerkleTreeDepth
-  RlnConfig* = $(%* { 
-    "resources_folder": "tree_height_" & $MerkleTreeDepth & "/", 
-    "tree_config": {
-      "cache_capacity": 15_000, 
-      "mode": "high_throughput", 
-      "compression": false,
-      "flush_interval": 12_000
-    } 
-  })
+  DefaultRlnTreePath* = "rln_tree.db"
 
 # temporary variables to test waku-rln-relay performance in the static group mode
 const

--- a/waku/v2/waku_rln_relay/rln/wrappers.nim
+++ b/waku/v2/waku_rln_relay/rln/wrappers.nim
@@ -53,14 +53,14 @@ proc membershipKeyGen*(ctxPtr: ptr RLN): RlnRelayResult[IdentityCredential] =
 
   return ok(identityCredential)
 
-type RlnTreeConfig* = ref object of RootObj
+type RlnTreeConfig = ref object of RootObj
   cache_capacity*: int
   mode*: string
   compression*: bool
   flush_interval*: int
   path*: string
 
-type RlnConfig* = ref object of RootObj
+type RlnConfig = ref object of RootObj
   resources_folder*: string
   tree_config*: RlnTreeConfig
 
@@ -75,7 +75,7 @@ proc `%`(c: RlnConfig): JsonNode =
   return %[("resources_folder", %c.resources_folder),
            ("tree_config", %tree_config)]
 
-proc createRLNInstanceLocal*(d = MerkleTreeDepth, 
+proc createRLNInstanceLocal(d = MerkleTreeDepth, 
                              tree_path = DefaultRlnTreePath): RLNResult =
   ## generates an instance of RLN
   ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations

--- a/waku/v2/waku_rln_relay/rln/wrappers.nim
+++ b/waku/v2/waku_rln_relay/rln/wrappers.nim
@@ -54,15 +54,15 @@ proc membershipKeyGen*(ctxPtr: ptr RLN): RlnRelayResult[IdentityCredential] =
   return ok(identityCredential)
 
 type RlnTreeConfig = ref object of RootObj
-  cache_capacity*: int
-  mode*: string
-  compression*: bool
-  flush_interval*: int
-  path*: string
+  cache_capacity: int
+  mode: string
+  compression: bool
+  flush_interval: int
+  path: string
 
 type RlnConfig = ref object of RootObj
-  resources_folder*: string
-  tree_config*: RlnTreeConfig
+  resources_folder: string
+  tree_config: RlnTreeConfig
 
 proc `%`(c: RlnConfig): JsonNode =
   ## wrapper around the generic JObject constructor.

--- a/waku/v2/waku_rln_relay/rln/wrappers.nim
+++ b/waku/v2/waku_rln_relay/rln/wrappers.nim
@@ -1,4 +1,6 @@
 import
+  std/json
+import
   chronicles,
   options,
   stew/[arrayops, results],
@@ -51,30 +53,69 @@ proc membershipKeyGen*(ctxPtr: ptr RLN): RlnRelayResult[IdentityCredential] =
 
   return ok(identityCredential)
 
-proc createRLNInstanceLocal*(d: int = MerkleTreeDepth): RLNResult =
+type RlnTreeConfig* = ref object of RootObj
+  cache_capacity*: int
+  mode*: string
+  compression*: bool
+  flush_interval*: int
+  path*: string
+
+type RlnConfig* = ref object of RootObj
+  resources_folder*: string
+  tree_config*: RlnTreeConfig
+
+proc `%`(c: RlnConfig): JsonNode =
+  ## wrapper around the generic JObject constructor.
+  ## We don't need to have a separate proc for the tree_config field
+  let tree_config = %{ "cache_capacity": %c.tree_config.cache_capacity,
+                       "mode": %c.tree_config.mode,
+                       "compression": %c.tree_config.compression,
+                       "flush_interval": %c.tree_config.flush_interval,
+                       "path": %c.tree_config.path }
+  return %[("resources_folder", %c.resources_folder),
+           ("tree_config", %tree_config)]
+
+proc createRLNInstanceLocal*(d = MerkleTreeDepth, 
+                             tree_path = DefaultRlnTreePath): RLNResult =
   ## generates an instance of RLN
   ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations
   ## d indicates the depth of Merkle tree
+  ## tree_path indicates the path of the Merkle tree 
   ## Returns an error if the instance creation fails
+  
+  let rln_config = RlnConfig(
+    resources_folder: "tree_height_" & $d & "/",
+    tree_config: RlnTreeConfig(
+      cache_capacity: 15_000,
+      mode: "high_throughput",
+      compression: false,
+      flush_interval: 12_000,
+      path: if tree_path != "": tree_path else: DefaultRlnTreePath
+    )
+  )
+
+  var serialized_rln_config = $(%rln_config)
+
   var
     rlnInstance: ptr RLN
     merkleDepth: csize_t = uint(d)
-    resourcesPathBuffer = RlnConfig.toOpenArrayByte(0, RlnConfig.high).toBuffer()
+    configBuffer = serialized_rln_config.toOpenArrayByte(0, serialized_rln_config.high).toBuffer()
 
   # create an instance of RLN
-  let res = new_circuit(merkleDepth, addr resourcesPathBuffer, addr rlnInstance)
+  let res = new_circuit(merkleDepth, addr configBuffer, addr rlnInstance)
   # check whether the circuit parameters are generated successfully
   if (res == false):
     debug "error in parameters generation"
     return err("error in parameters generation")
   return ok(rlnInstance)
 
-proc createRLNInstance*(d: int = MerkleTreeDepth): RLNResult =
+proc createRLNInstance*(d = MerkleTreeDepth, 
+                        tree_path = DefaultRlnTreePath): RLNResult =
   ## Wraps the rln instance creation for metrics
   ## Returns an error if the instance creation fails
   var res: RLNResult
   waku_rln_instance_creation_duration_seconds.nanosecondTime:
-    res = createRLNInstanceLocal(d)
+    res = createRLNInstanceLocal(d, tree_path)
   return res
 
 proc sha256*(data: openArray[byte]): RlnRelayResult[MerkleNode] =

--- a/waku/v2/waku_rln_relay/rln_relay.nim
+++ b/waku/v2/waku_rln_relay/rln_relay.nim
@@ -40,6 +40,7 @@ type WakuRlnConfig* = object
   rlnRelayEthAccountAddress*: string
   rlnRelayCredPath*: string
   rlnRelayCredentialsPassword*: string
+  rlnRelayTreePath*: string
 
 proc createMembershipList*(rln: ptr RLN, n: int): RlnRelayResult[(
     seq[RawMembershipCredentials], string
@@ -338,7 +339,7 @@ proc mount(conf: WakuRlnConfig,
     credentials: MembershipCredentials
     persistCredentials = false
   # create an RLN instance
-  let rlnInstanceRes = createRLNInstance()
+  let rlnInstanceRes = createRLNInstance(tree_path = conf.rlnRelayTreePath)
   if rlnInstanceRes.isErr():
     raise newException(CatchableError, "RLN instance creation failed")
   let rlnInstance = rlnInstanceRes.get()


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This pr allows the user/operator to pass in the path to the persisted merkle tree, this will allow users to only sync 
from the block that they need to, instead of syncing from the start every single time. 

# Changes

<!-- List of detailed changes -->

- [x] Converted RlnConfig into a struct, and initializes it in `createRlnInstanceLocal`, which is the only proc that 
uses it
- [x] Added a new config to the wakunode2 config, `--rln-relay-tree-path` that accepts a string

<!--
## How to test

1.
1.
1.

-->

**Note**:
- A follow up PR will be created to actually make sure that the onchain sync starts from the last processed block, split 
the prs to reduce cognitive load.

## Issue

addresses a part of https://github.com/waku-org/nwaku/issues/1772
