### PR TITLE
feat: ENR can now be updated

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -541,12 +541,14 @@ proc startNode(node: WakuNode, conf: WakuNodeConf,
 
 proc startApp*(app: App): Future[AppResult[void]] {.async.} =
   if app.wakuDiscv5.isSome():
-    let res = app.wakuDiscv5.get().start()
+    let wakuDiscv5 = app.wakuDiscv5.get()
 
+    let res = wakuDiscv5.start()
     if res.isErr():
       return err("failed to start waku discovery v5: " & $res.error)
 
-    asyncSpawn app.wakuDiscv5.get().searchLoop(app.node.peerManager, some(app.record))
+    asyncSpawn wakuDiscv5.searchLoop(app.node.peerManager, some(app.record))
+    asyncSpawn wakuDiscv5.subscriptionsListener(app.node.topicSubscriptionQueue)
 
   return await startNode(
     app.node,

--- a/tests/test_waku_enr.nim
+++ b/tests/test_waku_enr.nim
@@ -262,8 +262,10 @@ suite "Waku ENR - Relay static sharding":
       shardIndex: uint16 = 1024
 
     ## When
-    expect Defect:
-      discard RelayShards.init(shardCluster, shardIndex)
+    let res = RelayShards.init(shardCluster, shardIndex)
+
+    ## Then
+    assert res.isErr(), $res.get()
 
   test "new relay shards field with single invalid index in list":
     ## Given
@@ -272,8 +274,10 @@ suite "Waku ENR - Relay static sharding":
       shardIndices: seq[uint16] = @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16, 1024u16]
 
     ## When
-    expect Defect:
-      discard RelayShards.init(shardCluster, shardIndices)
+    let res = RelayShards.init(shardCluster, shardIndices)
+
+    ## Then
+    assert res.isErr(), $res.get()
 
   test "new relay shards field with single valid index":
     ## Given
@@ -284,7 +288,7 @@ suite "Waku ENR - Relay static sharding":
     let topic = NsPubsubTopic.staticSharding(shardCluster, shardIndex)
 
     ## When
-    let shards = RelayShards.init(shardCluster, shardIndex)
+    let shards = RelayShards.init(shardCluster, shardIndex).expect("Valid Shards")
 
     ## Then
     check:
@@ -310,7 +314,7 @@ suite "Waku ENR - Relay static sharding":
       shardIndices: seq[uint16] = @[1u16, 2u16, 2u16, 3u16, 3u16, 3u16]
 
     ## When
-    let shards = RelayShards.init(shardCluster, shardIndices)
+    let shards = RelayShards.init(shardCluster, shardIndices).expect("Valid Shards")
 
     ## Then
     check:
@@ -344,7 +348,7 @@ suite "Waku ENR - Relay static sharding":
       shardCluster: uint16 = 22
       shardIndices: seq[uint16] = @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16]
 
-    let shards = RelayShards.init(shardCluster, shardIndices)
+    let shards = RelayShards.init(shardCluster, shardIndices).expect("Valid Shards")
 
     ## When
     var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)
@@ -370,7 +374,7 @@ suite "Waku ENR - Relay static sharding":
       enrSeqNum = 1u64
       enrPrivKey = generatesecp256k1key()
 
-    let shards = RelayShards.init(33, toSeq(0u16 ..< 64u16))
+    let shards = RelayShards.init(33, toSeq(0u16 ..< 64u16)).expect("Valid Shards")
 
     var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)
     require builder.withWakuRelaySharding(shards).isOk()
@@ -398,8 +402,8 @@ suite "Waku ENR - Relay static sharding":
       enrPrivKey = generatesecp256k1key()
 
     let
-      shardsIndicesList = RelayShards.init(22, @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16])
-      shardsBitVector = RelayShards.init(33, @[13u16, 24u16, 37u16, 61u16, 98u16, 159u16])
+      shardsIndicesList = RelayShards.init(22, @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16]).expect("Valid Shards")
+      shardsBitVector = RelayShards.init(33, @[13u16, 24u16, 37u16, 61u16, 98u16, 159u16]).expect("Valid Shards")
 
 
     var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)

--- a/waku/node/jsonrpc/relay/handlers.nim
+++ b/waku/node/jsonrpc/relay/handlers.nim
@@ -56,10 +56,9 @@ proc installRelayApiHandlers*(node: WakuNode, server: RpcServer, cache: MessageC
     debug "post_waku_v2_relay_v1_subscriptions"
 
     # Subscribe to all requested topics
-    for topic in topics:
-      if cache.isSubscribed(topic):
-        continue
+    let newTopics = topics.filterIt(not cache.isSubscribed(it))
 
+    for topic in newTopics:
       cache.subscribe(topic)
       node.subscribe(topic, topicHandler)
 
@@ -70,7 +69,9 @@ proc installRelayApiHandlers*(node: WakuNode, server: RpcServer, cache: MessageC
     debug "delete_waku_v2_relay_v1_subscriptions"
 
     # Unsubscribe all handlers from requested topics
-    for topic in topics:
+    let subscribedTopics = topics.filterIt(cache.isSubscribed(it))
+
+    for topic in subscribedTopics:
       node.unsubscribe(topic)
       cache.unsubscribe(topic)
 

--- a/waku/node/rest/relay/handlers.nim
+++ b/waku/node/rest/relay/handlers.nim
@@ -55,13 +55,12 @@ proc installRelayPostSubscriptionsV1Handler*(router: var RestRouter, node: WakuN
 
     let req: RelayPostSubscriptionsRequest = reqResult.get()
 
-    for topic in req:
-      if cache.isSubscribed(string(topic)):
-        # Only subscribe to topics for which we have no subscribed topic handlers yet
-        continue
+    # Only subscribe to topics for which we have no subscribed topic handlers yet
+    let newTopics = req.filterIt(not cache.isSubscribed(it))
 
-      cache.subscribe(string(topic))
-      node.subscribe(string(topic), cache.messageHandler())
+    for topic in newTopics:
+      cache.subscribe(topic)
+      node.subscribe(topic, cache.messageHandler())
 
     return RestApiResponse.ok()
 
@@ -88,8 +87,8 @@ proc installRelayDeleteSubscriptionsV1Handler*(router: var RestRouter, node: Wak
 
     # Unsubscribe all handlers from requested topics
     for topic in req:
-      node.unsubscribe(string(topic))
-      cache.unsubscribe(string(topic))
+      node.unsubscribe(topic)
+      cache.unsubscribe(topic)
 
     # Successfully unsubscribed from all requested topics
     return RestApiResponse.ok()

--- a/waku/waku_core/topics.nim
+++ b/waku/waku_core/topics.nim
@@ -7,3 +7,12 @@ export
   content_topic,
   pubsub_topic,
   sharding
+
+type
+  SubscriptionKind* = enum ContentSub, ContentUnsub, PubsubSub, PubsubUnsub
+  SubscriptionEvent* = object
+    case kind*: SubscriptionKind
+      of PubsubSub:  pubsubSub*:  string
+      of ContentSub: contentSub*: string
+      of PubsubUnsub:  pubsubUnsub*:  string
+      of ContentUnsub: contentUnsub*: string


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
I added a way to update the Discv5 ENR and used a `AsyncEventQueue` to broadcast topic subscriptions.

# Changes
- [x] Discv5 add/remove shard from ENR
- [x] event system for topic subscriptions  

Fix #1843

Followed by #1918