### PR TITLE
fix(Makefile): invalid path to crate build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ endif
 
 ### RLN
 
-LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit/target/release
+LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit
 
 ifeq ($(OS),Windows_NT)
 LIBRLN_FILE := rln.lib


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
ref: https://ci.infra.status.im/job/nim-waku/job/manual/51/execution/node/23/log/
```
 error: manifest path `/app/vendor/zerokit/target/release/rln/Cargo.toml` does not exist
```
Removed the `/target/release` from the `LIBRLN_BUILDDIR` var

# Changes

<!-- List of detailed changes -->

- [x] Removed the `/target/release` from the `LIBRLN_BUILDDIR` var

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
