### PR TITLE
fix(ci): fix broken test with wrong import

### DIFF
--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -10,7 +10,7 @@ import
   libp2p/multiaddress,
   libp2p/switch
 import
-  ../../apps/wakunode2/config,
+  ../../apps/wakunode2/external_config,
   ../../apps/wakunode2/app,
   ../v2/testlib/common,
   ../v2/testlib/wakucore


### PR DESCRIPTION
* due to this renaming `apps/wakunode2/config.nim → apps/wakunode2/external_config.nim` a test that wasnt updated broke ci.
* fix broken test with wrong import