### PR TITLE
fix(rln-relay): waku_rln_number_registered_memberships metrics appropriately handled

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -105,7 +105,8 @@ method atomicBatch*(g: OnchainGroupManager,
     let operationSuccess = g.rlnInstance.atomicWrite(some(start), idCommitments, toRemoveIndices)
   if not operationSuccess:
     raise newException(ValueError, "atomic batch operation failed")
-  waku_rln_number_registered_memberships.inc(int64(idCommitments.len - toRemoveIndices.len))
+  # TODO: when slashing is enabled, we need to track slashed members
+  waku_rln_number_registered_memberships.set(int64(start.int + idCommitments.len - toRemoveIndices.len))
 
   if g.registerCb.isSome():
     var membersSeq = newSeq[Membership]()
@@ -304,7 +305,7 @@ proc getAndHandleEvents(g: OnchainGroupManager,
                         toBlock: BlockNumber): Future[void] {.async.} =
   initializedGuard(g)
 
-  let blockTable = await g.getBlockTable(fromBlock, toBlock)    
+  let blockTable = await g.getBlockTable(fromBlock, toBlock)
   await g.handleEvents(blockTable)
   await g.handleRemovedEvents(blockTable)
 

--- a/waku/waku_rln_relay/protocol_metrics.nim
+++ b/waku/waku_rln_relay/protocol_metrics.nim
@@ -35,7 +35,8 @@ declarePublicHistogram(identifier = waku_rln_valid_messages_total,
   buckets = generateBucketsForHistogram(AcceptableRootWindowSize))
 declarePublicCounter(waku_rln_errors_total, "number of errors detected while operating the rln relay", ["type"])
 declarePublicCounter(waku_rln_proof_verification_total, "number of times the rln proofs are verified")
-declarePublicCounter(waku_rln_number_registered_memberships, "number of registered and active rln memberships")
+# this is a gauge so that we can set it based on the events we receive
+declarePublicGauge(waku_rln_number_registered_memberships, "number of registered and active rln memberships")
 
 # Timing metrics
 declarePublicGauge(waku_rln_proof_verification_duration_seconds, "time taken to verify a proof")


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR sets the number of registered memberships to the `start` index (i.e last index that was inserted) + number of commitments - commitments removed

Upon startup, if we fetch the tree db, there is no way currently from the zerokit ffi api to fetch the number of members registered - hence, we set the metric based on the event thrown by the contract.

# Changes

<!-- List of detailed changes -->

- [x] changed counter to gauge, since we want to `set` the value of the collector 

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #2008
