### PR TITLE
fix: sanity-check the docker image start

### DIFF
--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -67,6 +67,14 @@ pipeline {
       } }
     }
 
+    stage('Check') {
+      steps { script {
+        image.inside('--entrypoint=""') { c ->
+          sh '/usr/bin/wakunode --version'
+        }
+      } }
+    }
+
     stage('Push') {
       steps { script {
         withDockerRegistry([credentialsId: "dockerhub-statusteam-auto", url: ""]) {


### PR DESCRIPTION
To avoid basic runtime failures due to missing libraries:
```
 > docker run --rm statusteam/nim-waku:deploy-wakuv2-test --version
could not load: libpq.so(.5|)
```