### PR TITLE
chore(api): validate rln message before sending (rest + rpc)

### DIFF
--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -658,7 +658,7 @@ suite "Waku rln relay":
       # it is a duplicate
       result3.value == true
 
-  asyncTest "validateMessage test":
+  asyncTest "validateMessageAndUpdateLog test":
     let index = MembershipIndex(5)
 
     let rlnConf = WakuRlnConfig(rlnRelayDynamic: false,
@@ -695,13 +695,13 @@ suite "Waku rln relay":
     # validate messages
     # validateMessage proc checks the validity of the message fields and adds it to the log (if valid)
     let
-      msgValidate1 = wakuRlnRelay.validateMessage(wm1, some(time))
+      msgValidate1 = wakuRlnRelay.validateMessageAndUpdateLog(wm1, some(time))
       # wm2 is published within the same Epoch as wm1 and should be found as spam
-      msgValidate2 = wakuRlnRelay.validateMessage(wm2, some(time))
+      msgValidate2 = wakuRlnRelay.validateMessageAndUpdateLog(wm2, some(time))
       # a valid message should be validated successfully
-      msgValidate3 = wakuRlnRelay.validateMessage(wm3, some(time))
+      msgValidate3 = wakuRlnRelay.validateMessageAndUpdateLog(wm3, some(time))
       # wm4 has no rln proof and should not be validated
-      msgValidate4 = wakuRlnRelay.validateMessage(wm4, some(time))
+      msgValidate4 = wakuRlnRelay.validateMessageAndUpdateLog(wm4, some(time))
 
 
     check:
@@ -750,13 +750,13 @@ suite "Waku rln relay":
     # validateMessage proc checks the validity of the message fields and adds it to the log (if valid)
     let
       # this should be no verification, Valid
-      msgValidate1 = wakuRlnRelay.validateMessage(wm1, some(time))
+      msgValidate1 = wakuRlnRelay.validateMessageAndUpdateLog(wm1, some(time))
       # this should be verification, Valid
-      msgValidate2 = wakuRlnRelay.validateMessage(wm2, some(time))
+      msgValidate2 = wakuRlnRelay.validateMessageAndUpdateLog(wm2, some(time))
       # this should be verification, Invalid
-      msgValidate3 = wakuRlnRelay.validateMessage(wm3, some(time))
+      msgValidate3 = wakuRlnRelay.validateMessageAndUpdateLog(wm3, some(time))
       # this should be verification, Spam
-      msgValidate4 = wakuRlnRelay.validateMessage(wm4, some(time))
+      msgValidate4 = wakuRlnRelay.validateMessageAndUpdateLog(wm4, some(time))
 
     check:
       msgValidate1 == MessageValidationResult.Valid
@@ -848,7 +848,7 @@ suite "Waku rln relay":
 
     # getMembershipCredentials returns the credential in the keystore which matches
     # the query, in this case the query is =
-    # chainId = "5" and 
+    # chainId = "5" and
     # address = "0x0123456789012345678901234567890123456789" and
     # treeIndex = 1
     let readKeystoreMembership = readKeystoreRes.get()

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/sequtils,
+  std/[sequtils,tempfiles],
   stew/byteutils,
   stew/shims/net,
   testutils/unittests,
@@ -22,6 +22,9 @@ import
   ../testlib/wakucore,
   ../testlib/wakunode
 
+when defined(rln):
+  import
+    ../../../waku/waku_rln_relay
 
 proc testWakuNode(): WakuNode =
   let
@@ -183,6 +186,10 @@ suite "Waku v2 Rest API - Relay":
     let node = testWakuNode()
     await node.start()
     await node.mountRelay()
+    when defined(rln):
+      await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
+          rlnRelayCredIndex: 1,
+          rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup
     let restPort = Port(58014)

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -191,9 +191,8 @@ proc validator(pubsubTopic: string, message: messages.Message): Future[Validatio
 proc isSubscribed*(w: WakuRelay, topic: PubsubTopic): bool =
   GossipSub(w).topics.hasKey(topic)
 
-iterator subscribedTopics*(w: WakuRelay): lent PubsubTopic =
-  for topic in GossipSub(w).topics.keys():
-    yield topic
+proc subscribedTopics*(w: WakuRelay): seq[PubsubTopic] =
+  return toSeq(GossipSub(w).topics.keys())
 
 proc subscribe*(w: WakuRelay, pubsubTopic: PubsubTopic, handler: WakuRelayHandler) =
   debug "subscribe", pubsubTopic=pubsubTopic
@@ -202,7 +201,7 @@ proc subscribe*(w: WakuRelay, pubsubTopic: PubsubTopic, handler: WakuRelayHandle
   let wrappedHandler = proc(pubsubTopic: string, data: seq[byte]): Future[void] {.gcsafe, raises: [].} =
     let decMsg = WakuMessage.decode(data)
     if decMsg.isErr():
-      # fine if triggerSelf enabled, since validators are bypassed
+      # fine if triggerSelf enabled, since validators are bypassed
       error "failed to decode WakuMessage, validator passed a wrong message", error = decMsg.error
       let fut = newFuture[void]()
       fut.complete()

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -181,7 +181,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay,
   # track message count for metrics
   waku_rln_messages_total.inc()
 
-  #  checks if the `msg`'s epoch is far from the current epoch
+  # checks if the `msg`'s epoch is far from the current epoch
   # it corresponds to the validation of rln external nullifier
   var epoch: Epoch
   if timeOption.isSome():
@@ -190,20 +190,19 @@ proc validateMessage*(rlnPeer: WakuRLNRelay,
     # get current rln epoch
     epoch = getCurrentEpoch()
 
-  debug "current epoch", currentEpoch = fromEpoch(epoch)
   let
     msgEpoch = proof.epoch
     # calculate the gaps
     gap = absDiff(epoch, msgEpoch)
 
-  debug "message epoch", msgEpoch = fromEpoch(msgEpoch)
+  debug "epoch info", currentEpoch = fromEpoch(epoch), msgEpoch = fromEpoch(msgEpoch)
 
   # validate the epoch
   if gap > MaxEpochGap:
     # message's epoch is too old or too ahead
     # accept messages whose epoch is within +-MaxEpochGap from the current epoch
     warn "invalid message: epoch gap exceeds a threshold", gap = gap,
-        payload = string.fromBytes(msg.payload), msgEpoch = fromEpoch(proof.epoch)
+        payloadLen = msg.payload.len, msgEpoch = fromEpoch(proof.epoch)
     waku_rln_invalid_messages_total.inc(labelValues=["invalid_epoch"])
     return MessageValidationResult.Invalid
 
@@ -224,11 +223,11 @@ proc validateMessage*(rlnPeer: WakuRLNRelay,
 
   if proofVerificationRes.isErr():
     waku_rln_errors_total.inc(labelValues=["proof_verification"])
-    warn "invalid message: proof verification failed", payload = string.fromBytes(msg.payload)
+    warn "invalid message: proof verification failed", payloadLen = msg.payload.len
     return MessageValidationResult.Invalid
   if not proofVerificationRes.value():
     # invalid proof
-    debug "invalid message: invalid proof", payload = string.fromBytes(msg.payload)
+    debug "invalid message: invalid proof", payloadLen = msg.payload.len
     waku_rln_invalid_messages_total.inc(labelValues=["invalid_proof"])
     return MessageValidationResult.Invalid
 
@@ -241,7 +240,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay,
   if hasDup.isErr():
     waku_rln_errors_total.inc(labelValues=["duplicate_check"])
   elif hasDup.value == true:
-    debug "invalid message: message is spam", payload = string.fromBytes(msg.payload)
+    debug "invalid message: message is spam", payloadLen = msg.payload.len
     waku_rln_spam_messages_total.inc()
     return MessageValidationResult.Spam
 
@@ -249,7 +248,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay,
   # the result of `updateLog` is discarded because message insertion is guaranteed by the implementation i.e.,
   # it will never error out
   discard rlnPeer.updateLog(proofMetadataRes.get())
-  debug "message is valid", payload = string.fromBytes(msg.payload)
+  debug "message is valid", payloadLen = msg.payload.len
   let rootIndex = rlnPeer.groupManager.indexOfRoot(proof.merkleRoot)
   waku_rln_valid_messages_total.observe(rootIndex.toFloat())
   return MessageValidationResult.Valid


### PR DESCRIPTION
Description:
* Adds validation to rest+rpc api so that an rln message proof is verified before sending the message. If the proof is wrong or the message is considered spam, the message won't be sent and it will error out so that the user is aware that the message didn't made it.
* Adds validation to rest+rpc api so that it errors out when trying to publish to a topic that the node is not subcribed, since it risks that there are no connected peers "listening" in that topic.
* Update tests so that they work with rln enabled/disabled.

How to test it:


```
./build/wakunode2 \
--rln-relay=true \
--rpc-address=0.0.0.0 \
--rpc-admin=true \
--rest=true \
--rest-admin=true \
--rest-private=true \
--rest-address=0.0.0.0 \
--rln-relay-dynamic=true \
--rln-relay-cred-password=password \
--rln-relay-cred-path=rlnKeystore_420.json \
--rln-relay-membership-index=420 \
--rln-relay-tree-path=rln_tree_1.db \
--rln-relay-eth-contract-address=0x8e1F3742B987d8BA376c0CBbD7357fE1F003ED71  \
--rln-relay-eth-client-address=wss://you_endpoint \
--log-level=debug
```

Rest API
```
curl -X 'POST'   'localhost:8645/relay/v1/messages/%2Fwaku%2F2%2Fdefault-waku%2Fproto'   -H 'accept: */*'   -H 'Content-Type: application/json'   -d '{
  "payload": "string",
  "contentTopic": "string",
  "version": 0,
  "timestamp": 0
}'
```

RPC API

```
curl http://localhost:8545 -d '{"jsonrpc":"2.0","method":"post_waku_v2_relay_v1_message","params":["/waku/2/default-waku/proto", {"payload": "SGkgdGhlcmUgZXRoY2M=", "timestamp": 1, "contentTopic": "some-topic", "ephemeral": false}],"id":1}' -H 'Content-Type: application/json'
```