### PR TITLE
chore(rln): run rln in all relay pubsubtopics + remove cli flags

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -456,7 +456,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
     let peerInfo = parsePeerInfo(conf.lightpushnode)
     if peerInfo.isOk():
       await mountLightPush(node)
-      node.mountLightPushClient() 
+      node.mountLightPushClient()
       node.peerManager.addServicePeer(peerInfo.value, WakuLightpushCodec)
     else:
       error "LightPush not mounted. Couldn't parse conf.lightpushnode",
@@ -510,8 +510,6 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
 
         let rlnConf = WakuRlnConfig(
           rlnRelayDynamic: conf.rlnRelayDynamic,
-          rlnRelayPubsubTopic: conf.rlnRelayPubsubTopic,
-          rlnRelayContentTopic: conf.rlnRelayContentTopic,
           rlnRelayCredIndex: conf.rlnRelayCredIndex,
           rlnRelayMembershipGroupIndex: conf.rlnRelayMembershipGroupIndex,
           rlnRelayEthContractAddress: conf.rlnRelayEthContractAddress,

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -242,16 +242,6 @@ type
       defaultValue: 0
       name: "rln-relay-membership-group-index" }: uint
 
-    rlnRelayContentTopic* {.
-      desc: "the content topic for which rln-relay gets enabled",
-      defaultValue: "/toy-chat/3/mingde/proto"
-      name: "rln-relay-content-topic" }: ContentTopic
-
-    rlnRelayPubsubTopic* {.
-      desc: "the pubsub topic for which rln-relay gets enabled",
-      defaultValue: "/waku/2/default-waku/proto"
-      name: "rln-relay-pubsub-topic" }: string
-
     rlnRelayDynamic* {.
       desc: "Enable waku-rln-relay with on-chain dynamic group management: true|false",
       defaultValue: false

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -397,8 +397,6 @@ proc setupProtocols(node: WakuNode,
 
       let rlnConf = WakuRlnConfig(
         rlnRelayDynamic: conf.rlnRelayDynamic,
-        rlnRelayPubsubTopic: conf.rlnRelayPubsubTopic,
-        rlnRelayContentTopic: conf.rlnRelayContentTopic,
         rlnRelayCredIndex: conf.rlnRelayCredIndex,
         rlnRelayMembershipGroupIndex: conf.rlnRelayMembershipGroupIndex,
         rlnRelayEthContractAddress: conf.rlnRelayEthContractAddress,

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -155,16 +155,6 @@ type
       defaultValue: 0
       name: "rln-relay-membership-group-index" }: uint
 
-    rlnRelayPubsubTopic* {.
-      desc: "the pubsub topic for which rln-relay gets enabled",
-      defaultValue: "/waku/2/default-waku/proto"
-      name: "rln-relay-pubsub-topic" }: string
-
-    rlnRelayContentTopic* {.
-      desc: "the content topic for which rln-relay gets enabled",
-      defaultValue: "/toy-chat/3/mingde/proto"
-      name: "rln-relay-content-topic" }: string
-
     rlnRelayDynamic* {.
       desc: "Enable  waku-rln-relay with on-chain dynamic group management: true|false",
       defaultValue: false

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -18,9 +18,6 @@ import
   ../../../waku/waku_keystore,
   ../testlib/common
 
-const RlnRelayPubsubTopic = "waku/2/rlnrelay/proto"
-const RlnRelayContentTopic = "waku/2/rlnrelay/proto"
-
 proc createRLNInstanceWrapper(): RLNResult =
   return createRlnInstance(tree_path = genTempPath("rln_tree", "waku_rln_relay"))
 
@@ -256,7 +253,7 @@ suite "Waku rln relay":
     require:
       rlnInstance.isOk()
     let rln = rlnInstance.get()
-    
+
     require:
       rln.setMetadata(RlnMetadata(lastProcessedBlock: 128)).isOk()
 
@@ -269,7 +266,7 @@ suite "Waku rln relay":
 
     check:
       metadata.lastProcessedBlock == 128
- 
+
 
   test "Merkle tree consistency check between deletion and insertion":
     # create an RLN instance
@@ -660,8 +657,6 @@ suite "Waku rln relay":
     let index = MembershipIndex(5)
 
     let rlnConf = WakuRlnConfig(rlnRelayDynamic: false,
-                                rlnRelayPubsubTopic: RlnRelayPubsubTopic,
-                                rlnRelayContentTopic: RlnRelayContentTopic,
                                 rlnRelayCredIndex: index.uint,
                                 rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_2"))
     let wakuRlnRelayRes = await WakuRlnRelay.new(rlnConf)
@@ -709,13 +704,11 @@ suite "Waku rln relay":
       msgValidate2 == MessageValidationResult.Spam
       msgValidate3 == MessageValidationResult.Valid
       msgValidate4 == MessageValidationResult.Invalid
-  
+
   asyncTest "should validate invalid proofs if bandwidth is available":
     let index = MembershipIndex(5)
 
     let rlnConf = WakuRlnConfig(rlnRelayDynamic: false,
-                                rlnRelayPubsubTopic: RlnRelayPubsubTopic,
-                                rlnRelayContentTopic: RlnRelayContentTopic,
                                 rlnRelayCredIndex: index.uint,
                                 rlnRelayBandwidthThreshold: 4,
                                 rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_3"))
@@ -736,7 +729,7 @@ suite "Waku rln relay":
       # this message will be over the bandwidth threshold, hence has to be verified, will be false (since no proof)
       wm3 = WakuMessage(payload: "Invalid message".toBytes())
       wm4 = WakuMessage(payload: "Spam message".toBytes())
-    
+
     let
       proofAdded1 = wakuRlnRelay.appendRLNProof(wm1, time)
       proofAdded2 = wakuRlnRelay.appendRLNProof(wm2, time+EpochUnitSeconds)
@@ -765,7 +758,7 @@ suite "Waku rln relay":
       msgValidate2 == MessageValidationResult.Valid
       msgValidate3 == MessageValidationResult.Invalid
       msgValidate4 == MessageValidationResult.Spam
-  
+
 
   test "toIDCommitment and toUInt256":
     # create an instance of rln

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -405,7 +405,7 @@ proc filterSubscribe*(node: WakuNode, pubsubTopic: Option[PubsubTopic], contentT
         error "can't get shard", error=topicMapRes.error
         return
       else: topicMapRes.get()
-    
+
     var futures = collect(newSeq):
       for pubsub, topics in topicMap.pairs:
         info "registering filter subscription to content", pubsubTopic=pubsub, contentTopics=topics, peer=remotePeer.peerId
@@ -456,7 +456,7 @@ proc filterUnsubscribe*(node: WakuNode, pubsubTopic: Option[PubsubTopic], conten
         error "can't get shard", error = topicMapRes.error
         return
       else: topicMapRes.get()
-    
+
     var futures = collect(newSeq):
       for pubsub, topics in topicMap.pairs:
         info "deregistering filter subscription to content", pubsubTopic=pubsub, contentTopics=topics, peer=remotePeer.peerId
@@ -741,11 +741,12 @@ when defined(rln):
       raise newException(CatchableError, "failed to mount WakuRlnRelay: {rlnRelayRes.error}")
     let rlnRelay = rlnRelayRes.get()
     let validator = generateRlnValidator(rlnRelay, spamHandler)
-    let pb = PubSub(node.wakuRelay)
-    pb.addValidator(rlnRelay.pubsubTopic, validator)
+
+    # register rln validator for all subscribed relay pubsub topics
+    for pubsubTopic in node.wakuRelay.subscribedTopics:
+      debug "Registering RLN validator for topic", pubsubTopic=pubsubTopic
+      procCall GossipSub(node.wakuRelay).addValidator(pubsubTopic, validator)
     node.wakuRlnRelay = rlnRelay
-
-
 
 ## Waku peer-exchange
 

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -31,8 +31,6 @@ logScope:
 
 type WakuRlnConfig* = object
   rlnRelayDynamic*: bool
-  rlnRelayPubsubTopic*: PubsubTopic
-  rlnRelayContentTopic*: ContentTopic
   rlnRelayCredIndex*: uint
   rlnRelayMembershipGroupIndex*: uint
   rlnRelayEthContractAddress*: string
@@ -80,10 +78,6 @@ proc calcEpoch*(t: float64): Epoch =
   return toEpoch(e)
 
 type WakuRLNRelay* = ref object of RootObj
-  pubsubTopic*: string # the pubsub topic for which rln relay is mounted
-                       # contentTopic should be of type waku_core.ContentTopic, however, due to recursive module dependency, the underlying type of ContentTopic is used instead
-                       # TODO a long-term solution is to place types with recursive dependency inside one file
-  contentTopic*: string
   # the log of nullifiers and Shamir shares of the past messages grouped per epoch
   nullifierLog*: Table[Epoch, seq[ProofMetadata]]
   lastEpoch*: Epoch # the epoch of the last published rln message
@@ -170,7 +164,7 @@ proc absDiff*(e1, e2: Epoch): uint64 =
   else:
     return epoch2 - epoch1
 
-proc validateMessage*(rlnPeer: WakuRLNRelay, 
+proc validateMessage*(rlnPeer: WakuRLNRelay,
                       msg: WakuMessage,
                       timeOption = none(float64)): MessageValidationResult =
   ## validate the supplied `msg` based on the waku-rln-relay routing protocol i.e.,
@@ -292,10 +286,8 @@ proc appendRLNProof*(rlnPeer: WakuRLNRelay,
 proc generateRlnValidator*(wakuRlnRelay: WakuRLNRelay,
                            spamHandler: Option[SpamHandler] = none(SpamHandler)): pubsub.ValidatorHandler =
   ## this procedure is a thin wrapper for the pubsub addValidator method
-  ## it sets a validator for the waku messages published on the supplied pubsubTopic and contentTopic
-  ## if contentTopic is empty, then validation takes place for All the messages published on the given pubsubTopic
+  ## it sets a validator for waku messages, acting in the registered pubsub topic
   ## the message validation logic is according to https://rfc.vac.dev/spec/17/
-  let contentTopic = wakuRlnRelay.contentTopic
   proc validator(topic: string, message: messages.Message): Future[pubsub.ValidationResult] {.async.} =
     trace "rln-relay topic validator is called"
 
@@ -308,21 +300,12 @@ proc generateRlnValidator*(wakuRlnRelay: WakuRLNRelay,
         info "message bandwidth limit exceeded, running rate limit proof validation"
     except OverflowDefect: # not a problem
       debug "not enough bandwidth, running rate limit proof validation"
-   
 
     let decodeRes = WakuMessage.decode(message.data)
     if decodeRes.isOk():
-      let
-        wakumessage = decodeRes.value
-        payload = string.fromBytes(wakumessage.payload)
-
-      # check the contentTopic
-      if (wakumessage.contentTopic != "") and (contentTopic != "") and (wakumessage.contentTopic != contentTopic):
-        trace "content topic did not match:", contentTopic=wakumessage.contentTopic, payload=payload
-        return pubsub.ValidationResult.Accept
-
-
+      let wakumessage = decodeRes.value
       let decodeRes = RateLimitProof.init(wakumessage.proof)
+
       if decodeRes.isErr():
         return pubsub.ValidationResult.Reject
 
@@ -337,6 +320,7 @@ proc generateRlnValidator*(wakuRlnRelay: WakuRLNRelay,
         shareX = inHex(msgProof.shareX)
         shareY = inHex(msgProof.shareY)
         nullifier = inHex(msgProof.nullifier)
+        payload = string.fromBytes(wakumessage.payload)
       case validationRes:
         of Valid:
           debug "message validity is verified, relaying:",  contentTopic=wakumessage.contentTopic, epoch=epoch, timestamp=wakumessage.timestamp, payload=payload
@@ -402,12 +386,10 @@ proc mount(conf: WakuRlnConfig,
   await groupManager.startGroupSync()
 
   let messageBucket = if conf.rlnRelayBandwidthThreshold > 0:
-                      some(TokenBucket.new(conf.rlnRelayBandwidthThreshold)) 
+                      some(TokenBucket.new(conf.rlnRelayBandwidthThreshold))
                       else: none(TokenBucket)
 
-  return WakuRLNRelay(pubsubTopic: conf.rlnRelayPubsubTopic,
-                      contentTopic: conf.rlnRelayContentTopic,
-                      groupManager: groupManager,
+  return WakuRLNRelay(groupManager: groupManager,
                       messageBucket: messageBucket)
 
 


### PR DESCRIPTION
# Changes

* Remove `rln-relay-pubsub-topic` and `rln-relay-content-topic` cli flags.
* Remove all references to pubsub and content topics in rln.
* Mount rln in all pubsub topics that relay is configured with.
* Adds tests to ensure that rln is applied in all pubsub/content topics configured in relay.

Related https://github.com/waku-org/nwaku/issues/1906