### PR TITLE
fix: deprecated --topic config option should be ignored when using newer options

### DIFF
--- a/waku/waku_core/topics/sharding.nim
+++ b/waku/waku_core/topics/sharding.nim
@@ -47,6 +47,14 @@ proc getShard*(topic: NsContentTopic): Result[NsPubsubTopic, string] =
     of 0: return ok(getGenZeroShard(topic, GenerationZeroShardsCount))
     else: return err("Generation > 0 are not supported yet")
 
+proc getShard*(topic: ContentTopic): Result[PubsubTopic, string] =
+  let parsedTopic = NsContentTopic.parse(topic).valueOr:
+    return err($error)
+
+  let shard = ?getShard(parsedTopic)
+
+  ok($shard)
+
 proc parseSharding*(pubsubTopic: Option[PubsubTopic], contentTopics: ContentTopic|seq[ContentTopic]): Result[Table[NsPubsubTopic, seq[NsContentTopic]], string] =
   var topics: seq[ContentTopic]
   when contentTopics is seq[ContentTopic]:


### PR DESCRIPTION
The deprecated `--topic` config has a default.

When using the newer options `--content-topic` & `--pubsub-topic` it should be ignored.

Also added `getShard` that take and return `string`