### PR TITLE
chore(refactor): Move record creation & fix libwaku compilation

### DIFF
--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -537,13 +537,6 @@ proc validateDbUrl*(val: string): ConfResult[string] =
   else:
     err("invalid 'db url' option format: " & val)
 
-proc validateExtMultiAddrs*(vals: seq[string]): ConfResult[seq[MultiAddress]] =
-  var multiaddrs: seq[MultiAddress]
-  for val in vals:
-    let multiaddr = ? MultiAddress.init(val)
-    multiaddrs.add(multiaddr)
-  ok(multiaddrs)
-
 ## Load
 
 proc readValue*(r: var TomlReader, value: var crypto.PrivateKey) {.raises: [SerializationError].} =

--- a/apps/wakunode2/internal_config.nim
+++ b/apps/wakunode2/internal_config.nim
@@ -1,21 +1,35 @@
 import
+  stew/shims/net,
   stew/results,
   libp2p/crypto/crypto
 import
   ../../waku/common/utils/nat,
-  ../../waku/v2/node/config,
-  ../../waku/v2/node/waku_node,
-  ../../waku/v2/waku_enr,
-  ./external_config
+  ../../waku/v2/node/config
 
-proc networkConfiguration*(conf: WakuNodeConf): NetConfigResult =
+proc networkConfiguration*(tcpPort: Port,
+                            nat: string,
+                            portsShift: uint16,
+                            udpPort: Port,
+                            dns4DomainName: string,
+                            discv5Discovery: bool,
+                            discv5UdpPort: Port,
+                            extMultiAddrs: seq[string],
+                            lightpush: bool,
+                            filter: bool,
+                            store: bool,
+                            relay: bool,
+                            listenAddress: ValidIpAddress,
+                            websocketPort: Port,
+                            websocketSupport: bool,
+                            websocketSecureSupport: bool,
+                            ): NetConfigResult =
 
   ## `udpPort` is only supplied to satisfy underlying APIs but is not
   ## actually a supported transport for libp2p traffic.
-  let udpPort = conf.tcpPort
-  let natRes = setupNat(conf.nat, clientId,
-                        Port(uint16(conf.tcpPort) + conf.portsShift),
-                        Port(uint16(udpPort) + conf.portsShift))
+  let udpPort = tcpPort
+  let natRes = setupNat(nat, clientId,
+                        Port(uint16(tcpPort) + portsShift),
+                        Port(uint16(udpPort) + portsShift))
   if natRes.isErr():
     return err("failed to setup NAT: " & $natRes.error)
 
@@ -23,21 +37,21 @@ proc networkConfiguration*(conf: WakuNodeConf): NetConfigResult =
   let (extIp, extTcpPort, _) = natRes.get()
 
   let
-    dns4DomainName = if conf.dns4DomainName != "": some(conf.dns4DomainName)
+    dns4DomainName = if dns4DomainName != "": some(dns4DomainName)
                       else: none(string)
 
-    discv5UdpPort = if conf.discv5Discovery: some(Port(uint16(conf.discv5UdpPort) + conf.portsShift))
+    discv5UdpPort = if discv5Discovery: some(Port(uint16(discv5UdpPort) + portsShift))
                     else: none(Port)
 
     ## TODO: the NAT setup assumes a manual port mapping configuration if extIp config is set. This probably
     ## implies adding manual config item for extPort as well. The following heuristic assumes that, in absence of manual
     ## config, the external port is the same as the bind port.
     extPort = if (extIp.isSome() or dns4DomainName.isSome()) and extTcpPort.isNone():
-                some(Port(uint16(conf.tcpPort) + conf.portsShift))
+                some(Port(uint16(tcpPort) + portsShift))
               else:
                 extTcpPort
-    extMultiAddrs = if (conf.extMultiAddrs.len > 0):
-                      let extMultiAddrsValidationRes = validateExtMultiAddrs(conf.extMultiAddrs)
+    extMultiAddrs = if (extMultiAddrs.len > 0):
+                      let extMultiAddrsValidationRes = validateExtMultiAddrs(extMultiAddrs)
                       if extMultiAddrsValidationRes.isErr():
                         return err("invalid external multiaddress: " & $extMultiAddrsValidationRes.error)
 
