### PR TITLE
chore(rln-relay): Verify proofs based on bandwidth usage

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -383,7 +383,8 @@ proc setupProtocols(node: WakuNode,
         rlnRelayEthAccountAddress: conf.rlnRelayEthAccountAddress,
         rlnRelayCredPath: conf.rlnRelayCredPath,
         rlnRelayCredentialsPassword: conf.rlnRelayCredentialsPassword,
-        rlnRelayTreePath: conf.rlnRelayTreePath
+        rlnRelayTreePath: conf.rlnRelayTreePath,
+        rlnRelayBandwidthThreshold: conf.rlnRelayBandwidthThreshold
       )
 
       try:

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -214,7 +214,7 @@ type
     rlnRelayBandwidthThreshold* {.
       desc: "Message rate in bytes/sec after which verification of proofs should happen",
       defaultValue: 0 # to maintain backwards compatibility
-      name: "rln-relay-bandwidth-cutff" }: int
+      name: "rln-relay-bandwidth-cutoff" }: int
 
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -214,7 +214,7 @@ type
     rlnRelayBandwidthThreshold* {.
       desc: "Message rate in bytes/sec after which verification of proofs should happen",
       defaultValue: 0 # to maintain backwards compatibility
-      name: "rln-relay-bandwidth-cutoff" }: int
+      name: "rln-relay-bandwidth-threshold" }: int
 
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -213,7 +213,7 @@ type
 
     rlnRelayBandwidthThreshold* {.
       desc: "Message rate in bytes/sec after which verification of proofs should happen",
-      defaultValue: 1_000_000
+      defaultValue: 0 # to maintain backwards compatibility
       name: "rln-relay-bandwidth-cutff" }: int
 
     staticnodes* {.

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -211,6 +211,11 @@ type
       defaultValue: ""
       name: "rln-relay-tree-path" }: string
 
+    rlnRelayBandwidthThreshold* {.
+      desc: "Message rate in bytes/sec after which verification of proofs should happen",
+      defaultValue: 1_000_000
+      name: "rln-relay-bandwidth-cutff" }: int
+
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."
       name: "staticnode" }: seq[string]

--- a/tests/v2/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/v2/waku_rln_relay/test_waku_rln_relay.nim
@@ -662,7 +662,8 @@ suite "Waku rln relay":
     let rlnConf = WakuRlnConfig(rlnRelayDynamic: false,
                                 rlnRelayPubsubTopic: RlnRelayPubsubTopic,
                                 rlnRelayContentTopic: RlnRelayContentTopic,
-                                rlnRelayCredIndex: index.uint)
+                                rlnRelayCredIndex: index.uint,
+                                rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_2"))
     let wakuRlnRelayRes = await WakuRlnRelay.new(rlnConf)
     require:
       wakuRlnRelayRes.isOk()
@@ -708,6 +709,63 @@ suite "Waku rln relay":
       msgValidate2 == MessageValidationResult.Spam
       msgValidate3 == MessageValidationResult.Valid
       msgValidate4 == MessageValidationResult.Invalid
