### PR TITLE
feat: store API launch discovery process if needed

### DIFF
--- a/tests/wakunode_rest/test_rest_store.nim
+++ b/tests/wakunode_rest/test_rest_store.nim
@@ -82,7 +82,13 @@ procSuite "Waku v2 Rest API - Store":
     let restAddress = ValidIpAddress.init("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
 
-    installStoreApiHandlers(restServer.router, node)
+    let handler = proc(
+      histQuery: HistoryQuery,
+      storePeer: Option[RemotePeerInfo],
+      ): Future[WakuStoreResult[HistoryResponse]] {.async, closure.} =
+      return await node.query(histQuery, storePeer.get())
+
+    installStoreApiHandlers(restServer.router, handler)
     restServer.start()
 
     # WakuStore setup
@@ -152,7 +158,13 @@ procSuite "Waku v2 Rest API - Store":
     let restAddress = ValidIpAddress.init("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
 
-    installStoreApiHandlers(restServer.router, node)
+    let handler = proc(
+      histQuery: HistoryQuery,
+      storePeer: Option[RemotePeerInfo],
+      ): Future[WakuStoreResult[HistoryResponse]] {.async, closure.} =
+      return await node.query(histQuery, storePeer.get())
+
+    installStoreApiHandlers(restServer.router, handler)
     restServer.start()
 
     # WakuStore setup
@@ -250,7 +262,13 @@ procSuite "Waku v2 Rest API - Store":
     let restAddress = ValidIpAddress.init("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
 
-    installStoreApiHandlers(restServer.router, node)
+    let handler = proc(
+      histQuery: HistoryQuery,
+      storePeer: Option[RemotePeerInfo],
+      ): Future[WakuStoreResult[HistoryResponse]] {.async, closure.} =
+      return await node.query(histQuery, storePeer.get())
+
+    installStoreApiHandlers(restServer.router, handler)
     restServer.start()
 
     # WakuStore setup
@@ -324,7 +342,13 @@ procSuite "Waku v2 Rest API - Store":
     let restAddress = ValidIpAddress.init("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
 
-    installStoreApiHandlers(restServer.router, node)
+    let handler = proc(
+      histQuery: HistoryQuery,
+      storePeer: Option[RemotePeerInfo],
+      ): Future[WakuStoreResult[HistoryResponse]] {.async, closure.} =
+      return await node.query(histQuery, storePeer.get())
+
+    installStoreApiHandlers(restServer.router, handler)
     restServer.start()
 
     # WakuStore setup
@@ -415,7 +439,13 @@ procSuite "Waku v2 Rest API - Store":
     let restAddress = ValidIpAddress.init("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
 
-    installStoreApiHandlers(restServer.router, node)
+    let handler = proc(
+      histQuery: HistoryQuery,
+      storePeer: Option[RemotePeerInfo],
+      ): Future[WakuStoreResult[HistoryResponse]] {.async, closure.} =
+      return await node.query(histQuery, storePeer.get())
+
+    installStoreApiHandlers(restServer.router, handler)
     restServer.start()
 
     # WakuStore setup
@@ -472,7 +502,17 @@ procSuite "Waku v2 Rest API - Store":
     let restAddress = ValidIpAddress.init("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
 
-    installStoreApiHandlers(restServer.router, node)
+    let handler = proc(
+      histQuery: HistoryQuery,
+      storePeer: Option[RemotePeerInfo],
+      ): Future[WakuStoreResult[HistoryResponse]] {.async, closure.} =
+      let remotePeerInfo = storePeer.valueOr:
+        node.peerManager.selectPeer(WakuStoreCodec).valueOr:
+          return err("Missing known store-peer node")
+      
+      return await node.query(histQuery, remotePeerInfo)
+
+    installStoreApiHandlers(restServer.router, handler)
     restServer.start()
 
     # WakuStore setup
@@ -510,7 +550,7 @@ procSuite "Waku v2 Rest API - Store":
                         encodeUrl(""),
                         encodeUrl(DefaultPubsubTopic))
     check:
-      response.status == 412
+      response.status == 400
       $response.contentType == $MIMETYPE_TEXT
       response.data.messages.len == 0
       response.data.error_message.get == "Missing known store-peer node"


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
First step in a refactor of the way external APIs work. REST APIs requests now trigger a handler from the app layer. This new handler is responsible for tying peer manager, discv5 and node. It returns the result of the request without any knowledge of the internals of the REST APIs.

Next step would be to do the same for all APIs.

I'm still not sure of the timeout. Is it long enough? Should we loop wait until a peer is found?
Maybe start searching for a peer but return an error right away. Asking the client to try again later?

# Changes

<!-- List of detailed changes -->

- [x] added a closure in `app` that ties discv5, peer manager and node 
- [x] it's called by the STORE REST API
- [x] tests

Tracking #1941