### PR TITLE
chore: move SubscriptionManager under waku_core 

### DIFF
--- a/waku/waku_core.nim
+++ b/waku/waku_core.nim
@@ -2,10 +2,12 @@ import
   ./waku_core/topics,
   ./waku_core/time,
   ./waku_core/message,
-  ./waku_core/peers
+  ./waku_core/peers,
+  ./waku_core/subscription
 
 export
   topics,
   time,
   message,
-  peers
+  peers,
+  subscription

--- a/waku/waku_core/subscription.nim
+++ b/waku/waku_core/subscription.nim
@@ -1,0 +1,7 @@
+import
+  ./subscription/subscription_manager,
+  ./subscription/push_handler
+
+export
+  subscription_manager,
+  push_handler

--- a/waku/waku_core/subscription/push_handler.nim
+++ b/waku/waku_core/subscription/push_handler.nim
@@ -1,0 +1,13 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  chronos
+
+import
+  ../topics,
+  ../message
+
+type FilterPushHandler* = proc(pubsubTopic: PubsubTopic, message: WakuMessage) {.async, gcsafe, closure.}

--- a/waku/waku_core/subscription/subscription_manager.nim
+++ b/waku/waku_core/subscription/subscription_manager.nim
@@ -1,0 +1,48 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/tables,
+  stew/results,
+  chronicles,
+  chronos
+
+import
+  ./push_handler,
+  ../topics,
+  ../message
+
+## Subscription manager
+type SubscriptionManager* = object
+    subscriptions: TableRef[(string, ContentTopic), FilterPushHandler]
+
+proc init*(T: type SubscriptionManager): T =
+  SubscriptionManager(subscriptions: newTable[(string, ContentTopic), FilterPushHandler]())
+
+proc clear*(m: var SubscriptionManager) =
+  m.subscriptions.clear()
+
+proc registerSubscription*(m: SubscriptionManager, pubsubTopic: PubsubTopic, contentTopic: ContentTopic, handler: FilterPushHandler) =
+  try:
+    # TODO: Handle over subscription surprises
+    m.subscriptions[(pubsubTopic, contentTopic)]= handler
+  except CatchableError:
+    error "failed to register filter subscription", error=getCurrentExceptionMsg()
+
+proc removeSubscription*(m: SubscriptionManager, pubsubTopic: PubsubTopic, contentTopic: ContentTopic) =
+  m.subscriptions.del((pubsubTopic, contentTopic))
+
+proc notifySubscriptionHandler*(m: SubscriptionManager, pubsubTopic: PubsubTopic, contentTopic: ContentTopic, message: WakuMessage) =
+  if not m.subscriptions.hasKey((pubsubTopic, contentTopic)):
+    return
+
+  try:
+    let handler = m.subscriptions[(pubsubTopic, contentTopic)]
+    asyncSpawn handler(pubsubTopic, message)
+  except CatchableError:
+    discard
+
+proc getSubscriptionsCount*(m: SubscriptionManager): int =
+  m.subscriptions.len()


### PR DESCRIPTION
# Description
Cherry pick from[Filter V2 Rest API PR](https://github.com/waku-org/nwaku/pull/1890) to separate one.
FilterV1 client hold FilterPushHandler and SubscriptionManager which was not the right place to import from.
Better moved to under waku_core/subscription to be easily reused.

## How to test
All existing tests on Waku Filter (v1 or legacy) covers the change properly.