### PR TITLE
chore(ci): add js-waku as a dependency for pre-release createion

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -104,7 +104,7 @@ jobs:
 
   create-release-candidate:
     runs-on: ubuntu-latest
-    needs: [ tag-name, build-and-publish ]
+    needs: [ tag-name, build-and-publish, js-waku ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Forgot to add `js-waku` job into `needs` for the `create-release-candidate job` - which means the RC creation is not gated by the js-waku job

# Changes

<!-- List of detailed changes -->

- [ ] add `js-waku` to `needs` 
- [ ] ...

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->