### PR TITLE
fix: libwaku.nim: unsubscribe -> unsubscribeAll to make it build properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - 'vendor/**'
           - 'Makefile'
           - 'waku.nimble'
+          - 'library/**'
 
           v2:
           - 'waku/**'

--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -99,7 +99,8 @@ proc process*(self: ptr RelayRequest,
       node.wakuRelay.subscribe($self.pubsubTopic, self.relayEventCallback)
 
     of UNSUBSCRIBE:
-      node.wakuRelay.unsubscribe($self.pubsubTopic)
+      # TODO: properly perform 'unsubscribe'
+      node.wakuRelay.unsubscribeAll($self.pubsubTopic)
 
     of PUBLISH:
       let numPeers = await node.wakuRelay.publish($self.pubsubTopic,


### PR DESCRIPTION
# Description
We introduced a change in the next PR
https://github.com/waku-org/nwaku/pull/1983/files
that made the `libwaku` to stop building properly
(make libwaku) because a signature change in the
`unsubscribe` proc of waku/waku_relay/protocol.nim.

This commit is a temporary workaround to make it work, and not block any ongoing PR tests,
although not exactly as it is expected because we are unsubscribing from all topics.

