### PR TITLE
libwaku: annotate thread-shared callback with .nimcall.

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -45,7 +45,8 @@ type
 var extEventCallback*: WakuCallBack = nil
 
 proc relayEventCallback(pubsubTopic: PubsubTopic,
-                        msg: WakuMessage): Future[void] {.async, gcsafe.} =
+                        msg: WakuMessage):
+                        Future[void] {.async, gcsafe, nimcall.} =
   # Callback that hadles the Waku Relay events. i.e. messages or errors.
   if not isNil(extEventCallback):
     try:


### PR DESCRIPTION
## Description
This is needed to ensure the `proc relayEventCallback(...` proc is not considered a closure. Therefore, no hidden GC'ed environment context is kept when sharing or copying its address to another thread.

This PR is motivated by the following Jacek's comment on Discord:
> other types of "hidden" references are closures - these appear a bit here and there but must also be avoided - the closure environment itself is a hidden GC:d type, so passing closures between threads is also not allowed - thus, any proc types used with threads must be annotated with {.nimcall.} at least which prevents them from capturing a garbage-collected environment

## Changes

- [x] Annotating `proc relayEventCallback(...` with `.nimcall.`.