@@ -47,64 +61,27 @@ proc networkConfiguration*(conf: WakuNodeConf): NetConfigResult =
                       @[]
 
     wakuFlags = CapabilitiesBitfield.init(
-        lightpush = conf.lightpush,
-        filter = conf.filter,
-        store = conf.store,
-        relay = conf.relay
+        lightpush = lightpush,
+        filter = filter,
+        store = store,
+        relay = relay
       )
 
   # Wrap in none because NetConfig does not have a default constructor
   # TODO: We could change bindIp in NetConfig to be something less restrictive than ValidIpAddress,
   # which doesn't allow default construction
   let netConfigRes = NetConfig.init(
-      bindIp = conf.listenAddress,
-      bindPort = Port(uint16(conf.tcpPort) + conf.portsShift),
+      bindIp = listenAddress,
+      bindPort = Port(uint16(tcpPort) + portsShift),
       extIp = extIp,
       extPort = extPort,
       extMultiAddrs = extMultiAddrs,
-      wsBindPort = Port(uint16(conf.websocketPort) + conf.portsShift),
-      wsEnabled = conf.websocketSupport,
-      wssEnabled = conf.websocketSecureSupport,
+      wsBindPort = Port(uint16(websocketPort) + portsShift),
+      wsEnabled = websocketSupport,
+      wssEnabled = websocketSecureSupport,
       dns4DomainName = dns4DomainName,
       discv5UdpPort = discv5UdpPort,
       wakuFlags = some(wakuFlags),
     )
 
   netConfigRes
-
-proc createRecord*(topics: seq[string],
-                   netConf: NetConfig,
-                   key: crypto.PrivateKey):
-                   Result[enr.Record, string] =
-  let relayShardsRes = topicsToRelayShards(topics)
-
-  let relayShardOp =
-    if relayShardsRes.isErr():
-      return err("building ENR with relay sharding failed: " & $relayShardsRes.error)
-    else: relayShardsRes.get()
-
-  var builder = EnrBuilder.init(key)
-
-  builder.withIpAddressAndPorts(
-      ipAddr = netConf.enrIp,
-      tcpPort = netConf.enrPort,
-      udpPort = netConf.discv5UdpPort,
-  )
-
-  if netConf.wakuFlags.isSome():
-    builder.withWakuCapabilities(netConf.wakuFlags.get())
-
-  builder.withMultiaddrs(netConf.enrMultiaddrs)
-
-  if relayShardOp.isSome():
-    let res = builder.withWakuRelaySharding(relayShardOp.get())
-
-    if res.isErr():
-      return err("building ENR with relay sharding failed: " & $res.error)
-
-  let res = builder.build()
-
-  if res.isErr():
-    return err("building ENR failed: " & $res.error)
-
-  ok(res.get())

--- a/apps/wakunode2/internal_config.nim
+++ b/apps/wakunode2/internal_config.nim
@@ -1,87 +1,89 @@
 import
+  std/options,
   stew/shims/net,
   stew/results,
-  libp2p/crypto/crypto
+  libp2p/crypto/crypto,
+  libp2p/multiaddress
 import
   ../../waku/common/utils/nat,
-  ../../waku/v2/node/config
+  ../../waku/v2/node/config,
+  ../../waku/v2/waku_enr/capabilities,
+  ./external_config
 
-proc networkConfiguration*(tcpPort: Port,
-                            nat: string,
-                            portsShift: uint16,
-                            udpPort: Port,
-                            dns4DomainName: string,
-                            discv5Discovery: bool,
-                            discv5UdpPort: Port,
-                            extMultiAddrs: seq[string],
-                            lightpush: bool,
-                            filter: bool,
-                            store: bool,
-                            relay: bool,
-                            listenAddress: ValidIpAddress,
-                            websocketPort: Port,
-                            websocketSupport: bool,
-                            websocketSecureSupport: bool,
-                            ): NetConfigResult =
+proc validateExtMultiAddrs*(vals: seq[string]):
+                            Result[seq[MultiAddress], string] =
+  var multiaddrs: seq[MultiAddress]
+  for val in vals:
+    let multiaddr = ? MultiAddress.init(val)
+    multiaddrs.add(multiaddr)
+  return ok(multiaddrs)
+
+proc networkConfiguration*(conf: WakuNodeConf,
+                           clientId: string,
+                           ): NetConfigResult =
 
   ## `udpPort` is only supplied to satisfy underlying APIs but is not
   ## actually a supported transport for libp2p traffic.
-  let udpPort = tcpPort
-  let natRes = setupNat(nat, clientId,
-                        Port(uint16(tcpPort) + portsShift),
-                        Port(uint16(udpPort) + portsShift))
+  let natRes = setupNat(conf.nat, clientId,
+                        Port(uint16(conf.tcpPort) + conf.portsShift),
+                        Port(uint16(conf.tcpPort) + conf.portsShift))
   if natRes.isErr():
     return err("failed to setup NAT: " & $natRes.error)
-
 
   let (extIp, extTcpPort, _) = natRes.get()
 
   let
