### PR TITLE
feat: filter service peers by shard

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -652,8 +652,14 @@ proc selectPeer*(pm: PeerManager, proto: string, shard: Option[PubsubTopic] = no
 
   # For other protocols, we select the peer that is slotted for the given protocol
   pm.serviceSlots.withValue(proto, serviceSlot):
-    debug "Got peer from service slots", peerId=serviceSlot[].peerId, multi=serviceSlot[].addrs[0], protocol=proto
-    return some(serviceSlot[])
+    if shard.isSome() and serviceSlot[].enr.isSome() and
+      serviceSlot[].enr.get().containsShard(shard.get()):
+
+      debug "Got peer from service slots",
+        peerId = serviceSlot[].peerId, multi = serviceSlot[].addrs[0], protocol = proto
+
+      return some(serviceSlot[])
+    else: debug "Peer from service slots does not support this shard", shard=$shard.get()
 
   # If not slotted, we select a random peer for the given protocol
   if peers.len > 0:

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -654,10 +654,12 @@ proc selectPeer*(pm: PeerManager, proto: string, shard: Option[PubsubTopic] = no
   pm.serviceSlots.withValue(proto, serviceSlot):
     if shard.isSome() and serviceSlot[].enr.isSome() and
       serviceSlot[].enr.get().containsShard(shard.get()):
-
       debug "Got peer from service slots",
         peerId = serviceSlot[].peerId, multi = serviceSlot[].addrs[0], protocol = proto
-
+      return some(serviceSlot[])
+    elif shard.isNone():
+      debug "Got peer from service slots",
+        peerId = serviceSlot[].peerId, multi = serviceSlot[].addrs[0], protocol = proto
       return some(serviceSlot[])
     else: debug "Peer from service slot does not support this shard", shard = shard.get()
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -659,7 +659,7 @@ proc selectPeer*(pm: PeerManager, proto: string, shard: Option[PubsubTopic] = no
         peerId = serviceSlot[].peerId, multi = serviceSlot[].addrs[0], protocol = proto
 
       return some(serviceSlot[])
-    else: debug "Peer from service slots does not support this shard", shard=$shard.get()
+    else: debug "Peer from service slot does not support this shard", shard = shard.get()
 
   # If not slotted, we select a random peer for the given protocol
   if peers.len > 0:


### PR DESCRIPTION
# Description
When selecting a peer via `peer_manager` if a service slot is chosen, the shard that the peer support is checked.

