### PR TITLE
feat: lightpush rest api

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -52,6 +52,7 @@ import
   ../../waku/node/rest/filter/handlers as rest_filter_api,
   ../../waku/node/rest/store/handlers as rest_store_api,
   ../../waku/node/rest/health/handlers as rest_health_api,
+  ../../waku/node/rest/lightpush/handlers as rest_lightpush_api,
   ../../waku/node/jsonrpc/admin/handlers as rpc_admin_api,
   ../../waku/node/jsonrpc/debug/handlers as rpc_debug_api,
   ../../waku/node/jsonrpc/filter/handlers as rpc_filter_api,
@@ -589,6 +590,8 @@ proc startRestServer(app: App, address: ValidIpAddress, port: Port, conf: WakuNo
 
   ## Store REST API
   installStoreApiHandlers(server.router, app.node)
+
+  installLightPushPostPushRequestHandler(server.router, app.node)
 
   server.start()
   info "Starting REST HTTP server", url = "http://" & $address & ":" & $port & "/"

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -591,7 +591,7 @@ proc startRestServer(app: App, address: ValidIpAddress, port: Port, conf: WakuNo
   ## Store REST API
   installStoreApiHandlers(server.router, app.node)
 
-  installLightPushPostPushRequestHandler(server.router, app.node)
+  installLightPushRequestHandler(server.router, app.node)
 
   server.start()
   info "Starting REST HTTP server", url = "http://" & $address & ":" & $port & "/"

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -97,7 +97,8 @@ import
   ./wakunode_rest/test_rest_serdes,
   ./wakunode_rest/test_rest_store,
   ./wakunode_rest/test_rest_filter,
-  ./wakunode_rest/test_rest_legacy_filter
+  ./wakunode_rest/test_rest_legacy_filter,
+  ./wakunode_rest/test_rest_lightpush
 
 import
   ./waku_rln_relay/test_waku_rln_relay,

--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -64,6 +64,8 @@ proc init(T: type RestLightPushTest): Future[T] {.async.} =
             testSetup.consumerNode.peerInfo.toRemotePeerInfo(),
             WakuRelayCodec)
 
+  await testSetup.serviceNode.connectToNodes(@[testSetup.consumerNode.peerInfo.toRemotePeerInfo()])
+
   testSetup.pushNode.peerManager.addServicePeer(
             testSetup.serviceNode.peerInfo.toRemotePeerInfo(),
             WakuLightPushCodec)

--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -148,6 +148,8 @@ suite "Waku v2 Rest API - lightpush":
     check:
       response.status == 400
       $response.contentType == $MIMETYPE_TEXT
+      response.data.startsWith("Invalid content body")
+
 
     # when
     response = await restLightPushTest.client.sendPushRequest(badRequestBody2)
@@ -156,6 +158,7 @@ suite "Waku v2 Rest API - lightpush":
     check:
       response.status == 400
       $response.contentType == $MIMETYPE_TEXT
+      response.data.startsWith("Invalid content body")
 
     # when
     response = await restLightPushTest.client.sendPushRequest(badRequestBody3)
@@ -164,16 +167,13 @@ suite "Waku v2 Rest API - lightpush":
     check:
       response.status == 400
       $response.contentType == $MIMETYPE_TEXT
+      response.data.startsWith("Invalid content body")
 
     await restLightPushTest.shutdown()
 
   asyncTest "Push message request service not available":
     # Given
     let restLightPushTest = await RestLightPushTest.init()
-
-    # restLightPushTest.serviceNode.subscribe(DefaultPubsubTopic)
-    # require:
-    #   toSeq(restLightPushTest.serviceNode.wakuRelay.subscribedTopics).len == 1
 
     # When
     let message : RelayWakuMessage = fakeWakuMessage(contentTopic = DefaultContentTopic,
@@ -189,5 +189,6 @@ suite "Waku v2 Rest API - lightpush":
     check:
       response.status == 503
       $response.contentType == $MIMETYPE_TEXT
+      response.data == "Failed to request a message push: Can not publish to any peers"
 
     await restLightPushTest.shutdown()

--- a/tests/wakunode_rest/test_rest_relay_serdes.nim
+++ b/tests/wakunode_rest/test_rest_relay_serdes.nim
@@ -19,7 +19,7 @@ suite "Waku v2 Rest API - Relay - serialization":
     test "optional fields are not provided":
       # Given
       let payload = base64.encode("MESSAGE")
-      let jsonBytes = toBytes("{\"payload\":\"" & $payload & "\"}")
+      let jsonBytes = toBytes("{\"payload\":\"" & $payload & "\",\"contentTopic\":\"some/topic\"}")
 
       # When
       let res = decodeFromJsonBytes(RelayWakuMessage, jsonBytes, requireAllFields = true)
@@ -29,7 +29,8 @@ suite "Waku v2 Rest API - Relay - serialization":
       let value = res.get()
       check:
         value.payload == payload
-        value.contentTopic.isNone()
+        value.contentTopic.isSome()
+        value.contentTopic.get() == "some/topic"
         value.version.isNone()
         value.timestamp.isNone()
 

--- a/waku/node/rest/lightpush/client.nim
+++ b/waku/node/rest/lightpush/client.nim
@@ -1,0 +1,49 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  json,
+  std/sets,
+  stew/byteutils,
+  strformat,
+  chronicles,
+  json_serialization,
+  json_serialization/std/options,
+  presto/[route, client, common]
+import
+  ../../../waku_core,
+  ../serdes,
+  ../responses,
+  ./types
+
+export types
+
+logScope:
+  topics = "waku node rest client v2"
+
+proc encodeBytes*(value: PushRequest,
+                  contentType: string): RestResult[seq[byte]] =
+  if MediaType.init(contentType) != MIMETYPE_JSON:
+    error "Unsupported contentType value", contentType = contentType
+    return err("Unsupported contentType")
+
+  let encoded = ?encodeIntoJsonBytes(value)
+  return ok(encoded)
+
+proc decodeBytes*(t: typedesc[string], value: openarray[byte],
+                  contentType: Opt[ContentTypeData]): RestResult[string] =
+  if MediaType.init($contentType) != MIMETYPE_TEXT:
+    error "Unsupported contentType value", contentType = contentType
+    return err("Unsupported contentType")
+
+  var res: string
+  if len(value) > 0:
+    res = newString(len(value))
+    copyMem(addr res[0], unsafeAddr value[0], len(value))
+  return ok(res)
+
+proc sendPushRequest*(body: PushRequest):
+        RestResponse[string]
+        {.rest, endpoint: "/lightpush/v1/message", meth: HttpMethod.MethodPost.}

--- a/waku/node/rest/lightpush/handlers.nim
+++ b/waku/node/rest/lightpush/handlers.nim
@@ -54,7 +54,7 @@ proc installLightPushPostPushRequestHandler*(router: var RestRouter,
                                              node: WakuNode) =
 
   router.api(MethodPost, ROUTE_LIGHTPUSH) do (contentBody: Option[ContentBody]) -> RestApiResponse:
-    ## Subscribes a node to a list of contentTopics of a pubsubTopic
+    ## Send a request to push a waku message
     debug "post", ROUTE_LIGHTPUSH, contentBody
 
     let decodedBody = decodeRequestBody[PushRequest](contentBody)

--- a/waku/node/rest/lightpush/handlers.nim
+++ b/waku/node/rest/lightpush/handlers.nim
@@ -1,0 +1,83 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/strformat,
+  std/sequtils,
+  stew/byteutils,
+  chronicles,
+  json_serialization,
+  json_serialization/std/options,
+  presto/route,
+  presto/common
+
+import
+  ../../../waku_core,
+  ../../peer_manager,
+  ../../waku_node,
+  ../../waku/waku_lightpush,
+  ../serdes,
+  ../responses,
+  ./types
+
+export types
+
+logScope:
+  topics = "waku node rest lightpush api"
+
+const futTimeoutForPushRequestProcessing* = 5.seconds
+
+#### Request handlers
+
+const ROUTE_LIGHTPUSH* = "/lightpush/v1/message"
+
+func decodeRequestBody[T](contentBody: Option[ContentBody]) : Result[T, RestApiResponse] =
+  if contentBody.isNone():
+    return err(RestApiResponse.badRequest("Missing content body"))
+
+  let reqBodyContentType = MediaType.init($contentBody.get().contentType)
+  if reqBodyContentType != MIMETYPE_JSON:
+    return err(RestApiResponse.badRequest("Wrong Content-Type, expected application/json"))
+
+  let reqBodyData = contentBody.get().data
+
+  let requestResult = decodeFromJsonBytes(T, reqBodyData)
+  if requestResult.isErr():
+    return err(RestApiResponse.badRequest("Invalid content body, could not decode. " &
+                                          $requestResult.error))
+
+  return ok(requestResult.get())
+
+proc installLightPushPostPushRequestHandler*(router: var RestRouter,
+                                             node: WakuNode) =
+
+  router.api(MethodPost, ROUTE_LIGHTPUSH) do (contentBody: Option[ContentBody]) -> RestApiResponse:
+    ## Subscribes a node to a list of contentTopics of a pubsubTopic
+    debug "post", ROUTE_LIGHTPUSH, contentBody
+
+    let decodedBody = decodeRequestBody[PushRequest](contentBody)
+
+    if decodedBody.isErr():
+      return decodedBody.error()
+
+    let req: PushRequest = decodedBody.value()
+    let msg = req.message.toWakuMessage()
+
+    if msg.isErr():
+      return RestApiResponse.badRequest("Invalid message: {msg.error}")
+
+    let peerOpt = node.peerManager.selectPeer(WakuLightPushCodec)
+    if peerOpt.isNone():
+      return RestApiResponse.serviceUnavailable("No suitable remote lightpush peers")
+
+    let subFut = node.lightpushPublish(req.pubsubTopic,
+                                       msg.value(),
+                                       peerOpt.get())
+
+    if not await subFut.withTimeout(futTimeoutForPushRequestProcessing):
+      error "Failed to request a message push due to timeout!"
+      return RestApiResponse.serviceUnavailable("Push request timed out")
+
+    return RestApiResponse.ok()

--- a/waku/node/rest/lightpush/handlers.nim
+++ b/waku/node/rest/lightpush/handlers.nim
@@ -80,9 +80,7 @@ proc installLightPushRequestHandler*(router: var RestRouter,
       error "Failed to request a message push due to timeout!"
       return RestApiResponse.serviceUnavailable("Push request timed out")
 
-    let handleRes: WakuLightPushResult[void] = subFut.read()
-    if handleRes.isErr():
-      error fmt("Failed to request a message push: {handleRes.error}")
-      return RestApiResponse.serviceUnavailable(fmt("Failed to request a message push: {handleRes.error}"))
+    if subFut.value().isErr():
+      return RestApiResponse.serviceUnavailable(fmt("Failed to request a message push: {subFut.value().error}"))
 
     return RestApiResponse.ok()

--- a/waku/node/rest/lightpush/openapi.yaml
+++ b/waku/node/rest/lightpush/openapi.yaml
@@ -1,0 +1,84 @@
+openapi: 3.0.3
+info:
+  title: Waku V2 node REST API
+  version: 1.0.0
+  contact:
+    name: VAC Team
+    url: https://forum.vac.dev/
+
+tags:
+  - name: lightpush
+    description: Lightpush REST API for WakuV2 node
+
+paths:
+  /lightpush/v1/message:
+    post:
+      summary: Request a message relay from a LightPush service provider
+      description: Push a message to be relayed on a PubSub topic.
+      operationId: postMessagesToPubsubTopic
+      tags:
+        - lightpush
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PushRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+        '400':
+          description: Bad request.
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+        '503':
+          description: Service not available
+          content:
+            text/plain:
+              schema:
+                type: string
+
+components:
+  schemas:
+    PubsubTopic:
+      type: string
+
+    ContentTopic:
+      type: string
+
+    WakuMessage:
+      type: object
+      properties:
+        payload:
+          type: string
+          format: byte
+        contentTopic:
+          $ref: '#/components/schemas/ContentTopic'
+        version:
+          type: number
+        timestamp:
+          type: number
+      required:
+        - payload
+        - contentTopic
+
+    PushRequest:
+      type: object
+      properties:
+        pusbsubTopic:
+          $ref: '#/components/schemas/PubsubTopic'
+        message:
+          $ref: '#/components/schemas/WakuMessage'
+      required:
+        - message

--- a/waku/node/rest/lightpush/types.nim
+++ b/waku/node/rest/lightpush/types.nim
@@ -1,0 +1,65 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/[sets, strformat],
+  chronicles,
+  json_serialization,
+  json_serialization/std/options,
+  presto/[route, client, common]
+
+import
+  ../../../common/base64,
+  ../../../waku_core,
+  ../relay/types as relay_types,
+  ../serdes
+
+export relay_types
+
+#### Types
+
+type PushRequest* = object
+      pubsubTopic*: Option[PubSubTopic]
+      message*: RelayWakuMessage
+
+#### Serialization and deserialization
+
+proc writeValue*(writer: var JsonWriter[RestJson], value: PushRequest)
+  {.raises: [IOError].} =
+  writer.beginRecord()
+  if value.pubsubTopic.isSome():
+    writer.writeField("pubsubTopic", value.pubsubTopic.get())
+  writer.writeField("message", value.message)
+  writer.endRecord()
+
+proc readValue*(reader: var JsonReader[RestJson], value: var PushRequest)
+  {.raises: [SerializationError, IOError].} =
+  var
+    pubsubTopic = none(PubsubTopic)
+    message = none(RelayWakuMessage)
+
+  var keys = initHashSet[string]()
+  for fieldName in readObjectFields(reader):
+    # Check for reapeated keys
+    if keys.containsOrIncl(fieldName):
+      let err = try: fmt"Multiple `{fieldName}` fields found"
+                except CatchableError: "Multiple fields with the same name found"
+      reader.raiseUnexpectedField(err, "PushRequest")
+
+    case fieldName
+    of "pubsubTopic":
+      pubsubTopic = some(reader.readValue(PubsubTopic))
+    of "message":
+      message = some(reader.readValue(RelayWakuMessage))
+    else:
+      unrecognizedFieldWarning()
+
+  if message.isNone():
+    reader.raiseUnexpectedValue("Field `message` is missing")
+
+  value = PushRequest(
+    pubsubTopic: if pubsubTopic.isNone() or pubsubTopic.get() == "": none(string) else: some(pubsubTopic.get()),
+    message: message.get()
+  )

--- a/waku/node/rest/relay/types.nim
+++ b/waku/node/rest/relay/types.nim
@@ -103,8 +103,11 @@ proc readValue*(reader: var JsonReader[RestJson], value: var RelayWakuMessage)
     else:
       unrecognizedFieldWarning()
 
-  if payload.isNone():
-    reader.raiseUnexpectedValue("Field `payload` is missing")
+  if payload.isNone() or isEmptyOrWhitespace(string(payload.get())):
+    reader.raiseUnexpectedValue("Field `payload` is missing or empty")
+
+  if contentTopic.isNone() or contentTopic.get().isEmptyOrWhitespace():
+    reader.raiseUnexpectedValue("Field `contentTopic` is missing or empty")
 
   value = RelayWakuMessage(
     payload: payload.get(),

--- a/waku/node/rest/responses.nim
+++ b/waku/node/rest/responses.nim
@@ -24,6 +24,11 @@ proc internalServerError*(t: typedesc[RestApiResponse],
                           RestApiResponse =
   RestApiResponse.error(Http500, msg, $MIMETYPE_TEXT)
 
+proc serviceUnavailable*(t: typedesc[RestApiResponse],
+                         msg: string = ""):
+                        RestApiResponse =
+  RestApiResponse.error(Http503, msg, $MIMETYPE_TEXT)
+
 proc badRequest*(t: typedesc[RestApiResponse],
                  msg: string = ""):
                  RestApiResponse =


### PR DESCRIPTION
# Description
As part of epic https://github.com/waku-org/nwaku/issues/1076 RestApi endpoint for lightpush service is provided here

# Changes
New endpoint POST:/lightpush/v1/message is added for wakunode.

## How to test

1. nim c -r ./tests/wakunode_rest/test_rest_lightpush.nim

## Issue
https://github.com/waku-org/nwaku/issues/2040