### PR TITLE
chore(networkmonitor): refactor setConnectedPeersMetrics, make it partially concurrent, add version

### DIFF
--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -77,6 +77,7 @@ proc analyzePeer(
     customPeerInfo.retries += 1
     return err(customPeerInfo.connError)
 
+  customPeerInfo.connError = ""
   info "successfully pinged peer", peer=peerInfo, duration=pingDelay.millis
   networkmonitor_peer_ping.observe(pingDelay.millis)
 

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -64,7 +64,6 @@ type
       defaultValue: 8009,
       name: "metrics-rest-port" }: uint16
 
-
 proc parseCmdArg*(T: type ValidIpAddress, p: string): T =
   try:
     result = ValidIpAddress.init(p)
@@ -85,7 +84,7 @@ proc completeCmdArg*(T: type chronos.Duration, val: string): seq[string] =
 
 proc loadConfig*(T: type NetworkMonitorConf): Result[T, string] =
   try:
-    let conf = NetworkMonitorConf.load()
+    let conf = NetworkMonitorConf.load(version=git_version)
     ok(conf)
   except CatchableError:
     err(getCurrentExceptionMsg())

--- a/apps/networkmonitor/networkmonitor_metrics.nim
+++ b/apps/networkmonitor/networkmonitor_metrics.nim
@@ -25,21 +25,29 @@ logScope:
 #discovery_message_requests_outgoing_total{response=""}
 #discovery_message_requests_outgoing_total{response="no_response"}
 
-declarePublicGauge peer_type_as_per_enr,
+declarePublicGauge networkmonitor_peer_type_as_per_enr,
     "Number of peers supporting each capability according the the ENR",
     labels = ["capability"]
 
-declarePublicGauge peer_type_as_per_protocol,
+declarePublicGauge networkmonitor_peer_type_as_per_protocol,
     "Number of peers supporting each protocol, after a successful connection) ",
     labels = ["protocols"]
 
-declarePublicGauge peer_user_agents,
+declarePublicGauge networkmonitor_peer_user_agents,
     "Number of peers with each user agent",
     labels = ["user_agent"]
 
-declarePublicHistogram peer_ping,
+declarePublicHistogram networkmonitor_peer_ping,
     "Histogram tracking ping durations for discovered peers",
     buckets = [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 2000.0, Inf]
+
+declarePublicGauge networkmonitor_peer_count,
+    "Number of discovered peers",
+    labels = ["connected"]
+
+declarePublicGauge networkmonitor_peer_country_count,
+    "Number of peers per country",
+    labels = ["country"]
 
 type
   CustomPeerInfo* = object

--- a/apps/networkmonitor/networkmonitor_metrics.nim
+++ b/apps/networkmonitor/networkmonitor_metrics.nim
@@ -64,8 +64,10 @@ type
     # only after a ok/nok connection
     connError*: string
 
+  CustomPeerInfoRef* = ref CustomPeerInfo
+
   # Stores information about all discovered/connected peers
-  CustomPeersTableRef* = TableRef[string, CustomPeerInfo]
+  CustomPeersTableRef* = TableRef[string, CustomPeerInfoRef]
 
   # stores the content topic and the count of rx messages
   ContentTopicMessageTableRef* = TableRef[string, int]


### PR DESCRIPTION
# Description

This PR refactors `setConnectedPeersMetrics` proc a bit

* splits out the `shouldReconnect` check
* splits out the reconnection (i.e. dial and ping) to separate proc
* uses seq of futures to make the dials to newly discovered peers concurrent
* adds `ResetRetriesAfter` time (in seconds) to retry peers we failed to connect (if they are re-discovered)

It also adds `--version` (cc @jakubgs)

# Changes

<!-- List of detailed changes -->

- [x] add `shouldReconnect`
- [x] add `analyzePeer`
- [x] add concurrency to peer analysis
- [x] add `--version`

<!--
## How to test

1.
1.
1.

-->



## Issue

partially based on comments from #2068 
