### PR TITLE
chore(rln-relay): use the only key from keystore if only 1 exists

### DIFF
--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -233,9 +233,8 @@ type
       name: "rln-relay-cred-path" }: string
 
     rlnRelayCredIndex* {.
-      desc: "the index of credentials to use",
-      defaultValue: 0
-      name: "rln-relay-cred-index" }: uint
+      desc: "the index of the onchain commitment to use",
+      name: "rln-relay-cred-index" }: Option[uint]
 
     rlnRelayDynamic* {.
       desc: "Enable waku-rln-relay with on-chain dynamic group management: true|false",
@@ -296,6 +295,12 @@ proc parseCmdArg*(T: type Port, p: string): T =
 
 proc completeCmdArg*(T: type Port, val: string): seq[string] =
   return @[]
+
+proc parseCmdArg*(T: type Option[uint], p: string): T =
+  try:
+    some(parseUint(p))
+  except CatchableError:
+    raise newException(ConfigurationError, "Invalid unsigned integer")
 
 func defaultListenAddress*(conf: Chat2Conf): ValidIpAddress =
   # TODO: How should we select between IPv4 and IPv6

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -146,9 +146,8 @@ type
       name: "rln-relay-cred-path" }: string
 
     rlnRelayCredIndex* {.
-      desc: "the index of credentials to use",
-      defaultValue: 0
-      name: "rln-relay-membership-index" }: uint
+      desc: "the index of the onchain commitment to use",
+      name: "rln-relay-membership-index" }: Option[uint]
 
     rlnRelayDynamic* {.
       desc: "Enable  waku-rln-relay with on-chain dynamic group management: true|false",
@@ -505,6 +504,12 @@ proc parseCmdArg*(T: type Option[int], p: string): T =
     some(parseInt(p))
   except CatchableError:
     raise newException(ConfigurationError, "Invalid number")
+
+proc parseCmdArg*(T: type Option[uint], p: string): T =
+  try:
+    some(parseUint(p))
+  except CatchableError:
+    raise newException(ConfigurationError, "Invalid unsigned integer")
 
 ## Configuration validation
 

--- a/tests/test_waku_keystore.nim
+++ b/tests/test_waku_keystore.nim
@@ -3,7 +3,7 @@
 import
   std/[os, json],
   chronos,
-  testutils/unittests 
+  testutils/unittests
 import
   ../../waku/waku_keystore,
   ./testlib/common
@@ -123,3 +123,89 @@ procSuite "Credentials test suite":
       recoveredCredentialsRes.isOk()
       recoveredCredentialsRes.get() == expectedMembership
 
+  test "if the keystore contains only one credential, fetch that irrespective of treeIndex":
+
+    let filepath = "./testAppKeystore.txt"
+    defer: removeFile(filepath)
+
+    # We generate random identity credentials (inter-value constrains are not enforced, otherwise we need to load e.g. zerokit RLN keygen)
+    let
+      idTrapdoor = randomSeqByte(rng[], 32)
+      idNullifier =  randomSeqByte(rng[], 32)
+      idSecretHash = randomSeqByte(rng[], 32)
+      idCommitment = randomSeqByte(rng[], 32)
+      idCredential = IdentityCredential(idTrapdoor: idTrapdoor, idNullifier: idNullifier, idSecretHash: idSecretHash, idCommitment: idCommitment)
+
+    let contract = MembershipContract(chainId: "5", address: "0x0123456789012345678901234567890123456789")
+    let index = MembershipIndex(1)
+    let membershipCredential = KeystoreMembership(membershipContract: contract,
+                                                  treeIndex: index,
+                                                  identityCredential: idCredential)
+
+    let password = "%m0um0ucoW%"
+
+    let keystoreRes = addMembershipCredentials(path = filepath,
+                                               membership = membershipCredential,
+                                               password = password,
+                                               appInfo = testAppInfo)
+
+    assert(keystoreRes.isOk(), $keystoreRes.error)
+
+    # We test retrieval of credentials.
+    let expectedMembership = membershipCredential
+    let membershipQuery = KeystoreMembership(membershipContract: contract)
+
+    let recoveredCredentialsRes = getMembershipCredentials(path = filepath,
+                                                           password = password,
+                                                           query = membershipQuery,
+                                                           appInfo = testAppInfo)
+
+    assert(recoveredCredentialsRes.isOk(), $recoveredCredentialsRes.error)
+    check: recoveredCredentialsRes.get() == expectedMembership
+
+  test "if the keystore contains multiple credentials, then error out if treeIndex has not been passed in":
+    let filepath = "./testAppKeystore.txt"
+    defer: removeFile(filepath)
+
+    # We generate random identity credentials (inter-value constrains are not enforced, otherwise we need to load e.g. zerokit RLN keygen)
+    let
+      idTrapdoor = randomSeqByte(rng[], 32)
+      idNullifier =  randomSeqByte(rng[], 32)
+      idSecretHash = randomSeqByte(rng[], 32)
+      idCommitment = randomSeqByte(rng[], 32)
+      idCredential = IdentityCredential(idTrapdoor: idTrapdoor, idNullifier: idNullifier, idSecretHash: idSecretHash, idCommitment: idCommitment)
+
+    # We generate two distinct membership groups
+    let contract = MembershipContract(chainId: "5", address: "0x0123456789012345678901234567890123456789")
+    let index = MembershipIndex(1)
+    var membershipCredential = KeystoreMembership(membershipContract: contract,
+                                                  treeIndex: index,
+                                                  identityCredential: idCredential)
+
+    let password = "%m0um0ucoW%"
+
+    let keystoreRes = addMembershipCredentials(path = filepath,
+                                                membership = membershipCredential,
+                                                password = password,
+                                                appInfo = testAppInfo)
+
+    assert(keystoreRes.isOk(), $keystoreRes.error)
+
+    membershipCredential.treeIndex = MembershipIndex(2)
+    let keystoreRes2 = addMembershipCredentials(path = filepath,
+                                                membership = membershipCredential,
+                                                password = password,
+                                                appInfo = testAppInfo)
+    assert(keystoreRes2.isOk(), $keystoreRes2.error)
+
+    # We test retrieval of credentials.
+    let membershipQuery = KeystoreMembership(membershipContract: contract)
+
+    let recoveredCredentialsRes = getMembershipCredentials(path = filepath,
+                                                           password = password,
+                                                           query = membershipQuery,
+                                                           appInfo = testAppInfo)
+
+    check:
+      recoveredCredentialsRes.isErr()
+      recoveredCredentialsRes.error.kind == KeystoreCredentialNotFoundError

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -662,7 +662,7 @@ suite "Waku rln relay":
     let index = MembershipIndex(5)
 
     let rlnConf = WakuRlnConfig(rlnRelayDynamic: false,
-                                rlnRelayCredIndex: index.uint,
+                                rlnRelayCredIndex: some(index),
                                 rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_2"))
     let wakuRlnRelayRes = await WakuRlnRelay.new(rlnConf)
     require:
@@ -714,7 +714,7 @@ suite "Waku rln relay":
     let index = MembershipIndex(5)
 
     let rlnConf = WakuRlnConfig(rlnRelayDynamic: false,
-                                rlnRelayCredIndex: index.uint,
+                                rlnRelayCredIndex: some(index),
                                 rlnRelayBandwidthThreshold: 4,
                                 rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_3"))
     let wakuRlnRelayRes = await WakuRlnRelay.new(rlnConf)

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -45,7 +45,7 @@ procSuite "WakuNode - RLN relay":
 
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 1.uint,
+      rlnRelayCredIndex: some(1.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode"),
     ))
 
@@ -55,7 +55,7 @@ procSuite "WakuNode - RLN relay":
     await node2.mountRelay(@[DefaultPubsubTopic])
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 2.uint,
+      rlnRelayCredIndex: some(2.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_2"),
     ))
 
@@ -65,7 +65,7 @@ procSuite "WakuNode - RLN relay":
     await node3.mountRelay(@[DefaultPubsubTopic])
 
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 3.uint,
+      rlnRelayCredIndex: some(3.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_3"),
     ))
 
