### PR TITLE
feat(rln_db_inspector): create rln_db_inspector tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,10 @@ rln-keystore-generator: | build deps librln-experimental
 	echo -e $(BUILD_MSG) "build/$@" && \
 	$(ENV_SCRIPT) nim rln_keystore_generator $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
 
+rln-db-inspector: | build deps librln-experimental
+	echo -e $(BUILD_MSG) "build/$@" && \
+	$(ENV_SCRIPT) nim rln_db_inspector $(NIM_PARAMS) $(EXPERIMENTAL_PARAMS) waku.nims
+
 chat2bridge: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim chat2bridge $(NIM_PARAMS) waku.nims

--- a/tools/rln_db_inspector/external_config.nim
+++ b/tools/rln_db_inspector/external_config.nim
@@ -43,7 +43,5 @@ proc loadConfig*(T: type RlnDbInspectorConf): Result[T, string] =
     if conf.rlnRelayTreePath == "":
       return err("--rln-relay-tree-path must be set")
     ok(conf)
-  except CatchableError:
-    err(getCurrentExceptionMsg())
-  except Exception:
+  except CatchableError, Exception:
     err(getCurrentExceptionMsg())

--- a/tools/rln_db_inspector/external_config.nim
+++ b/tools/rln_db_inspector/external_config.nim
@@ -1,0 +1,49 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  stew/results,
+  chronos,
+  confutils,
+  confutils/defs,
+  confutils/toml/defs as confTomlDefs,
+  confutils/toml/std/net as confTomlNet,
+  libp2p/crypto/crypto,
+  libp2p/crypto/secp,
+  libp2p/multiaddress,
+  secp256k1
+import
+  ../../waku/common/confutils/envvar/defs as confEnvvarDefs,
+  ../../waku/common/confutils/envvar/std/net as confEnvvarNet
+
+export
+  confTomlDefs,
+  confTomlNet,
+  confEnvvarDefs,
+  confEnvvarNet
+
+type
+  RlnDbInspectorConf* = object
+    configFile* {.
+      desc: "Loads configuration from a TOML file (cmd-line parameters take precedence)",
+      name: "config-file" }: Option[InputFile]
+
+    ## General node config
+    rlnRelayTreePath* {.
+      desc: "The path to the rln-relay tree",
+      defaultValue: "",
+      name: "rln-relay-tree-path" }: string
+
+
+proc loadConfig*(T: type RlnDbInspectorConf): Result[T, string] =
+  try:
+    let conf = RlnDbInspectorConf.load()
+    if conf.rlnRelayTreePath == "":
+      return err("--rln-relay-tree-path must be set")
+    ok(conf)
+  except CatchableError:
+    err(getCurrentExceptionMsg())
+  except Exception:
+    err(getCurrentExceptionMsg())

--- a/tools/rln_db_inspector/nim.cfg
+++ b/tools/rln_db_inspector/nim.cfg
@@ -1,0 +1,3 @@
+-d:chronicles_line_numbers
+-d:chronicles_runtime_filtering=on
+#-d:"chronicles_enabled_topics=GossipSub:TRACE,WakuRelay:TRACE"

--- a/tools/rln_db_inspector/rln_db_inspector.nim
+++ b/tools/rln_db_inspector/rln_db_inspector.nim
@@ -19,12 +19,9 @@ logScope:
 when isMainModule:
   {.pop.}
   # 1. load configuration
-  let confRes = RlnDbInspectorConf.loadConfig()
-  if confRes.isErr():
+  let conf = RlnDbInspectorConf.loadConfig().isOkOr:
     error "failure while loading the configuration", error=confRes.error
     quit(1)
-
-  let conf = confRes.get()
 
   trace "configuration", conf = $conf
 

--- a/tools/rln_db_inspector/rln_db_inspector.nim
+++ b/tools/rln_db_inspector/rln_db_inspector.nim
@@ -1,0 +1,53 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  chronicles,
+  sequtils,
+  stew/[results]
+
+import
+  ../../waku/waku_rln_relay/rln,
+  ../../waku/waku_rln_relay/conversion_utils,
+  ./external_config
+
+logScope:
+  topics = "rln_db_inspector"
+
+when isMainModule:
+  {.pop.}
+  # 1. load configuration
+  let confRes = RlnDbInspectorConf.loadConfig()
+  if confRes.isErr():
+    error "failure while loading the configuration", error=confRes.error
+    quit(1)
+
+  let conf = confRes.get()
+
+  trace "configuration", conf = $conf
+
+  # 2. initialize rlnInstance
+  let rlnInstanceRes = createRLNInstance(d=20,
+                                         tree_path = conf.rlnRelayTreePath)
+  if rlnInstanceRes.isErr():
+    error "failure while creating RLN instance", error=rlnInstanceRes.error
+    quit(1)
+
+  let rlnInstance = rlnInstanceRes.get()
+
+  # 3. get metadata
+  let metadataGetRes = rlnInstance.getMetadata()
+  if metadataGetRes.isErr():
+    error "failure while getting RLN metadata", error=metadataGetRes.error
+    quit(1)
+
+  let metadata = metadataGetRes.get()
+
+  info "RLN metadata", lastProcessedBlock = metadata.lastProcessedBlock, 
+                       chainId = metadata.chainId,
+                       contractAddress = metadata.contractAddress,
+                       validRoots = metadata.validRoots.mapIt(it.inHex())
+
+  quit(0)

--- a/waku.nimble
+++ b/waku.nimble
@@ -74,6 +74,10 @@ task rln_keystore_generator, "Build the rln keystore generator":
   let name = "rln_keystore_generator"
   buildBinary name, "tools/rln_keystore_generator/"
 
+task rln_db_inspector, "Build the rln db inspector":
+  let name = "rln_db_inspector"
+  buildBinary name, "tools/rln_db_inspector/"
+
 task test, "Build & run Waku tests":
   test "all_tests_waku"
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
While debugging and running simulations, it can be useful to inspect the rln tree db. 
Future PRs can add more inspection capabilities, but this will be useful for now.

# Changes

<!-- List of detailed changes -->

- [x] new tool `rln_db_inspector`
- [x] updated makefile entry and `waku.nimble`


## How to test

1. Have a pre-existing rln tree db (from running wakunode2)
1. Compile the binary `make -j12 rln-db-inspector`
1. Run `./build/rln-db-inspector --rln-relay-tree-path:<path>`


<img width="801" alt="image" src="https://github.com/waku-org/nwaku/assets/43716372/7ec22859-6c73-4ae4-96aa-3a50b52795a5">




<!--
## Issue

closes #
-->
