### PR TITLE
chore(ci): execute js-waku integration tests on image build

### DIFF
--- a/.github/workflows/ci-experimental.yml
+++ b/.github/workflows/ci-experimental.yml
@@ -128,3 +128,10 @@ jobs:
     with:
       experimental: true
     secrets: inherit
+
+  js-waku:
+    needs: build-docker-image
+    uses: waku-org/js-waku/.github/workflows/ci.yml@master
+    with:
+      nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
+      caller: nwaku

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,10 @@ jobs:
     if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' || needs.changes.outputs.docker == 'true' }}
     uses: waku-org/nwaku/.github/workflows/container-image.yml@master
     secrets: inherit
+
+  js-waku:
+    needs: build-docker-image
+    uses: waku-org/js-waku/.github/workflows/ci.yml@master
+    with:
+      nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
+      caller: nwaku

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -5,6 +5,10 @@ on:
     inputs:
       experimental:
         type: boolean
+    outputs:
+      image:
+        description: The resulting image link
+        value: ${{ jobs.build-docker-image.outputs.image }}
 
 env:
   NPROC: 2
@@ -20,6 +24,8 @@ jobs:
     timeout-minutes: 60
 
     name: docker-build-${{ matrix.os }}
+    outputs:
+      image: ${{ steps.build.outputs.image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -51,6 +57,7 @@ jobs:
           IMAGE=quay.io/wakuorg/nwaku-pr:${TAG}
 
           echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
           docker login -u ${QUAY_USER} -p ${QUAY_PASSWORD} quay.io
           docker build -t ${IMAGE} -f docker/binaries/Dockerfile.bn.amd64 --label quay.expires-after=7d .
@@ -70,4 +77,6 @@ jobs:
             ```
             ${{steps.build.outputs.image}}
             ```
+
+            Built from ${{ steps.build.outputs.commit_hash }}
           comment_tag: execution${{ inputs.experimental && '**experimental**' || ''}}


### PR DESCRIPTION
# Description

Depends on https://github.com/waku-org/js-waku/pull/1541 (merged)

This PR adds another step in our CI workflow - it executes js-waku tests on top of the image built from a PR - you can think of this as an integration test attempt


# Changes

<!-- List of detailed changes -->

- [ ] add reusable workflow from js-waku
- [ ] update PR image build comment to also mention the commit hash (cc @alrevuelta)

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->