### PR TITLE
fix(Makefile): error out if rln-keystore-generator not compiled with rln flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,11 +135,14 @@ $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE):
 	echo -e $(BUILD_MSG) "$@" && \
 		./scripts/build_rln.sh $(LIBRLN_BUILDDIR)
 
+librln-experimental:
+EXPERIMENTAL_PARAMS += -d:rln --passL:$(LIBRLN_FILE) --passL:-lm
+librln: $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE)
+
 ifneq ($(RLN), true)
 librln: ; # noop
 else
-EXPERIMENTAL_PARAMS += -d:rln --passL:$(LIBRLN_FILE) --passL:-lm
-librln: $(LIBRLN_BUILDDIR)/$(LIBRLN_FILE)
+librln: | librln-experimental
 endif
 
 clean-librln:
@@ -184,13 +187,9 @@ chat2: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim chat2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
-rln-keystore-generator: | build deps librln
-ifeq ($(RLN),true)
-		echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim rln_keystore_generator $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
-else
-		$(error RLN is not true. To build rln-keystore-generator, set RLN=true.)
-endif
+rln-keystore-generator: | build deps librln-experimental
+	echo -e $(BUILD_MSG) "build/$@" && \
+	$(ENV_SCRIPT) nim rln_keystore_generator $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
 chat2bridge: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ endif
 
 ### RLN
 
-LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit
+LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit/target/release
 
 ifeq ($(OS),Windows_NT)
 LIBRLN_FILE := rln.lib
@@ -185,8 +185,12 @@ chat2: | build deps librln
 		$(ENV_SCRIPT) nim chat2 $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
 rln-keystore-generator: | build deps librln
-	echo -e $(BUILD_MSG) "build/$@" && \
+ifeq ($(RLN),true)
+		echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim rln_keystore_generator $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
+else
+		$(error RLN is not true. To build rln-keystore-generator, set RLN=true.)
+endif
 
 chat2bridge: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This pr is associated to https://github.com/waku-org/nwaku/pull/1956#issuecomment-1695562089
We need to ensure that RLN is set to true when compiling the `rln-keystore-generator` target

# Changes

<!-- List of detailed changes -->

- [x] Prevents rebuilding of rln by fixing the LIBRLN_BUILDDIR
- [x] conditional compilation of rln-keystore-generator

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
