### PR TITLE
chore: resolving DNS IP and publishing it when no extIp provided

### DIFF
--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -15,12 +15,13 @@ import
   ../testlib/common,
   ../testlib/wakucore
 
-proc defaultTestWakuNodeConf(): WakuNodeConf =
+proc defaultTestWakuNodeConf*(): WakuNodeConf =
   WakuNodeConf(
     listenAddress: ValidIpAddress.init("127.0.0.1"),
     rpcAddress: ValidIpAddress.init("127.0.0.1"),
     restAddress: ValidIpAddress.init("127.0.0.1"),
     metricsServerAddress: ValidIpAddress.init("127.0.0.1"),
+    dnsAddrsNameServers: @[ValidIpAddress.init("1.1.1.1"), ValidIpAddress.init("1.0.0.1")],
     nat: "any",
     maxConnections: 50,
     topics: @["/waku/2/default-waku/proto"],


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
When running a node and no external IP is provided but a DNS4 address is, we want the ENR to use the resolved DNS IP instead of using `0.0.0.0`, which is currently the case.

# Changes

<!-- List of detailed changes -->

- [x] If there's no external IP but a DNS address was provided, do a DNS IP lookup and use the result as external IP in the node's network configuration
- [x] Updated procedure `newTestWakuNode` to account for the above scenario
- [x] Added test cases for the success and failure flows of the DNS lookup

<!--
## How to test

1.
1.
1.

-->


## Issue

closes [#1576](https://github.com/waku-org/nwaku/issues/1576)
