### PR TITLE
fix(rln-relay): modify keystore credentials logic

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -508,11 +508,10 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
         let rlnConf = WakuRlnConfig(
           rlnRelayDynamic: conf.rlnRelayDynamic,
           rlnRelayCredIndex: conf.rlnRelayCredIndex,
-          rlnRelayMembershipGroupIndex: conf.rlnRelayMembershipGroupIndex,
           rlnRelayEthContractAddress: conf.rlnRelayEthContractAddress,
           rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress,
           rlnRelayCredPath: conf.rlnRelayCredPath,
-          rlnRelayCredentialsPassword: conf.rlnRelayCredentialsPassword
+          rlnRelayCredPassword: conf.rlnRelayCredPassword
         )
 
         waitFor node.mountRlnRelay(rlnConf,

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -237,11 +237,6 @@ type
       defaultValue: 0
       name: "rln-relay-cred-index" }: uint
 
-    rlnRelayMembershipGroupIndex* {.
-      desc: "the index of credentials to use, within a specific rln membership set",
-      defaultValue: 0
-      name: "rln-relay-membership-group-index" }: uint
-
     rlnRelayDynamic* {.
       desc: "Enable waku-rln-relay with on-chain dynamic group management: true|false",
       defaultValue: false
@@ -267,7 +262,7 @@ type
       defaultValue: ""
       name: "rln-relay-eth-contract-address" }: string
 
-    rlnRelayCredentialsPassword* {.
+    rlnRelayCredPassword* {.
       desc: "Password for encrypting RLN credentials",
       defaultValue: ""
       name: "rln-relay-cred-password" }: string

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -398,11 +398,10 @@ proc setupProtocols(node: WakuNode,
       let rlnConf = WakuRlnConfig(
         rlnRelayDynamic: conf.rlnRelayDynamic,
         rlnRelayCredIndex: conf.rlnRelayCredIndex,
-        rlnRelayMembershipGroupIndex: conf.rlnRelayMembershipGroupIndex,
         rlnRelayEthContractAddress: conf.rlnRelayEthContractAddress,
         rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress,
         rlnRelayCredPath: conf.rlnRelayCredPath,
-        rlnRelayCredentialsPassword: conf.rlnRelayCredentialsPassword,
+        rlnRelayCredPassword: conf.rlnRelayCredPassword,
         rlnRelayTreePath: conf.rlnRelayTreePath,
         rlnRelayBandwidthThreshold: conf.rlnRelayBandwidthThreshold
       )

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -150,11 +150,6 @@ type
       defaultValue: 0
       name: "rln-relay-membership-index" }: uint
 
-    rlnRelayMembershipGroupIndex* {.
-      desc: "the index of credentials to use, within a specific rln membership set",
-      defaultValue: 0
-      name: "rln-relay-membership-group-index" }: uint
-
     rlnRelayDynamic* {.
       desc: "Enable  waku-rln-relay with on-chain dynamic group management: true|false",
       defaultValue: false
@@ -180,7 +175,7 @@ type
       defaultValue: ""
       name: "rln-relay-eth-contract-address" }: string
 
-    rlnRelayCredentialsPassword* {.
+    rlnRelayCredPassword* {.
       desc: "Password for encrypting RLN credentials",
       defaultValue: ""
       name: "rln-relay-cred-password" }: string

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -846,7 +846,7 @@ suite "Waku rln relay":
                                                          appInfo = RLNAppInfo)
 
     require:
-      readKeystoreRes.isOk()
+      assert readKeystoreRes.isOk(), readKeystoreRes.error
 
     # getMembershipCredentials returns the credential in the keystore which matches
     # the query, in this case the query is =

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -844,9 +844,7 @@ suite "Waku rln relay":
                                                          # to avoid re-declaration
                                                          query = keystoreMembership,
                                                          appInfo = RLNAppInfo)