@@ -126,7 +126,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     for index, node in nodes:
       await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-        rlnRelayCredIndex: index.uint + 1,
+        rlnRelayCredIndex: some(index.uint + 1),
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_" & $(index+1))))
 
     # start them
@@ -204,7 +204,7 @@ procSuite "WakuNode - RLN relay":
 
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 1.uint,
+      rlnRelayCredIndex: some(1.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_4"),
       rlnRelayBandwidthThreshold: 0,
     ))
@@ -215,7 +215,7 @@ procSuite "WakuNode - RLN relay":
     await node2.mountRelay(@[DefaultPubsubTopic])
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 2.uint,
+      rlnRelayCredIndex: some(2.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_5"),
       rlnRelayBandwidthThreshold: 0,
     ))
@@ -226,7 +226,7 @@ procSuite "WakuNode - RLN relay":
     await node3.mountRelay(@[DefaultPubsubTopic])
 
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 3.uint,
+      rlnRelayCredIndex: some(3.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_6"),
       rlnRelayBandwidthThreshold: 0,
     ))
@@ -306,7 +306,7 @@ procSuite "WakuNode - RLN relay":
 
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 1.uint,
+      rlnRelayCredIndex: some(1.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_7"),
       rlnRelayBandwidthThreshold: 0,
     ))
@@ -318,7 +318,7 @@ procSuite "WakuNode - RLN relay":
 
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 2.uint,
+      rlnRelayCredIndex: some(2.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_8"),
       rlnRelayBandwidthThreshold: 0,
     ))
