### PR TITLE
fix(ci): only add comment on PR and do not duplicate it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v2
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           message: |
             You can find the image built from this PR at
@@ -169,3 +170,4 @@ jobs:
             ```
             ${{steps.build.outputs.image}}
             ```
+          comment_tag: execution


### PR DESCRIPTION
# Description

This PR makes sure the `comment` step only runs on PRs (as it fails CI for `master` otherwise)

It also configures the action to only update the comment and not post a new comment after each CI run

# Changes

<!-- List of detailed changes -->

- [ ] add condition to only run on PRs
- [ ] update the comment rather than add new comment on each run

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->