### PR TITLE
fix(ci): add mising OS arch option to image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Build binaries
         id: build
         run: |
-          make -j${NPROC} V=1 QUICK_AND_DIRTY_COMPILER=1 wakunode2
+          make -j${NPROC} V=1 QUICK_AND_DIRTY_COMPILER=1 NIMFLAGS="-d:disableMarchNative" wakunode2
 
           TAG=$([ "${PR_NUMBER}" == "" ] && echo "master" || echo "${PR_NUMBER}")
           IMAGE=quay.io/wakuorg/nwaku-pr:${TAG}


### PR DESCRIPTION
# Description

We were missing the `disableMarchNative` to prevent using CPU instructions only available on the action runners. Without this users might get  `Illegal instruction (core dumped)` error when running the PR image
# Changes

<!-- List of detailed changes -->

- [x] add `disableMarchNative` to make for PR image


<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->