### PR TITLE
fix(rln-relay): waitFor startup, otherwise valid proofs will be marked invalid

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -515,7 +515,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
           rlnRelayCredentialsPassword: conf.rlnRelayCredentialsPassword
         )
 
-        await node.mountRlnRelay(rlnConf,
+        waitFor node.mountRlnRelay(rlnConf,
                                  spamHandler=some(spamHandler))
 
         let membershipIndex = node.wakuRlnRelay.groupManager.membershipIndex.get()

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -408,7 +408,7 @@ proc setupProtocols(node: WakuNode,
       )
 
       try:
-        await node.mountRlnRelay(rlnConf)
+        waitFor node.mountRlnRelay(rlnConf)
       except CatchableError:
         return err("failed to mount waku RLN relay protocol: " & getCurrentExceptionMsg())
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -731,11 +731,8 @@ when defined(rln):
 
     if node.wakuRelay.isNil():
       raise newException(CatchableError, "WakuRelay protocol is not mounted, cannot mount WakuRlnRelay")
-    # TODO: check whether the pubsub topic is supported at the relay level
-    # if rlnConf.rlnRelayPubsubTopic notin node.wakuRelay.defaultPubsubTopics:
-    #   error "The relay protocol does not support the configured pubsub topic for WakuRlnRelay"
 
-    let rlnRelayRes = await WakuRlnRelay.new(rlnConf,
+    let rlnRelayRes = waitFor WakuRlnRelay.new(rlnConf,
                                              registrationHandler)
     if rlnRelayRes.isErr():
       raise newException(CatchableError, "failed to mount WakuRlnRelay: " & rlnRelayRes.error)


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR ensures that messages are processed only after the rln-relay is ready to verify proofs, i.e updated till latest 
head

# Changes

<!-- List of detailed changes -->

- [x] `s/await/waitFor` in chat2/wakunode2/waku_node 

<!--
## How to test

1.
1.
1.

-->


## Issue

Addresses a part of #1906
