### PR TITLE
fix(ci): rename tools artifact to prevent conflict

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: tools
+          name: wakutools
           path: ${{steps.vars.outputs.nwakutools}}
           retention-days: 2
 
@@ -130,4 +130,4 @@ jobs:
 
           gh release create ${{steps.vars.outputs.release}} --prerelease ${TARGET} \
             --title ${{steps.vars.outputs.release}} --notes-file release_notes.md \
-            wakunode2/* tools/*
+            wakunode2/* wakutools/*


### PR DESCRIPTION
# Description

Addition of [rln_keystore_generator](https://github.com/waku-org/nwaku/tree/master/tools/rln_keystore_generator) broke `pre-release` (nightly, rc) workflow

# Changes

<!-- List of detailed changes -->

- [x] rename the `tools` artifact to prefent conflict with existing `tools` folder

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->