### PR TITLE
feat(rln-relay): metadata ffi api

### DIFF
--- a/tests/v2/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/v2/waku_rln_relay/test_waku_rln_relay.nim
@@ -238,6 +238,24 @@ suite "Waku rln relay":
     check:
       rln.removeMember(MembershipIndex(0))
 
+  test "setMetadata rln utils":
+    # create an RLN instance which also includes an empty Merkle tree
+    let rlnInstance = createRLNInstance()
+    require:
+      rlnInstance.isOk()
+    let rln = rlnInstance.get()
+    check:
+      rln.setMetadata("")
+
+  test "getMetadata rln utils":
+    # create an RLN instance which also includes an empty Merkle tree
+    let rlnInstance = createRLNInstance()
+    require:
+      rlnInstance.isOk()
+    let rln = rlnInstance.get()
+    check:
+      rln.setMetadata("")
+
   test "Merkle tree consistency check between deletion and insertion":
     # create an RLN instance
     let rlnInstance = createRLNInstance()

--- a/tests/v2/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/v2/waku_rln_relay/test_waku_rln_relay.nim
@@ -245,7 +245,7 @@ suite "Waku rln relay":
       rlnInstance.isOk()
     let rln = rlnInstance.get()
     check:
-      rln.setMetadata("")
+      rln.setMetadata(RlnMetadata(lastProcessedBlock: 128)).isOk()
 
   test "getMetadata rln utils":
     # create an RLN instance which also includes an empty Merkle tree
@@ -253,8 +253,20 @@ suite "Waku rln relay":
     require:
       rlnInstance.isOk()
     let rln = rlnInstance.get()
+    
+    require:
+      rln.setMetadata(RlnMetadata(lastProcessedBlock: 128)).isOk()
+
+    let metadataRes = rln.getMetadata()
+
+    require:
+      metadataRes.isOk()
+
+    let metadata = metadataRes.get()
+
     check:
-      rln.setMetadata("")
+      metadata.lastProcessedBlock == 128
+ 
 
   test "Merkle tree consistency check between deletion and insertion":
     # create an RLN instance

--- a/waku/v2/waku_rln_relay/rln/rln_interface.nim
+++ b/waku/v2/waku_rln_relay/rln/rln_interface.nim
@@ -175,3 +175,16 @@ proc poseidon*(input_buffer: ptr Buffer,
 ## inputs_buffer holds the hash input as a byte seq
 ## the hash output is generated and populated inside output_buffer
 ## the output_buffer contains 32 bytes hash output
+
+#-------------------------------- Persistent Metadata utils -------------------------------------------
+
+proc set_metadata*(ctx: ptr RLN, input_buffer: ptr Buffer): bool {.importc: "set_metadata".}
+## sets the metadata stored by ctx to the value passed by input_buffer
+## the input_buffer holds a serialized representation of the metadata (format to be defined)
+## input_buffer holds the metadata as a byte seq
+## the return bool value indicates the success or failure of the operation
+
+proc get_metadata*(ctx: ptr RLN, output_buffer: ptr Buffer): bool {.importc: "get_metadata".}
+## gets the metadata stored by ctx and populates the passed pointer output_buffer with it
+## the output_buffer holds the metadata as a byte seq
+## the return bool value indicates the success or failure of the operation

--- a/waku/v2/waku_rln_relay/rln/wrappers.nim
+++ b/waku/v2/waku_rln_relay/rln/wrappers.nim
@@ -348,18 +348,15 @@ proc getMerkleRoot*(rlnInstance: ptr RLN): MerkleNodeResult =
   return ok(rootValue)
 
 type
-  Metadata = object
-    lastProcessedBlock: uint64
+  RlnMetadata* = object
+    lastProcessedBlock*: uint64
 
-proc serialize(metadata: Metadata): seq[byte] =
+proc serialize(metadata: RlnMetadata): seq[byte] =
   ## serializes the metadata
   ## returns the serialized metadata
-  var
-    lastProcessedBlockBytes = metadata.lastProcessedBlock.toBytes()
-    serializedMetadata = serialize(lastProcessedBlockBytes)
-  return serializedMetadata
+  return @(metadata.lastProcessedBlock.toBytes())
 
-proc setMetadata*(rlnInstance: ptr RLN, metadata: Metadata): RlnRelayResult[void] =
+proc setMetadata*(rlnInstance: ptr RLN, metadata: RlnMetadata): RlnRelayResult[void] =
   ## sets the metadata of the RLN instance
   ## returns an error if the metadata could not be set
   ## returns void if the metadata is set successfully
@@ -375,7 +372,7 @@ proc setMetadata*(rlnInstance: ptr RLN, metadata: Metadata): RlnRelayResult[void
     return err("could not set the metadata")
   return ok()
 
-proc getMetadata*(rlnInstance: ptr RLN): RlnRelayResult[Metadata] =
+proc getMetadata*(rlnInstance: ptr RLN): RlnRelayResult[RlnMetadata] =
   ## gets the metadata of the RLN instance
   ## returns an error if the metadata could not be retrieved
   ## returns the metadata if the metadata is retrieved successfully
@@ -391,5 +388,4 @@ proc getMetadata*(rlnInstance: ptr RLN): RlnRelayResult[Metadata] =
     return err("wrong output size")
 
   var metadataValue = cast[ptr uint64] (metadata.`ptr`)[]
-  let lastProcessedBlock = metadataValue[]
-  return ok(Metadata(lastProcessedBlock: lastProcessedBlock))
+  return ok(RlnMetadata(lastProcessedBlock: metadataValue))


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR introduces 2 new api's from zerokit, `set_metadata`, and `get_metadata`. They are both used to persist metadata about merkle tree state, like last block synced, etc. This is very useful to resume sync from an existing tree database.

# Changes

<!-- List of detailed changes -->

- [x] new ffi api's `get_metadata`, `set_metadata`
- [x] Helpers for both
- [x] Tests for both

<!--
## How to test

1.
1.
1.

-->



## Issue

Unblocks https://github.com/waku-org/nwaku/issues/1772