### PR TITLE
fix(rln-relay): RLN DB should be aware of chain and contract address

### DIFF
--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -245,7 +245,9 @@ suite "Waku rln relay":
       rlnInstance.isOk()
     let rln = rlnInstance.get()
     check:
-      rln.setMetadata(RlnMetadata(lastProcessedBlock: 128)).isOk()
+      rln.setMetadata(RlnMetadata(lastProcessedBlock: 128,
+                                  chainId: 1155511,
+                                  contractAddress: "0x9c09146844c1326c2dbc41c451766c7138f88155")).isOk()
 
   test "getMetadata rln utils":
     # create an RLN instance which also includes an empty Merkle tree
@@ -255,7 +257,9 @@ suite "Waku rln relay":
     let rln = rlnInstance.get()
 
     require:
-      rln.setMetadata(RlnMetadata(lastProcessedBlock: 128)).isOk()
+      rln.setMetadata(RlnMetadata(lastProcessedBlock: 128,
+                                  chainId: 1155511,
+                                  contractAddress: "0x9c09146844c1326c2dbc41c451766c7138f88155")).isOk()
 
     let metadataRes = rln.getMetadata()
 
@@ -266,7 +270,8 @@ suite "Waku rln relay":
 
     check:
       metadata.lastProcessedBlock == 128
-
+      metadata.chainId == 1155511
+      metadata.contractAddress == "0x9c09146844c1326c2dbc41c451766c7138f88155"
 
   test "Merkle tree consistency check between deletion and insertion":
     # create an RLN instance


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
If an operator runs waku-rln-relay in 2 different runs, once with chainId x and another with chainId y, then the tree 
used would be the same. This leads to inconsistencies, and hence, we use the `metadata` feature to store the chainId, as 
well as the contractAddress. If there is a mismatch in any of the 2 fields, we raise an exception and prevent the node 
from starting up.

# Changes

<!-- List of detailed changes -->

- [x] added 2 fields `chainId`, `contractAddress` to `RlnMetadata`
- [x] updated tests, and serde

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #1921

