### PR TITLE
feat(rln-relay): resume onchain sync from persisted tree db

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -552,7 +552,8 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
         rlnRelayEthAccountPrivateKey: conf.rlnRelayEthAccountPrivateKey,
         rlnRelayEthAccountAddress: conf.rlnRelayEthAccountAddress,
         rlnRelayCredPath: conf.rlnRelayCredPath,
-        rlnRelayCredentialsPassword: conf.rlnRelayCredentialsPassword
+        rlnRelayCredentialsPassword: conf.rlnRelayCredentialsPassword,
+        rlnRelayTreePath: conf.rlnRelayTreePath
       )
 
       try:

--- a/waku/v2/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/v2/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -259,6 +259,13 @@ proc handleEvents(g: OnchainGroupManager,
       raise newException(ValueError, "failed to insert members into the tree")
     trace "new members added to the Merkle tree", commitments=members.mapIt(it[0].idCommitment.inHex())
     g.latestProcessedBlock = some(blockNumber)
+    let metadataSetRes = g.rlnInstance.setMetadata(RlnMetadata(
+                            lastProcessedBlock: blockNumber))
+    if metadataSetRes.isErr():
+      # this is not a fatal error, hence we don't raise an exception
+      warn "failed to persist rln metadata", error=metadataSetRes.error()
+    else:
+      info "rln metadata persisted", lastProcessedBlock = blockNumber
 
   return
 
@@ -306,11 +313,19 @@ proc startListeningToEvents(g: OnchainGroupManager): Future[void] {.async.} =
   except CatchableError:
     raise newException(ValueError, "failed to subscribe to block headers: " & getCurrentExceptionMsg())
 
-proc startOnchainSync(g: OnchainGroupManager, fromBlock: BlockNumber = BlockNumber(0)): Future[void] {.async.} =
+proc startOnchainSync(g: OnchainGroupManager): Future[void] {.async.} =
   initializedGuard(g)
 
+  let fromBlock = if g.latestProcessedBlock.isSome():
+    info "resuming onchain sync from block", fromBlock = g.latestProcessedBlock.get()
+    g.latestProcessedBlock.get()
+  else:
+    info "starting onchain sync from scratch"
+    BlockNumber(0)
+
   try:
-    await g.getAndHandleEvents(fromBlock, some(fromBlock))
+    # we always want to sync from last processed block => latest
+    await g.getAndHandleEvents(fromBlock, some(BlockNumber(0)))
   except CatchableError:
     raise newException(ValueError, "failed to get the history/reconcile missed blocks: " & getCurrentExceptionMsg())
 
@@ -445,12 +460,20 @@ method init*(g: OnchainGroupManager): Future[void] {.async.} =
     g.idCredentials = some(parsedCreds[g.keystoreIndex].identityCredential)
     g.membershipIndex = some(parsedCreds[g.keystoreIndex].membershipGroups[g.membershipGroupIndex].treeIndex)
 
+  let metadataGetRes = g.rlnInstance.getMetadata()
+  if metadataGetRes.isErr():
+    warn "could not initialize with persisted rln metadata"
+    g.latestProcessedBlock = some(BlockNumber(0))
+  else:
+    let metadata = metadataGetRes.get()
+    g.latestProcessedBlock = some(metadata.lastProcessedBlock)
+
   ethRpc.ondisconnect = proc() =
     error "Ethereum client disconnected"
     let fromBlock = g.latestProcessedBlock.get()
     info "reconnecting with the Ethereum client, and restarting group sync", fromBlock = fromBlock
     try:
-      asyncSpawn g.startOnchainSync(fromBlock)
+      asyncSpawn g.startOnchainSync()
     except CatchableError:
       error "failed to restart group sync", error = getCurrentExceptionMsg()
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This feature makes use of the new ffi api's `set_metadata` and `get_metadata` introduced in #1803. This allows us to insert the block number we sync 
to, and to resume sync when we re-use the database. reduces complexity and improves node startup time *significantly*

# Changes

<!-- List of detailed changes -->

- [x] Use `setMetadata` in `handleEvents`
- [x] Use `getMetadata` in `init` for the group manager

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #1772
