### PR TITLE
fix(rln-relay): mark duplicated messages as spam

### DIFF
--- a/waku/v2/waku_rln_relay/rln_relay.nim
+++ b/waku/v2/waku_rln_relay/rln_relay.nim
@@ -110,8 +110,8 @@ proc hasDuplicate*(rlnPeer: WakuRLNRelay,
     return ok(false)
   try:
     if rlnPeer.nullifierLog[externalNullifier].contains(proofMetadata):
-      # there is an identical record, ignore rhe mag
-      return ok(false)
+      # there is an identical record, mark it as spam
+      return ok(true)
 
     # check for a message with the same nullifier but different secret shares
     let matched = rlnPeer.nullifierLog[externalNullifier].filterIt((

--- a/waku/v2/waku_rln_relay/rln_relay.nim
+++ b/waku/v2/waku_rln_relay/rln_relay.nim
@@ -100,7 +100,7 @@ method stop*(rlnPeer: WakuRLNRelay) {.async.} =
 proc hasDuplicate*(rlnPeer: WakuRLNRelay,
                    proofMetadata: ProofMetadata): RlnRelayResult[bool] =
   ## returns true if there is another message in the  `nullifierLog` of the `rlnPeer` with the same
-  ## epoch and nullifier as `proofMetadata`'s epoch and nullifier but different Shamir secret shares
+  ## epoch and nullifier as `proofMetadata`'s epoch and nullifier
   ## otherwise, returns false
   ## Returns an error if it cannot check for duplicates
 


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
If we have the same externalNullifier and proofMetadata, and same `share_x` and `share_y` we should mark the message as spam.

# Changes

<!-- List of detailed changes -->

- [x] Marks duplicated messages with the same proof as spam

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #1862
