### PR TITLE
chore(libp2p): Revert "chore(libp2p): update nim-libp2p"

### DIFF
--- a/waku/v2/waku_relay/protocol.nim
+++ b/waku/v2/waku_relay/protocol.nim
@@ -199,7 +199,7 @@ proc subscribe*(w: WakuRelay, pubsubTopic: PubsubTopic, handler: WakuRelayHandle
   debug "subscribe", pubsubTopic=pubsubTopic
 
   # we need to wrap the handler since gossipsub doesnt understand WakuMessage
-  let wrappedHandler = proc(pubsubTopic: string, data: seq[byte]): Future[void] {.gcsafe, raises: [].} =
+  let wrappedHandler = proc(pubsubTopic: string, data: seq[byte]): Future[void] {.gcsafe, raises: [Defect].} =
     let decMsg = WakuMessage.decode(data)
     if decMsg.isErr():
       # fine if triggerSelf enabled, since validators are bypassed


### PR DESCRIPTION
Reverts waku-org/nwaku#1786

There is a regression in that nim-libp2p version causing constant nwaku crashes
Tracking regression here: https://github.com/status-im/nim-libp2p/issues/910