### PR TITLE
chore(postgres): Adding healtcheck and reconnection mechanism to the postgres archive driver

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -411,10 +411,17 @@ proc setupProtocols(node: WakuNode,
         return err("failed to mount waku RLN relay protocol: " & getCurrentExceptionMsg())
 
   if conf.store:
+    var onErrAction = proc(msg: string) {.gcsafe, closure.} =
+      ## Action to be taken when an internal error occurs during the node run.
+      ## e.g. the connection with the database is lost and not recovered.
+      error "Unrecoverable error occurred", error = msg
+      quit(QuitFailure)
+
     # Archive setup
     let archiveDriverRes = ArchiveDriver.new(conf.storeMessageDbUrl,
                                              conf.storeMessageDbVacuum,
-                                             conf.storeMessageDbMigration)
+                                             conf.storeMessageDbMigration,
+                                             onErrAction)
     if archiveDriverRes.isErr():
       return err("failed to setup archive driver: " & archiveDriverRes.error)
 

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -16,6 +16,7 @@ const DefaultPageSize*: uint = 25
 type
   ArchiveDriverResult*[T] = Result[T, string]
   ArchiveDriver* = ref object of RootObj
+  OnErrHandler* = proc(errMsg: string) {.gcsafe, closure.}
 
 type ArchiveRow* = (PubsubTopic, WakuMessage, seq[byte], Timestamp)
 

--- a/waku/waku_archive/driver/builder.nim
+++ b/waku/waku_archive/driver/builder.nim
@@ -25,8 +25,13 @@ export
 proc new*(T: type ArchiveDriver,
           url: string,
           vacuum: bool,
-          migrate: bool):
+          migrate: bool,
+          onErrAction: OnErrHandler):
           Result[T, string] =
+  ## url - string that defines the database
+  ## vacuum - if true, a cleanup operation will be applied to the database
+  ## migrate - if true, the database schema will be updated
+  ## onErrAction - called if, e.g., the connection with db got lost forever
 
   let dbUrlValidationRes = dburl.validateDbUrl(url)
   if dbUrlValidationRes.isErr():
@@ -74,7 +79,7 @@ proc new*(T: type ArchiveDriver,
 
   of "postgres":
     const MaxNumConns = 5 #TODO: we may need to set that from app args (maybe?)
-    let res = PostgresDriver.new(url, MaxNumConns)
+    let res = PostgresDriver.new(url, MaxNumConns, onErrAction)
     if res.isErr():
       return err("failed to init postgres archive driver: " & res.error)
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_healthcheck.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_healthcheck.nim
@@ -1,0 +1,47 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  chronos,
+  stew/results
+import
+  ../../driver,
+  ../../../common/databases/db_postgres
+
+## Simple query to validate that the postgres is working and attending requests
+const HealthCheckQuery = "SELECT version();"
+const CheckConnectivityInterval = 30.seconds
+const MaxNumTrials = 20
+const TrialInterval = 1.seconds
+
+proc checkConnectivity*(connPool: PgAsyncPool,
+                        onErrAction: OnErrHandler) {.async.} =
+
+  while true:
+
+    (await connPool.exec(HealthCheckQuery)).isOkOr:
+
+      ## The connection failed once. Let's try reconnecting for a while.
+      ## Notice that the 'exec' proc tries to establish a new connection.
+
+      block errorBlock:
+        ## Force close all the opened connections. No need to close gracefully.
+        (await connPool.resetConnPool()).isOkOr:
+          onErrAction("checkConnectivity resetConnPool error: " & error)
+
+        var numTrial = 0
+        while numTrial < MaxNumTrials:
+          let res = await connPool.exec(HealthCheckQuery)
+          if res.isOk():
+            ## Connection resumed. Let's go back to the normal healthcheck.
+            break errorBlock
+
+          await sleepAsync(TrialInterval)
+          numTrial.inc()
+
+        ## The connection couldn't be resumed. Let's inform the upper layers.
+        onErrAction("postgres health check error: " & error)
+
+    await sleepAsync(CheckConnectivityInterval)


### PR DESCRIPTION
# Description
It starts an asynchronous infinite task that checks the connectivity with the database.

In case of error, the `postgres_healthcheck` task tries to reconnect for a while, and if it determines that the connection cannot be resumed, then it invokes a callback indicating that situation.

For the case of the `wakunode2` app, that callback quits the application itself and adds a log trace indicating the connectivity issue with the database.


# Changes

- [x] New `proc resetConnPool*(pool: PgAsyncPool)` to force close the pool if either the database got down or lost the connection with it.
- [x] `wakunode2` quits if it has _Store_ mounted and the _Postgres_ database goes down for more than 30''.
- [x] New `waku/waku_archive/driver/postgres_driver/postgres_healthcheck.nim` that contains the infinite health check proc.

## How to test
### Test case: `wakunode2` stops if the database gets stopped.
1. Run node A - `./build/wakunode2 --config-file=cfg_node_a.txt`
[cfg_node_a.txt](https://github.com/waku-org/nwaku/files/12537414/cfg_node_a.txt)

2. Run node B - `./build/wakunode2 --config-file=cfg_node_b.txt`
[cfg_node_b.txt](https://github.com/waku-org/nwaku/files/12537417/cfg_node_b.txt)

3. Run a _Postgres_ instance: `docker compose -f postgres-docker-compose.yml up`
Content of postgres-docker-compose.yml:
```
version: "3.8"

services:
  db:
    image: postgres:9.6-alpine
    restart: always
    environment:
      POSTGRES_PASSWORD: test123
    ports:
      - "5432:5432"
```
4. Close the _Postgres_ instance started in 3. After less than 30'' the `wakunode2` should stop.

### Test case: `wakunode2` resumes connection with the _Postgres_ database.
1. Run node A - `./build/wakunode2 --config-file=cfg_node_a.txt`
[cfg_node_a.txt](https://github.com/waku-org/nwaku/files/12537414/cfg_node_a.txt)

2. Run node B - `./build/wakunode2 --config-file=cfg_node_b.txt`
[cfg_node_b.txt](https://github.com/waku-org/nwaku/files/12537417/cfg_node_b.txt)

3. Run a _Postgres_ instance: `docker compose -f postgres-docker-compose.yml up`
Content of postgres-docker-compose.yml:
```
version: "3.8"

services:
  db:
    image: postgres:9.6-alpine
    restart: always
    environment:
      POSTGRES_PASSWORD: test123
    ports:
      - "5432:5432"
```
4.
  - Perform a _Store_ request: `curl -d '{"jsonrpc":"2.0","id":"id","method":"get_waku_v2_store_v1_messages"}' --header "Content-Type: application/json" http://localhost:8546`
  In this case, a valid response should be returned.
  - Close the database started in 3.
  - Send another _Store_ request.
  Now, the next error should appear: `{"jsonrpc":"2.0","id":"id","error":{"code":-32000,"message":"get_waku_v2_store_v1_messages raised an exception","data":"BAD_REQUEST: invalid cursor"}}`
 - Start the database again (point 3.) and wait for 30''.
 - Send another _Store_ request. A valid response should come.

## Issue
closes https://github.com/waku-org/nwaku/issues/1893
