### PR TITLE
chore(refactoring): external_config.nim - cleanup 'store-resume-peer' attribute

### DIFF
--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -244,11 +244,6 @@ type
       defaultValue: true,
       name: "store-message-db-migration" }: bool
 
-    storeResumePeer* {.
-      desc: "Peer multiaddress to resume the message store at boot.",
-      defaultValue: "",
-      name: "store-resume-peer" }: string
-
     ## Filter config
 
     filter* {.


### PR DESCRIPTION
# Description
Little cleanup of the `external_config.nim`. Removing the `store-resume-peer` attribute.
The _Store_ resume feature was partially removed in the next commit:
https://github.com/waku-org/nwaku/commit/c8081c885975d5b39803ee086df8d4b59af54f34

Hanno commented:
> I think this functionality can also be removed/disable in go-waku. It was sort of an experimental start to a "fault tolerant" store that will retrieve messages it's missed after an offline period from another store node. But the feature is not very fleshed out and should not be used in production. This would rather be followed-up by a proper redesign of the store protocol, roadmapped by the Waku Research team

> The resume code is still there behind a compile flag: https://github.com/waku-org/nwaku/blob/7d53aec16430b637b60ef8b9fd6b5a066b8b1974/waku/waku_store/client.nim#L162 The config item is indeed not used and should be removed.

Thanks for raising the issue @chaitanyaprem !