### PR TITLE
fix: preventing IP 0.0.0.0 from being published

### DIFF
--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -5,7 +5,8 @@ import
   ./waku_core/test_namespaced_topics,
   ./waku_core/test_time,
   ./waku_core/test_message_digest,
-  ./waku_core/test_peers
+  ./waku_core/test_peers,
+  ./waku_core/test_published_address
 
 
 # Waku archive test suite

--- a/tests/waku_core/test_published_address.nim
+++ b/tests/waku_core/test_published_address.nim
@@ -1,0 +1,27 @@
+{.used.}
+
+import
+  stew/shims/net as stewNet,
+  std/strutils,
+  testutils/unittests
+import
+  ../testlib/wakucore,
+  ../testlib/wakunode
+
+suite "Waku Core - Published Address":
+  
+  test "Test IP 0.0.0.0":  
+    let 
+      node = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init(
+        "0.0.0.0"),Port(0))
+ 
+    check:
+      ($node.announcedAddresses).contains("127.0.0.1")
+
+  test "Test custom IP":  
+    let 
+      node = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init(
+        "8.8.8.8"),Port(0))
+ 
+    check:
+      ($node.announcedAddresses).contains("8.8.8.8")

--- a/tests/wakunode_jsonrpc/test_jsonrpc_admin.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_admin.nim
@@ -31,10 +31,10 @@ procSuite "Waku v2 JSON-RPC API - Admin":
   asyncTest "connect to ad-hoc peers":
     # Create a couple of nodes
     let
-      node1 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60600))
-      node2 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60602))
+      node1 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(60600))
+      node2 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(60602))
       peerInfo2 = node2.switch.peerInfo
-      node3 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60604))
+      node3 = newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(60604))
       peerInfo3 = node3.switch.peerInfo
 
     await allFutures([node1.start(), node2.start(), node3.start()])
@@ -90,7 +90,7 @@ procSuite "Waku v2 JSON-RPC API - Admin":
 
   asyncTest "get managed peer information":
     # Create 3 nodes and start them with relay
-    let nodes = toSeq(0..<3).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(60220+it*2)))
+    let nodes = toSeq(0..<3).mapIt(newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(60220+it*2)))
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
 

--- a/waku/node/config.nim
+++ b/waku/node/config.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[options, sequtils],
+  std/[options, sequtils, strutils],
   stew/results,
   stew/shims/net,
   libp2p/multiaddress
@@ -52,6 +52,11 @@ template wsFlag(wssEnabled: bool): MultiAddress =
   if wssEnabled: MultiAddress.init("/wss").tryGet()
   else: MultiAddress.init("/ws").tryGet()
 
+
+proc formatListenAddress(inputMultiAdd: MultiAddress): MultiAddress =
+    let inputStr = $inputMultiAdd
+    # If MultiAddress contains "0.0.0.0", replace it for "127.0.0.1"
+    return MultiAddress.init(inputStr.replace("0.0.0.0", "127.0.0.1")).get()
 
 proc init*(T: type NetConfig,
     bindIp: ValidIpAddress,
@@ -111,7 +116,7 @@ proc init*(T: type NetConfig,
   if hostExtAddress.isSome():
     announcedAddresses.add(hostExtAddress.get())
   else:
-    announcedAddresses.add(hostAddress) # We always have at least a bind address for the host
+    announcedAddresses.add(formatListenAddress(hostAddress)) # We always have at least a bind address for the host
 
   # External multiaddrs that the operator may have configured
   if extMultiAddrs.len > 0:

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -121,8 +121,9 @@ proc addPeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo, origin = UnknownO
   discard remotePeerInfo.peerId.extractPublicKey(publicKey)
 
   if pm.peerStore[AddressBook][remotePeerInfo.peerId] == remotePeerInfo.addrs and
-     pm.peerStore[KeyBook][remotePeerInfo.peerId] == publicKey:
-    # Peer already managed
+     pm.peerStore[KeyBook][remotePeerInfo.peerId] == publicKey and
+     pm.peerStore[ENRBook][remotePeerInfo.peerId].raw.len > 0:
+    # Peer already managed and ENR info is already saved
     return
 
   trace "Adding peer to manager", peerId = remotePeerInfo.peerId, addresses = remotePeerInfo.addrs


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Currently, the IP address `0.0.0.0` is being published in the Identify message when there's no external addresses found. This happens in cases when Waku nodes are being run locally.

This goes against [RFC 1122](https://www.rfc-editor.org/rfc/rfc1122#page-29), section 3.2.1.3 where referring to the `0.0.0.0` IP it states:
>This host on this network. MUST NOT be sent, except as a source address as part of an initialization procedure by which the host learns its own IP address.

In that case, we will publish localhost's loopback interface's address `127.0.0.1` instead.
# Changes


<!-- List of detailed changes -->

- [x] Added function `formatListenAddress`, which checks if IP `0.0.0.0` is present in the node's published address and if so, replaces it for `127.0.0.1`.
- [x] Added an unit test suite for this functionality
- [x] Allowing the function `addPeer` to modify an existing peer entry whenever it's missing ENR data
- [x] Modified tests that used and expected the IP `0.0.0.0` to use IP `127.0.0.1`  

## How to test

When running the node locally, if no IP address is specified (or if the 0 IP is provided as an input), the node should publish the `127.0.0.1` IP instead.

![image](https://github.com/waku-org/nwaku/assets/101006718/56ffe458-59b9-4ae8-96b2-e2f96342ea07)

If a custom IP is provided, it should be published

![image](https://github.com/waku-org/nwaku/assets/101006718/bbb96e2f-8acf-4c89-b7ad-93a797b4defc)



## Issue

closes [#1427](https://github.com/waku-org/nwaku/issues/1427)
