### PR TITLE
chore(rln-relay): clean up nullifier table every MaxEpochGap

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -402,7 +402,6 @@ proc setupProtocols(node: WakuNode,
         rlnRelayCredPath: conf.rlnRelayCredPath,
         rlnRelayCredPassword: conf.rlnRelayCredPassword,
         rlnRelayTreePath: conf.rlnRelayTreePath,
-        rlnRelayBandwidthThreshold: conf.rlnRelayBandwidthThreshold
       )
 
       try:


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR clears the nullifier table every time there are more than `MaxEpochGap` epochs stored in it

# Changes

<!-- List of detailed changes -->

- [x] Updated rln-relay validator to clear nullifier log on invocation
- [x] Added test

<!--
## How to test

1.
1.
1.

-->



## Issue

Addresses a part of #1906
