### PR TITLE
fix(rln-relay): invalid start index being set results in invalid proofs 

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -671,7 +671,7 @@ when defined(rln):
     let rlnRelayRes = await WakuRlnRelay.new(rlnConf,
                                              registrationHandler)
     if rlnRelayRes.isErr():
-      raise newException(CatchableError, "failed to mount WakuRlnRelay: {rlnRelayRes.error}")
+      raise newException(CatchableError, "failed to mount WakuRlnRelay: " & rlnRelayRes.error)
     let rlnRelay = rlnRelayRes.get()
     let validator = generateRlnValidator(rlnRelay, spamHandler)
     let pb = PubSub(node.wakuRelay)

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -102,6 +102,7 @@ method registerBatch*(g: OnchainGroupManager, idCommitments: seq[IDCommitment]):
   initializedGuard(g)
 
   await g.atomicBatch(g.latestIndex, idCommitments)
+  g.latestIndex += MembershipIndex(idCommitments.len())
 
 
 method register*(g: OnchainGroupManager, identityCredentials: IdentityCredential): Future[void] {.async.} =

--- a/waku/waku_rln_relay/rln/wrappers.nim
+++ b/waku/waku_rln_relay/rln/wrappers.nim
@@ -89,7 +89,7 @@ proc createRLNInstanceLocal(d = MerkleTreeDepth,
       cache_capacity: 15_000,
       mode: "high_throughput",
       compression: false,
-      flush_interval: 12_000,
+      flush_interval: 500,
       path: if tree_path != "": tree_path else: DefaultRlnTreePath
     )
   )

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -95,6 +95,7 @@ method stop*(rlnPeer: WakuRLNRelay) {.async.} =
   ## Throws an error if it cannot stop the rln-relay protocol
 
   # stop the group sync, and flush data to tree db
+  info "stopping rln-relay"
   await rlnPeer.groupManager.stop()
 
 proc hasDuplicate*(rlnPeer: WakuRLNRelay,
@@ -217,7 +218,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay,
 
   let rootValidationRes = rlnPeer.groupManager.validateRoot(proof.merkleRoot)
   if not rootValidationRes:
-    debug "invalid message: provided root does not belong to acceptable window of roots", provided=proof.merkleRoot, validRoots=rlnPeer.groupManager.validRoots.mapIt(it.inHex())
+    debug "invalid message: provided root does not belong to acceptable window of roots", provided=proof.merkleRoot.inHex(), validRoots=rlnPeer.groupManager.validRoots.mapIt(it.inHex())
     waku_rln_invalid_messages_total.inc(labelValues=["invalid_root"])
     return MessageValidationResult.Invalid
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewers -->
This pr introduces a couple small changes for logging and fixes the startIndex starting from 0 instead of 1 like the contract

# Changes

<!-- List of detailed changes -->

- [x] logging improvements
- [x] fixed startIndex

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->