### PR TITLE
chore(networking): disconnect due to colocation ip in conn handler

### DIFF
--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -743,29 +743,28 @@ procSuite "Peer Manager":
 
     let pInfos = nodes.mapIt(it.switch.peerInfo.toRemotePeerInfo())
 
+    # force max 1 conn per ip
+    nodes[0].peerManager.colocationLimit = 1
+
     # 2 in connections
     discard await nodes[1].peerManager.connectRelay(pInfos[0])
     discard await nodes[2].peerManager.connectRelay(pInfos[0])
+
+    # but one is pruned
+    check nodes[0].peerManager.switch.connManager.getConnections().len == 1
 
     # 2 out connections
     discard await nodes[0].peerManager.connectRelay(pInfos[3])
     discard await nodes[0].peerManager.connectRelay(pInfos[4])
 
-    # force max 1 conn per ip
-    nodes[0].peerManager.colocationLimit = 1
-    nodes[0].peerManager.updateIpTable()
+    # they are also prunned 
+    check nodes[0].peerManager.switch.connManager.getConnections().len == 1
 
-    # table is updated and we have 4 conns (2in 2out)
-    check:
-      nodes[0].peerManager.ipTable["127.0.0.1"].len == 4
-      nodes[0].peerManager.switch.connManager.getConnections().len == 4
-      nodes[0].peerManager.peerStore.peers().len == 4
-
-    await nodes[0].peerManager.pruneConnsByIp()
-
-    # peers are pruned, max 1 conn per ip
-    nodes[0].peerManager.updateIpTable()
+    # we should have 4 peers (2in/2out) but due to collocation limit
+    # they are pruned to max 1
     check:
       nodes[0].peerManager.ipTable["127.0.0.1"].len == 1
       nodes[0].peerManager.switch.connManager.getConnections().len == 1
       nodes[0].peerManager.peerStore.peers().len == 1
+
+    await allFutures(nodes.mapIt(it.stop()))


### PR DESCRIPTION
# Description
* Before: Disconnections due to ip collocation factor where triggered at a given fixed interval, using a "cleanup" function scheduled every few seconds.
* With this PR: Disconnections are triggered in the connection handle, which is executed right after the peer joins. This allows to react faster to such attacks, where we are attacked by sybils under the same IP.
* It also uses `asyncSpawn` to trigger disconnections instead.