### PR TITLE
feat(rln-relay): integrate get_leaf ffi api

### DIFF
--- a/waku/v2/waku_rln_relay/constants.nim
+++ b/waku/v2/waku_rln_relay/constants.nim
@@ -1,5 +1,4 @@
 import
-  std/json,
   stint
 
 import

--- a/waku/v2/waku_rln_relay/rln/rln_interface.nim
+++ b/waku/v2/waku_rln_relay/rln/rln_interface.nim
@@ -54,6 +54,11 @@ proc set_leaf*(ctx: ptr RLN, index: uint, input_buffer: ptr Buffer): bool {.impo
 ## the input_buffer holds a serialized leaf of 32 bytes
 ## the return bool value indicates the success or failure of the operation
 
+proc get_leaf*(ctx: ptr RLN, index: uint, output_buffer: ptr Buffer): bool {.importc: "get_leaf".}
+## gets the leaf at position index in the tree stored by ctx
+## the output_buffer holds a serialized leaf of 32 bytes
+## the return bool value indicates the success or failure of the operation
+
 proc init_tree_with_leaves*(ctx: ptr RLN, input_buffer: ptr Buffer): bool {.importc: "init_tree_with_leaves".}
 ## sets multiple leaves in the tree stored by ctx to the value passed by input_buffer
 ## the input_buffer holds a serialized vector of leaves (32 bytes each)

--- a/waku/v2/waku_rln_relay/rln/wrappers.nim
+++ b/waku/v2/waku_rln_relay/rln/wrappers.nim
@@ -271,6 +271,25 @@ proc insertMember*(rlnInstance: ptr RLN, idComm: IDCommitment): bool =
   let memberAdded = update_next_member(rlnInstance, pkBufferPtr)
   return memberAdded
 
+proc getMember*(rlnInstance: ptr RLN, index: MembershipIndex): RlnRelayResult[IDCommitment] =
+  ## returns the member at the given index
+  ## returns an error if the index is out of bounds
+  ## returns the member if the index is valid
+  var
+    idCommitment {.noinit.}: Buffer = Buffer()
+    idCommitmentPtr = addr(idCommitment)
+    memberRetrieved = get_leaf(rlnInstance, index, idCommitmentPtr)
+
+  if not memberRetrieved:
+    return err("could not get the member")
+
+  if not idCommitment.len == 32:
+    return err("wrong output size")
+
+  let idCommitmentValue = (cast[ptr array[32, byte]](idCommitment.`ptr`))[]
+
+  return ok(@idCommitmentValue)
+
 proc atomicWrite*(rlnInstance: ptr RLN, 
                   index = none(MembershipIndex), 
                   idComms = newSeq[IDCommitment](),


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This pr introduces the get_leaf ffi api that was recently merged to zerokit's master (https://github.com/vacp2p/zerokit/pull/177)

# Changes

<!-- List of detailed changes -->

- [x] new ffi api `get_leaf`
- [x] wrapper fn for `get_leaf`, `getMember`

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
