### PR TITLE
fix(archive): dburl check

### DIFF
--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -509,18 +509,6 @@ proc parseCmdArg*(T: type Option[uint], p: string): T =
   except CatchableError:
     raise newException(ValueError, "Invalid unsigned integer")
 
-## Configuration validation
-
-let DbUrlRegex = re"^[\w\+]+:\/\/[\w\/\\\.\:\@]+$"
-
-proc validateDbUrl*(val: string): ConfResult[string] =
-  let val = val.strip()
-
-  if val == "" or val == "none" or val.match(DbUrlRegex):
-    ok(val)
-  else:
-    err("invalid 'db url' option format: " & val)
-
 ## Load
 
 proc readValue*(r: var TomlReader, value: var crypto.PrivateKey) {.raises: [SerializationError].} =

--- a/waku/common/databases/dburl.nim
+++ b/waku/common/databases/dburl.nim
@@ -9,7 +9,7 @@ proc validateDbUrl*(dbUrl: string): Result[string, string] =
   ## See: https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls
   let regex = re"^\w+:\/\/.+:.+@[\w*-.]+:[0-9]+\/[\w*-.]+$"
   let dbUrl = dbUrl.strip()
-  if dbUrl == "" or dbUrl == "none" or dbUrl.match(regex):
+  if "sqlite" in dbUrl or dbUrl == "" or dbUrl == "none" or dbUrl.match(regex):
     return ok(dbUrl)
   else:
     return err("invalid 'db url' option format: " & dbUrl)

--- a/waku/common/databases/dburl.nim
+++ b/waku/common/databases/dburl.nim
@@ -7,7 +7,7 @@ import
 proc validateDbUrl*(dbUrl: string): Result[string, string] =
   ## dbUrl mimics SQLAlchemy Database URL schema
   ## See: https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls
-  let regex = re"^\w+:\/\/[\w*-.]+:[\w*-.]+@[\w*-.]+:[0-9]+\/[\w*-.]+$"
+  let regex = re"^\w+:\/\/.+:.+@[\w*-.]+:[0-9]+\/[\w*-.]+$"
   let dbUrl = dbUrl.strip()
   if dbUrl == "" or dbUrl == "none" or dbUrl.match(regex):
     return ok(dbUrl)

--- a/waku/common/databases/dburl.nim
+++ b/waku/common/databases/dburl.nim
@@ -7,7 +7,7 @@ import
 proc validateDbUrl*(dbUrl: string): Result[string, string] =
   ## dbUrl mimics SQLAlchemy Database URL schema
   ## See: https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls
-  let regex = re"^[\w\+]+:\/\/[\w\/\\\.\:\@]+$"
+  let regex = re"^\w+:\/\/[\w*-.]+:[\w*-.]+@[\w*-.]+:[0-9]+\/[\w*-.]+$"
   let dbUrl = dbUrl.strip()
   if dbUrl == "" or dbUrl == "none" or dbUrl.match(regex):
     return ok(dbUrl)


### PR DESCRIPTION
# Description
This is to make the database URL regex to accept `.` and `-` within the hostname.
Also, the user and password fields can be anything not empty.

notes:
- also cleaning dead code in `apps/wakunode2/external_config.nim`.
- creating the temporary quay image with POSTGRES=1 in .github/workflows/container-image.yml

## How to test

1. Run `nwaku` with `--store-message-db-url = "postgres://nim-waku-user:nim-waku-pass@store-db-01.do-ams3.shards.test.wg:5432/postgres"`.
2. The node should start and complain about not being able to resolve the host name but it shouldn't complain anything about the db URL format.

## Issue

https://github.com/status-im/infra-shards/pull/8#issuecomment-1731393876
