### PR TITLE
chore: add size retention policy

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -114,7 +114,7 @@ jobs:
 
   create-release-candidate:
     runs-on: ubuntu-latest
-    needs: [ tag-name, build-and-publish, js-waku ]
+    needs: [ tag-name, build-and-publish, js-waku-node, js-waku-node-optional ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,10 @@ nimbus-build-system.paths
 *.sqlite3-wal
 
 /examples/nodejs/build/
+
+# Coverage
+coverage_html_report/
+*.info
+
+# Wildcard
+*.ignore.*

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ DOCKER_IMAGE_NIMFLAGS := $(DOCKER_IMAGE_NIMFLAGS) $(HEAPTRACK_PARAMS)
 # build a docker image for the fleet
 docker-image: MAKE_TARGET ?= wakunode2
 docker-image: DOCKER_IMAGE_TAG ?= $(MAKE_TARGET)-$(GIT_VERSION)
-docker-image: DOCKER_IMAGE_NAME ?= statusteam/nim-waku:$(DOCKER_IMAGE_TAG)
+docker-image: DOCKER_IMAGE_NAME ?= wakuorg/nwaku:$(DOCKER_IMAGE_TAG)
 docker-image:
 	docker build \
 		--build-arg="MAKE_TARGET=$(MAKE_TARGET)" \

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,18 @@ cwaku_example: | build libwaku
 		vendor/nim-libbacktrace/libbacktrace_wrapper.o \
 		vendor/nim-libbacktrace/install/usr/lib/libbacktrace.a
 
+cppwaku_example: | build libwaku
+	echo -e $(BUILD_MSG) "build/$@" && \
+		g++ -o "build/$@" \
+		./examples/cpp/waku.cpp \
+		./examples/cpp/base64.cpp \
+		-lwaku -Lbuild/ \
+		-pthread -ldl -lm \
+		-lminiupnpc -Lvendor/nim-nat-traversal/vendor/miniupnp/miniupnpc/build/ \
+		-lnatpmp -Lvendor/nim-nat-traversal/vendor/libnatpmp-upstream/ \
+		vendor/nim-libbacktrace/libbacktrace_wrapper.o \
+		vendor/nim-libbacktrace/install/usr/lib/libbacktrace.a
+
 nodejswaku: | build deps
 		echo -e $(BUILD_MSG) "build/$@" && \
 		node-gyp build --directory=examples/nodejs/

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -374,10 +374,10 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
     echo "Connecting to " & $conf.fleet & " fleet using DNS discovery..."
 
     if conf.fleet == Fleet.test:
-      dnsDiscoveryUrl = some("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im")
+      dnsDiscoveryUrl = some("enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im")
     else:
       # Connect to prod by default
-      dnsDiscoveryUrl = some("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im")
+      dnsDiscoveryUrl = some("enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im")
 
   elif conf.dnsDiscovery and conf.dnsDiscoveryUrl != "":
     # No pre-selected fleet. Discover nodes via DNS using user config

--- a/apps/networkmonitor/README.md
+++ b/apps/networkmonitor/README.md
@@ -39,7 +39,7 @@ Connect to the network through a given bootstrap node, with default parameters. 
 ```
 
 ```console
-./build/networkmonitor --log-level=INFO --dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.nodes.status.im
+./build/networkmonitor --log-level=INFO --dns-discovery-url=enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im
 ```
 
 ## Metrics

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -64,7 +64,6 @@ type
       defaultValue: 8009,
       name: "metrics-rest-port" }: uint16
 
-
 proc parseCmdArg*(T: type ValidIpAddress, p: string): T =
   try:
     result = ValidIpAddress.init(p)
@@ -85,7 +84,7 @@ proc completeCmdArg*(T: type chronos.Duration, val: string): seq[string] =
 
 proc loadConfig*(T: type NetworkMonitorConf): Result[T, string] =
   try:
-    let conf = NetworkMonitorConf.load()
+    let conf = NetworkMonitorConf.load(version=git_version)
     ok(conf)
   except CatchableError:
     err(getCurrentExceptionMsg())

--- a/apps/networkmonitor/networkmonitor_metrics.nim
+++ b/apps/networkmonitor/networkmonitor_metrics.nim
@@ -25,21 +25,29 @@ logScope:
 #discovery_message_requests_outgoing_total{response=""}
 #discovery_message_requests_outgoing_total{response="no_response"}
 
-declarePublicGauge peer_type_as_per_enr,
+declarePublicGauge networkmonitor_peer_type_as_per_enr,
     "Number of peers supporting each capability according the the ENR",
     labels = ["capability"]
 
-declarePublicGauge peer_type_as_per_protocol,
+declarePublicGauge networkmonitor_peer_type_as_per_protocol,
     "Number of peers supporting each protocol, after a successful connection) ",
     labels = ["protocols"]
 
-declarePublicGauge peer_user_agents,
+declarePublicGauge networkmonitor_peer_user_agents,
     "Number of peers with each user agent",
     labels = ["user_agent"]
 
-declarePublicHistogram peer_ping,
+declarePublicHistogram networkmonitor_peer_ping,
     "Histogram tracking ping durations for discovered peers",
     buckets = [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 2000.0, Inf]
+
+declarePublicGauge networkmonitor_peer_count,
+    "Number of discovered peers",
+    labels = ["connected"]
+
+declarePublicGauge networkmonitor_peer_country_count,
+    "Number of peers per country",
+    labels = ["country"]
 
 type
   CustomPeerInfo* = object
@@ -64,8 +72,10 @@ type
     # only after a ok/nok connection
     connError*: string
 
+  CustomPeerInfoRef* = ref CustomPeerInfo
+
   # Stores information about all discovered/connected peers
-  CustomPeersTableRef* = TableRef[string, CustomPeerInfo]
+  CustomPeersTableRef* = TableRef[string, CustomPeerInfoRef]
 
   # stores the content topic and the count of rx messages
   ContentTopicMessageTableRef* = TableRef[string, int]

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -19,7 +19,7 @@ pipeline {
     string(
       name: 'IMAGE_TAG',
       description: 'Name of Docker tag to push. Optional Parameter.',
-      defaultValue: params.IMAGE_TAG ?: 'deploy-wakuv2-test',
+      defaultValue: getDefaultImageTag()
     )
     string(
       name: 'IMAGE_NAME',
@@ -76,6 +76,7 @@ pipeline {
     }
 
     stage('Push') {
+      when { expression { params.IMAGE_TAG != '' } }
       steps { script {
         withDockerRegistry([
           credentialsId: params.DOCKER_CRED, url: ""
@@ -86,6 +87,7 @@ pipeline {
       } }
     }
   } // stages
+
   post {
     success { script {
       def discord = load 'ci/discord.groovy'
@@ -97,3 +99,14 @@ pipeline {
     always { sh 'docker image prune -f' }
   } // post
 } // pipeline
+
+def getDefaultImageTag() {
+  if (env.JOB_BASE_NAME) {
+    return env.JOB_BASE_NAME
+  }
+  switch (env.JOB_BASE_NAME) {
+    case 'docker-latest':      return 'latest'
+    case 'docker-release':     return 'stable'
+    default:                   return ''
+  }
+}

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -24,7 +24,12 @@ pipeline {
     string(
       name: 'IMAGE_NAME',
       description: 'Name of Docker image to push.',
-      defaultValue: params.IMAGE_NAME ?: 'statusteam/nim-waku',
+      defaultValue: params.IMAGE_NAME ?: 'wakuorg/nwaku',
+    )
+    string(
+      name: 'DOCKER_CRED',
+      description: 'Name of Docker Hub credential.',
+      defaultValue: params.DOCKER_CRED ?: 'dockerhub-vacorgbot-api-token',
     )
     string(
       name: 'NIMFLAGS',
@@ -72,7 +77,9 @@ pipeline {
 
     stage('Push') {
       steps { script {
-        withDockerRegistry([credentialsId: "dockerhub-statusteam-auto", url: ""]) {
+        withDockerRegistry([
+          credentialsId: params.DOCKER_CRED, url: ""
+        ]) {
           image.push()
           image.push(env.IMAGE_TAG)
         }

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -81,7 +81,8 @@ pipeline {
   } // stages
   post {
     success { script {
-      discordNotify(
+      def discord = load 'ci/discord.groovy'
+      discord.notify(
         header: 'Nim-Waku deployment successful!',
         cred: 'discord-waku-deployments-webhook',
       )
@@ -89,42 +90,3 @@ pipeline {
     always { sh 'docker image prune -f' }
   } // post
 } // pipeline
-
-def discordNotify(Map args=[:]) {
-  def opts = [
-    header: args.header ?: 'Deployment successful!',
-    cred: args.cred ?: null,
-  ]
-  def repo = [
-    url: GIT_URL.minus('.git'),
-    branch: GIT_BRANCH.minus('origin/'),
-    commit: GIT_COMMIT.take(8),
-    prev: (
-      env.GIT_PREVIOUS_SUCCESSFUL_COMMIT ?: env.GIT_PREVIOUS_COMMIT ?: 'master'
-    ).take(8),
-  ]
-  wrap([$class: 'BuildUser']) {
-    BUILD_USER_ID = env.BUILD_USER_ID
-  }
-  withCredentials([
-    string(
-      credentialsId: opts.cred,
-      variable: 'DISCORD_WEBHOOK',
-    ),
-  ]) {
-    discordSend(
-      link: env.BUILD_URL,
-      result: currentBuild.currentResult,
-      webhookURL: env.DISCORD_WEBHOOK,
-      title: "${env.JOB_NAME}#${env.BUILD_NUMBER}",
-      description: """
-        ${opts.header}
-        Image: [`${IMAGE_NAME}:${IMAGE_TAG}`](https://hub.docker.com/r/${IMAGE_NAME}/tags?name=${IMAGE_TAG})
-        Branch: [`${repo.branch}`](${repo.url}/commits/${repo.branch})
-        Commit: [`${repo.commit}`](${repo.url}/commit/${repo.commit})
-        Diff: [`${repo.prev}...${repo.commit}`](${repo.url}/compare/${repo.prev}...${repo.commit})
-        By: [`${BUILD_USER_ID}`](${repo.url}/commits?author=${BUILD_USER_ID})
-      """,
-    )
-  }
-}

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -57,7 +57,7 @@ pipeline {
     stage('Build') {
       steps { script {
         image = docker.build(
-          "${params.IMAGE_NAME}:${env.GIT_COMMIT.take(8)}",
+          "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
           "--label=commit='${env.GIT_COMMIT.take(8)}' " +
           "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
           "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
@@ -82,7 +82,10 @@ pipeline {
           credentialsId: params.DOCKER_CRED, url: ""
         ]) {
           image.push()
-          image.push(env.IMAGE_TAG)
+          /* If Git ref is a tag push it as Docker tag too. */
+          if (params.GIT_REF ==~ /v\d+\.\d+\.\d+.*/) {
+            image.push(params.GIT_REF)
+          }
         }
       } }
     }

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -93,8 +93,8 @@ pipeline {
 
   post {
     success { script {
-      def discord = load 'ci/discord.groovy'
-      discord.notify(
+      def discord = load "${WORKSPACE}/ci/discord.groovy"
+      discord.send(
         header: 'Nim-Waku deployment successful!',
         cred: 'discord-waku-deployments-webhook',
       )

--- a/ci/discord.groovy
+++ b/ci/discord.groovy
@@ -1,0 +1,40 @@
+def discordNotify(Map args=[:]) {
+  def opts = [
+    header: args.header ?: 'Deployment successful!',
+    cred: args.cred ?: null,
+  ]
+  def repo = [
+    url: GIT_URL.minus('.git'),
+    branch: GIT_BRANCH.minus('origin/'),
+    commit: GIT_COMMIT.take(8),
+    prev: (
+      env.GIT_PREVIOUS_SUCCESSFUL_COMMIT ?: env.GIT_PREVIOUS_COMMIT ?: 'master'
+    ).take(8),
+  ]
+  wrap([$class: 'BuildUser']) {
+    BUILD_USER_ID = env.BUILD_USER_ID
+  }
+  withCredentials([
+    string(
+      credentialsId: opts.cred,
+      variable: 'DISCORD_WEBHOOK',
+    ),
+  ]) {
+    discordSend(
+      link: env.BUILD_URL,
+      result: currentBuild.currentResult,
+      webhookURL: env.DISCORD_WEBHOOK,
+      title: "${env.JOB_NAME}#${env.BUILD_NUMBER}",
+      description: """
+        ${opts.header}
+        Image: [`${IMAGE_NAME}:${IMAGE_TAG}`](https://hub.docker.com/r/${IMAGE_NAME}/tags?name=${IMAGE_TAG})
+        Branch: [`${repo.branch}`](${repo.url}/commits/${repo.branch})
+        Commit: [`${repo.commit}`](${repo.url}/commit/${repo.commit})
+        Diff: [`${repo.prev}...${repo.commit}`](${repo.url}/compare/${repo.prev}...${repo.commit})
+        By: [`${BUILD_USER_ID}`](${repo.url}/commits?author=${BUILD_USER_ID})
+      """,
+    )
+  }
+}
+
+return this

--- a/ci/discord.groovy
+++ b/ci/discord.groovy
@@ -1,4 +1,4 @@
-def discordNotify(Map args=[:]) {
+def void send(Map args=[:]) {
   def opts = [
     header: args.header ?: 'Deployment successful!',
     cred: args.cred ?: null,

--- a/docs/contributors/release-process.md
+++ b/docs/contributors/release-process.md
@@ -71,11 +71,11 @@ Ensure all items in this list are ticked:
 ### After the release
 
 1. Announce the release on Twitter, Discord and other channels.
-2. Deploy the release image to [Dockerhub](https://hub.docker.com/layers/statusteam/nim-waku/a5f8b9/images/sha256-88691a8f82bd6a4242fa99053a65b7fc4762b23a2b4e879d0f8b578c798a0e09?context=explore) by triggering [the manual Jenkins deployment job](https://ci.infra.status.im/job/nim-waku/job/manual/build).
+2. Deploy the release image to [Dockerhub](https://hub.docker.com/layers/wakuorg/nwaku/a5f8b9/images/sha256-88691a8f82bd6a4242fa99053a65b7fc4762b23a2b4e879d0f8b578c798a0e09?context=explore) by triggering [the manual Jenkins deployment job](https://ci.infra.status.im/job/nim-waku/job/manual/build).
   > Ensure the following build parameters are set:
   > - `MAKE_TARGET`: `wakunode2`
   > - `IMAGE_TAG`: the release tag (e.g. `v0.16.0`)
-  > - `IMAGE_NAME`: `statusteam/nim-waku`
+  > - `IMAGE_NAME`: `wakuorg/nwaku`
   > - `NIMFLAGS`: `--colors:off -d:disableMarchNative -d:chronicles_colors:none`
   > - `GIT_REF` the release tag (e.g. `v0.16.0`)
 3. Deploy the release to appropriate fleets:

--- a/docs/operators/docker-quickstart.md
+++ b/docs/operators/docker-quickstart.md
@@ -16,16 +16,16 @@ sudo sh get-docker.sh
 
 ## Step 1: Get Docker image
 
-Nwaku Docker images are published to the Docker Hub public registry under [`statusteam/nim-waku`](https://hub.docker.com/r/statusteam/nim-waku).
-For specific releases the published images are tagged with the release version, e.g. [`statusteam/nim-waku:v0.16.0`](https://hub.docker.com/layers/statusteam/nim-waku/v0.16.0/images/sha256-7b7f14e7aa1c0a70db297dfd4d43251bda339a14da32885f57ee4b25983c9470?context=explore).
+Nwaku Docker images are published to the Docker Hub public registry under [`wakuorg/nwaku`](https://hub.docker.com/r/wakuorg/nwaku).
+For specific releases the published images are tagged with the release version, e.g. [`wakuorg/nwaku:v0.20.0`](https://hub.docker.com/layers/wakuorg/nwaku/v0.20.0/images/sha256-9976ac2dc536fae49b21f7b77618aa6f0efb59c694e7b3181e54c08be0c4f089?context=explore).
 Images are also published for each commit to the `master` branch in the [nwaku repo](https://github.com/status-im/nwaku/commits/master)
 and tagged with the corresponding commit hash.
-See [`statusteam/nim-waku`](https://hub.docker.com/r/statusteam/nim-waku/tags) on Docker Hub for a full list of available tags.
+See [`wakuorg/nwaku`](https://hub.docker.com/r/wakuorg/nwaku/tags) on Docker Hub for a full list of available tags.
 
 To pull the image of your choice, use
 
 ```bash
-docker pull statusteam/nim-waku:v0.16.0 # or, whichever tag you prefer in the format statusteam/nim-waku:[tag]
+docker pull wakuorg/nwaku:v0.20.0 # or, whichever tag you prefer in the format wakuorg/nwaku:[tag]
 ```
 
 You can also build the Docker image locally using
@@ -33,7 +33,7 @@ You can also build the Docker image locally using
 ```bash
 git clone --recurse-submodules https://github.com/waku-org/nwaku
 cd nwaku
-docker build -t statusteam/nim-waku:latest .
+docker build -t wakuorg/nwaku:latest .
 ```
 
 ## Step 2: Run
@@ -56,14 +56,14 @@ and any discovery ports (e.g. the Waku discv5 port) that must be reachable from 
 As an example, consider the following command to run nwaku in a Docker container with the most typical configuration:
 
 ```bash
-docker run -i -t -p 60000:60000 -p 9000:9000/udp statusteam/nim-waku:v0.16.0 \
+docker run -i -t -p 60000:60000 -p 9000:9000/udp wakuorg/nwaku:v0.20.0 \
   --dns-discovery:true \
   --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
   --discv5-discovery \
   --nat:extip:[yourpublicip] # or, if you are behind a nat: --nat=any
 ```
 
-This runs nwaku in a new container from the `statusteam/nim-waku:v0.16.0` image,
+This runs nwaku in a new container from the `wakuorg/nwaku:v0.20.0` image,
 connects to `wakuv2.prod` as bootstrap fleet and
 enables [Waku Discovery v5](https://rfc.vac.dev/spec/33/) for ambient peer discovery,
 while mapping the default libp2p listening port (`60000`)

--- a/docs/operators/docker-quickstart.md
+++ b/docs/operators/docker-quickstart.md
@@ -58,7 +58,7 @@ As an example, consider the following command to run nwaku in a Docker container
 ```bash
 docker run -i -t -p 60000:60000 -p 9000:9000/udp wakuorg/nwaku:v0.20.0 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im \
   --discv5-discovery \
   --nat:extip:[yourpublicip] # or, if you are behind a nat: --nat=any
 ```

--- a/docs/operators/droplet-quickstart.md
+++ b/docs/operators/droplet-quickstart.md
@@ -255,8 +255,8 @@ a. Add the parent directory of the wakunode2 binary to your environment:
   ```
 
 b. Choose the fleet you wish to connect your node to:
-  - waku prod: enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im
-  - waku test: enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im
+  - waku prod: enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im
+  - waku test: enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im
 
   ```bash
   export WAKU_FLEET=<fleet>

--- a/docs/operators/how-to/configure-dns-disc.md
+++ b/docs/operators/how-to/configure-dns-disc.md
@@ -24,7 +24,7 @@ A node will attempt connection to all discovered nodes.
 
 This can be used, for example, to connect to one of the existing fleets.
 Current URLs for the published fleet lists:
-- production fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im`
-- test fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im`
+- production fleet: `enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im`
+- test fleet: `enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im`
 
 See the [separate tutorial](../../tutorial/dns-disc.md) for a complete guide to DNS discovery.

--- a/docs/operators/how-to/configure.md
+++ b/docs/operators/how-to/configure.md
@@ -34,7 +34,7 @@ wakunode2 --tcp-port=65000
 In the case of using docker to run you node you should provide the commandline options after the image name as follows:
 
 ```shell
-docker run statusteam/nim-waku --tcp-port=65000
+docker run wakuorg/nwaku --tcp-port=65000
 ```
 
 Run `wakunode2 --help` to get a comprehensive list of configuration options (and its default values):
@@ -73,7 +73,7 @@ WAKUNODE2_TCP_PORT=65000 wakunode2
 In the case of using docker to run you node you should start the node using the `-e` command options:
 
 ```shell
-docker run -e "WAKUNODE2_TCP_PORT=65000" statusteam/nim-waku
+docker run -e "WAKUNODE2_TCP_PORT=65000" wakuorg/nwaku
 ```
 
 This is the second configuration method in order of precedence. Any command line configuration option will override the configuration

--- a/docs/operators/how-to/run-with-rln.md
+++ b/docs/operators/how-to/run-with-rln.md
@@ -2,7 +2,7 @@
 
 This guide explains how to run a nwaku node with RLN (Rate Limiting Nullifier) enabled.
 
-[RLN](https://rfc.vac.dev/spec/32/) is a protocol integrated into waku v2, 
+[RLN](https://rfc.vac.dev/spec/32/) is a protocol integrated into waku v2,
 which prevents spam-based attacks on the network.
 
 For further background on the research for RLN tailored to waku, refer
@@ -12,7 +12,7 @@ Registering to the membership group has been left out for brevity.
 If you would like to register to the membership group and send messages with RLN,
 refer to the [on-chain chat2 tutorial](../../tutorial/onchain-rln-relay-chat2.md).
 
-This guide specifically allows a node to participate in RLN testnet 2. 
+This guide specifically allows a node to participate in RLN testnet 2.
 You may alter the rln-specific arguments as required.
 
 ## Prerequisites
@@ -55,7 +55,7 @@ If you are running the nwaku node within docker, follow [Step 2](../docker-quick
 export WAKU_FLEET=<entree of the fleet>
 export SEPOLIA_WS_NODE_ADDRESS=<WS RPC URL to a Sepolia Node>
 export RLN_RELAY_CONTRACT_ADDRESS="0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4" # Replace this with any compatible implementation
-docker run -i -t -p 60000:60000 -p 9000:9000/udp statusteam/nim-waku:v0.12.0 \
+docker run -i -t -p 60000:60000 -p 9000:9000/udp wakuorg/nwaku:v0.20.0 \
   --dns-discovery:true \
   --dns-discovery-url:"$WAKU_FLEET" \
   --discv5-discovery \

--- a/docs/operators/how-to/run.md
+++ b/docs/operators/how-to/run.md
@@ -167,7 +167,7 @@ Discovery v5 will attempt to extract the ENRs of the discovered nodes as bootstr
 ./build/wakunode2 \
   --ports-shift:1 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im \
   --discv5-discovery:true
 ```
 
@@ -182,7 +182,7 @@ Discovery v5 will attempt to extract the ENRs of the discovered nodes as bootstr
 ./build/wakunode2 \
   --ports-shift:1 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im \
   --discv5-discovery:true
 ```
 
@@ -202,7 +202,7 @@ appears below.
   --db-path:/mnt/nwaku/data/db1/ \
   --store-capacity:150000 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im \
   --discv5-discovery:true
 ```
 

--- a/docs/operators/overview.md
+++ b/docs/operators/overview.md
@@ -17,7 +17,7 @@ or download a precompiled binary from our [releases page](https://github.com/wak
 
 If you'd like to test latest changes without building the binaries yourself, you can refer to [nightly release](https://github.com/waku-org/nwaku/releases/tag/nightly).
 
-Docker images are published to [statusteam/nim-waku](https://hub.docker.com/r/statusteam/nim-waku/tags) on Docker Hub.
+Docker images are published to [wakuorg/nwaku](https://hub.docker.com/r/wakuorg/nwaku/tags) on Docker Hub.
 See our [Docker quickstart guide](./docker-quickstart.md) to run nwaku in a Docker container.
 
 ## 2. Run

--- a/docs/operators/quickstart.md
+++ b/docs/operators/quickstart.md
@@ -29,7 +29,7 @@ make wakunode2
 
 ```bash
 docker run -i -t -p 60000:60000 -p 9000:9000/udp \
-  statusteam/nim-waku:v0.12.0 \ # or, the image:tag of your choice
+  wakuorg/nwaku:v0.20.0 \ # or, the image:tag of your choice
     --dns-discovery:true \
     --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
     --discv5-discovery \

--- a/docs/operators/quickstart.md
+++ b/docs/operators/quickstart.md
@@ -18,7 +18,7 @@ cd nwaku
 make wakunode2
 ./build/wakunode2 \
   --dns-discovery:true \
-  --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
+  --dns-discovery-url:enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im \
   --discv5-discovery \
   --nat=extip:[yourpublicip] # or, if you are behind a nat: --nat=any
 ```
@@ -31,7 +31,7 @@ make wakunode2
 docker run -i -t -p 60000:60000 -p 9000:9000/udp \
   wakuorg/nwaku:v0.20.0 \ # or, the image:tag of your choice
     --dns-discovery:true \
-    --dns-discovery-url:enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im \
+    --dns-discovery-url:enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im \
     --discv5-discovery \
     --nat:extip:[yourpublicip] # or, if you are behind a nat: --nat=any
 ```

--- a/examples/cpp/base64.cpp
+++ b/examples/cpp/base64.cpp
@@ -1,0 +1,53 @@
+
+#include <vector>
+#include "base64.h"
+
+// Base64 encoding
+// source: https://nachtimwald.com/2017/11/18/base64-encode-and-decode-in-c/
+size_t b64_encoded_size(size_t inlen)
+{
+	size_t ret;
+
+	ret = inlen;
+	if (inlen % 3 != 0)
+		ret += 3 - (inlen % 3);
+	ret /= 3;
+	ret *= 4;
+
+	return ret;
+}
+
+const char b64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+void b64_encode(char* in, size_t len, std::vector<char>& out)
+{
+	size_t  elen;
+	size_t  i;
+	size_t  j;
+	size_t  v;
+
+	if (in == NULL || len == 0)
+		return;
+
+	elen = b64_encoded_size(len);
+	out.reserve(elen+1);
+
+	for (i=0, j=0; i<len; i+=3, j+=4) {
+		v = in[i];
+		v = i+1 < len ? v << 8 | in[i+1] : v << 8;
+		v = i+2 < len ? v << 8 | in[i+2] : v << 8;
+
+		out[j]   = b64chars[(v >> 18) & 0x3F];
+		out[j+1] = b64chars[(v >> 12) & 0x3F];
+		if (i+1 < len) {
+			out[j+2] = b64chars[(v >> 6) & 0x3F];
+		} else {
+			out[j+2] = '=';
+		}
+		if (i+2 < len) {
+			out[j+3] = b64chars[v & 0x3F];
+		} else {
+			out[j+3] = '=';
+		}
+	}
+}

--- a/examples/cpp/base64.h
+++ b/examples/cpp/base64.h
@@ -1,0 +1,11 @@
+
+#ifndef _BASE64_H_
+#define _BASE64_H_
+
+#include <stdlib.h>
+
+size_t b64_encoded_size(size_t inlen);
+
+void b64_encode(char* in, size_t len, std::vector<char>& out);
+
+#endif

--- a/examples/cpp/waku.cpp
+++ b/examples/cpp/waku.cpp
@@ -1,0 +1,271 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <argp.h>
+#include <signal.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <vector>
+#include <iostream>
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#include "base64.h"
+#include "../../library/libwaku.h"
+
+#define WAKU_CALL(call)                                                        \
+do {                                                                           \
+  int ret = call;                                                              \
+  if (ret != 0) {                                                              \
+    std::cout << "Failed the call to: " << #call << ". Code: " << ret << "\n"; \
+  }                                                                            \
+} while (0)
+
+struct ConfigNode {
+    char    host[128];
+    int          port;
+    char     key[128];
+    int         relay;
+    char  peers[2048];
+};
+
+// Arguments parsing
+static char doc[] = "\nC example that shows how to use the waku library.";
+static char args_doc[] = "";
+
+static struct argp_option options[] = {
+    { "host",  'h', "HOST",  0, "IP to listen for for LibP2P traffic. (default: \"0.0.0.0\")"},
+    { "port",  'p', "PORT",  0, "TCP listening port. (default: \"60000\")"},
+    { "key",   'k', "KEY",   0, "P2P node private key as 64 char hex string."},
+    { "relay", 'r', "RELAY", 0, "Enable relay protocol: 1 or 0. (default: 1)"},
+    { "peers", 'a', "PEERS", 0, "Comma-separated list of peer-multiaddress to connect\
+ to. (default: \"\") e.g. \"/ip4/127.0.0.1/tcp/60001/p2p/16Uiu2HAmVFXtAfSj4EiR7mL2KvL4EE2wztuQgUSBoj2Jx2KeXFLN\""},
+    { 0 }
+};
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+
+    struct ConfigNode *cfgNode = (ConfigNode *) state->input;
+    switch (key) {
+        case 'h':
+            snprintf(cfgNode->host, 128, "%s", arg);
+            break;
+        case 'p':
+            cfgNode->port = atoi(arg);
+            break;
+        case 'k':
+            snprintf(cfgNode->key, 128, "%s", arg);
+            break;
+        case 'r':
+            cfgNode->relay = atoi(arg);
+            break;
+        case 'a':
+            snprintf(cfgNode->peers, 2048, "%s", arg);
+            break;
+        case ARGP_KEY_ARG:
+            if (state->arg_num >= 1) /* Too many arguments. */
+            argp_usage(state);
+            break;
+        case ARGP_KEY_END:
+            break;
+        default:
+            return ARGP_ERR_UNKNOWN;
+        }
+
+    return 0;
+}
+
+static struct argp argp = { options, parse_opt, args_doc, doc, 0, 0, 0 };
+
+// Beginning of UI program logic
+
+enum PROGRAM_STATE {
+    MAIN_MENU,
+    SUBSCRIBE_TOPIC_MENU,
+    CONNECT_TO_OTHER_NODE_MENU,
+    PUBLISH_MESSAGE_MENU
+};
+
+enum PROGRAM_STATE current_state = MAIN_MENU;
+
+void show_main_menu() {
+    printf("\nPlease, select an option:\n");
+    printf("\t1.) Subscribe to topic\n");
+    printf("\t2.) Connect to other node\n");
+    printf("\t3.) Publish a message\n");
+}
+
+void handle_user_input() {
+    char cmd[1024];
+    memset(cmd, 0, 1024);
+    int numRead = read(0, cmd, 1024);
+    if (numRead <= 0) {
+        return;
+    }
+
+    int c;
+    while ( (c = getchar()) != '\n' && c != EOF ) { }
+
+    switch (atoi(cmd))
+    {
+    case SUBSCRIBE_TOPIC_MENU:
+    {
+        printf("Indicate the Pubsubtopic to subscribe:\n");
+        char pubsubTopic[128];
+        scanf("%127s", pubsubTopic);
+        // if (!waku_relay_subscribe(pubsubTopic, &mResp)) {
+        //     printf("Error subscribing to PubsubTopic: %s\n", mResp->data);
+        // }
+        // printf("Waku Relay subscription response: %s\n", mResp->data);
+
+        show_main_menu();
+    }
+    break;
+
+    case CONNECT_TO_OTHER_NODE_MENU:
+        printf("Connecting to a node. Please indicate the peer Multiaddress:\n");
+        printf("e.g.: /ip4/127.0.0.1/tcp/60001/p2p/16Uiu2HAmVFXtAfSj4EiR7mL2KvL4EE2wztuQgUSBoj2Jx2KeXFLN\n");
+        char peerAddr[512];
+        scanf("%511s", peerAddr);
+        // if (!waku_connect(peerAddr, 10000 /* timeoutMs */, &mResp)) {
+        //     printf("Couldn't connect to the remote peer: %s\n", mResp->data);
+        // }
+        show_main_menu();
+    break;
+
+    case PUBLISH_MESSAGE_MENU:
+    {
+        printf("Indicate the Pubsubtopic:\n");
+        char pubsubTopic[128];
+        scanf("%127s", pubsubTopic);
+
+        printf("Type the message tp publish:\n");
+        char msg[1024];
+        scanf("%1023s", msg);
+
+        char jsonWakuMsg[1024];
+        std::vector<char> msgPayload;
+        b64_encode(msg, strlen(msg), msgPayload);
+
+        // waku_content_topic("appName",
+        //                     1,
+        //                     "contentTopicName",
+        //                     "encoding",
+        //                     &mResp);
+
+        // snprintf(jsonWakuMsg,
+        //          1024,
+        //          "{\"payload\":\"%s\",\"content_topic\":\"%s\"}",
+        //          msgPayload, mResp->data);
+
+        // free(msgPayload);
+
+        // waku_relay_publish(pubsubTopic, jsonWakuMsg, 10000 /*timeout ms*/, &mResp);
+        // printf("waku relay response [%s]\n", mResp->data);
+        show_main_menu();
+    }
+    break;
+
+    case MAIN_MENU:
+        break;
+    }
+}
+
+// End of UI program logic
+
+void show_help_and_exit() {
+    printf("Wrong parameters\n");
+    exit(1);
+}
+
+void event_handler(const char* msg, size_t len) {
+    printf("Receiving message %s\n", msg);
+}
+
+void handle_error(const char* msg, size_t len) {
+    printf("Error: %s\n", msg);
+    exit(1);
+}
+
+template <class F>
+auto cify(F&& f) {
+  static F fn = std::forward<F>(f);
+  return [](const char* msg, size_t len) {
+    return fn(msg, len);
+  };
+}
+
+int main(int argc, char** argv) {
+
+    struct ConfigNode cfgNode;
+    // default values
+    snprintf(cfgNode.host, 128, "0.0.0.0");
+    snprintf(cfgNode.key, 128,
+             "364d111d729a6eb6d2e6113e163f017b5ef03a6f94c9b5b7bb1bb36fa5cb07a9");
+    cfgNode.port = 60000;
+    cfgNode.relay = 1;
+
+    if (argp_parse(&argp, argc, argv, 0, 0, &cfgNode)
+                    == ARGP_ERR_UNKNOWN) {
+        show_help_and_exit();
+    }
+
+    char jsonConfig[1024];
+    snprintf(jsonConfig, 1024, "{ \
+                                    \"host\": \"%s\",   \
+                                    \"port\": %d,       \
+                                    \"key\": \"%s\",    \
+                                    \"relay\": %s,      \
+                                }", cfgNode.host,
+                                    cfgNode.port,
+                                    cfgNode.key,
+                                    cfgNode.relay ? "true":"false");
+
+    WAKU_CALL(waku_new(jsonConfig, cify([](const char* msg, size_t len) {
+        std::cout << "Error: " << msg << std::endl;
+        exit(1);
+    })));
+
+    // example on how to retrieve a value from the `libwaku` callback.
+    std::string defaultPubsubTopic;
+    WAKU_CALL(waku_default_pubsub_topic(cify([&defaultPubsubTopic](const char* msg, size_t len) {
+        defaultPubsubTopic = msg;
+    })));
+
+    std::cout << "Default pubsub topic: " << defaultPubsubTopic << std::endl;
+
+    WAKU_CALL(waku_version(cify([&](const char* msg, size_t len) {
+        std::cout << "Git Version: " << msg << std::endl;
+    })));
+
+    printf("Bind addr: %s:%u\n", cfgNode.host, cfgNode.port);
+    printf("Waku Relay enabled: %s\n", cfgNode.relay == 1 ? "YES": "NO");
+
+    std::string pubsubTopic;
+    WAKU_CALL(waku_pubsub_topic("example", cify([&](const char* msg, size_t len) {
+        pubsubTopic = msg;
+    })));
+
+    std::cout << "Custom pubsub topic: " << pubsubTopic << std::endl;
+
+    waku_set_event_callback(event_handler);
+    waku_start();
+
+    WAKU_CALL( waku_connect(cfgNode.peers,
+                        10000 /* timeoutMs */,
+                        handle_error) );
+
+    WAKU_CALL( waku_relay_subscribe(defaultPubsubTopic.c_str(),
+                                    handle_error) );
+
+    std::cout << "Establishing connection with: " << cfgNode.peers << std::endl;
+    WAKU_CALL(waku_connect(cfgNode.peers, 10000 /* timeoutMs */, handle_error));
+
+    show_main_menu();
+    while(1) {
+        handle_user_input();
+    }
+}

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -11,6 +11,10 @@
 #define RET_ERR               1
 #define RET_MISSING_CALLBACK  2
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void (*WakuCallBack) (const char* msg, size_t len_0);
 
 // Creates a new instance of the waku node.
@@ -50,5 +54,9 @@ int waku_relay_unsubscribe(const char* pubSubTopic,
 int waku_connect(const char* peerMultiAddr,
                  unsigned int timeoutMs,
                  WakuCallBack onErrCb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __libwaku__ */

--- a/scripts/run_cov.sh
+++ b/scripts/run_cov.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Check if env.sh has been loaded, or if this file is being ran from it.
+# Using NIMC as a proxy for this, as it's defined in the nimbus-build-system's env.sh.
+if [ -z "$NIMC" ]
+then
+    echo "[ERROR] This tool can only be ran from the Nimbus environment. Either:" 
+    echo "- Source env.sh 'source /path/to/env.sh', and then run the script directly '/path/to/scripts/run_cov.sh'." 
+    echo "- Run this script as a parameter to env.sh '/path/to/env.sh /path/to/scripts/run_cov.sh'."
+    exit 1
+fi
+
+# Check for lcov tool
+which lcov 1>/dev/null 2>&1
+if [ $? != 0 ]
+then
+    echo "[ERROR] You need to have lcov installed in order to generate the test coverage report."
+    exit 2
+fi
+
+SCRIPT_PATH=$(dirname "$(realpath -s "$0")")
+REPO_ROOT=$(dirname $SCRIPT_PATH)
+generated_not_to_break_here="$REPO_ROOT/generated_not_to_break_here"
+
+if [ -f $generated_not_to_break_here ]
+then
+    echo "The file '$generated_not_to_break_here' already exists. Do you want to continue? (y/n)"
+    read -r response
+    if [ "$response" != "y" ]
+    then
+        exit 3
+    fi
+fi
+
+output_directory="$REPO_ROOT/coverage_html_report"
+base_filepath="$REPO_ROOT/tests/test_all"
+nim_filepath=$base_filepath.nim
+info_filepath=$base_filepath.info
+
+# Workaround a nim bug. See https://github.com/nim-lang/Nim/issues/12376
+touch $generated_not_to_break_here
+
+# Generate the coverage report
+nim --debugger:native --passC:--coverage --passL:--coverage --passL:librln_v0.3.4.a --passL:-lm c $nim_filepath
+lcov --base-directory . --directory . --zerocounters -q
+$base_filepath
+lcov --base-directory . --directory . --include "*/waku/**" --include "*/apps/**" --exclude "*/vendor/**" -c -o $info_filepath
+genhtml -o $output_directory $info_filepath
+
+# Cleanup
+rm -rf $info_filepath $base_filepath nimcache
+rm $generated_not_to_break_here

--- a/tests/all_tests_common.nim
+++ b/tests/all_tests_common.nim
@@ -1,9 +1,3 @@
 {.used.}
 
-# Waku common test suite
-import
-  ./common/test_envvar_serialization,
-  ./common/test_confutils_envvar,
-  ./common/test_protobuf_validation,
-  ./common/test_enr_builder,
-  ./common/test_sqlite_migrations
+import ./common/test_all

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -72,6 +72,7 @@ import
   ./test_peer_exchange,
   ./test_waku_noise,
   ./test_waku_noise_sessions,
+  ./test_waku_netconfig,
   ./test_waku_switch,
   ./test_waku_rendezvous
 

--- a/tests/all_tests_wakunode2.nim
+++ b/tests/all_tests_wakunode2.nim
@@ -1,6 +1,3 @@
 ## Wakunode2
 
-import
-  ./wakunode2/test_app,
-  ./wakunode2/test_validators
-
+import ./wakunode2/test_all

--- a/tests/common/test_all.nim
+++ b/tests/common/test_all.nim
@@ -1,0 +1,7 @@
+import
+  ./test_base64_codec,
+  ./test_confutils_envvar,
+  ./test_enr_builder,
+  ./test_envvar_serialization,
+  ./test_protobuf_validation,
+  ./test_sqlite_migrations

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -1,0 +1,6 @@
+{.used.}
+
+import
+  ./all_tests_common,
+  ./all_tests_waku,
+  ./all_tests_wakunode2

--- a/tests/test_waku_netconfig.nim
+++ b/tests/test_waku_netconfig.nim
@@ -1,0 +1,340 @@
+{.used.}
+
+import
+  chronos,
+  confutils/toml/std/net,
+  libp2p/multiaddress,
+  testutils/unittests
+
+import
+  ./testlib/wakunode,
+  ../../waku/waku_enr/capabilities
+
+include
+  ../../waku/node/config
+
+proc defaultTestWakuFlags(): CapabilitiesBitfield =
+  CapabilitiesBitfield.init(
+      lightpush = false,
+      filter = false,
+      store = false,
+      relay = true
+  )
+    
+suite "Waku NetConfig":
+  
+  asyncTest "Create NetConfig with default values":
+
+    let conf = defaultTestWakuNodeConf()
+    
+    let wakuFlags = defaultTestWakuFlags()
+    
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      extIp = none(ValidIpAddress),
+      extPort = none(Port),
+      extMultiAddrs = @[],
+      wsBindPort = conf.websocketPort,
+      wsEnabled = conf.websocketSupport,
+      wssEnabled = conf.websocketSecureSupport,
+      dns4DomainName = none(string),
+      discv5UdpPort = none(Port),
+      wakuFlags = some(wakuFlags)
+    )
+
+    check:
+      netConfigRes.isOk()
+
+  asyncTest "AnnouncedAddresses contains only bind address when no external addresses are provided":
+
+    let conf = defaultTestWakuNodeConf()
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 1  # Only bind address should be present
+      netConfig.announcedAddresses[0] == formatListenAddress(ip4TcpEndPoint(conf.listenAddress, conf.tcpPort))
+
+
+  asyncTest "AnnouncedAddresses contains external address if extIp/Port are provided":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      extIp = ValidIpAddress.init("1.2.3.4")
+      extPort = Port(1234)
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      extIp = some(extIp),
+      extPort = some(extPort)
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 1  # Only external address should be present
+      netConfig.announcedAddresses[0] == ip4TcpEndPoint(extIp, extPort)
+
+  asyncTest "AnnouncedAddresses contains dns4DomainName if provided":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      dns4DomainName = "example.com"
+      extPort = Port(1234)
+
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      dns4DomainName = some(dns4DomainName),
+      extPort = some(extPort)
+    )
+      
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 1  # Only DNS address should be present
+      netConfig.announcedAddresses[0] == dns4TcpEndPoint(dns4DomainName, extPort)
+
+  asyncTest "AnnouncedAddresses includes extMultiAddrs when provided":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      extIp = ValidIpAddress.init("1.2.3.4")
+      extPort = Port(1234)
+      extMultiAddrs = @[ip4TcpEndPoint(extIp, extPort)]
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      extMultiAddrs = extMultiAddrs
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 2  # Bind address + extAddress
+      netConfig.announcedAddresses[1] == extMultiAddrs[0]
+
+
+  asyncTest "AnnouncedAddresses uses dns4DomainName over extIp when both are provided":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      dns4DomainName = "example.com"
+      extIp = ValidIpAddress.init("1.2.3.4")
+      extPort = Port(1234)
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      dns4DomainName = some(dns4DomainName),
+      extIp = some(extIp),
+      extPort = some(extPort)
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 1  # DNS address
+      netConfig.announcedAddresses[0] == dns4TcpEndPoint(dns4DomainName, extPort) 
+
+  asyncTest "AnnouncedAddresses includes WebSocket addresses when enabled":
+
+    var 
+      conf = defaultTestWakuNodeConf()
+      wssEnabled = false
+        
+    var netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      wsEnabled = true,
+      wssEnabled = wssEnabled
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    var netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 2  # Bind address + wsHostAddress
+      netConfig.announcedAddresses[1] == (ip4TcpEndPoint(conf.listenAddress, 
+        conf.websocketPort) & wsFlag(wssEnabled))
+    
+    ## Now try the same for the case of wssEnabled = true
+        
+    wssEnabled = true
+    
+    netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      wsEnabled = true,
+      wssEnabled = wssEnabled
+    )
+
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 2  # Bind address + wsHostAddress
+      netConfig.announcedAddresses[1] == (ip4TcpEndPoint(conf.listenAddress, 
+        conf.websocketPort) & wsFlag(wssEnabled))
+    
+  asyncTest "Announced WebSocket address contains external IP if provided":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      extIp = ValidIpAddress.init("1.2.3.4")
+      extPort = Port(1234)
+      wssEnabled = false
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      extIp = some(extIp),
+      extPort = some(extPort),
+      wsEnabled = true,
+      wssEnabled = wssEnabled
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 2  # External address + wsHostAddress
+      netConfig.announcedAddresses[1] == (ip4TcpEndPoint(extIp, 
+        conf.websocketPort) & wsFlag(wssEnabled))
+
+  asyncTest "Announced WebSocket address contains dns4DomainName if provided":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      dns4DomainName = "example.com"
+      extPort = Port(1234)
+      wssEnabled = false
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      dns4DomainName = some(dns4DomainName),
+      extPort = some(extPort),
+      wsEnabled = true,
+      wssEnabled = wssEnabled
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 2  # Bind address + wsHostAddress
+      netConfig.announcedAddresses[1] == (dns4TcpEndPoint(dns4DomainName, conf.websocketPort) & 
+        wsFlag(wssEnabled))
+
+  asyncTest "Announced WebSocket address contains dns4DomainName if provided alongside extIp":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      dns4DomainName = "example.com"
+      extIp = ValidIpAddress.init("1.2.3.4")
+      extPort = Port(1234)
+      wssEnabled = false
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      dns4DomainName = some(dns4DomainName),
+      extIp = some(extIp),
+      extPort = some(extPort),
+      wsEnabled = true,
+      wssEnabled = wssEnabled
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.announcedAddresses.len == 2  # DNS address + wsHostAddress
+      netConfig.announcedAddresses[0] == dns4TcpEndPoint(dns4DomainName, extPort)
+      netConfig.announcedAddresses[1] == (dns4TcpEndPoint(dns4DomainName, conf.websocketPort) & 
+        wsFlag(wssEnabled))      
+
+  asyncTest "ENR is set with bindIp/Port if no extIp/Port are provided":
+
+    let conf = defaultTestWakuNodeConf()
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.enrIp.get() == conf.listenAddress
+      netConfig.enrPort.get() == conf.tcpPort
+
+  asyncTest "ENR is set with extIp/Port if provided":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      extIp = ValidIpAddress.init("1.2.3.4")
+      extPort = Port(1234)
+        
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      extIp = some(extIp),
+      extPort = some(extPort)
+    )
+     
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.extIp.get() == extIp
+      netConfig.enrPort.get() == extPort
+
+  asyncTest "ENR is set with dns4DomainName if provided":
+
+    let 
+      conf = defaultTestWakuNodeConf()
+      dns4DomainName = "example.com"
+      extPort = Port(1234)
+
+    let netConfigRes = NetConfig.init(
+      bindIp = conf.listenAddress,
+      bindPort = conf.tcpPort,
+      dns4DomainName = some(dns4DomainName),
+      extPort = some(extPort)
+    )
+
+    assert netConfigRes.isOk(), $netConfigRes.error
+
+    let netConfig = netConfigRes.get()
+
+    check:
+      netConfig.enrMultiaddrs.contains(dns4TcpEndPoint(dns4DomainName, extPort))
+

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -13,12 +13,27 @@ import
   ../../../waku/node/peer_manager,
   ../../../waku/waku_enr,
   ../../../waku/waku_discv5,
+  ../../apps/wakunode2/external_config,
   ../../apps/wakunode2/internal_config,
-  ../wakunode2/test_app,
   ./common
 
 
 # Waku node
+
+proc defaultTestWakuNodeConf*(): WakuNodeConf =
+  WakuNodeConf(
+    tcpPort: Port(60000),
+    websocketPort: Port(8000),
+    listenAddress: ValidIpAddress.init("0.0.0.0"),
+    rpcAddress: ValidIpAddress.init("127.0.0.1"),
+    restAddress: ValidIpAddress.init("127.0.0.1"),
+    metricsServerAddress: ValidIpAddress.init("127.0.0.1"),
+    dnsAddrsNameServers: @[ValidIpAddress.init("1.1.1.1"), ValidIpAddress.init("1.0.0.1")],
+    nat: "any",
+    maxConnections: 50,
+    topics: @["/waku/2/default-waku/proto"],
+    relay: true
+  )
 
 proc newTestWakuNode*(nodeKey: crypto.PrivateKey,
                       bindIp: ValidIpAddress,

--- a/tests/waku_archive/test_all.nim
+++ b/tests/waku_archive/test_all.nim
@@ -1,0 +1,13 @@
+{.used.}
+
+import
+  ./test_driver_postgres_query,
+  ./test_driver_postgres,
+  ./test_driver_queue_index,
+  ./test_driver_queue_pagination,
+  ./test_driver_queue_query,
+  ./test_driver_queue,
+  ./test_driver_sqlite_query,
+  ./test_driver_sqlite,
+  ./test_retention_policy,
+  ./test_waku_archive

--- a/tests/waku_archive/test_retention_policy.nim
+++ b/tests/waku_archive/test_retention_policy.nim
@@ -66,12 +66,15 @@ suite "Waku Archive - Retention policy":
 
     let retentionPolicy: RetentionPolicy = SizeRetentionPolicy.init(size=sizeLimit)
 
+    require (waitFor retentionPolicy.execute(driver)).isOk()
+    
     ## When
     for i in 1..excess:
       let msg = fakeWakuMessage(payload= @[byte i], contentTopic=DefaultContentTopic, ts=Timestamp(i))
 
       require (waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msg.timestamp)).isOk()
-      require (waitFor retentionPolicy.execute(driver)).isOk()
+    
+    require (waitFor retentionPolicy.execute(driver)).isOk()
     ## Then
     # calculate the current database size
     let pageSize = (waitFor driver.getPagesSize()).tryGet()

--- a/tests/waku_core/test_all.nim
+++ b/tests/waku_core/test_all.nim
@@ -1,0 +1,9 @@
+{.used.}
+
+import 
+  ./test_message_digest,
+  ./test_namespaced_topics,
+  ./test_peers,
+  ./test_published_address,
+  ./test_sharding,
+  ./test_time

--- a/tests/waku_filter_v2/test_all.nim
+++ b/tests/waku_filter_v2/test_all.nim
@@ -1,0 +1,6 @@
+{.used.}
+
+import
+  ./test_waku_client,
+  ./test_waku_filter_protocol,
+  ./test_waku_filter

--- a/tests/waku_relay/test_all.nim
+++ b/tests/waku_relay/test_all.nim
@@ -1,0 +1,5 @@
+{.used.}
+
+import 
+  ./test_waku_relay,
+  ./test_wakunode_relay

--- a/tests/waku_rln_relay/test_all.nim
+++ b/tests/waku_rln_relay/test_all.nim
@@ -1,0 +1,7 @@
+{.used.}
+
+import
+  ./test_rln_group_manager_onchain,
+  ./test_rln_group_manager_static,
+  ./test_waku_rln_relay,
+  ./test_wakunode_rln_relay

--- a/tests/waku_store/test_all.nim
+++ b/tests/waku_store/test_all.nim
@@ -1,0 +1,7 @@
+{.used.}
+
+import
+  ./test_resume,
+  ./test_rpc_codec,
+  ./test_waku_store,
+  ./test_wakunode_store

--- a/tests/wakunode2/test_all.nim
+++ b/tests/wakunode2/test_all.nim
@@ -1,0 +1,5 @@
+{.used.}
+
+import
+  ./test_app,
+  ./test_validators

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -10,23 +10,10 @@ import
   libp2p/multiaddress,
   libp2p/switch
 import
-  ../../apps/wakunode2/external_config,
-  ../../apps/wakunode2/app,
   ../testlib/common,
-  ../testlib/wakucore
-
-proc defaultTestWakuNodeConf*(): WakuNodeConf =
-  WakuNodeConf(
-    listenAddress: ValidIpAddress.init("127.0.0.1"),
-    rpcAddress: ValidIpAddress.init("127.0.0.1"),
-    restAddress: ValidIpAddress.init("127.0.0.1"),
-    metricsServerAddress: ValidIpAddress.init("127.0.0.1"),
-    dnsAddrsNameServers: @[ValidIpAddress.init("1.1.1.1"), ValidIpAddress.init("1.0.0.1")],
-    nat: "any",
-    maxConnections: 50,
-    topics: @["/waku/2/default-waku/proto"],
-    relay: true
-  )
+  ../testlib/wakucore,
+  ../testlib/wakunode,
+  ../../apps/wakunode2/app
 
 suite "Wakunode2 - App":
   test "compilation version should be reported":

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -15,12 +15,13 @@ import
   ../testlib/common,
   ../testlib/wakucore
 
-proc defaultTestWakuNodeConf(): WakuNodeConf =
+proc defaultTestWakuNodeConf*(): WakuNodeConf =
   WakuNodeConf(
     listenAddress: ValidIpAddress.init("127.0.0.1"),
     rpcAddress: ValidIpAddress.init("127.0.0.1"),
     restAddress: ValidIpAddress.init("127.0.0.1"),
     metricsServerAddress: ValidIpAddress.init("127.0.0.1"),
+    dnsAddrsNameServers: @[ValidIpAddress.init("1.1.1.1"), ValidIpAddress.init("1.0.0.1")],
     nat: "any",
     maxConnections: 50,
     topics: @["/waku/2/default-waku/proto"],

--- a/tests/wakunode_jsonrpc/test_all.nim
+++ b/tests/wakunode_jsonrpc/test_all.nim
@@ -1,0 +1,8 @@
+{.used.}
+
+import
+  ./test_jsonrpc_admin,
+  ./test_jsonrpc_debug,
+  ./test_jsonrpc_filter,
+  ./test_jsonrpc_relay,
+  ./test_jsonrpc_store

--- a/tests/wakunode_rest/test_all.nim
+++ b/tests/wakunode_rest/test_all.nim
@@ -1,0 +1,12 @@
+{.used.}
+
+import
+  ./test_rest_debug_serdes,
+  ./test_rest_debug,
+  ./test_rest_filter,
+  ./test_rest_health,
+  ./test_rest_legacy_filter,
+  ./test_rest_relay_serdes,
+  ./test_rest_relay,
+  ./test_rest_serdes,
+  ./test_rest_store

--- a/waku/README.md
+++ b/waku/README.md
@@ -194,8 +194,8 @@ A node will attempt connection to all discovered nodes.
 
 This can be used, for example, to connect to one of the existing fleets.
 Current URLs for the published fleet lists:
-- production fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im`
-- test fleet: `enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im`
+- production fleet: `enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im`
+- test fleet: `enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im`
 
 See the [separate tutorial](../../docs/tutorial/dns-disc.md) for a complete guide to DNS discovery.
 

--- a/waku/common/databases/db_sqlite.nim
+++ b/waku/common/databases/db_sqlite.nim
@@ -485,3 +485,4 @@ proc performSqliteVacuum*(db: SqliteDatabase): DatabaseResult[void] =
     return err("failed to execute vacuum: " & resVacuum.error)
 
   debug "finished sqlite database vacuuming"
+  ok()

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -51,7 +51,7 @@ method getPagesCount*(driver: ArchiveDriver):
 method getPagesSize*(driver: ArchiveDriver):
                          Future[ArchiveDriverResult[int64]] {.base, async.} = discard
 
-method performsSqliteVacuum*(driver: ArchiveDriver):
+method performsVacuum*(driver: ArchiveDriver):
               Future[ArchiveDriverResult[void]] {.base, async.} = discard
 
 method getOldestMessageTimestamp*(driver: ArchiveDriver):

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -45,6 +45,15 @@ method getMessages*(driver: ArchiveDriver,
 method getMessagesCount*(driver: ArchiveDriver):
                          Future[ArchiveDriverResult[int64]] {.base, async.} = discard
 
+method getPagesCount*(driver: ArchiveDriver):
+                         Future[ArchiveDriverResult[int64]] {.base, async.} = discard
+
+method getPagesSize*(driver: ArchiveDriver):
+                         Future[ArchiveDriverResult[int64]] {.base, async.} = discard
+
+method performsSqliteVacuum*(driver: ArchiveDriver):
+              Future[ArchiveDriverResult[void]] {.base, async.} = discard
+
 method getOldestMessageTimestamp*(driver: ArchiveDriver):
                                   Future[ArchiveDriverResult[Timestamp]] {.base, async.} = discard
 

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -280,6 +280,18 @@ method getMessagesCount*(driver: QueueDriver):
                          Future[ArchiveDriverResult[int64]] {.async} =
   return ok(int64(driver.len()))
 
+method getPagesCount*(driver: QueueDriver):
+                         Future[ArchiveDriverResult[int64]] {.async} =
+  return ok(int64(driver.len()))
+
+method getPagesSize*(driver: QueueDriver):
+                         Future[ArchiveDriverResult[int64]] {.async} =
+  return ok(int64(driver.len()))
+
+method performsSqliteVacuum*(driver: QueueDriver):
+              Future[ArchiveDriverResult[void]] {.async.} =
+  return ok()
+
 method getOldestMessageTimestamp*(driver: QueueDriver):
                                   Future[ArchiveDriverResult[Timestamp]] {.async.} =
   return driver.first().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -288,9 +288,9 @@ method getPagesSize*(driver: QueueDriver):
                          Future[ArchiveDriverResult[int64]] {.async} =
   return ok(int64(driver.len()))
 
-method performsSqliteVacuum*(driver: QueueDriver):
+method performsVacuum*(driver: QueueDriver):
               Future[ArchiveDriverResult[void]] {.async.} =
-  return ok()
+  return err("interface method not implemented")
 
 method getOldestMessageTimestamp*(driver: QueueDriver):
                                   Future[ArchiveDriverResult[Timestamp]] {.async.} =

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -117,7 +117,7 @@ method getPagesSize*(s: SqliteDriver):
                          Future[ArchiveDriverResult[int64]] {.async.} =
   return s.db.getPageSize()
 
-method performsSqliteVacuum*(s: SqliteDriver):
+method performsVacuum*(s: SqliteDriver):
                          Future[ArchiveDriverResult[void]] {.async.} =
   return s.db.performSqliteVacuum()
 

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -109,6 +109,18 @@ method getMessagesCount*(s: SqliteDriver):
                          Future[ArchiveDriverResult[int64]] {.async.} =
   return s.db.getMessageCount()
 
+method getPagesCount*(s: SqliteDriver):
+                         Future[ArchiveDriverResult[int64]] {.async.} =
+  return s.db.getPageCount()
+
+method getPagesSize*(s: SqliteDriver):
+                         Future[ArchiveDriverResult[int64]] {.async.} =
+  return s.db.getPageSize()
+
+method performsSqliteVacuum*(s: SqliteDriver):
+                         Future[ArchiveDriverResult[void]] {.async.} =
+  return s.db.performSqliteVacuum()
+
 method getOldestMessageTimestamp*(s: SqliteDriver):
                                   Future[ArchiveDriverResult[Timestamp]] {.async.} =
   return s.db.selectOldestReceiverTimestamp()

--- a/waku/waku_archive/retention_policy/builder.nim
+++ b/waku/waku_archive/retention_policy/builder.nim
@@ -11,7 +11,8 @@ import
 import
   ../retention_policy,
   ./retention_policy_time,
-  ./retention_policy_capacity
+  ./retention_policy_capacity,
+  ./retention_policy_size
 
 proc new*(T: type RetentionPolicy,
           retPolicy: string):
@@ -49,6 +50,39 @@ proc new*(T: type RetentionPolicy,
       return err("invalid capacity retention policy argument")
 
     let retPolicy: RetentionPolicy = CapacityRetentionPolicy.init(retentionCapacity)
+    return ok(some(retPolicy))
+
+  elif policy == "size":
+    var retentionSize: string
+    retentionSize = policyArgs
+    
+    # captures the size unit such as Gb or Mb
+    let sizeUnit = retentionSize.substr(retentionSize.len-2)
+    # captures the string type number data of the size provided  
+    let sizeQuantityStr = retentionSize.substr(0,retentionSize.len-3)
+    # to hold the numeric value data of size
+    var sizeQuantity: float
+    
+    if sizeUnit in ["gb", "Gb", "GB", "gB"]:
+      # parse the actual value into integer type var
+      try:
+        sizeQuantity = parseFloat(sizeQuantityStr)
+      except ValueError:
+        return err("invalid size retention policy argument")
+      # Gb data is converted into Mb for uniform processing
+      sizeQuantity = sizeQuantity * 1024
+    elif sizeUnit in ["mb", "Mb", "MB", "mB"]:
+      try:
+        sizeQuantity = parseFloat(sizeQuantityStr)  
+      except ValueError:
+        return err("invalid size retention policy argument")
+    else:
+      return err ("""invalid size retention value unit: expected "Mb" or "Gb" but got """ & sizeUnit )
+    
+    if sizeQuantity <= 0:
+          return err("invalid size retention policy argument: a non-zero value is required")
+
+    let retPolicy: RetentionPolicy = SizeRetentionPolicy.init(sizeQuantity)
     return ok(some(retPolicy))
 
   else:

--- a/waku/waku_archive/retention_policy/retention_policy_size.nim
+++ b/waku/waku_archive/retention_policy/retention_policy_size.nim
@@ -51,12 +51,11 @@ method execute*(p: SizeRetentionPolicy,
   var pageCount: int64 = pageCountRes.value
 
   # get page size of database
-  var pageSizeRes = await driver.getPagesSize()
-  if pageSizeRes.isErr():
-    return err("failed to get Page size: " & pageSizeRes.error)
+  let pageSizeRes = await driver.getPagesSize()
+  var pageSize: int64 = int64(pageSizeRes.valueOr(0) div 1024)
 
-  # get the page size in kilobytes Kb)
-  var pageSize: int64 = int64(pageSizeRes.value div 1024)
+  if pageSize == 0:
+    return err("failed to get Page size: " & pageSizeRes.error)
 
   # database size in megabytes (Mb)
   var totalSizeOfDB: float = float(pageSize * pageCount)/1024.0
@@ -80,7 +79,7 @@ method execute*(p: SizeRetentionPolicy,
 
   # vacuum to get the deleted pages defragments to save storage space
   # this will resize the database size
-  let resVaccum = await driver.performsSqliteVacuum()
+  let resVaccum = await driver.performsVacuum()
   if resVaccum.isErr():
     return err("vacuumming failed: " & resVaccum.error)
 

--- a/waku/waku_archive/retention_policy/retention_policy_size.nim
+++ b/waku/waku_archive/retention_policy/retention_policy_size.nim
@@ -1,0 +1,87 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/times,
+  stew/results,
+  chronicles,
+  chronos
+import
+  ../driver,
+  ../retention_policy
+
+logScope:
+  topics = "waku archive retention_policy"
+
+# default size is 30 Gb
+const DefaultRetentionSize*: float = 30_720
+
+# to remove 20% of the outdated data from database
+const DeleteLimit = 0.80
+
+type
+  # SizeRetentionPolicy implements auto delete as follows:
+  # - sizeLimit is the size in megabytes (Mbs) the database can grow upto
+  # to reduce the size of the databases, remove the rows/number-of-messages
+  # DeleteLimit is the total number of messages to delete beyond this limit
+  # when the database size crosses the sizeLimit, then only a fraction of messages are kept,
+  # rest of the outdated message are deleted using deleteOldestMessagesNotWithinLimit(),
+  # upon deletion process the fragmented space is retrieve back using Vacuum process. 
+  SizeRetentionPolicy* = ref object of RetentionPolicy
+      sizeLimit: float
+
+proc init*(T: type SizeRetentionPolicy, size=DefaultRetentionSize): T =
+  SizeRetentionPolicy(
+    sizeLimit: size
+  )
+
+method execute*(p: SizeRetentionPolicy,
+                driver: ArchiveDriver):
+                Future[RetentionPolicyResult[void]] {.async.} =
+  ## when db size overshoots the database limit, shread 20% of outdated messages 
+  
+  # to get the size of the database, pageCount and PageSize is required
+  # get page count in "messages" database
+  var pageCountRes = await driver.getPagesCount()
+  if pageCountRes.isErr():
+    return err("failed to get Pages count: " & pageCountRes.error)
+
+  var pageCount: int64 = pageCountRes.value
+
+  # # get page size of database
+  var pageSizeRes = await driver.getPagesSize()
+  if pageSizeRes.isErr():
+    return err("failed to get Page size: " & pageSizeRes.error)
+
+  # get the page size in kilobytes Kb)
+  var pageSize: int64 = int64(pageSizeRes.value div 1024)
+
+  # database size in megabytes (Mb)
+  var totalSizeOfDB: float = float(pageSize * pageCount)/1024.0
+
+  # check if current databse size crosses the db size limit
+  if totalSizeOfDB <= p.sizeLimit:
+    return ok()
+
+  # to shread/delete messsges, get the total row/message count
+  var numMessagesRes = await driver.getMessagesCount()
+  if numMessagesRes.isErr():
+    return err("failed to get messages count: " & numMessagesRes.error)
+  var numMessages = numMessagesRes.value
+
+  # 80% of the total messages are to be kept, delete others
+  let pageDeleteWindow = int(float(numMessages) * DeleteLimit)
+
+  let res = await driver.deleteOldestMessagesNotWithinLimit(limit=pageDeleteWindow)
+  if res.isErr():
+      return err("deleting oldest messages failed: " & res.error)
+
+  # vacuum to get the deleted pages defragments to save storage space
+  # this will resize the database size
+  let resVaccum = await driver.performsSqliteVacuum()
+  if resVaccum.isErr():
+    return err("vacuumming failed: " & resVaccum.error)
+
+  return ok()

--- a/waku/waku_archive/retention_policy/retention_policy_size.nim
+++ b/waku/waku_archive/retention_policy/retention_policy_size.nim
@@ -50,7 +50,7 @@ method execute*(p: SizeRetentionPolicy,
 
   var pageCount: int64 = pageCountRes.value
 
-  # # get page size of database
+  # get page size of database
   var pageSizeRes = await driver.getPagesSize()
   if pageSizeRes.isErr():
     return err("failed to get Page size: " & pageSizeRes.error)
@@ -62,7 +62,7 @@ method execute*(p: SizeRetentionPolicy,
   var totalSizeOfDB: float = float(pageSize * pageCount)/1024.0
 
   # check if current databse size crosses the db size limit
-  if totalSizeOfDB <= p.sizeLimit:
+  if totalSizeOfDB < p.sizeLimit:
     return ok()
 
   # to shread/delete messsges, get the total row/message count


### PR DESCRIPTION
# Description
Size retention Policy has been added. Based on the size limit provided in mb or gb. Once the size limit overflows by messages, then the 20% of the outdated messages are dropped and a vacuum of database for defragmentation is triggered.

# Changes

<!-- List of detailed changes -->

- [x] Size related retention policy
- [x] Vacuum after the deletion of database entries

<!--
## How to test
 test case provided that checks message nsertion against a size limit. Result shows the 20% of the database is dropped to make space more incoming messages.
-->


<!--
## Issue

fixes #1885
-->