-    dns4DomainName = if dns4DomainName != "": some(dns4DomainName)
-                      else: none(string)
+    dns4DomainName = if conf.dns4DomainName != "": some(conf.dns4DomainName)
+                     else: none(string)
 
-    discv5UdpPort = if discv5Discovery: some(Port(uint16(discv5UdpPort) + portsShift))
+    discv5UdpPort = if conf.discv5Discovery:
+                      some(Port(uint16(conf.discv5UdpPort) + conf.portsShift))
                     else: none(Port)
 
-    ## TODO: the NAT setup assumes a manual port mapping configuration if extIp config is set. This probably
-    ## implies adding manual config item for extPort as well. The following heuristic assumes that, in absence of manual
-    ## config, the external port is the same as the bind port.
-    extPort = if (extIp.isSome() or dns4DomainName.isSome()) and extTcpPort.isNone():
-                some(Port(uint16(tcpPort) + portsShift))
+    ## TODO: the NAT setup assumes a manual port mapping configuration if extIp
+    ## config is set. This probably implies adding manual config item for
+    ## extPort as well. The following heuristic assumes that, in absence of
+    ## manual config, the external port is the same as the bind port.
+
+    extPort = if (extIp.isSome() or dns4DomainName.isSome()) and
+                extTcpPort.isNone():
+                some(Port(uint16(conf.tcpPort) + conf.portsShift))
               else:
                 extTcpPort
-    extMultiAddrs = if (extMultiAddrs.len > 0):
-                      let extMultiAddrsValidationRes = validateExtMultiAddrs(extMultiAddrs)
-                      if extMultiAddrsValidationRes.isErr():
-                        return err("invalid external multiaddress: " & $extMultiAddrsValidationRes.error)
 
+    extMultiAddrs = if (conf.extMultiAddrs.len > 0):
+                      let extMultiAddrsValidationRes =
+                          validateExtMultiAddrs(conf.extMultiAddrs)
+                      if extMultiAddrsValidationRes.isErr():
+                        return err("invalid external multiaddress: " &
+                                   $extMultiAddrsValidationRes.error)
                       else:
                         extMultiAddrsValidationRes.get()
                     else:
                       @[]
 
     wakuFlags = CapabilitiesBitfield.init(
-        lightpush = lightpush,
-        filter = filter,
-        store = store,
-        relay = relay
+        lightpush = conf.lightpush,
+        filter = conf.filter,
+        store = conf.store,
+        relay = conf.relay
       )
 
   # Wrap in none because NetConfig does not have a default constructor
-  # TODO: We could change bindIp in NetConfig to be something less restrictive than ValidIpAddress,
-  # which doesn't allow default construction
+  # TODO: We could change bindIp in NetConfig to be something less restrictive
+  # than ValidIpAddress, which doesn't allow default construction
   let netConfigRes = NetConfig.init(
-      bindIp = listenAddress,
-      bindPort = Port(uint16(tcpPort) + portsShift),
+      bindIp = conf.listenAddress,
+      bindPort = Port(uint16(conf.tcpPort) + conf.portsShift),
       extIp = extIp,
       extPort = extPort,
       extMultiAddrs = extMultiAddrs,
-      wsBindPort = Port(uint16(websocketPort) + portsShift),
-      wsEnabled = websocketSupport,
-      wssEnabled = websocketSecureSupport,
+      wsBindPort = Port(uint16(conf.websocketPort) + conf.portsShift),
+      wsEnabled = conf.websocketSupport,
+      wssEnabled = conf.websocketSecureSupport,
       dns4DomainName = dns4DomainName,
       discv5UdpPort = discv5UdpPort,
       wakuFlags = some(wakuFlags),
     )
 
-  netConfigRes
+  return netConfigRes

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -14,6 +14,7 @@ import
   ../../waku/common/utils/nat,
   ../../waku/v2/waku_enr/capabilities,
   ../../waku/v2/waku_enr/multiaddr,
+  ../../waku/v2/waku_enr/sharding,
   ../../waku/v2/waku_core/message/codec,
   ../../waku/v2/waku_core/message/message,
   ../../waku/v2/waku_core/topics/pubsub_topic,
@@ -49,17 +50,12 @@ type
 
 var eventCallback:EventCallback = nil
 
-proc relayEventCallback(pubsubTopic: string, data: seq[byte]): Future[void] {.gcsafe, raises: [Defect].} =
+proc relayEventCallback(pubsubTopic: string,
+                        msg: WakuMessage):
+                        Future[void] {.gcsafe, raises: [Defect].} =
   # Callback that hadles the Waku Relay events. i.e. messages or errors.
   if not isNil(eventCallback):
