### PR TITLE
feat(postgres): integration of postgres in wakunode2

### DIFF
--- a/waku/v2/waku_archive/driver/builder.nim
+++ b/waku/v2/waku_archive/driver/builder.nim
@@ -13,11 +13,13 @@ import
   ../../../common/databases/db_sqlite,
   ./sqlite_driver,
   ./sqlite_driver/migrations as archive_driver_sqlite_migrations,
-  ./queue_driver
+  ./queue_driver,
+  ./postgres_driver
 
 export
   sqlite_driver,
-  queue_driver
+  queue_driver,
+  postgres_driver
 
 proc new*(T: type ArchiveDriver,
           url: string,
@@ -68,6 +70,18 @@ proc new*(T: type ArchiveDriver,
       return err("failed to init sqlite archive driver: " & res.error)
 
     return ok(res.get())
+
+  of "postgres":
+    const MaxNumConns = 5 #TODO: we may need to set that from app args (maybe?)
+    let res = PostgresDriver.new(url, MaxNumConns)
+    if res.isErr():
+      return err("failed to init postgres archive driver: " & res.error)
+
+    let driver = res.get()
+    # The table should exist beforehand.
+    discard driver.createMessageTable()
+
+    return ok(driver)
 
   else:
     debug "setting up in-memory waku archive driver"

--- a/waku/v2/waku_archive/driver/builder.nim
+++ b/waku/v2/waku_archive/driver/builder.nim
@@ -6,7 +6,8 @@ else:
 
 import
   stew/results,
-  chronicles
+  chronicles,
+  chronos
 import
   ../driver,
   ../../../common/databases/dburl,
@@ -78,8 +79,14 @@ proc new*(T: type ArchiveDriver,
       return err("failed to init postgres archive driver: " & res.error)
 
     let driver = res.get()
-    # The table should exist beforehand.
-    discard driver.createMessageTable()
+
+    try:
+      # The table should exist beforehand.
+      let newTableRes = waitFor driver.createMessageTable()
+      if newTableRes.isErr():
+        return err("error creating table: " & newTableRes.error)
+    except CatchableError:
+      return err("exception creating table: " & getCurrentExceptionMsg())
 
     return ok(driver)
 

--- a/waku/v2/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/v2/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -238,9 +238,10 @@ proc getInt(s: PostgresDriver,
   if fields.len != 1:
     return err("failed in getRow: Expected one field but got " & $fields.len)
 
-  var retInt: int64
+  var retInt = 0'i64
   try:
-    retInt = parseInt(fields[0])
+    if fields[0] != "":
+      retInt = parseInt(fields[0])
   except ValueError:
     return err("exception in getRow, parseInt: " & getCurrentExceptionMsg())
 
@@ -269,7 +270,7 @@ method getNewestMessageTimestamp*(s: PostgresDriver):
 
   let intRes = await s.getInt("SELECT MAX(storedAt) FROM messages")
   if intRes.isErr():
-    return err("error in getOldestMessageTimestamp: " & intRes.error)
+    return err("error in getNewestMessageTimestamp: " & intRes.error)
 
   return ok(Timestamp(intRes.get()))
 

--- a/waku/v2/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/v2/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -52,8 +52,8 @@ proc new*(T: type PostgresDriver,
 
   return ok(PostgresDriver(connPool: connPoolRes.get()))
 
-proc createMessageTable(s: PostgresDriver):
-                        Future[ArchiveDriverResult[void]] {.async.}  =
+proc createMessageTable*(s: PostgresDriver):
+                         Future[ArchiveDriverResult[void]] {.async.}  =
 
   let execRes = await s.connPool.exec(createTableQuery())
   if execRes.isErr():


### PR DESCRIPTION
## Summary
This PR is a combination of:
   1. Integration of Postgres in wakunode2.
   2. refactoring of Waku Archive, database, etc.

## Details
First, apologies for that big PR:S. I started the integration of Postgres into wakinode2 but during the process, I ended up doing a more generic refactoring, sorry about that. I can explain everything until we are all happy with it.

The main purpose of this PR is to allow a Nwaku to mount the Waku Archive protocol by using Postgres as the underlying database. For that, run the WakuNode with:

`./build/wakunode2 --store-message-db-url="postgres://postgres:test123@localhost:5432/postgres" ...`

## How to test
As usual, we can run two Nwaku nodes, `a`, and `b`.
`b` will act as the store node and will connect to the Postgres database.

1. Start local Postgres database. Go to the repo's root folder and run the next:
   ```code
   sudo docker compose -f tests/postgres-docker-compose.yml up
   ```
   
   where the `postgres-docker-compose.yml` contains:
   ```code
   version: "3.8"

   services:
     db:
       image: postgres:9.6-alpine
       restart: always
       environment:
         POSTGRES_PASSWORD: test123
       ports:
         - "5432:5432"
   ```
     
2. Start a node that will act as a client
   ```code
   ./build/wakunode2 --config-file=cfg_node_a.txt
   ```   
[cfg_node_a.txt](https://github.com/waku-org/nwaku/files/11772154/cfg_node_a.txt)
   
   
3. Start a node that will act as the "store", which will connect to the Postgres database.
   ```code
      ./build/wakunode2 --config-file=cfg_node_b.txt
   ```   
[cfg_node_b.txt](https://github.com/waku-org/nwaku/files/11772166/cfg_node_b.txt)

4. Send a couple of requests to store two messages.
   The next command sends requests to node b (started in 3.)
   ```code
   curl -d "{\"jsonrpc\":\"2.0\",\"id\":"$(date +%s%N)",\"method\":\"post_waku_v2_relay_v1_message\", \"params\":[\"/waku/2/default-waku/proto\", {\"timestamp\":"$(date +%s%N)", \"payload\":\"VGhpcyBpcyBhIG1lc3NhZ2UK\"}]}" --header "Content-Type: application/json" http://localhost:8546
   ```
   
5. Finally, send a "get_waku_v2_store_v1_messages" request to node `a` (started in 2.)
   ```code
   curl -d '{"jsonrpc":"2.0","id":"id","method":"get_waku_v2_store_v1_messages"}' --header "Content-Type: application/json" http://localhost:8545
   ```   
   And this should bring the two messages stored in point 4.
   
## Issue
https://github.com/waku-org/nwaku/issues/1604