### PR TITLE
fix(rln-relay): flaky static group manager test

### DIFF
--- a/tests/v2/waku_rln_relay/test_rln_group_manager_static.nim
+++ b/tests/v2/waku_rln_relay/test_rln_group_manager_static.nim
@@ -21,6 +21,9 @@ import
   eth/keys,
   discovery/dnsdisc/builder
 
+import
+  std/tempfiles
+
 proc generateCredentials(rlnInstance: ptr RLN): IdentityCredential =
   let credRes = membershipKeyGen(rlnInstance)
   return credRes.get()
@@ -33,7 +36,7 @@ proc generateCredentials(rlnInstance: ptr RLN, n: int): seq[IdentityCredential] 
 
 suite "Static group manager":
   setup:
-    let rlnInstanceRes = createRlnInstance()
+    let rlnInstanceRes = createRlnInstance(tree_path = genTempPath("rln_tree", "static"))
     require:
       rlnInstanceRes.isOk()
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Generates a new temp path for the tree db, as it was failing intermittently due to same path being used between tests.

# Changes

<!-- List of detailed changes -->

- [x] imports std/tempfiles and generates a new temp path

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #1796
