### PR TITLE
fix(discv5): Fixing issue that prevented the wakunode2 from starting

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -501,7 +501,7 @@ proc startNode(node: WakuNode, conf: WakuNodeConf,
 
 proc startApp*(app: App): Future[AppResult[void]] {.async.} =
   if app.wakuDiscv5.isSome():
-    let res = await app.wakuDiscv5.get().start()
+    let res = app.wakuDiscv5.get().start()
 
     if res.isErr():
       return err("failed to start waku discovery v5: " & res.error)

--- a/examples/v2/publisher.nim
+++ b/examples/v2/publisher.nim
@@ -69,7 +69,7 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
     await node.mountRelay()
     node.peerManager.start()
 
-    let discv5Res = await wakuDiscv5.start()
+    let discv5Res = wakuDiscv5.start()
     if discv5Res.isErr():
       error "failed to start discv5", error= discv5Res.error
       quit(1)

--- a/examples/v2/subscriber.nim
+++ b/examples/v2/subscriber.nim
@@ -64,7 +64,7 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
     await node.mountRelay()
     node.peerManager.start()
 
-    let discv5Res = await wakuDiscv5.start()
+    let discv5Res = wakuDiscv5.start()
     if discv5Res.isErr():
       error "failed to start discv5", error = discv5Res.error
       quit(1)

--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -120,7 +120,14 @@ procSuite "Waku Discovery v5":
         bootstrapRecords = @[record1, record2]
     )
 
-    await allFutures(node1.start(), node2.start(), node3.start())
+    let res1 = node1.start()
+    assert res1.isOk(), res1.error
+
+    let res2 = node2.start()
+    assert res2.isOk(), res2.error
+
+    let res3 = node3.start()
+    assert res3.isOk(), res3.error
 
     ## When
     let res = await node3.findRandomPeers()
@@ -231,7 +238,17 @@ procSuite "Waku Discovery v5":
     )
 
     # Start nodes' discoveryV5 protocols
-    await allFutures(node1.start(), node2.start(), node3.start(), node4.start())
+    let res1 = node1.start()
+    assert res1.isOk(), res1.error
+
+    let res2 = node2.start()
+    assert res2.isOk(), res2.error
+
+    let res3 = node3.start()
+    assert res3.isOk(), res3.error
+
+    let res4 = node4.start()
+    assert res4.isOk(), res4.error
 
     ## Given
     let recordPredicate: WakuDiscv5Predicate = proc(record: waku_enr.Record): bool =

--- a/tests/v2/test_waku_peer_exchange.nim
+++ b/tests/v2/test_waku_peer_exchange.nim
@@ -151,7 +151,10 @@ procSuite "Waku Peer Exchange":
 
 
     await allFutures(node1.start(), node2.start(), node3.start())
-    await allFutures(disc1.start(), disc2.start())
+    let resultDisc1StartRes = disc1.start()
+    assert resultDisc1StartRes.isOk(), resultDisc1StartRes.error
+    let resultDisc2StartRes = disc2.start()
+    assert resultDisc2StartRes.isOk(), resultDisc2StartRes.error
     asyncSpawn disc1.searchLoop(node1.peerManager, none(enr.Record))
     asyncSpawn disc2.searchLoop(node2.peerManager, none(enr.Record))
 

--- a/waku/v2/waku_discv5.nim
+++ b/waku/v2/waku_discv5.nim
@@ -185,7 +185,7 @@ proc searchLoop*(wd: WakuDiscoveryV5, peerManager: PeerManager, record: Option[e
     # Also, give some time to dial the discovered nodes and update stats, etc.
     await sleepAsync(5.seconds)
 
-proc start*(wd: WakuDiscoveryV5): Future[Result[void, string]] {.async.} =
+proc start*(wd: WakuDiscoveryV5): Result[void, string] =
   if wd.listening:
     return err("already listening")
 
@@ -204,6 +204,8 @@ proc start*(wd: WakuDiscoveryV5): Future[Result[void, string]] {.async.} =
 
   debug "Successfully started discovery v5 service"
   info "Discv5: discoverable ENR ", enr = wd.protocol.localNode.record.toUri()
+
+  ok()
 
 proc stop*(wd: WakuDiscoveryV5): Future[void] {.async.} =
   if not wd.listening:


### PR DESCRIPTION
## Description
The issue was introduced in PR#1818.

Before this commit, the `wakunode2` app crashed with the next error:

ERR 2023-06-27 15:57:27.268+00:00 5/7 Starting node and protocols failed topics="wakunode main" tid=1 file=wakunode2.nim:92 error="failed to start waku discovery v5: "

## To replicate the issue, and the corresponding fix, just do:
```
./build/wakunode2 --config-file=cfg_node_a.txt
```
[cfg_node_a.txt](https://github.com/waku-org/nwaku/files/11885542/cfg_node_a.txt)
