### PR TITLE
fix: check nil before calling clearTimer

### DIFF
--- a/waku/v2/waku_filter_v2/protocol.nim
+++ b/waku/v2/waku_filter_v2/protocol.nim
@@ -266,5 +266,6 @@ method start*(wf: WakuFilter) {.async.} =
 
 method stop*(wf: WakuFilter) {.async.} =
   debug "stopping filter protocol"
-  wf.maintenanceTask.clearTimer()
+  if not wf.maintenanceTask.isNil():
+    wf.maintenanceTask.clearTimer()
   await procCall LPProtocol(wf).stop()


### PR DESCRIPTION
# Description

When setting up RPC server failed and a clean up process started, Filter v2 protocol attempted to call `clearTimer` on uninitialized attribute which caused `SIGSEGV: Illegal storage access. (Attempt to read from nil?)`

# Changes

<!-- List of detailed changes -->

- [ ] check if `maintenanceTask` is Nil before calling `clearTimer`


## How to test

1. Run Waku node as described in #1866 
  ```
   docker run --network host -it statusteam/nim-waku:v0.18.0 --relay=true --filter=true --lightpush=true --rpc-admin=true --rpc-port=8545 --rpc-address=0.0.0.0 --websocket-support=true --nodekey=ca18f11664fed73af38b11ffc3ccdbdd0738c475488dfab18a91f43a1f78711a
  ```
2. Run the same command again in separate terminal - you'll get SIGSEGV because it fails to setup RPC server (conflicting port) and the clean up hits this issue
3. Compile `wakunode2` from this PR and run it instead - you will get the actual error log and the clean up runs normally 
  ```
  ERR 2023-08-01 20:35:07.556+02:00 5/7 Starting node and protocols failed     topics="wakunode main" tid=34662 file=wakunode2.nim:92 error="failed to start waku node: (98) Address already in use"
   ```





## Issue

closes #1866
