### PR TITLE
fix(sqlite): Prevent the execution of 'migrate' script if user_version==0

### DIFF
--- a/waku/common/databases/db_sqlite.nim
+++ b/waku/common/databases/db_sqlite.nim
@@ -437,10 +437,11 @@ proc migrate*(db: SqliteDatabase,
   ## NOTE: Down migration it is not currently supported
   let userVersion = ?db.getUserVersion()
 
-  if userVersion == targetVersion:
+  if userVersion == targetVersion or
+     userVersion == 0'i64: ## https://github.com/waku-org/nwaku/issues/2027
     debug "database schema is up to date", userVersion=userVersion, targetVersion=targetVersion
     return ok()
-  
+
   info "database schema is outdated", userVersion=userVersion, targetVersion=targetVersion
 
   # Load migration scripts

--- a/waku/common/databases/db_sqlite.nim
+++ b/waku/common/databases/db_sqlite.nim
@@ -437,11 +437,10 @@ proc migrate*(db: SqliteDatabase,
   ## NOTE: Down migration it is not currently supported
   let userVersion = ?db.getUserVersion()
 
-  if userVersion == targetVersion or
-     userVersion == 0'i64: ## https://github.com/waku-org/nwaku/issues/2027
+  if userVersion == targetVersion:
     debug "database schema is up to date", userVersion=userVersion, targetVersion=targetVersion
     return ok()
-
+  
   info "database schema is outdated", userVersion=userVersion, targetVersion=targetVersion
 
   # Load migration scripts

--- a/waku/waku_archive/driver/sqlite_driver/migrations.nim
+++ b/waku/waku_archive/driver/sqlite_driver/migrations.nim
@@ -19,26 +19,37 @@ const SchemaVersion* = 7 # increase this when there is an update in the database
 template projectRoot: string = currentSourcePath.rsplit(DirSep, 1)[0] / ".." / ".." / ".." / ".."
 const MessageStoreMigrationPath: string = projectRoot / "migrations" / "message_store"
 
-proc getNumColumnsInPK*(db: SqliteDatabase): DatabaseResult[int64] =
-  ## Temporary proc created to extract the number of columns the PK has in the Message table.
-  ## This is to consider whether the table actually belongs to the SchemaVersion 7.
-  ## During many nwaku versions (0.13.0 until 0.18.0), the SchemaVersion wasn't set or checked
-  ## and therefore, in 0.19.0 we started to check it and the migration started to fail because
-  ## the migration scripts tried to migrate a database that was already in SchemaVersion 7,
-  ## and that made it to crash.
+proc isSchemaVersion7*(db: SqliteDatabase): DatabaseResult[bool] =
+  ## Temporary proc created to analyse when the table actually belongs to the SchemaVersion 7.
   ##
-  ## TODO: remove this proc after 0.23.0
+  ## During many nwaku versions, 0.14.0 until 0.18.0, the SchemaVersion wasn't set or checked.
+  ## Docker `nwaku` nodes that start working from these versions, 0.14.0 until 0.18.0, they started
+  ## with this discrepancy: `user_version`== 0 (not set) but Message table with SchemaVersion 7.
+  ##
+  ## We found issues where `user_version` (SchemaVersion) was set to 0 in the database even though
+  ## its scheme structure reflected SchemaVersion 7. In those cases, when `nwaku` re-started to
+  ## apply the migration scripts (in 0.19.0) the node didn't start properly because it tried to
+  ## migrate a database that already had the Schema structure #7, so it failed when changing the PK.
+  ##
+  ## TODO: This was added in version 0.20.0. We might remove this in version 0.30.0, as we
+  ##       could consider that many users use +0.20.0.
 
-  var count: int64
+  var pkColumns = newSeq[string]()
   proc queryRowCallback(s: ptr sqlite3_stmt) =
-    count = sqlite3_column_int64(s, 0)
+    let colName = cstring sqlite3_column_text(s, 0)
+    pkColumns.add($colName)
 
-  let query = """SELECT count(l.name) FROM pragma_table_info("Message") as l WHERE l.pk != 0;"""
+  let query = """SELECT l.name FROM pragma_table_info("Message") as l WHERE l.pk != 0;"""
   let res = db.query(query, queryRowCallback)
   if res.isErr():
-    return err("failed to count number of columns that are PK")
+    return err("failed to determine the current SchemaVersion: " & $res.error)
 
-  ok(count)
+  if pkColumns == @["pubsubTopic", "id", "storedAt"]:
+    return ok(true)
+
+  else:
+    info "Not considered schema version 7"
+    ok(false)
 
 proc migrate*(db: SqliteDatabase, targetVersion = SchemaVersion): DatabaseResult[void] =
   ## Compares the `user_version` of the sqlite database with the provided `targetVersion`, then
@@ -52,13 +63,12 @@ proc migrate*(db: SqliteDatabase, targetVersion = SchemaVersion): DatabaseResult
   debug "starting message store's sqlite database migration"
 
   let userVersion = ? db.getUserVersion()
-  let numColumnsInPK = ? db.getNumColumnsInPK()
+  let isSchemaVersion7 = ? db.isSchemaVersion7()
 
-  if userVersion == 0'i64 and numColumnsInPK == 3:
+  if userVersion == 0'i64 and isSchemaVersion7:
     info "We found user_version 0 but the database schema reflects the user_version 7"
     ## Force the correct schema version
     ? db.setUserVersion( 7 )
-    return ok()
 
   let migrationRes = migrate(db, targetVersion, migrationsScriptsDir=MessageStoreMigrationPath)
   if migrationRes.isErr():

--- a/waku/waku_archive/driver/sqlite_driver/migrations.nim
+++ b/waku/waku_archive/driver/sqlite_driver/migrations.nim
@@ -3,7 +3,8 @@
 import
   std/[tables, strutils, os],
   stew/results,
-  chronicles
+  chronicles,
+  sqlite3_abi # sqlite3_column_int64
 import
   ../../../common/databases/db_sqlite,
   ../../../common/databases/common

--- a/waku/waku_archive/driver/sqlite_driver/migrations.nim
+++ b/waku/waku_archive/driver/sqlite_driver/migrations.nim
@@ -36,7 +36,7 @@ proc getNumColumnsInPK*(db: SqliteDatabase): DatabaseResult[int64] =
   let query = """SELECT count(l.name) FROM pragma_table_info("Message") as l WHERE l.pk != 0;"""
   let res = db.query(query, queryRowCallback)
   if res.isErr():
-    return err("failed to count number of messages in the database")
+    return err("failed to count number of columns that are PK")
 
   ok(count)
 

--- a/waku/waku_archive/driver/sqlite_driver/migrations.nim
+++ b/waku/waku_archive/driver/sqlite_driver/migrations.nim
@@ -18,6 +18,26 @@ const SchemaVersion* = 7 # increase this when there is an update in the database
 template projectRoot: string = currentSourcePath.rsplit(DirSep, 1)[0] / ".." / ".." / ".." / ".."
 const MessageStoreMigrationPath: string = projectRoot / "migrations" / "message_store"
 
+proc getNumColumnsInPK*(db: SqliteDatabase): DatabaseResult[int64] =
+  ## Temporary proc created to extract the number of columns the PK has in the Message table.
+  ## This is to consider whether the table actually belongs to the SchemaVersion 7.
+  ## During many nwaku versions (0.13.0 until 0.18.0), the SchemaVersion wasn't set or checked
+  ## and therefore, in 0.19.0 we started to check it and the migration started to fail because
+  ## the migration scripts tried to migrate a database that was already in SchemaVersion 7,
+  ## and that made it to crash.
+  ##
+  ## TODO: remove this proc after 0.23.0
+
+  var count: int64
+  proc queryRowCallback(s: ptr sqlite3_stmt) =
+    count = sqlite3_column_int64(s, 0)
+
+  let query = """SELECT count(l.name) FROM pragma_table_info("Message") as l WHERE l.pk != 0;"""
+  let res = db.query(query, queryRowCallback)
+  if res.isErr():
+    return err("failed to count number of messages in the database")
+
+  ok(count)
 
 proc migrate*(db: SqliteDatabase, targetVersion = SchemaVersion): DatabaseResult[void] =
   ## Compares the `user_version` of the sqlite database with the provided `targetVersion`, then
@@ -29,6 +49,15 @@ proc migrate*(db: SqliteDatabase, targetVersion = SchemaVersion): DatabaseResult
   ##
   ## NOTE: Down migration it is not currently supported
   debug "starting message store's sqlite database migration"
+
+  let userVersion = ? db.getUserVersion()
+  let numColumnsInPK = ? db.getNumColumnsInPK()
+
+  if userVersion == 0'i64 and numColumnsInPK == 3:
+    info "We found user_version 0 but the database schema reflects the user_version 7"
+    ## Force the correct schema version
+    ? db.setUserVersion( 7 )
+    return ok()
 
   let migrationRes = migrate(db, targetVersion, migrationsScriptsDir=MessageStoreMigrationPath)
   if migrationRes.isErr():


### PR DESCRIPTION
## Description
Given a `nwaku` node with _Store-SQLite_ mounted, it will try to apply a migration script because the `user_version` present in the SQLite file is 0, whereas the expected version is 7. 

## Changes

- [x] Avoid migrate the _SQLite_ schema if the `user_version` == 0 and the # of columns in PK is 3. In this case, we also enforce the SchemaVersion 7.


## How to replicate the issue:

In order to replicate the issue, the node should have a certain amount of messages stored in the database.

Use the next command, tailored by @vpavlin, to start the node, but change the docker image each time:
```
docker run -it --rm -v $PWD/data:/data:z XXXdocker-imageXXX --relay --store --store-message-db-url=sqlite:///data/wakustore.sqlite3 --log-level=DEBUG --dns-discovery=true --dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im --discv5-discovery=true --discv5-udp-port=9005 --discv5-enr-auto-update=True
```

1. Start the node with: statusteam/nim-waku:v0.17.0. This will start normally.
2. Start the node with: statusteam/nim-waku:v0.19.0. The node fails to start with the message: "failed to setup archive driver: failed to execute migration scripts: failed to execute migration statement".

## How to validate the fix:
1. Start the node with: statusteam/nim-waku:v0.17.0. This will start normally.
2. Start the node with: quay.io/wakuorg/nwaku-pr:2031. This will start normally, and the next message should appear: "We found user_version 0 but the database schema reflects the user_version 7".
3. Start the node with: statusteam/nim-waku:v0.19.0. This will start normally.



## Issue

closes https://github.com/waku-org/nwaku/issues/2027