### PR TITLE
fix(ci): incorrect use of braces

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           EXPERIMENTAL=${{ inputs.experimental }}
 
-          make -j${NPROC} V=1 QUICK_AND_DIRTY_COMPILER=1 NIMFLAGS="-d:disableMarchNative" wakunode2 EXPERIMENTAL=${{EXPERIMENTAL}}
+          make -j${NPROC} V=1 QUICK_AND_DIRTY_COMPILER=1 NIMFLAGS="-d:disableMarchNative" wakunode2 EXPERIMENTAL=${EXPERIMENTAL}
 
           TAG=$([ "${PR_NUMBER}" == "" ] && echo "master" || echo "${PR_NUMBER}")
           TAG=$([ "${EXPERIMENTAL}" == "true" ] && echo "${TAG}-experimental" || echo "${TAG}")


### PR DESCRIPTION
# Description

Using double braces leads to workflow trying to resolve env var as a template

# Changes

<!-- List of detailed changes -->

- [ ] remove one set of braces

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->