### PR TITLE
chore: Revert lightpush error handling to allow zero peer publish again succeed

### DIFF
--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -171,24 +171,27 @@ suite "Waku v2 Rest API - lightpush":
 
     await restLightPushTest.shutdown()
 
-  asyncTest "Push message request service not available":
-    # Given
-    let restLightPushTest = await RestLightPushTest.init()
+  ## TODO: Re-work this test when lightpush protocol change is done: https://github.com/waku-org/pm/issues/93
+  ## This test is similar when no available peer exists for publish. Currently it is returning success,
+  ## that makes this test not useful.
+  # asyncTest "Push message request service not available":
+  #   # Given
+  #   let restLightPushTest = await RestLightPushTest.init()
 
-    # When
-    let message : RelayWakuMessage = fakeWakuMessage(contentTopic = DefaultContentTopic,
-                                                     payload = toBytes("TEST-1")).toRelayWakuMessage()
+  #   # When
+  #   let message : RelayWakuMessage = fakeWakuMessage(contentTopic = DefaultContentTopic,
+  #                                                    payload = toBytes("TEST-1")).toRelayWakuMessage()
 
-    let requestBody = PushRequest(pubsubTopic: some("NoExistTopic"),
-                                  message: message)
-    let response = await restLightPushTest.client.sendPushRequest(requestBody)
+  #   let requestBody = PushRequest(pubsubTopic: some("NoExistTopic"),
+  #                                 message: message)
+  #   let response = await restLightPushTest.client.sendPushRequest(requestBody)
 
-    echo "response", $response
+  #   echo "response", $response
 
-    # Then
-    check:
-      response.status == 503
-      $response.contentType == $MIMETYPE_TEXT
-      response.data == "Failed to request a message push: Can not publish to any peers"
+  #   # Then
+  #   check:
+  #     response.status == 503
+  #     $response.contentType == $MIMETYPE_TEXT
+  #     response.data == "Failed to request a message push: Can not publish to any peers"
 
-    await restLightPushTest.shutdown()
+  #   await restLightPushTest.shutdown()

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -227,7 +227,7 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
 proc subscribe*(node: WakuNode, subscription: SubscriptionEvent, handler = none(WakuRelayHandler)) =
   ## Subscribes to a PubSub or Content topic. Triggers handler when receiving messages on
   ## this topic. WakuRelayHandler is a method that takes a topic and a Waku message.
-  
+
   if node.wakuRelay.isNil():
     error "Invalid API call to `subscribe`. WakuRelay not mounted."
     return
@@ -242,7 +242,7 @@ proc subscribe*(node: WakuNode, subscription: SubscriptionEvent, handler = none(
         (shard, some(subscription.topic))
       of PubsubSub: (subscription.topic, none(ContentTopic))
       else: return
-      
+
   if contentTopicOp.isSome() and node.contentTopicHandlers.hasKey(contentTopicOp.get()):
     error "Invalid API call to `subscribe`. Was already subscribed"
     return
@@ -260,7 +260,7 @@ proc subscribe*(node: WakuNode, subscription: SubscriptionEvent, handler = none(
 
 proc unsubscribe*(node: WakuNode, subscription: SubscriptionEvent) =
   ## Unsubscribes from a specific PubSub or Content topic.
-  
+
   if node.wakuRelay.isNil():
     error "Invalid API call to `unsubscribe`. WakuRelay not mounted."
     return
@@ -876,7 +876,8 @@ proc mountLightPush*(node: WakuNode) {.async.} =
       let publishedCount = await node.wakuRelay.publish(pubsubTopic, message.encode().buffer)
 
       if publishedCount == 0:
-        return err("Can not publish to any peers")
+        ## Agreed change expected to the lightpush protocol to better handle such case. https://github.com/waku-org/pm/issues/93
+        debug("Lightpush request has not been published to any peers")
 
       return ok()
 


### PR DESCRIPTION
# Description
Previous change on lightpush error handling caused js-waku tests failing and thus ci errors on nwaku side as well.
There had been a discussion around and decision is made to enrich the protocol for the future.
[[Epic] Enhance light push protocol ](https://github.com/waku-org/pm/issues/93)

Up until than we do not return error in case there is no suitable peer to publish message comes from lightpush.

# Changes

- [X] Changed return error to debug log in lightpush callback in waku_node
- [X] Commented out relevant test that would fail.

# Check
- CI's js-waku should not fail