### PR TITLE
chore(ci): add jq, fix RLN build script to not use rustup 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG NIM_COMMIT
 ARG LOG_LEVEL=TRACE
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl rust cargo
+RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq rust cargo
 
 WORKDIR /app
 COPY . .

--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -10,42 +10,37 @@ build_dir=$1
 rln_version=$2
 output_filename=$3
 
-if [[ -z "$build_dir" ]]; then
-    echo "No build directory specified"
-    exit 1
-fi
-
-if [[ -z "$rln_version" ]]; then
-    echo "No rln version specified"
-    exit 1
-fi
-
-if [[ -z "$output_filename" ]]; then
-    echo "No output filename specified"
-    exit 1
-fi
+[[ -z "${build_dir}" ]]       && { echo "No build directory specified"; exit 1; }
+[[ -z "${rln_version}" ]]     && { echo "No rln version specified";     exit 1; }
+[[ -z "${output_filename}" ]] && { echo "No output filename specified"; exit 1; }
 
 # Get the host triplet
-host_triplet=$(rustup show | grep "Default host: " | cut -d' ' -f3)
+host_triplet=$(rustc --version --verbose | awk '/host:/{print $2}')
 
 # Download the prebuilt rln library if it is available
-if curl --silent --fail-with-body -L "https://github.com/vacp2p/zerokit/releases/download/$rln_version/$host_triplet-rln.tar.gz" >> "$host_triplet-rln.tar.gz"
+if curl --silent --fail-with-body -L \
+  "https://github.com/vacp2p/zerokit/releases/download/$rln_version/${host_triplet}-rln.tar.gz" \
+  -o "${host_triplet}-rln.tar.gz";
 then
-    echo "Downloaded $host_triplet-rln.tar.gz"
-    tar -xzf "$host_triplet-rln.tar.gz"
-    mv release/librln.a $output_filename
-    rm -rf "$host_triplet-rln.tar.gz" release
+    echo "Downloaded ${host_triplet}-rln.tar.gz"
+    tar -xzf "${host_triplet}-rln.tar.gz"
+    mv "release/librln.a" "${output_filename}"
+    rm -rf "${host_triplet}-rln.tar.gz" release
 else
-    echo "Failed to download $host_triplet-rln.tar.gz"
+    echo "Failed to download ${host_triplet}-rln.tar.gz"
     # Build rln instead
     # first, check if submodule version = version in Makefile
-    submodule_version=$(cargo metadata --format-version=1 --no-deps | jq '.packages[] | select(.name == "rln") | .version')
-    if [[ "v$submodule_version" != "$rln_version" ]]; then
-        echo "Submodule version (v$submodule_version) does not match version in Makefile ($rln_version)"
-        echo "Please update the submodule to $rln_version"
+    cargo metadata --format-version=1 --no-deps --manifest-path "${build_dir}/rln/Cargo.toml"
+    submodule_version=$(
+      cargo metadata --format-version=1 --no-deps --manifest-path "${build_dir}/rln/Cargo.toml" \
+        | jq -r '.packages[] | select(.name == "rln") | .version'
+    )
+    if [[ "v${submodule_version}" != "${rln_version}" ]]; then
+        echo "Submodule version (v${submodule_version}) does not match version in Makefile (${rln_version})"
+        echo "Please update the submodule to ${rln_version}"
         exit 1
     fi
     # if submodule version = version in Makefile, build rln
-    cargo build --release -p rln --manifest-path "$build_dir/rln/Cargo.toml"
-    cp "$build_dir/target/release/librln.a" $output_filename
+    cargo build --release -p rln --manifest-path "${build_dir}/rln/Cargo.toml"
+    cp "${build_dir}/target/release/librln.a" "${output_filename}"
 fi


### PR DESCRIPTION
To resolve RLN build issues like this:
```
Building: librln_v0.3.4.a
./scripts/build_rln.sh: line 29: rustup: command not found

Warning: to ensure you are building in a supported repo state, please always run "make update" after "git pull"
(it looks like you've forgotten to do this).
This also applies whenever you switch to a new branch or commit, e.g.: whenever you run "git checkout ...".

Failed to download -rln.tar.gz
./scripts/build_rln.sh: line 42: jq: command not found
error: could not find `Cargo.toml` in `/app` or any parent directory
make: *** [Makefile:131: librln_v0.3.4.a] Error 127
```
https://ci.infra.status.im/job/nim-waku/job/deploy-wakuv2-test/301/console