### PR TITLE
chore: Adding -d:postgres flag when creating a Docker image for release and PRs

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -48,7 +48,7 @@ jobs:
         id: build
         run: |
 
-          make -j${NPROC} V=1 QUICK_AND_DIRTY_COMPILER=1 NIMFLAGS="-d:disableMarchNative" wakunode2 
+          make -j${NPROC} V=1 QUICK_AND_DIRTY_COMPILER=1 NIMFLAGS="-d:disableMarchNative -d:postgres" wakunode2
 
           SHORT_REF=$(git rev-parse --short HEAD)
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -66,7 +66,8 @@ jobs:
           make QUICK_AND_DIRTY_COMPILER=1 V=1 CI=false NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" \
             update
 
-          make QUICK_AND_DIRTY_COMPILER=1 V=1 CI=false NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" \
+          make QUICK_AND_DIRTY_COMPILER=1 V=1 CI=false\
+            NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}} -d:postgres" \
             wakunode2\
             chat2\
             tools

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -53,7 +53,7 @@ jobs:
           OS=$([[ "${{runner.os}}" == "macOS" ]] && echo "macosx" || echo "linux")
 
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" V=1 update
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" CI=false wakunode2
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}} -d:postgres" CI=false wakunode2
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" CI=false chat2
           tar -cvzf ${{steps.vars.outputs.nwaku}} ./build/
 

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -12,6 +12,7 @@ pipeline {
         '-d:insecure',
         '-d:disableMarchNative',
         '--parallelBuild:6',
+        '-d:postgres',
       ].join(' ')
     )
     string(

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -34,6 +34,7 @@ pipeline {
         '-d:disableMarchNative',
         '-d:chronicles_colors:none',
         '-d:insecure',
+        '-d:postgres',
       ].join(' ')
     )
     string(


### PR DESCRIPTION
# Description
The `-d:postgres` _Nim_ flag was added in order to not build the _Postgres_ archive driver when a new user wanted to compile the `wakunode` from the command line manually. However, we do want to have _Postgres_ support on each _Docker_ image, both in releases and in PRs.

# Changes

<!-- List of detailed changes -->

- [x] Addition of `-d:postgres` in `.github/workflows/container-image.yml`.
- [x] Addition of `-d:postgres` in `ci/Jenkinsfile.prs`.
- [x] Addition of `-d:postgres` in `ci/Jenkinsfile.release`.
- [x] Addition of `-d:postgres` in `.github/workflows/pre-release.yml`.
- [x] Addition of `-d:postgres` in `.github/workflows/release-assets.yml`.
