### PR TITLE
fix(rln-relay): missed roots during sync

### DIFF
--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -193,6 +193,8 @@ suite "Onchain group manager":
       manager.initialized
       manager.rlnContractDeployedBlockNumber > 0
 
+    await manager.stop()
+
   asyncTest "should error on initialization when loaded metadata does not match":
     let manager = await setup()
     await manager.init()
@@ -220,12 +222,14 @@ suite "Onchain group manager":
 
     await manager.init()
     await manager.startGroupSync()
+    await manager.stop()
 
   asyncTest "startGroupSync: should guard against uninitialized state":
     let manager = await setup()
 
     expect(ValueError):
       await manager.startGroupSync()
+    await manager.stop()
 
   asyncTest "startGroupSync: should sync to the state of the group":
     let manager = await setup()
@@ -241,6 +245,7 @@ suite "Onchain group manager":
 
     proc generateCallback(fut: Future[void]): OnRegisterCallback =
       proc callback(registrations: seq[Membership]): Future[void] {.async.} =
+        debug "registrations", registrations
         require:
           registrations.len == 1
           registrations[0].idCommitment == credentials.idCommitment
@@ -262,6 +267,7 @@ suite "Onchain group manager":
 
     check:
       merkleRootBefore != merkleRootAfter
+    await manager.stop()
 
   asyncTest "startGroupSync: should fetch history correctly":
     let manager = await setup()
@@ -303,6 +309,7 @@ suite "Onchain group manager":
     check:
       merkleRootBefore != merkleRootAfter
       manager.validRootBuffer.len() == credentialCount - AcceptableRootWindowSize
+    await manager.stop()
 
   asyncTest "register: should guard against uninitialized state":
     let manager = await setup()
@@ -310,6 +317,7 @@ suite "Onchain group manager":
 
     expect(ValueError):
       await manager.register(dummyCommitment)
+    await manager.stop()
 
   asyncTest "register: should register successfully":
     let manager = await setup()
@@ -329,6 +337,7 @@ suite "Onchain group manager":
     check:
       merkleRootAfter.inHex() != merkleRootBefore.inHex()
       manager.latestIndex == 1
+    await manager.stop()
 
   asyncTest "register: callback is called":
     let manager = await setup()
@@ -354,6 +363,7 @@ suite "Onchain group manager":
 
     check:
       manager.rlnInstance.getMetadata().get().validRoots == manager.validRoots.toSeq()
+    await manager.stop()
 
   asyncTest "withdraw: should guard against uninitialized state":
     let manager = await setup()
@@ -361,6 +371,7 @@ suite "Onchain group manager":
 
     expect(ValueError):
       await manager.withdraw(idSecretHash)
+    await manager.stop()
 
   asyncTest "validateRoot: should validate good root":
     let manager = await setup()
@@ -402,6 +413,7 @@ suite "Onchain group manager":
 
     check:
       validated
+    await manager.stop()
 
   asyncTest "validateRoot: should reject bad root":
     let manager = await setup()
@@ -432,6 +444,7 @@ suite "Onchain group manager":
 
     check:
       validated == false
+    await manager.stop()
 
   asyncTest "verifyProof: should verify valid proof":
     let manager = await setup()
@@ -474,6 +487,7 @@ suite "Onchain group manager":
 
     check:
       verifiedRes.get()
+    await manager.stop()
 
   asyncTest "verifyProof: should reject invalid proof":
     let manager = await setup()
@@ -510,6 +524,7 @@ suite "Onchain group manager":
 
     check:
       verifiedRes.get() == false
+    await manager.stop()
 
   asyncTest "backfillRootQueue: should backfill roots in event of chain reorg":
     let manager = await setup()
@@ -554,6 +569,7 @@ suite "Onchain group manager":
       manager.validRoots.len() == credentialCount - 1
       manager.validRootBuffer.len() == 0
       manager.validRoots[credentialCount - 2] == expectedLastRoot
+    await manager.stop()
 
   asyncTest "isReady should return false if ethRpc is none":
     var manager = await setup()
@@ -563,6 +579,7 @@ suite "Onchain group manager":
 
     check:
       (await manager.isReady()) == false
+    await manager.stop()
 
   asyncTest "isReady should return false if lastSeenBlockHead > lastProcessed":
     var manager = await setup()
@@ -570,6 +587,7 @@ suite "Onchain group manager":
 
     check:
       (await manager.isReady()) == false
+    await manager.stop()
 
   asyncTest "isReady should return true if ethRpc is ready":
     var manager = await setup()
@@ -579,6 +597,7 @@ suite "Onchain group manager":
     
     check:
       (await manager.isReady()) == true
+    await manager.stop()
 
 
   ################################


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
on a new block header, processes min(g.latestProcessedBlock, newHeadNumber) to account for missed blocks 

# Changes

<!-- List of detailed changes -->

- [x] newBlockHeader processing strategy

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #2002