-    let msg = WakuMessage.decode(data)
-    var event: JsonSignal
-    if msg.isOk():
-      event = JsonMessageEvent.new(pubsubTopic, msg.value)
-    else:
-      let errorMsg = string("Error decoding message.") & $msg.error
-      event = JsonErrorEvent.new(errorMsg)
-
+    let event = JsonMessageEvent.new(pubsubTopic, msg)
     try:
       eventCallback(cstring($event))
     except Exception:
@@ -189,6 +185,11 @@ proc waku_new(config: ConfigNode,
     enrBuilder.withWakuCapabilities(netConfig.wakuFlags.get())
 
   enrBuilder.withMultiaddrs(netConfig.enrMultiaddrs)
+  ## TODO: pass the topics from conf parameter. We will pass it from
+  ## json array in upcoming PRs.
+  let addShardedTopics = enrBuilder.withShardedTopics(@["/waku/2/default-waku/proto"])
+  if addShardedTopics.isErr():
+      return false
 
   let recordRes = enrBuilder.build()
   let record =
@@ -325,7 +326,8 @@ Kindly set it with the 'waku_set_event_callback' function""")
     jsonResp = errResp("Cannot subscribe without Waku Relay enabled.")
     return false
 
-  node.wakuRelay.subscribe(PubsubTopic($pubSubTopic), PubsubRawHandler(relayEventCallback))
+  node.wakuRelay.subscribe(PubsubTopic($pubSubTopic),
+                           WakuRelayHandler(relayEventCallback))
 
   jsonResp = okResp("true")
   return true
@@ -345,7 +347,7 @@ Kindly set it with the 'waku_set_event_callback' function""")
     jsonResp = errResp("Cannot unsubscribe without Waku Relay enabled.")
     return false
 
-  node.wakuRelay.unsubscribeAll(PubsubTopic($pubSubTopic))
+  node.wakuRelay.unsubscribe(PubsubTopic($pubSubTopic))
 
   jsonResp = okResp("true")
   return true

--- a/waku/v2/waku_enr/sharding.nim
+++ b/waku/v2/waku_enr/sharding.nim
@@ -187,6 +187,22 @@ func withWakuRelaySharding*(builder: var EnrBuilder, rs: RelayShards): EnrResult
   else:
     builder.withWakuRelayShardingIndicesList(rs)
 
+func withShardedTopics*(builder: var EnrBuilder, topics: seq[string]): Result[void, string] =
+  let relayShardsRes = topicsToRelayShards(topics)
+  let relayShardOp =
+    if relayShardsRes.isErr():
+      return err("building ENR with relay sharding failed: " & $relayShardsRes.error)
+    else: relayShardsRes.get()
+
+  if relayShardOp.isNone():
+    return ok()
+
+  let res = builder.withWakuRelaySharding(relayShardOp.get())
+
+  if res.isErr():
+    return err($res.error)
+
+  ok()
 
 # ENR record accessors (e.g., Record, TypedRecord, etc.)
 

--- a/waku/v2/waku_enr/sharding.nim
+++ b/waku/v2/waku_enr/sharding.nim
@@ -187,11 +187,14 @@ func withWakuRelaySharding*(builder: var EnrBuilder, rs: RelayShards): EnrResult
   else:
     builder.withWakuRelayShardingIndicesList(rs)
 
-func withShardedTopics*(builder: var EnrBuilder, topics: seq[string]): Result[void, string] =
+func withShardedTopics*(builder: var EnrBuilder,
+                        topics: seq[string]):
+                        Result[void, string] =
   let relayShardsRes = topicsToRelayShards(topics)
   let relayShardOp =
     if relayShardsRes.isErr():
-      return err("building ENR with relay sharding failed: " & $relayShardsRes.error)
+      return err("building ENR with relay sharding failed: " &
+                 $relayShardsRes.error)
     else: relayShardsRes.get()
 
   if relayShardOp.isNone():
@@ -202,7 +205,7 @@ func withShardedTopics*(builder: var EnrBuilder, topics: seq[string]): Result[vo
   if res.isErr():
     return err($res.error)
 
-  ok()
+  return ok()
 
 # ENR record accessors (e.g., Record, TypedRecord, etc.)
 


### PR DESCRIPTION
## Description
This PR brings the sharding creation to the `libwaku` and fixes compilation errors.

## Changes

<!-- List of detailed changes -->

- [x] Remove the `createRecord` from the `internal_config`
- [x] Fix a compilation issue in `libwaku` due to previous _Waku Relay_ refactoring.
- [x] Include the `builder.withRecord(record)` in the `libwaku`-`waku_new` proc.

