### PR TITLE
feat(wakucanary): add latency measurement using ping protocol

### DIFF
--- a/apps/wakucanary/wakucanary.nim
+++ b/apps/wakucanary/wakucanary.nim
@@ -47,7 +47,7 @@ type
 
     logLevel* {.
       desc: "Sets the log level",
-      defaultValue: LogLevel.DEBUG,
+      defaultValue: LogLevel.INFO,
       name: "log-level",
       abbr: "l".}: LogLevel
 
@@ -67,6 +67,11 @@ type
       desc: "Secure websocket Certificate path:   '/path/to/cert.txt' ",
       defaultValue: ""
       name: "websocket-secure-cert-path".}: string
+
+    ping* {.
+      desc: "Ping the peer node to measure latency",
+      defaultValue: true,
+      name: "ping" .}: bool
 
 proc parseCmdArg*(T: type chronos.Duration, p: string): T =
   try:
@@ -97,6 +102,18 @@ proc areProtocolsSupported(
     return true
 
   return false
+
+proc pingNode(node: WakuNode, peerInfo: RemotePeerInfo): Future[void] {.async, gcsafe.} =
+  try:
+    let conn = await node.switch.dial(peerInfo.peerId, peerInfo.addrs, PingCodec)
+    let pingDelay = await node.libp2pPing.ping(conn)
+    info "Peer response time (ms)", peerId = peerInfo.peerId, ping=pingDelay.millis
+
+  except CatchableError:
+    var msg = getCurrentExceptionMsg()
+    if msg == "Future operation cancelled!":
+      msg = "timedout"
+    error "Failed to ping the peer", peer=peerInfo, err=msg
 
 proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
   let conf: WakuCanaryConf = WakuCanaryConf.load()
@@ -173,7 +190,18 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
 
   let node = builder.build().tryGet()
 
+  if conf.ping:
+    try:
+      await mountLibp2pPing(node)
+    except CatchableError:
+      error "failed to mount libp2p ping protocol: " & getCurrentExceptionMsg()
+      return 1
+
   await node.start()
+
+  var pingFut:Future[bool]
+  if conf.ping:
+    pingFut = pingNode(node, peer).withTimeout(conf.timeout)
 
   let timedOut = not await node.connectToNodes(@[peer]).withTimeout(conf.timeout)
   if timedOut:
@@ -182,6 +210,9 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
 
   let lp2pPeerStore = node.switch.peerStore
   let conStatus = node.peerManager.peerStore[ConnectionBook][peer.peerId]
+
+  if conf.ping:
+    discard await pingFut
 
   if conStatus in [Connected, CanConnect]:
     let nodeProtocols = lp2pPeerStore[ProtoBook][peer.peerId]


### PR DESCRIPTION
# Description

Since this is very similar to #2068, I thought it might be interesting and useful to have the latency measured by wakucanary. 

Set it on by default with a switch `--ping=false` to disable it

```
INF 2023-09-25 12:53:31.315+02:00 Peer response time (ms)                    tid=2064003 file=wakucanary.nim:110 peerId=16U*ZsXy69 ping=59
```

# Changes

<!-- List of detailed changes -->

- [ ] add `--ping` option
- [ ] mount `ping` protocol
- [ ] measure latency is `--ping=true`

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->