### PR TITLE
chore: add peer manager config to builder

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -430,6 +430,7 @@ proc initNode(conf: WakuNodeConf,
       agentString = some(conf.agentString)
   )
   builder.withWakuDiscv5(wakuDiscv5.get(nil))
+  builder.withPeerManagerConfig(maxRelayPeers = some(conf.maxRelayPeers.int))
 
   node = ? builder.build().mapErr(proc (err: string): string = "failed to create waku node instance: " & err)
 

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -93,6 +93,11 @@ type
       defaultValue: 50
       name: "max-connections" }: uint16
 
+    maxRelayPeers* {.
+      desc: "Maximum allowed number of relay peers."
+      defaultValue: 50
+      name: "max-relay-peers" }: uint16
+
     peerStoreCapacity* {.
       desc: "Maximum stored peers in the peerstore."
       name: "peer-store-capacity" }: Option[int]

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -607,6 +607,7 @@ procSuite "Peer Manager":
       .withMaxConnections(5)
       .build(),
       maxFailedAttempts = 1,
+      maxRelayPeers = 5,
       storage = nil)
 
     # Create 15 peers and add them to the peerstore
@@ -659,6 +660,7 @@ procSuite "Peer Manager":
       initialBackoffInSec = 1, # with InitialBackoffInSec = 1 backoffs are: 1, 2, 4, 8secs.
       backoffFactor = 2,
       maxFailedAttempts = 10,
+      maxRelayPeers = 5,
       storage = nil)
     var p1: PeerId
     require p1.init("QmeuZJbXrszW2jdT7GdduSjQskPU3S7vvGWKtKgDfkDvW" & "1")
@@ -707,6 +709,7 @@ procSuite "Peer Manager":
         .withPeerStore(10)
         .withMaxConnections(5)
         .build(),
+        maxRelayPeers = 5,
         maxFailedAttempts = 150,
         storage = nil)
 
@@ -718,6 +721,7 @@ procSuite "Peer Manager":
         .withMaxConnections(5)
         .build(),
         maxFailedAttempts = 10,
+        maxRelayPeers = 5,
         storage = nil)
 
     let pm = PeerManager.new(
@@ -726,6 +730,7 @@ procSuite "Peer Manager":
       .withMaxConnections(5)
       .build(),
       maxFailedAttempts = 5,
+      maxRelayPeers = 5,
       storage = nil)
 
   asyncTest "colocationLimit is enforced by pruneConnsByIp()":

--- a/tests/v2/testlib/wakunode.nim
+++ b/tests/v2/testlib/wakunode.nim
@@ -67,7 +67,7 @@ proc newTestWakuNode*(nodeKey: crypto.PrivateKey,
     secureKey = if secureKey != "": some(secureKey) else: none(string),
     secureCert = if secureCert != "": some(secureCert) else: none(string),
     agentString = agentString,
-    
+
   )
   builder.withWakuDiscv5(wakuDiscv5.get(nil))
 

--- a/waku/v2/node/builder.nim
+++ b/waku/v2/node/builder.nim
@@ -180,8 +180,8 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
       peerStoreCapacity = builder.peerStorageCapacity,
       services = @[Service(getAutonatService(rng))],
     )
-  except:
-    return err("failed to create switch")
+  except CatchableError:
+    return err("failed to create switch: " & getCurrentExceptionMsg())
 
   let peerManager = PeerManager.new(
     switch = switch,


### PR DESCRIPTION
# Description
* Currently the `withPeerManager()` in the builder was not implemented nor used. This PR moves the switch creation from `waku_node` to the `builder` and simplifies `WakuNode.new()` having less parameters.
* This is done because otherwise, `withPeerManger` can't be used since to build the PeerManager, we need the Switch, since its built inside.
* This PR adds a new **unused** flag `max-relay-peers` to be used in future PRs.
* Note that it doesnt introduce any breaking change, unless `maxConnections` is configured <50, but this is not the case in the fleets.
* Prerequisite for https://github.com/waku-org/nwaku/pull/1813