### PR TITLE
chore(Dockerfile): forcing a particular heaptrack version to avoid build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,8 @@ RUN apk add -- gdb git g++ make cmake zlib-dev boost-dev libunwind-dev
 RUN git clone https://github.com/KDE/heaptrack.git /heaptrack
 
 WORKDIR /heaptrack/build
+# going to a commit that builds properly. We will revisit this for new releases
+RUN git reset --hard f9cc35ebbdde92a292fe3870fe011ad2874da0ca
 RUN cmake -DCMAKE_BUILD_TYPE=Release ..
 RUN make -j$(nproc)
 


### PR DESCRIPTION
# Description
For any reason, the `master` branch from [heaptrack](https://github.com/KDE/heaptrack) repo became unstable and the _Docker_ build isn't working due to that.

We are enforcing a working version, instead of cloning the `master` branch each time, which can cause esporadic failures.

