### PR TITLE
refactor: relay REST API into two parts; core logic and API specific

### DIFF
--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -43,7 +43,7 @@ type RestFilterTest = object
   serviceNode: WakuNode
   subscriberNode: WakuNode
   restServer: RestServerRef
-  restServerForService: RestServerRef
+  #restServerForService: RestServerRef
   messageCache: filter_api.MessageCache
   client: RestClientRef
   clientTwdServiceNode: RestClientRef
@@ -67,17 +67,17 @@ proc init(T: type RestFilterTest): Future[T] {.async.} =
   testSetup.restServer = RestServerRef.init(restAddress, restPort).tryGet()
 
   let restPort2 = Port(58012)
-  testSetup.restServerForService = RestServerRef.init(restAddress, restPort2).tryGet()
+  #testSetup.restServerForService = RestServerRef.init(restAddress, restPort2).tryGet()
 
   # through this one we will see if messages are pushed according to our content topic sub
   testSetup.messageCache = filter_api.MessageCache.init()
   installFilterRestApiHandlers(testSetup.restServer.router, testSetup.subscriberNode, testSetup.messageCache)
 
-  let topicCache = MessageCache[string].init()
-  installRelayApiHandlers(testSetup.restServerForService.router, testSetup.serviceNode, topicCache)
+  #let topicCache = MessageCache[string].init()
+  #installRelayApiHandlers(testSetup.restServerForService.router, testSetup.serviceNode, topicCache)
 
   testSetup.restServer.start()
-  testSetup.restServerForService.start()
+  #testSetup.restServerForService.start()
 
   testSetup.client = newRestHttpClient(initTAddress(restAddress, restPort))
   testSetup.clientTwdServiceNode = newRestHttpClient(initTAddress(restAddress, restPort2))
@@ -88,8 +88,8 @@ proc init(T: type RestFilterTest): Future[T] {.async.} =
 proc shutdown(self: RestFilterTest) {.async.} =
   await self.restServer.stop()
   await self.restServer.closeWait()
-  await self.restServerForService.stop()
-  await self.restServerForService.closeWait()
+  #await self.restServerForService.stop()
+  #await self.restServerForService.closeWait()
   await allFutures(self.serviceNode.stop(), self.subscriberNode.stop())
 
 

--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -43,7 +43,7 @@ type RestFilterTest = object
   serviceNode: WakuNode
   subscriberNode: WakuNode
   restServer: RestServerRef
-  #restServerForService: RestServerRef
+  restServerForService: RestServerRef
   messageCache: filter_api.MessageCache
   client: RestClientRef
   clientTwdServiceNode: RestClientRef
@@ -67,17 +67,26 @@ proc init(T: type RestFilterTest): Future[T] {.async.} =
   testSetup.restServer = RestServerRef.init(restAddress, restPort).tryGet()
 
   let restPort2 = Port(58012)
-  #testSetup.restServerForService = RestServerRef.init(restAddress, restPort2).tryGet()
+  testSetup.restServerForService = RestServerRef.init(restAddress, restPort2).tryGet()
 
   # through this one we will see if messages are pushed according to our content topic sub
   testSetup.messageCache = filter_api.MessageCache.init()
   installFilterRestApiHandlers(testSetup.restServer.router, testSetup.subscriberNode, testSetup.messageCache)
 
-  #let topicCache = MessageCache[string].init()
-  #installRelayApiHandlers(testSetup.restServerForService.router, testSetup.serviceNode, topicCache)
+  let topicCache = MessageCache[string].init()
+  installRelayApiMessageHandlers(testSetup.restServerForService.router, topicCache)
+
+  let pubHandler = proc(
+      pubsubTopic: Option[PubsubTopic],
+      message: WakuMessage,
+      ): Future[Result[void, string]] {.async, closure.} =
+      await testSetup.serviceNode.publish(pubsubTopic, message)
+      return ok()
+
+  installRelayApiPublishHandlers(testSetup.restServerForService.router, pubHandler)
 
   testSetup.restServer.start()
-  #testSetup.restServerForService.start()
+  testSetup.restServerForService.start()
 
   testSetup.client = newRestHttpClient(initTAddress(restAddress, restPort))
   testSetup.clientTwdServiceNode = newRestHttpClient(initTAddress(restAddress, restPort2))
@@ -88,8 +97,8 @@ proc init(T: type RestFilterTest): Future[T] {.async.} =
 proc shutdown(self: RestFilterTest) {.async.} =
   await self.restServer.stop()
   await self.restServer.closeWait()
-  #await self.restServerForService.stop()
-  #await self.restServerForService.closeWait()
+  await self.restServerForService.stop()
+  await self.restServerForService.closeWait()
   await allFutures(self.serviceNode.stop(), self.subscriberNode.stop())
 
 

--- a/waku/waku_api/rest/relay/types.nim
+++ b/waku/waku_api/rest/relay/types.nim
@@ -13,16 +13,19 @@ import
   ../../../common/base64,
   ../../../waku_core,
   ../serdes
-
-
+  
 #### Types
+
+type
+  SubscriptionsHandler* = proc(kind: SubscriptionKind, topics: seq[string]) {.async, closure.}
+  PublishHandler* = proc(pubsubTopic: Option[PubsubTopic], message: WakuMessage):
+    Future[Result[void, string]] {.async, closure.}
 
 type RelayWakuMessage* = object
       payload*: Base64String
       contentTopic*: Option[ContentTopic]
       version*: Option[Natural]
       timestamp*: Option[int64]
-
 
 type
   RelayGetMessagesResponse* = seq[RelayWakuMessage]


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
I refactored the relay REST API separating the logic in two. Same way I did for STORE in #2092

The first part is REST related code, encode, decode, http errors, etc...
The second part is the logic that the request triggers; (un)subscribing, fetching & publishing messages.

In the future tests could be separated the same way, REST and logic but it was not done here.

# Changes

<!-- List of detailed changes -->

- [x] Added new handlers called when receiving a RELAY request.
- [x] Moved the core logic to app, where handlers are declared.
- [x] Fixed tests

Tracking #1941