### PR TITLE
chore(rln-relay): rename keystore application to waku-rln-relay

### DIFF
--- a/waku/waku_rln_relay/constants.nim
+++ b/waku/waku_rln_relay/constants.nim
@@ -53,4 +53,4 @@ const MaxEpochGap* = uint64(MaxClockGapSeconds/EpochUnitSeconds)
 
 # RLN Keystore defaults
 const
-  RLNAppInfo* = AppInfo(application: "nwaku-rln-relay", appIdentifier: "01234567890abcdef", version: "0.1")
+  RLNAppInfo* = AppInfo(application: "waku-rln-relay", appIdentifier: "01234567890abcdef", version: "0.1")


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR renames the `application` field in the keystore to `waku-rln-relay` to make it agnostic to the client (go-waku, 
nwaku).

cc: @richard-ramos thanks for the report

cc: @alrevuelta this may require you to manually change the `application` in the keystore you're using for the 
simulations - `sed -i s/nwaku-rln-relay/waku-rln-relay/g rlnKeystore.json`

# Changes

<!-- List of detailed changes -->

- [x] s/nwaku-rln-relay/waku-rln-relay

<!--
## How to test

1.
1.
1.

-->

## Issue

closes #1903