+  
+  asyncTest "should validate invalid proofs if bandwidth is available":
+    let index = MembershipIndex(5)
+
+    let rlnConf = WakuRlnConfig(rlnRelayDynamic: false,
+                                rlnRelayPubsubTopic: RlnRelayPubsubTopic,
+                                rlnRelayContentTopic: RlnRelayContentTopic,
+                                rlnRelayCredIndex: index.uint,
+                                rlnRelayBandwidthThreshold: 4,
+                                rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_3"))
+    let wakuRlnRelayRes = await WakuRlnRelay.new(rlnConf)
+    require:
+      wakuRlnRelayRes.isOk()
+    let wakuRlnRelay = wakuRlnRelayRes.get()
+
+    # get the current epoch time
+    let time = epochTime()
+
+    #  create some messages from the same peer and append rln proof to them, except wm4
+    var
+      # this one will pass through the bandwidth threshold
+      wm1 = WakuMessage(payload: "Spam".toBytes())
+      # this message, will be over the bandwidth threshold, hence has to be verified
+      wm2 = WakuMessage(payload: "Valid message".toBytes())
+      # this message will be over the bandwidth threshold, hence has to be verified, will be false (since no proof)
+      wm3 = WakuMessage(payload: "Invalid message".toBytes())
+      wm4 = WakuMessage(payload: "Spam message".toBytes())
+    
+    let
+      proofAdded1 = wakuRlnRelay.appendRLNProof(wm1, time)
+      proofAdded2 = wakuRlnRelay.appendRLNProof(wm2, time+EpochUnitSeconds)
+      proofAdded3 = wakuRlnRelay.appendRLNProof(wm4, time)
+
+    # ensure proofs are added
+    require:
+      proofAdded1
+      proofAdded2
+      proofAdded3
+
+    # validate messages
+    # validateMessage proc checks the validity of the message fields and adds it to the log (if valid)
+    let
+      # this should be no verification, Valid
+      msgValidate1 = wakuRlnRelay.validateMessage(wm1, some(time))
+      # this should be verification, Valid
+      msgValidate2 = wakuRlnRelay.validateMessage(wm2, some(time))
+      # this should be verification, Invalid
+      msgValidate3 = wakuRlnRelay.validateMessage(wm3, some(time))
+      # this should be verification, Spam
+      msgValidate4 = wakuRlnRelay.validateMessage(wm4, some(time))
+
+    check:
+      msgValidate1 == MessageValidationResult.Valid
+      msgValidate2 == MessageValidationResult.Valid
+      msgValidate3 == MessageValidationResult.Invalid
+      msgValidate4 == MessageValidationResult.Spam
+  
 
   test "toIDCommitment and toUInt256":
     # create an instance of rln

--- a/tests/v2/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/v2/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -142,6 +142,7 @@ procSuite "WakuNode - RLN relay":
       rlnRelayContentTopic: contentTopic,
       rlnRelayCredIndex: 1.uint,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_4"),
+      rlnRelayBandwidthThreshold: 0,
     ))
 
     await node1.start()
@@ -154,6 +155,7 @@ procSuite "WakuNode - RLN relay":
       rlnRelayContentTopic: contentTopic,
       rlnRelayCredIndex: 2.uint,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_5"),
+      rlnRelayBandwidthThreshold: 0,
     ))
 
     await node2.start()
@@ -166,6 +168,7 @@ procSuite "WakuNode - RLN relay":
       rlnRelayContentTopic: contentTopic,
       rlnRelayCredIndex: 3.uint,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_6"),
+      rlnRelayBandwidthThreshold: 0,
     ))
 
     await node3.start()
@@ -248,6 +251,7 @@ procSuite "WakuNode - RLN relay":
       rlnRelayContentTopic: contentTopic,
       rlnRelayCredIndex: 1.uint,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_7"),
+      rlnRelayBandwidthThreshold: 0,
     ))
 
     await node1.start()
@@ -261,6 +265,7 @@ procSuite "WakuNode - RLN relay":
       rlnRelayContentTopic: contentTopic,
       rlnRelayCredIndex: 2.uint,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_8"),
+      rlnRelayBandwidthThreshold: 0,
     ))
 
     await node2.start()
@@ -274,6 +279,7 @@ procSuite "WakuNode - RLN relay":
       rlnRelayContentTopic: contentTopic,
       rlnRelayCredIndex: 3.uint,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_9"),
+      rlnRelayBandwidthThreshold: 0,
     ))
 
     await node3.start()


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Runs rln verification only if bandwidth exceeds 1mbps. @jm-clius, what is the bandwidth cutoff you'd like to be the default?

# Changes

<!-- List of detailed changes -->

- [x] Uses TokenBucket from chronos/ratelimit to check if bandwidth has been exceeded

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #1837