-
-    require:
-      assert readKeystoreRes.isOk(), readKeystoreRes.error
+    assert readKeystoreRes.isOk(), $readKeystoreRes.error
 
     # getMembershipCredentials returns the credential in the keystore which matches
     # the query, in this case the query is =

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -815,10 +815,14 @@ suite "Waku rln relay":
 
     let index = MembershipIndex(1)
 
-    let rlnMembershipContract = MembershipContract(chainId: "5", address: "0x0123456789012345678901234567890123456789")
-    let rlnMembershipGroup = MembershipGroup(membershipContract: rlnMembershipContract, treeIndex: index)
-    let rlnMembershipCredentials = MembershipCredentials(identityCredential: idCredential, membershipGroups: @[rlnMembershipGroup])
-
+    let keystoreMembership = KeystoreMembership(
+      membershipContract: MembershipContract(
+        chainId: "5",
+        address: "0x0123456789012345678901234567890123456789"
+      ),
+      treeIndex: index,
+      identityCredential: idCredential,
+    )
     let password = "%m0um0ucoW%"
 
     let filepath = "./testRLNCredentials.txt"
@@ -827,30 +831,31 @@ suite "Waku rln relay":
     # Write RLN credentials
     require:
       addMembershipCredentials(path = filepath,
-                                credentials = @[rlnMembershipCredentials],
-                                password = password,
-                                appInfo = RLNAppInfo).isOk()
+                               membership = keystoreMembership,
+                               password = password,
+                               appInfo = RLNAppInfo).isOk()
 
