### PR TITLE
feat(ci): add docker image builds per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,58 @@ jobs:
           fi
 
           make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 test2 testwakunode2
+
+  build-docker-image:
+    needs: changes
+    if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+
+    name: docker-build-v2-${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get submodules hash
+        id: submodules
+        run: |
+          echo "hash=$(git submodule status | awk '{print $1}' | sort | shasum -a 256 | sed 's/[ -]*//g')" >> $GITHUB_OUTPUT
+
+      - name: Cache submodules
+        uses: actions/cache@v3
+        with:
+          path: |
+            vendor/
+            .git/modules
+          key: ${{ runner.os }}-vendor-modules-${{ steps.submodules.outputs.hash }}
+
+      - name: Build binaries
+        id: build
+        run: |
+          make -j${NPROC} V=1 QUICK_AND_DIRTY_COMPILER=1 wakunode2
+
+          TAG=$([ "${PR_NUMBER}" == "" ] && echo "master" || echo "${PR_NUMBER}")
+          IMAGE=quay.io/wakuorg/nwaku-pr:${TAG}
+
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+
+          docker login -u ${QUAY_USER} -p ${QUAY_PASSWORD} quay.io
+          docker build -t ${IMAGE} -f docker/binaries/Dockerfile.bn.amd64 --label quay.expires-after=7d .
+          docker push ${IMAGE}
+        env:
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          PR_NUMBER: ${{ github.event.number }}
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            You can find the image built from this PR at
+
+            ```
+            ${{steps.build.outputs.image}}
+            ```

--- a/docker/binaries/Dockerfile.bn.amd64
+++ b/docker/binaries/Dockerfile.bn.amd64
@@ -1,0 +1,34 @@
+# Dockerfile to build a distributable container image from pre-existing binaries
+FROM debian:stable-slim as prod
+
+ARG MAKE_TARGET=wakunode2
+
+LABEL maintainer="vaclav@status.im"
+LABEL source="https://github.com/waku-org/nwaku"
+LABEL description="Wakunode: Waku client"
+LABEL commit="unknown"
+
+# DevP2P, LibP2P, and JSON RPC ports
+EXPOSE 30303 60000 8545
+
+# Referenced in the binary
+RUN apt-get update &&\
+    apt-get install -y libpcre3 libpq-dev &&\
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
+RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
+
+# Copy to separate location to accomodate different MAKE_TARGET values
+ADD ./build/$MAKE_TARGET /usr/local/bin/
+
+# Copy migration scripts for DB upgrades
+ADD ./migrations/ /app/migrations/
+
+# Symlink the correct wakunode binary
+RUN ln -sv /usr/local/bin/$MAKE_TARGET /usr/bin/wakunode
+
+ENTRYPOINT ["/usr/bin/wakunode"]
+
+# By default just show help if called without arguments
+CMD ["--help"]


### PR DESCRIPTION
# Description

This PR adds a separate Dockerfile which creates an image from a binary built in CI.

It also adds a job which pushes it to a Docker repository (quay.io/wakuorg/nwaku-pr) separate from the one where standard releases are pushed (to keep the latter clean of these "ephemeral" images) - the PR images are cleaned up after 7 days.

Additional step comments the PR to present the newly created image to contributor and reviewers.

You can see the example here: https://github.com/nwaku-test-org/nwaku/pull/12

There is one caveat - to get the image served as quickly as possible, there is an extra `wakunode2` build running, this is not ideal, but it would increase "interactivity" of the PR. It is also easy to just "append" these 2 steps to existing build job if that is preferred - interested in thoughts.

Another option would be to split the build job and first build `wakunode2` and the image and then the rest of the binaries (other apps and tools), which are not used any further anyway.

# Changes 

<!-- List of detailed changes -->

- [ ] additional Dockerfile under `docker/binaries/` (following nimbus folder structure here)
- [ ] additional job to build `wakunode2`, build the container image, push it to registry and provide comment

<!--
## How to test

1.
1.
1.

-->



## Issue

related to #1877
