### PR TITLE
fix: fix mac docker build alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD NIM APP ----------------------------------------------------------------
 
-FROM alpine:edge AS nim-build
+FROM alpine:3.16 AS nim-build
 
 ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2


### PR DESCRIPTION
* `docker build .` was broken in mac
* this PR fixes it by using `alpine:3.16`