@@ -330,7 +330,7 @@ procSuite "WakuNode - RLN relay":
 
     # mount rlnrelay in off-chain mode
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-      rlnRelayCredIndex: 3.uint,
+      rlnRelayCredIndex: some(3.uint),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_9"),
       rlnRelayBandwidthThreshold: 0,
     ))

--- a/tests/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -106,11 +106,11 @@ suite "Waku v2 JSON-RPC API - Relay":
 
     when defined(rln):
       await srcNode.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-          rlnRelayCredIndex: 1,
+          rlnRelayCredIndex: some(1.uint),
           rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
       await dstNode.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-          rlnRelayCredIndex: 2,
+          rlnRelayCredIndex: some(2.uint),
           rlnRelayTreePath: genTempPath("rln_tree", "wakunode_2")))
 
     await srcNode.connectToNodes(@[dstNode.peerInfo.toRemotePeerInfo()])

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -188,7 +188,7 @@ suite "Waku v2 Rest API - Relay":
     await node.mountRelay()
     when defined(rln):
       await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
-          rlnRelayCredIndex: 1,
+          rlnRelayCredIndex: some(1.uint),
           rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup

--- a/waku/waku_keystore/keystore.nim
+++ b/waku/waku_keystore/keystore.nim
@@ -7,6 +7,7 @@ import
   options,
   json,
   strutils,
+  sequtils,
   std/[tables, os]
 
 import
@@ -191,8 +192,10 @@ proc getMembershipCredentials*(path: string,
                                     msg: "No credentials found in keystore"))
       var keystoreCredential: JsonNode
       if keystoreCredentials.len == 1:
-        for v in keystoreCredentials.getFields().values():
-          keystoreCredential = v
+        keystoreCredential = keystoreCredentials
+                              .getFields()
+                              .values()
+                              .toSeq()[0]
       else:
         let key = query.hash()
         if not keystoreCredentials.hasKey(key):

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -31,7 +31,7 @@ logScope:
 
 type WakuRlnConfig* = object
   rlnRelayDynamic*: bool
-  rlnRelayCredIndex*: uint
+  rlnRelayCredIndex*: Option[uint]
   rlnRelayEthContractAddress*: string
   rlnRelayEthClientAddress*: string
   rlnRelayCredPath*: string
@@ -374,7 +374,7 @@ proc mount(conf: WakuRlnConfig,
       raise newException(ValueError, "Static group keys are not valid")
     groupManager = StaticGroupManager(groupSize: StaticGroupSize,
                                       groupKeys: parsedGroupKeysRes.get(),
-                                      membershipIndex: some(conf.rlnRelayCredIndex),
+                                      membershipIndex: conf.rlnRelayCredIndex,
                                       rlnInstance: rlnInstance)
     # we don't persist credentials in static mode since they exist in ./constants.nim
   else:
@@ -390,7 +390,7 @@ proc mount(conf: WakuRlnConfig,
                                        registrationHandler: registrationHandler,
                                        keystorePath: rlnRelayCredPath,
                                        keystorePassword: rlnRelayCredPassword,
-                                       membershipIndex: some(conf.rlnRelayCredIndex))
+                                       membershipIndex: conf.rlnRelayCredIndex)
   # Initialize the groupManager
   await groupManager.init()
   # Start the group sync


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
from the perspective of an end user, i will most likely have only one membership per chainId-contractAddress pair.
To account for this, we are removing `rln-relay-membership-index` as a compulsory argument to wakunode2, and instead, using the `only` available key in the keystore

# Changes

<!-- List of detailed changes -->

- [x] Changes to the keystore to account for this
- [x] Updated tests 
- [x] Updated config of wakunode2 and chat2 to make it an `Option` type
- [x] Updated OnchainGroupManager init process to set the membershipIndex appropriately


## How to test

1. Create a fresh keystore using rln-keystore-generator - contractAddress: `0x0A988fd9CA5BAebDf098b8A73621b2AaDa6492E8` 
1. Run wakunode2 with the following args 
```shell
./build/wakunode2 \
--rln-relay=true \
--rln-relay-dynamic=true \
--rln-relay-cred-password=$KEYSTORE_PASSWORD \
--rln-relay-cred-path=rlnKeystore.json \
--rln-relay-tree-path=rln_tree_new_1.db \
--rln-relay-eth-contract-address=0x0A988fd9CA5BAebDf098b8A73621b2AaDa6492E8  \
--rln-relay-eth-client-address=$SEPOLIA_URL \
--nodekey=161c2836197e8918d7eb1039758423795f0dc697a018ed55d5931aa9b0e5efb3 \
--log-level=debug
```

You should see that it is able to fetch the membership index from the decrypted keystore. Additionally, the rpc api is able to append proofs to messages as well.



## Issue

Addresses a part of #1906
