### PR TITLE
feat(networkmonitor): add ping latencies, optimize reconnections

### DIFF
--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -11,7 +11,7 @@ type
   NetworkMonitorConf* = object
     logLevel* {.
       desc: "Sets the log level",
-      defaultValue: LogLevel.DEBUG,
+      defaultValue: LogLevel.INFO,
       name: "log-level",
       abbr: "l" .}: LogLevel
 

--- a/apps/networkmonitor/networkmonitor_metrics.nim
+++ b/apps/networkmonitor/networkmonitor_metrics.nim
@@ -37,10 +37,15 @@ declarePublicGauge peer_user_agents,
     "Number of peers with each user agent",
     labels = ["user_agent"]
 
+declarePublicHistogram peer_ping,
+    "Histogram tracking ping durations for discovered peers",
+    buckets = [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 2000.0, Inf]
+
 type
   CustomPeerInfo* = object
     # populated after discovery
-    lastTimeDiscovered*: string
+    lastTimeDiscovered*: int64
+    discovered*: int64
     peerId*: string
     enr*: string
     ip*: string
@@ -49,9 +54,12 @@ type
     city*: string
 
     # only after ok connection
-    lastTimeConnected*: string
+    lastTimeConnected*: int64
+    retries*: int64
     supportedProtocols*: seq[string]
     userAgent*: string
+    lastPingDuration*: Duration
+    avgPingDuration*: Duration
 
     # only after a ok/nok connection
     connError*: string


### PR DESCRIPTION
# Description

This PR leverages `ping` protocol to measure latency in between the network monitor instance and discovered nodes.

It records the latency as a
* histogram metric
* last measured latency per node
* average latency per node with sliding window of 10 

It also adds retry limit for failed connections and adds a cliff to repeatedly discovered nodes to only reconnect to them after 60s

# Changes

<!-- List of detailed changes -->

- [ ] use `int64` for timestamps instead of strings
- [ ] add PingDuration (i.e. latency) fields
- [ ] add retries (how many times we failed to connect) and discovered (how many times we discovered the node) field
- [ ] only dial and ping the node if `ReconnectTime` passed
- [ ] only dial and ping unless we are over the `MaxConnectionRetries`
- [ ] use PeerId instead of public key
- [ ] add `ping()` proc to wrap dialling and executing ping protocol
- [ ] set default log level to INFO
<!--
## How to test

1. `make -j10 networkmonitor && ./build/networkmonitor --dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im`
1. access http://localhost:8008/metrics to review the histogram
1. access http://localhost:8009/allpeersinfo to review the API

-->


<!--
## Issue

closes #
-->