### PR TITLE
fix(rln-relay): bump zerokit to v0.3.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -143,7 +143,7 @@
 	path = vendor/zerokit
 	url = https://github.com/vacp2p/zerokit.git
 	ignore = dirty
-	branch = v0.3.1
+	branch = v0.3.2
 [submodule "vendor/nim-regex"]
 	path = vendor/nim-regex
 	url = https://github.com/nitely/nim-regex.git

--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -17,7 +17,7 @@ fi
 host_triplet=$(rustup show | grep "Default host: " | cut -d' ' -f3)
 
 # Download the prebuilt rln library if it is available
-if curl --silent --fail-with-body -L "https://github.com/vacp2p/zerokit/releases/download/v0.3.1/$host_triplet-rln.tar.gz" >> "$host_triplet-rln.tar.gz"
+if curl --silent --fail-with-body -L "https://github.com/vacp2p/zerokit/releases/download/v0.3.2/$host_triplet-rln.tar.gz" >> "$host_triplet-rln.tar.gz"
 then
     echo "Downloaded $host_triplet-rln.tar.gz"
     tar -xzf "$host_triplet-rln.tar.gz"


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
Bumps zerokit to v0.3.2, which includes a fix for tree persistence

# Changes

<!-- List of detailed changes -->

- [x] Updated .gitmodules zerokit branch
- [x] Updated zerokit submodule
- [x] Updated `build_rln.sh`

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #1944

