### PR TITLE
chore(Makefile): Small addon to be able to list all possible target in our Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,3 +300,11 @@ release-notes:
 			sed -E 's@#([0-9]+)@[#\1](https://github.com/waku-org/nwaku/issues/\1)@g'
 # I could not get the tool to replace issue ids with links, so using sed for now,
 # asked here: https://github.com/bvieira/sv4git/discussions/101
+
+#############################
+# List all possible Targets #
+#############################
+
+.PHONY: list
+list:
+	@LC_ALL=C $(MAKE) -pRrq -f $(firstword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/(^|\n)# Files(\n|$$)/,/(^|\n)# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'


### PR DESCRIPTION
Just a small addon, was useful for me initially (idea coming from how cmake generates Makefiles).
I hope it is still useful for others.