-    let readCredentialsResult = getMembershipCredentials(path = filepath,
+    let readKeystoreRes = getMembershipCredentials(path = filepath,
                                                          password = password,
-                                                         filterMembershipContracts = @[rlnMembershipContract],
+                                                         # here the query would not include
+                                                         # the identityCredential,
+                                                         # since it is not part of the query
+                                                         # but have used the same value
+                                                         # to avoid re-declaration
+                                                         query = keystoreMembership,
                                                          appInfo = RLNAppInfo)
 
     require:
-      readCredentialsResult.isOk()
+      readKeystoreRes.isOk()
 
-    # getMembershipCredentials returns all credentials in keystore as sequence matching the filter
-    let allMatchingCredentials = readCredentialsResult.get()
-    # if any is found, we return the first credential, otherwise credentials is none
-    var credentials = none(MembershipCredentials)
-    if allMatchingCredentials.len() > 0:
-      credentials = some(allMatchingCredentials[0])
-
-    require:
-      credentials.isSome()
+    # getMembershipCredentials returns the credential in the keystore which matches
+    # the query, in this case the query is =
+    # chainId = "5" and 
+    # address = "0x0123456789012345678901234567890123456789" and
+    # treeIndex = 1
+    let readKeystoreMembership = readKeystoreRes.get()
     check:
-      credentials.get().identityCredential == idCredential
-      credentials.get().membershipGroups == @[rlnMembershipGroup]
+      readKeystoreMembership == keystoreMembership
 
   test "histogram static bucket generation":
     let buckets = generateBucketsForHistogram(10)

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -79,19 +79,17 @@ when isMainModule:
   debug "Transaction hash", txHash = groupManager.registrationTxHash.get()
 
   # 6. write to keystore
-  let keystoreCred = MembershipCredentials(
+  let keystoreCred = KeystoreMembership(
+    membershipContract: MembershipContract(
+      chainId: $groupManager.chainId.get(),
+      address: conf.rlnRelayEthContractAddress,
+    ),
+    treeIndex: groupManager.membershipIndex.get(),
     identityCredential: credential,
-    membershipGroups: @[MembershipGroup(
-      membershipContract: MembershipContract(
-        chainId: $groupManager.chainId.get(),
-        address: conf.rlnRelayEthContractAddress,
-      ),
-      treeIndex: groupManager.membershipIndex.get(),
-    )]
   )
 
   let persistRes = addMembershipCredentials(conf.rlnRelayCredPath, 
-                                            @[keystoreCred], 
+                                            keystoreCred, 
                                             conf.rlnRelayCredPassword, 
                                             RLNAppInfo)
   if persistRes.isErr():

--- a/waku/waku_keystore/conversion_utils.nim
+++ b/waku/waku_keystore/conversion_utils.nim
@@ -8,21 +8,21 @@ import
   stew/[results, byteutils],
   ./protocol_types
 
-# Encodes a Membership credential to a byte sequence
-proc encode*(credential: MembershipCredentials): seq[byte] =
+# Encodes a KeystoreMembership credential to a byte sequence
+proc encode*(credential: KeystoreMembership): seq[byte] =
   # TODO: use custom encoding, avoid wordy json
   var stringCredential: string
   # NOTE: toUgly appends to the string, doesn't replace its contents
   stringCredential.toUgly(%credential)
   return toBytes(stringCredential)
 
-# Decodes a byte sequence to a Membership credential
-proc decode*(encodedCredential: seq[byte]): KeystoreResult[MembershipCredentials] =
+# Decodes a byte sequence to a KeystoreMembership credential
+proc decode*(encodedCredential: seq[byte]): KeystoreResult[KeystoreMembership] =
   # TODO: use custom decoding, avoid wordy json
   try:
     # we parse the json decrypted keystoreCredential
     let jsonObject = parseJson(string.fromBytes(encodedCredential))
-    return ok(to(jsonObject, MembershipCredentials))
+    return ok(to(jsonObject, KeystoreMembership))
   except JsonParsingError:
     return err(KeystoreJsonError)
   except Exception: #parseJson raises Exception

--- a/waku/waku_keystore/conversion_utils.nim
+++ b/waku/waku_keystore/conversion_utils.nim
@@ -24,6 +24,8 @@ proc decode*(encodedCredential: seq[byte]): KeystoreResult[KeystoreMembership] =
     let jsonObject = parseJson(string.fromBytes(encodedCredential))
     return ok(to(jsonObject, KeystoreMembership))
   except JsonParsingError:
-    return err(KeystoreJsonError)
+    return err(AppKeystoreError(kind: KeystoreJsonError, 
+                                msg: getCurrentExceptionMsg()))
   except Exception: #parseJson raises Exception
-    return err(KeystoreOsError)
+    return err(AppKeystoreError(kind: KeystoreOsError,
+                                msg: getCurrentExceptionMsg()))

--- a/waku/waku_keystore/protocol_types.nim
+++ b/waku/waku_keystore/protocol_types.nim
@@ -142,4 +142,7 @@ type
     kind*: AppKeystoreErrorKind
     msg*: string
 
+proc `$`*(e: AppKeystoreError) : string =
+  return $e.kind & ": " & e.msg
+
 type KeystoreResult*[T] = Result[T, AppKeystoreError]

--- a/waku/waku_keystore/protocol_types.nim
+++ b/waku/waku_keystore/protocol_types.nim
@@ -124,7 +124,7 @@ type AppKeystore* = object
   version*: string
 
 type
-  AppKeystoreError* = enum
+  AppKeystoreErrorKind* = enum
     KeystoreOsError               = "keystore error: OS specific error"
     KeystoreIoError               = "keystore error: IO specific error"
     KeystoreJsonKeyError          = "keystore error: fields not present in JSON"
@@ -137,5 +137,9 @@ type
     KeystoreReadKeyfileError      = "Error while reading keyfile for credentials"
     KeystoreCredentialAlreadyPresentError = "Error while adding credentials to keystore: credential already present"
     KeystoreCredentialNotFoundError = "Error while searching credentials in keystore: credential not found"
+
+  AppKeystoreError* = object
+    kind*: AppKeystoreErrorKind
+    msg*: string
 
 type KeystoreResult*[T] = Result[T, AppKeystoreError]

--- a/waku/waku_keystore/protocol_types.nim
+++ b/waku/waku_keystore/protocol_types.nim
@@ -95,7 +95,7 @@ type KeystoreMembership* = ref object of RootObj
   identityCredential*: IdentityCredential
 
 proc `$`*(m: KeystoreMembership): string =
-  return "KeystoreMembership(" & m.membershipContract.chainId & ", " & m.membershipContract.address & ", " & $m.treeIndex & ", "  & $m.identityCredential & ")"
+  return "KeystoreMembership(chainId: " & m.membershipContract.chainId & ", contractAddress: " & m.membershipContract.address & ", treeIndex: " & $m.treeIndex & ", identityCredential: "  & $m.identityCredential & ")"
 
 proc `==`*(x, y: KeystoreMembership): bool =
   return x.membershipContract.chainId == y.membershipContract.chainId and

--- a/waku/waku_keystore/utils.nim
+++ b/waku/waku_keystore/utils.nim
@@ -5,7 +5,9 @@ else:
 
 import
   json,
-  std/[options, os, sequtils],
+  std/[os, sequtils]
+
+import
   ./keyfile,
   ./protocol_types
 
@@ -13,14 +15,9 @@ import
 proc hasKeys*(data: JsonNode, keys: openArray[string]): bool =
   return all(keys, proc (key: string): bool = return data.hasKey(key))
 
-# Defines how to sort membership groups
-proc sortMembershipGroup*(a,b: MembershipGroup): int =
-  return cmp(a.membershipContract.address, b.membershipContract.address)
-
 # Safely saves a Keystore's JsonNode to disk.
 # If exists, the destination file is renamed with extension .bkp; the file is written at its destination and the .bkp file is removed if write is successful, otherwise is restored
 proc save*(json: JsonNode, path: string, separator: string): KeystoreResult[void] =
-
   # We first backup the current keystore
   if fileExists(path):
     try:
@@ -60,36 +57,3 @@ proc save*(json: JsonNode, path: string, separator: string): KeystoreResult[void
       return err(KeystoreOsError)
 
   return ok()
-
-# Filters a membership credential based on either input identity credential's value, membership contracts or both
-proc filterCredential*(credential: MembershipCredentials,
-                       filterIdentityCredentials: seq[IdentityCredential],
-                       filterMembershipContracts: seq[MembershipContract]): Option[MembershipCredentials] =
-
-  # We filter by identity credentials
-  if filterIdentityCredentials.len() != 0:
-    if (credential.identityCredential in filterIdentityCredentials) == false:
-      return none(MembershipCredentials)
-
-  # We filter by membership groups credentials
-  if filterMembershipContracts.len() != 0:
-    # Here we keep only groups that match a contract in the filter
-    var membershipGroupsIntersection: seq[MembershipGroup] = @[]
-    # We check if we have a group in the input credential matching any contract in the filter
-    for membershipGroup in credential.membershipGroups:
-      if membershipGroup.membershipContract in filterMembershipContracts:
-        membershipGroupsIntersection.add(membershipGroup)
-
-    if membershipGroupsIntersection.len() != 0:
-      # If we have a match on some groups, we return the credential with filtered groups
-      return some(MembershipCredentials(identityCredential: credential.identityCredential,
-                                        membershipGroups: membershipGroupsIntersection))
-
-    else:
-      return none(MembershipCredentials)
-
-  # We hit this return only if
-  # - filterIdentityCredentials.len() == 0 and filterMembershipContracts.len() == 0 (no filter)
-  # - filterIdentityCredentials.len() != 0 and filterMembershipContracts.len() == 0 (filter only on identity credential)
-  # Indeed, filterMembershipContracts.len() != 0 will have its exclusive return based on all values of membershipGroupsIntersection.len()
-  return some(credential)

--- a/waku/waku_rln_relay/constants.nim
+++ b/waku/waku_rln_relay/constants.nim
@@ -53,4 +53,4 @@ const MaxEpochGap* = uint64(MaxClockGapSeconds/EpochUnitSeconds)
 
 # RLN Keystore defaults
 const
-  RLNAppInfo* = AppInfo(application: "waku-rln-relay", appIdentifier: "01234567890abcdef", version: "0.1")
+  RLNAppInfo* = AppInfo(application: "waku-rln-relay", appIdentifier: "01234567890abcdef", version: "0.2")

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -56,8 +56,6 @@ type
     registrationTxHash*: Option[TxHash]
     chainId*: Option[Quantity]
     keystorePath*: Option[string]
-    keystoreIndex*: uint
-    membershipGroupIndex*: uint
     keystorePassword*: Option[string]
     registrationHandler*: Option[RegistrationHandler]
     # this buffer exists to backfill appropriate roots for the merkle tree,
@@ -440,19 +438,24 @@ method init*(g: OnchainGroupManager): Future[void] {.async.} =
   g.registryContract = some(registryContract)
 
   if g.keystorePath.isSome() and g.keystorePassword.isSome():
+    if g.membershipIndex.isNone():
+      raise newException(CatchableError, "membership index is not set when keystore is provided")
+    let keystoreQuery = KeystoreMembership(
+      membershipContract: MembershipContract(
+        chainId: $g.chainId.get(),
+        address: g.ethContractAddress
+      ),
+      treeIndex: MembershipIndex(g.membershipIndex.get()),
+    )
     waku_rln_membership_credentials_import_duration_seconds.nanosecondTime:
-      let parsedCredsRes = getMembershipCredentials(path = g.keystorePath.get(),
-                                                    password = g.keystorePassword.get(),
-                                                    filterMembershipContracts = @[MembershipContract(chainId: $chainId,
-                                                    address: g.ethContractAddress)],
-                                                    appInfo = RLNAppInfo)
-    if parsedCredsRes.isErr():
-      raise newException(ValueError, "could not parse the keystore: " & $parsedCredsRes.error())
-    let parsedCreds = parsedCredsRes.get()
-    if parsedCreds.len == 0:
-      raise newException(ValueError, "keystore is empty")
-    g.idCredentials = some(parsedCreds[g.keystoreIndex].identityCredential)
-    g.membershipIndex = some(parsedCreds[g.keystoreIndex].membershipGroups[g.membershipGroupIndex].treeIndex)
+      let keystoreCredRes = getMembershipCredentials(path = g.keystorePath.get(),
+                                                     password = g.keystorePassword.get(),
+                                                     query = keystoreQuery,
+                                                     appInfo = RLNAppInfo)
+    if keystoreCredRes.isErr():
+      raise newException(ValueError, "could not parse the keystore: " & $keystoreCredRes.error())
+    let keystoreCred = keystoreCredRes.get()
+    g.idCredentials = some(keystoreCred.identityCredential)
 
   let metadataGetRes = g.rlnInstance.getMetadata()
   if metadataGetRes.isErr():

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -453,7 +453,7 @@ method init*(g: OnchainGroupManager): Future[void] {.async.} =
                                                      query = keystoreQuery,
                                                      appInfo = RLNAppInfo)
     if keystoreCredRes.isErr():
-      raise newException(ValueError, "could not parse the keystore: " & $keystoreCredRes.error())
+      raise newException(ValueError, "could not parse the keystore: " & $keystoreCredRes.error)
     let keystoreCred = keystoreCredRes.get()
     g.idCredentials = some(keystoreCred.identityCredential)
 

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -32,11 +32,10 @@ logScope:
 type WakuRlnConfig* = object
   rlnRelayDynamic*: bool
   rlnRelayCredIndex*: uint
-  rlnRelayMembershipGroupIndex*: uint
   rlnRelayEthContractAddress*: string
   rlnRelayEthClientAddress*: string
   rlnRelayCredPath*: string
-  rlnRelayCredentialsPassword*: string
+  rlnRelayCredPassword*: string
   rlnRelayTreePath*: string
   rlnRelayBandwidthThreshold*: int
 
@@ -343,7 +342,6 @@ proc mount(conf: WakuRlnConfig,
           ): Future[WakuRlnRelay] {.async.} =
   var
     groupManager: GroupManager
-    credentials: MembershipCredentials
   # create an RLN instance
   let rlnInstanceRes = createRLNInstance(tree_path = conf.rlnRelayTreePath)
   if rlnInstanceRes.isErr():
@@ -365,15 +363,14 @@ proc mount(conf: WakuRlnConfig,
       if s == "": none(string) else: some(s)
     let
       rlnRelayCredPath = useValueOrNone(conf.rlnRelayCredPath)
-      rlnRelayCredentialsPassword = useValueOrNone(conf.rlnRelayCredentialsPassword)
+      rlnRelayCredPassword = useValueOrNone(conf.rlnRelayCredPassword)
     groupManager = OnchainGroupManager(ethClientUrl: conf.rlnRelayEthClientAddress,
                                        ethContractAddress: $conf.rlnRelayEthContractAddress,
                                        rlnInstance: rlnInstance,
                                        registrationHandler: registrationHandler,
                                        keystorePath: rlnRelayCredPath,
-                                       keystorePassword: rlnRelayCredentialsPassword,
-                                       keystoreIndex: conf.rlnRelayCredIndex,
-                                       membershipGroupIndex: conf.rlnRelayMembershipGroupIndex)
+                                       keystorePassword: rlnRelayCredPassword,
+                                       membershipIndex: some(conf.rlnRelayCredIndex))
   # Initialize the groupManager
   await groupManager.init()
   # Start the group sync


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR includes the modification to the waku_rln_keystore lib, where instead of credentials being sorted according to 
membership contract etc, we store it as a k-v pair, the key being `sha256(chainId|contractAddress|treeIndex)`

When the user starts a new `wakunode`, we hash the 3 together, and check if the corresponding credentials exist, if not, 
we error out.

The same goes for the `rln_keystore_generator`

This brings significant performance gains since reads are O(1) instead of O(n) 

# Changes

<!-- List of detailed changes -->

- [x] Updated `waku_rln_keystore` according to the changes above
- [x] Updated `waku_rln_relay` to work with new changes in the keystore
- [x] Updated `rln_keystore_generator` to work with new changes in the keystore 

> [!IMPORTANT]  
> This is a breaking change to existing keystores, and the version has been incremented to 0.2

## How to test

1. Generate a new set of credentials using the `rln_keystore_generator`

```
./build/rln_keystore_generator \
--rln-relay-cred-path=./rlnKeystore.json \
--rln-relay-eth-client-address=<url> \
--rln-relay-cred-password:password \
--rln-relay-eth-contract-address:0x8e1F3742B987d8BA376c0CBbD7357fE1F003ED71 \
--execute \
--rln-relay-eth-private-key=<private-key>
```

<a href="https://asciinema.org/a/605015" target="_blank"><img src="https://asciinema.org/a/605015.svg" /></a>


2. Use them in `wakunode2`

```
./build/wakunode2 \
--rln-relay=true \                          
--rln-relay-dynamic=true \
--rln-relay-eth-contract-address=0x8e1F3742B987d8BA376c0CBbD7357fE1F003ED71  \
--rln-relay-eth-client-address=<url> \
--log-level=debug \
--rln-relay-cred-password:password \
--rln-relay-cred-path:./rlnKeystore.json \
--rln-relay-membership-index:<index from generating keystore>
```

replace url and private-key as required in both snippets
the `--rln-relay-membership-index` is found after the `rln_keystore_generator` executes

## Issue

closes #1922

