### PR TITLE
feat: autosharding content topic in config

### DIFF
--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -227,6 +227,7 @@ type
 
     pubsubTopics* {.
       desc: "Default pubsub topic to subscribe to. Argument may be repeated."
+      defaultValue: @["/waku/2/default-waku/proto"]
       name: "pubsub-topic" .}: seq[string]
 
     contentTopics* {.

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -225,10 +225,13 @@ type
       defaultValue: false
       name: "keep-alive" }: bool
 
-    topics* {.
-      desc: "Default topic to subscribe to. Argument may be repeated."
-      defaultValue: @["/waku/2/default-waku/proto"]
-      name: "topic" .}: seq[string]
+    pubsubTopics* {.
+      desc: "Default pubsub topic to subscribe to. Argument may be repeated."
+      name: "pubsub-topic" .}: seq[string]
+
+    contentTopics* {.
+      desc: "Default content topic to subscribe to. Argument may be repeated."
+      name: "content-topic" .}: seq[string]
 
     ## Store and message store config
 

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -23,7 +23,7 @@ proc defaultTestWakuNodeConf(): WakuNodeConf =
     metricsServerAddress: ValidIpAddress.init("127.0.0.1"),
     nat: "any",
     maxConnections: 50,
-    topics: @["/waku/2/default-waku/proto"],
+    pubsubTopics: @["/waku/2/default-waku/proto"],
     relay: true
   )
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Added content topics in waku external config (pubsub VS content is now explicit). When used, a shard is picked and ENR is updated. Pubsub topics can also be used at the same time but only on the same cluster.

~~I also remove the default pubsub topic from config. Do we want to keep it until autoshard is working properly?~~

Let's not forget to deprecate the default pubsub topic when autosharding is :+1: 

# Changes

<!-- List of detailed changes -->

- [x] Added pubsub & content topic to external config.
- [x] Update ENR based on all topics. 

Tracking #1846

