### PR TITLE
refactor(internalconfig): avoid passing a 'WakuNodeConf' item to the 'createRecord' proc

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -113,7 +113,7 @@ proc init*(T: type App, rng: ref HmacDrbgContext, conf: WakuNodeConf): T =
       quit(QuitFailure)
     else: netConfigRes.get()
 
-  let recordRes = createRecord(conf, netConfig, key)
+  let recordRes = createRecord(conf.topics, netConfig, key)
   let record =
     if recordRes.isErr():
       error "failed to create record", error=recordRes.error

--- a/apps/wakunode2/internal_config.nim
+++ b/apps/wakunode2/internal_config.nim
@@ -72,8 +72,11 @@ proc networkConfiguration*(conf: WakuNodeConf): NetConfigResult =
 
   netConfigRes
 
-proc createRecord*(conf: WakuNodeConf, netConf: NetConfig, key: crypto.PrivateKey): Result[enr.Record, string] =
-  let relayShardsRes = topicsToRelayShards(conf.topics)
+proc createRecord*(topics: seq[string],
+                   netConf: NetConfig,
+                   key: crypto.PrivateKey):
+                   Result[enr.Record, string] =
+  let relayShardsRes = topicsToRelayShards(topics)
 
   let relayShardOp =
     if relayShardsRes.isErr():


### PR DESCRIPTION
# Description
This change is needed so that the `libwaku.nim` code gets simpler. The `libwaku.nim` can't import the 'WakuNodeConf' type because this is related to the wakunode2 app, and the library shouldn't know about it.

