### PR TITLE
chore(config): Deprecation of the 'topics' param

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -502,16 +502,7 @@ proc setupProtocols(node: WakuNode, conf: WakuNodeConf,
 
   if conf.relay:
 
-    var pubsubTopics = @[""]
-    if conf.topicsDeprecated != "/waku/2/default-waku/proto":
-      warn "The 'topics' parameter is deprecated. Better use the 'topic' one instead."
-      if conf.topics != @["/waku/2/default-waku/proto"]:
-        return err("Please don't specify 'topics' and 'topic' simultaneously. Only use the 'topic' parameter")
-
-      # This clause (if conf.topicsDeprecated ) should disapear in >= v0.18.0
-      pubsubTopics = conf.topicsDeprecated.split(" ")
-    else:
-      pubsubTopics = conf.topics
+    let pubsubTopics = conf.topics
     try:
       await mountRelay(node, pubsubTopics, peerExchangeHandler = peerExchangeHandler)
     except CatchableError:

--- a/apps/wakunode2/config.nim
+++ b/apps/wakunode2/config.nim
@@ -215,11 +215,6 @@ type
       defaultValue: false
       name: "keep-alive" }: bool
 
-    topicsDeprecated* {.
-      desc: "Default topics to subscribe to (space separated list). DEPRECATED: please use repeated --topic argument instead."
-      defaultValue: "/waku/2/default-waku/proto"
-      name: "topics" .}: string
-
     topics* {.
       desc: "Default topic to subscribe to. Argument may be repeated."
       defaultValue: @["/waku/2/default-waku/proto"]


### PR DESCRIPTION
# Description
This is for deprecating the `topics` param in favor of the `topic` one.

## How to test

1. From CLI:
   `./build/wakunode2 --topic="topic1" --topic="topic2" --config-file=cfg_node.txt`
   
   In this case, the CLI overrides the config file params.
   
2. From config file:
   `./build/wakunode2 --config-file=cfg_node.txt`

[cfg_node.txt](https://github.com/waku-org/nwaku/files/11769553/cfg_node.txt)

   
 
