### PR TITLE
chore(rln_keystore_generator): generate and persist credentials

### DIFF
--- a/tools/rln_keystore_generator/external_config.nim
+++ b/tools/rln_keystore_generator/external_config.nim
@@ -51,7 +51,7 @@ type
       defaultValue: "",
       name: "rln-relay-eth-contract-address" }: string
 
-    rlnRelayCredentialsPassword* {.
+    rlnRelayCredPassword* {.
       desc: "Password for encrypting RLN credentials",
       defaultValue: "",
       name: "rln-relay-cred-password" }: string
@@ -59,6 +59,12 @@ type
 proc loadConfig*(T: type RlnKeystoreGeneratorConf): Result[T, string] =
   try:
     let conf = RlnKeystoreGeneratorConf.load()
+    if conf.rlnRelayCredPath == "":
+      return err("--rln-relay-cred-path must be set")
+    if conf.rlnRelayEthContractAddress == "":
+      return err("--rln-relay-eth-contract-address must be set")
+    if conf.rlnRelayCredPassword == "":
+      return err("--rln-relay-cred-password must be set")
     ok(conf)
   except CatchableError:
     err(getCurrentExceptionMsg())

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -5,16 +5,21 @@ else:
 
 import
   chronicles,
-  stew/[results]
+  stew/[results],
+  std/tempfiles
 
 import
-    ./external_config
+  ../../waku/waku_keystore,
+  ../../waku/waku_rln_relay/rln,
+  ../../waku/waku_rln_relay/conversion_utils,
+  ./external_config
 
 logScope:
   topics = "rln_keystore_generator"
 
 when isMainModule:
   {.pop.}
+  # 1. load configuration
   let confRes = RlnKeystoreGeneratorConf.loadConfig()
   if confRes.isErr():
     error "failure while loading the configuration", error=confRes.error()
@@ -24,7 +29,48 @@ when isMainModule:
   
   debug "configuration", conf = $conf
 
-  # initialize keystore
+  # 2. initialize rlnInstance
+  let rlnInstanceRes = createRLNInstance(d=20, 
+                                         tree_path = genTempPath("rln_tree", "rln_keystore_generator"))
+  if rlnInstanceRes.isErr():
+    error "failure while creating RLN instance", error=rlnInstanceRes.error()
+    quit(1)
+  
+  let rlnInstance = rlnInstanceRes.get()
+
+  # 3. generate credentials
+  let credentialRes = rlnInstance.membershipKeyGen()
+  if credentialRes.isErr():
+    error "failure while generating credentials", error=credentialRes.error()
+    quit(1)
+
+  let credential = credentialRes.get()
+  debug "credentials", idTrapdoor = credential.idTrapdoor.inHex(), 
+                       idNullifier = credential.idNullifier.inHex(),
+                       idSecretHash = credential.idSecretHash.inHex(),
+                       idCommitment = credential.idCommitment.inHex()
+
+  # 4. write to keystore
+  ## TODO: after hooking up to the OnchainGroupManager, 
+  ## obtain chainId and treeIndex from the contract
+  let keystoreCred = MembershipCredentials(
+    identityCredential: credential,
+    membershipGroups: @[MembershipGroup(
+      membershipContract: MembershipContract(
+        chainId: "1155511",
+        address: conf.rlnRelayEthContractAddress,
+      ),
+      treeIndex: 0,
+    )]
+  )
+
+  let persistRes = addMembershipCredentials(conf.rlnRelayCredPath, @[keystoreCred], conf.rlnRelayCredPassword, RLNAppInfo)
+  if persistRes.isErr():
+    error "failed to persist credentials", error=persistRes.error()
+    quit(1)
+  
+  info "credentials persisted", path = conf.rlnRelayCredPath
+
   
 
 

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -22,7 +22,7 @@ when isMainModule:
   # 1. load configuration
   let confRes = RlnKeystoreGeneratorConf.loadConfig()
   if confRes.isErr():
-    error "failure while loading the configuration", error=confRes.error()
+    error "failure while loading the configuration", error=confRes.error
     quit(1)
 
   let conf = confRes.get()
@@ -33,7 +33,7 @@ when isMainModule:
   let rlnInstanceRes = createRLNInstance(d=20, 
                                          tree_path = genTempPath("rln_tree", "rln_keystore_generator"))
   if rlnInstanceRes.isErr():
-    error "failure while creating RLN instance", error=rlnInstanceRes.error()
+    error "failure while creating RLN instance", error=rlnInstanceRes.error
     quit(1)
   
   let rlnInstance = rlnInstanceRes.get()
@@ -41,7 +41,7 @@ when isMainModule:
   # 3. generate credentials
   let credentialRes = rlnInstance.membershipKeyGen()
   if credentialRes.isErr():
-    error "failure while generating credentials", error=credentialRes.error()
+    error "failure while generating credentials", error=credentialRes.error
     quit(1)
 
   let credential = credentialRes.get()
@@ -66,7 +66,7 @@ when isMainModule:
 
   let persistRes = addMembershipCredentials(conf.rlnRelayCredPath, @[keystoreCred], conf.rlnRelayCredPassword, RLNAppInfo)
   if persistRes.isErr():
-    error "failed to persist credentials", error=persistRes.error()
+    error "failed to persist credentials", error=persistRes.error
     quit(1)
   
   info "credentials persisted", path = conf.rlnRelayCredPath

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -64,7 +64,10 @@ when isMainModule:
     )]
   )
 
-  let persistRes = addMembershipCredentials(conf.rlnRelayCredPath, @[keystoreCred], conf.rlnRelayCredPassword, RLNAppInfo)
+  let persistRes = addMembershipCredentials(conf.rlnRelayCredPath, 
+                                            @[keystoreCred], 
+                                            conf.rlnRelayCredPassword, 
+                                            RLNAppInfo)
   if persistRes.isErr():
     error "failed to persist credentials", error=persistRes.error
     quit(1)


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
A follow up PR to #1925

# Changes

<!-- List of detailed changes -->

- [x] Creates an instance of the rln object
- [x] Generates credentials
- [x] Uses dummy chainId, contractAddress and treeIndex to write to a keystore

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
The next follow up PR will actually execute the registration if `--execute` is true
