### PR TITLE
fix: fixes out of bounds crash when waku2 is not set

### DIFF
--- a/waku/v2/waku_enr/capabilities.nim
+++ b/waku/v2/waku_enr/capabilities.nim
@@ -76,6 +76,9 @@ func waku2*(record: TypedRecord): Option[CapabilitiesBitfield] =
   if field.isNone():
     return none(CapabilitiesBitfield)
 
+  if field.get().len != 1:
+    return none(CapabilitiesBitfield)
+
   some(CapabilitiesBitfield(field.get()[0]))
 
 proc supportsCapability*(r: Record, cap: Capabilities): bool =


### PR DESCRIPTION
* Fixes an out of bounds crash when `waku2` field in the ENR is not set. This shouldn't really happen as thats not compliant with the spec and no node should have that field unset, but ofc we can't control that.
* Closes https://github.com/status-im/infra-misc/issues/164
* Note that while it was detected when using `networkmonitor` this could affect `wakunode2` if using waku2 field.
* Thanks @jakubgs for the report.