### PR TITLE
fix(ci): do not depend on number of procesors with job name

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -6,24 +6,23 @@ on:
     - 'v*' # "e.g. v0.4"
   
   workflow_dispatch:
-    
+
+env:
+  NPROC: 2
+
 jobs:
   build-and-upload:
     strategy:
       matrix:
-        env:
-          - { NPROC: 2 }
         os: [ubuntu-latest, macos-latest]
         arch: [amd64]
         include:
         - os: macos-latest
-          experimental: false
           arch: arm64
     runs-on: ${{ matrix.os }}
-    env: ${{ matrix.env }}
     timeout-minutes: 60
 
-    name: ${{ matrix.os }} - ${{ matrix.env.NPROC }} processes
+    name: ${{ matrix.os }} - ${{ matrix.arch }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Description
For some reason actions would omit the `env` when templating the matrix for the `include` section (i.e. Mac OS + arm64 combination), which would result in the workflow failing.

Since the `NPROC` is same for all the combinations anyway, this PR moves it out to `env` block and then uses `arch` in the job name (which also makes more sense)

# Changes

- [x] move NPROC to `env` block
- [x] change the job name to use `arch`

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->