### PR TITLE
fix(rln-relay): sync from deployed block number

### DIFF
--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -191,8 +191,7 @@ suite "Onchain group manager":
       manager.rlnContract.isSome()
       manager.membershipFee.isSome()
       manager.initialized
-      manager.rlnContractDeployedBlockNumber.isSome() 
-      manager.rlnContractDeployedBlockNumber.get() > 0
+      manager.rlnContractDeployedBlockNumber > 0
 
   asyncTest "should error on initialization when loaded metadata does not match":
     let manager = await setup()

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -191,6 +191,8 @@ suite "Onchain group manager":
       manager.rlnContract.isSome()
       manager.membershipFee.isSome()
       manager.initialized
+      manager.rlnContractDeployedBlockNumber.isSome() 
+      manager.rlnContractDeployedBlockNumber.get() > 0
 
   asyncTest "should error on initialization when loaded metadata does not match":
     let manager = await setup()

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -76,8 +76,6 @@ template initializedGuard(g: OnchainGroupManager): untyped =
 
 
 proc setMetadata*(g: OnchainGroupManager): RlnRelayResult[void] =
-  if g.latestProcessedBlock == 0:
-    return err("latest processed block is not set")
   try:
     let metadataSetRes = g.rlnInstance.setMetadata(RlnMetadata(
                             lastProcessedBlock: g.latestProcessedBlock,
@@ -358,9 +356,8 @@ proc startOnchainSync(g: OnchainGroupManager): Future[void] {.async.} =
     info "resuming onchain sync from block", fromBlock = g.latestProcessedBlock
     g.latestProcessedBlock + 1
   else:
-    let deployedBlockNumber = g.rlnContractDeployedBlockNumber
-    info "starting onchain sync from deployed block number", deployedBlockNumber = deployedBlockNumber
-    deployedBlockNumber
+    info "starting onchain sync from deployed block number", deployedBlockNumber = g.rlnContractDeployedBlockNumber
+    g.rlnContractDeployedBlockNumber
 
   let latestBlock = cast[BlockNumber](await ethRpc.provider.eth_blockNumber())
   try:


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
Syncs from the deployed block number to prevent excess network calls

# Changes

<!-- List of detailed changes -->

- [x] removed decay factor, static chunk size of 2000
- [x] handles eth rpc reconnection
- [x] syncs from deployment block of the storage contract

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #1942

