### PR TITLE
chore: not allowing tcp-port 0 input  by the user

### DIFF
--- a/apps/wakunode2/internal_config.nim
+++ b/apps/wakunode2/internal_config.nim
@@ -24,6 +24,9 @@ proc networkConfiguration*(conf: WakuNodeConf,
 
   ## `udpPort` is only supplied to satisfy underlying APIs but is not
   ## actually a supported transport for libp2p traffic.
+  if conf.tcpPort == Port(0):
+    return err("Choosing port 0 is not allowed")
+  
   let natRes = setupNat(conf.nat, clientId,
                         Port(uint16(conf.tcpPort) + conf.portsShift),
                         Port(uint16(conf.tcpPort) + conf.portsShift))

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -21,6 +21,7 @@ proc defaultTestWakuNodeConf(): WakuNodeConf =
     rpcAddress: ValidIpAddress.init("127.0.0.1"),
     restAddress: ValidIpAddress.init("127.0.0.1"),
     metricsServerAddress: ValidIpAddress.init("127.0.0.1"),
+    tcpPort: Port(60000),
     nat: "any",
     maxConnections: 50,
     topics: @["/waku/2/default-waku/proto"],


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
When the user chooses port 0, the node's published port is 0. However, that's not the port that we are getting bound to by the kernel.
Therefore, to avoid inconsistencies and imprecisions, we won't allow the user to choose port 0. Either the default port or a port explicitly chosen by the user will be used, avoiding non-deterministic outcomes.

# Changes

<!-- List of detailed changes -->

- [x] Throwing an error in case port 0 is selected by the user
- [x] Updating tests that configure Waku nodes with port 0 as default, and change them so they use our current default 60000 port

<!--
## How to test

1.
1.
1.

-->


## Issue

closes [#1883](https://github.com/waku-org/nwaku/issues/1883)
