### PR TITLE
fix(rln-relay): segfault when no params except rln-relay is passed in

### DIFF
--- a/waku/waku_rln_relay/group_manager/static/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/static/group_manager.nim
@@ -19,7 +19,8 @@ method init*(g: StaticGroupManager): Future[void] {.async,gcsafe.} =
   let
     groupSize = g.groupSize
     groupKeys = g.groupKeys
-    membershipIndex = g.membershipIndex.get()
+    membershipIndex = if g.membershipIndex.isSome(): g.membershipIndex.get() 
+                      else: raise newException(ValueError, "Membership index is not set") 
 
   if membershipIndex < MembershipIndex(0) or membershipIndex >= MembershipIndex(groupSize):
     raise newException(ValueError, "Invalid membership index. Must be within 0 and " & $(groupSize - 1) & "but was " & $membershipIndex)

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -409,7 +409,7 @@ proc isReady*(rlnPeer: WakuRLNRelay): Future[bool] {.async.} =
 
 proc new*(T: type WakuRlnRelay,
           conf: WakuRlnConfig,
-          registrationHandler: Option[RegistrationHandler] = none(RegistrationHandler)
+          registrationHandler = none(RegistrationHandler)
           ): Future[RlnRelayResult[WakuRlnRelay]] {.async.} =
   ## Mounts the rln-relay protocol on the node.
   ## The rln-relay protocol can be mounted in two modes: on-chain and off-chain.


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
When no other params except `--rln-relay` is provided to wakunode2, it segfaults.
This is due to the static group manager unwrapping the membership index without checking if it was set.
This PR fixes that and errors out appropriately.

# Changes

<!-- List of detailed changes -->

- [x] Errors out when membership index is not set

## How to test

1. Build wakunode2 `make -j12 wakunode2`
1. Run `./build/wakunode2 --rln-relay=true`
1. You should not see a segfault, but rather an error message asking to set the membership index.




## Issue

closes #2039


