### PR TITLE
chore(ci): use commit instead of master for docker image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -44,7 +44,9 @@ jobs:
 
           make -j${NPROC} V=1 QUICK_AND_DIRTY_COMPILER=1 NIMFLAGS="-d:disableMarchNative" wakunode2 EXPERIMENTAL=${EXPERIMENTAL}
 
-          TAG=$([ "${PR_NUMBER}" == "" ] && echo "master" || echo "${PR_NUMBER}")
+          SHORT_REF=$(git rev-parse --short HEAD)
+
+          TAG=$([ "${PR_NUMBER}" == "" ] && echo "${SHORT_REF}" || echo "${PR_NUMBER}")
           TAG=$([ "${EXPERIMENTAL}" == "true" ] && echo "${TAG}-experimental" || echo "${TAG}")
           IMAGE=quay.io/wakuorg/nwaku-pr:${TAG}
 


### PR DESCRIPTION
# Description

per @alrevuelta's reuest - replacing `master` tag with git commit for traceability 

# Changes

<!-- List of detailed changes -->

- [ ] replace `master` tag with `git rev-parse --short HEAD` output


<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->