### PR TITLE
fix(ci): update the dependency list in pre-release WF

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -114,7 +114,7 @@ jobs:
 
   create-release-candidate:
     runs-on: ubuntu-latest
-    needs: [ tag-name, build-and-publish, js-waku ]
+    needs: [ tag-name, build-and-publish, js-waku-node, js-waku-node-optional ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Pre-release (nightly) builds are failing due to rename of js-waku* tasks

# Changes

<!-- List of detailed changes -->

- [x] fix dependency list for `creare-release-candidate`


<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->