### PR TITLE
fix(p2p): fix possible connectivity issue

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -10,7 +10,6 @@ import
   chronicles,
   metrics,
   libp2p/multistream,
-  libp2p/connmanager,
   libp2p/muxers/muxer,
   libp2p/nameresolving/nameresolver
 import

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -10,6 +10,7 @@ import
   chronicles,
   metrics,
   libp2p/multistream,
+  libp2p/connmanager,
   libp2p/muxers/muxer,
   libp2p/nameresolving/nameresolver
 import
@@ -53,7 +54,7 @@ const
   ConnectivityLoopInterval = chronos.seconds(15)
 
   # How often the peer store is pruned
-  PrunePeerStoreInterval = chronos.minutes(5)
+  PrunePeerStoreInterval = chronos.minutes(10)
 
   # How often metrics and logs are shown/updated
   LogAndMetricsInterval = chronos.minutes(3)
@@ -583,15 +584,16 @@ proc connectToRelayPeers*(pm: PeerManager) {.async.} =
   let totalRelayPeers = inRelayPeers.len + outRelayPeers.len
   let inPeersTarget = maxConnections - pm.outRelayPeersTarget
 
-  if inRelayPeers.len > pm.inRelayPeersTarget:
-    await pm.pruneInRelayConns(inRelayPeers.len - pm.inRelayPeersTarget)
+  # TODO: Temporally disabled. Might be causing connection issues
+  #if inRelayPeers.len > pm.inRelayPeersTarget:
+  #  await pm.pruneInRelayConns(inRelayPeers.len - pm.inRelayPeersTarget)
 
   if outRelayPeers.len >= pm.outRelayPeersTarget:
     return
 
   let notConnectedPeers = pm.peerStore.getNotConnectedPeers().mapIt(RemotePeerInfo.init(it.peerId, it.addrs))
   let outsideBackoffPeers = notConnectedPeers.filterIt(pm.canBeConnected(it.peerId))
-  let numPeersToConnect = min(min(maxConnections - totalRelayPeers, outsideBackoffPeers.len), MaxParalelDials)
+  let numPeersToConnect = min(outsideBackoffPeers.len, MaxParalelDials)
 
   await pm.connectToNodes(outsideBackoffPeers[0..<numPeersToConnect])
 

--- a/waku/node/waku_switch.nim
+++ b/waku/node/waku_switch.nim
@@ -101,7 +101,7 @@ proc newWakuSwitch*(
     if peerStoreCapacity.isSome():
       b = b.withPeerStore(peerStoreCapacity.get())
     else:
-      let defaultPeerStoreCapacity = int(round(float64(maxConnections)*1.25))
+      let defaultPeerStoreCapacity = int(maxConnections)*5
       b = b.withPeerStore(defaultPeerStoreCapacity)
     if agentString.isSome():
       b = b.withAgentVersion(agentString.get())


### PR DESCRIPTION
Description:
* Temporally comment inbound relay peer prunning, since it may be causing connectivity issues. Note that prunning by IP is kept, this just affects the general prunning.
* Increase default peer store size. If the max amount of peers is `x` the peerstore size should be way bigger than that. If no, we wont benefit much from the exponential backoff, since after prunning, this state is "forgotten".
* Increase peerstore prunning interval to 10 minutes.

Test:
* Simulated in an environment with `waku-simulator`