### PR TITLE
fix(rln-relay): should error out on rln-relay mount failure

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -663,8 +663,7 @@ when defined(rln):
     info "mounting rln relay"
 
     if node.wakuRelay.isNil():
-      error "WakuRelay protocol is not mounted, cannot mount WakuRlnRelay"
-      return
+      raise newException(CatchableError, "WakuRelay protocol is not mounted, cannot mount WakuRlnRelay")
     # TODO: check whether the pubsub topic is supported at the relay level
     # if rlnConf.rlnRelayPubsubTopic notin node.wakuRelay.defaultPubsubTopics:
     #   error "The relay protocol does not support the configured pubsub topic for WakuRlnRelay"
@@ -672,8 +671,7 @@ when defined(rln):
     let rlnRelayRes = await WakuRlnRelay.new(rlnConf,
                                              registrationHandler)
     if rlnRelayRes.isErr():
-      error "failed to mount WakuRlnRelay", error=rlnRelayRes.error
-      return
+      raise newException(CatchableError, "failed to mount WakuRlnRelay: {rlnRelayRes.error}")
     let rlnRelay = rlnRelayRes.get()
     let validator = generateRlnValidator(rlnRelay, spamHandler)
     let pb = PubSub(node.wakuRelay)


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
Previously, we would let the node continue as usualy if the rln-relay failed to mount ~ this PR addresses that issue by bubbling up 
the error to the `setupProtocols` proc in `wakunode2.nim`

Thanks @alrevuelta for the suggestion

# Changes

<!-- List of detailed changes -->

- [x] Raises an exception instead of error logging on mount failure

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->

Maybe we should convert all the mounting procs to return a result instead of raising exceptions?
