### PR TITLE
chore(submodules): use zerokit v0.3.1 only

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -143,7 +143,7 @@
 	path = vendor/zerokit
 	url = https://github.com/vacp2p/zerokit.git
 	ignore = dirty
-	branch = master
+	branch = v0.3.1
 [submodule "vendor/nim-regex"]
 	path = vendor/nim-regex
 	url = https://github.com/nitely/nim-regex.git

--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -17,7 +17,7 @@ fi
 host_triplet=$(rustup show | grep "Default host: " | cut -d' ' -f3)
 
 # Download the prebuilt rln library if it is available
-if curl --silent --fail-with-body -L "https://github.com/vacp2p/zerokit/releases/download/nightly/$host_triplet-rln.tar.gz" >> "$host_triplet-rln.tar.gz"
+if curl --silent --fail-with-body -L "https://github.com/vacp2p/zerokit/releases/download/v0.3.1/$host_triplet-rln.tar.gz" >> "$host_triplet-rln.tar.gz"
 then
     echo "Downloaded $host_triplet-rln.tar.gz"
     tar -xzf "$host_triplet-rln.tar.gz"


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
Ensures that v0.3.1 of zerokit is used, since new updates to master will contain rln-v2 updates, and to improve 
stability for experimental tests.

# Changes

<!-- List of detailed changes -->

- [ ] Bumps submodule
- [ ] Updated `.gitmodules` to use specific branch
- [ ] Updated `scripts/build_rln.sh` to use the v0.3.1 static binary

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
