### PR TITLE
feat: limit relay connections below max conns

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -291,7 +291,7 @@ proc initNode(conf: WakuNodeConf,
       sendSignedPeerRecord = conf.relayPeerExchange, # We send our own signed peer record when peer exchange enabled
       agentString = some(conf.agentString)
   )
-  builder.withPeerManagerConfig(maxRelayPeers = some(conf.maxRelayPeers.int))
+  builder.withPeerManagerConfig(maxRelayPeers = conf.maxRelayPeers)
 
   node = ? builder.build().mapErr(proc (err: string): string = "failed to create waku node instance: " & err)
 

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -95,8 +95,7 @@ type
 
     maxRelayPeers* {.
       desc: "Maximum allowed number of relay peers."
-      defaultValue: 50
-      name: "max-relay-peers" }: uint16
+      name: "max-relay-peers" }: Option[int]
 
     peerStoreCapacity* {.
       desc: "Maximum stored peers in the peerstore."

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -607,7 +607,7 @@ procSuite "Peer Manager":
       .withMaxConnections(5)
       .build(),
       maxFailedAttempts = 1,
-      maxRelayPeers = 5,
+      maxRelayPeers = some(5),
       storage = nil)
 
     # Create 15 peers and add them to the peerstore
@@ -660,7 +660,7 @@ procSuite "Peer Manager":
       initialBackoffInSec = 1, # with InitialBackoffInSec = 1 backoffs are: 1, 2, 4, 8secs.
       backoffFactor = 2,
       maxFailedAttempts = 10,
-      maxRelayPeers = 5,
+      maxRelayPeers = some(5),
       storage = nil)
     var p1: PeerId
     require p1.init("QmeuZJbXrszW2jdT7GdduSjQskPU3S7vvGWKtKgDfkDvW" & "1")
@@ -709,7 +709,7 @@ procSuite "Peer Manager":
         .withPeerStore(10)
         .withMaxConnections(5)
         .build(),
-        maxRelayPeers = 5,
+        maxRelayPeers = some(5),
         maxFailedAttempts = 150,
         storage = nil)
 
@@ -721,7 +721,7 @@ procSuite "Peer Manager":
         .withMaxConnections(5)
         .build(),
         maxFailedAttempts = 10,
-        maxRelayPeers = 5,
+        maxRelayPeers = some(5),
         storage = nil)
 
     let pm = PeerManager.new(
@@ -730,7 +730,7 @@ procSuite "Peer Manager":
       .withMaxConnections(5)
       .build(),
       maxFailedAttempts = 5,
-      maxRelayPeers = 5,
+      maxRelayPeers = some(5),
       storage = nil)
 
   asyncTest "colocationLimit is enforced by pruneConnsByIp()":

--- a/waku/v2/node/builder.nim
+++ b/waku/v2/node/builder.nim
@@ -145,13 +145,6 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
   if builder.record.isNone():
     return err("node record is required")
 
-  # fallbck to max connections if not set
-  var maxRelayPeers: int
-  if builder.maxRelayPeers.isNone():
-    maxRelayPeers = builder.switchMaxConnections.get(builders.MaxConnections)
-  else:
-    maxRelayPeers = builder.maxRelayPeers.get()
-
   var switch: Switch
   try:
     switch = newWakuSwitch(
@@ -176,7 +169,7 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
   let peerManager = PeerManager.new(
     switch = switch,
     storage = builder.peerStorage.get(nil),
-    maxRelayPeers = maxRelayPeers,
+    maxRelayPeers = builder.maxRelayPeers,
   )
 
   var node: WakuNode

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -344,7 +344,7 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
 
 proc new*(T: type PeerManager,
           switch: Switch,
-          maxRelayPeers: Option[int],
+          maxRelayPeers: Option[int] = none(int),
           storage: PeerStorage = nil,
           initialBackoffInSec = InitialBackoffInSec,
           backoffFactor = BackoffFactor,

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -362,13 +362,13 @@ proc new*(T: type PeerManager,
   var maxRelayPeersValue = 0
   if maxRelayPeers.isSome():
     if maxRelayPeers.get() > maxConnections:
-      error "Max number of relay peers can't be greater the max amount of connections",
+      error "Max number of relay peers can't be greater than the max amount of connections",
            maxConnections = maxConnections,
            maxRelayPeers = maxRelayPeers.get()
-      raise newException(Defect, "Max number of relay peers can't be greater the max amount of connections")
+      raise newException(Defect, "Max number of relay peers can't be greater than the max amount of connections")
 
     if maxRelayPeers.get() == maxConnections:
-      warn "Max number of relay peers is equal to max amount of connections, peer wont be contribute to service peers",
+      warn "Max number of relay peers is equal to max amount of connections, peer won't be contributing to service peers",
            maxConnections = maxConnections,
            maxRelayPeers = maxRelayPeers.get()
     maxRelayPeersValue = maxRelayPeers.get()


### PR DESCRIPTION
# Description
* Prunes incoming relay connections exceeding `maxInRelayPeers`
* Does not attempt to connect to more than `maxOutRelayPeers`
* This leaves `maxConnections`-`maxInRelayPeers`-`maxOutRelayPeers` slots for service peers
* Amount of `maxRelayPeers` defaults to 80% of the `maxConnections`


![image](https://github.com/waku-org/nwaku/assets/8811422/e2b93a4b-ed4e-4d44-9e9c-4a4a74c27301)
[ref](https://excalidraw.com/#json=wmsjdjnZUWn0GKnoLy0mI,BG_ExLzzYByNYxdVBMN9MQ)


closes https://github.com/waku-org/nwaku/issues/1567