### PR TITLE
chore: postgres_driver - remove duplicated const MaxNumConns.

### DIFF
--- a/waku/waku_archive/driver/builder.nim
+++ b/waku/waku_archive/driver/builder.nim
@@ -81,8 +81,7 @@ proc new*(T: type ArchiveDriver,
 
   of "postgres":
     when defined(postgres):
-      const MaxNumConns = 5 #TODO: we may need to set that from app args (maybe?)
-      let res = PostgresDriver.new(url, MaxNumConns, onErrAction)
+      let res = PostgresDriver.new(dbUrl = url, onErrAction = onErrAction)
       if res.isErr():
         return err("failed to init postgres archive driver: " & res.error)
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -40,11 +40,11 @@ proc insertRow(): string =
  """INSERT INTO messages (id, storedAt, contentTopic, payload, pubsubTopic,
   version, timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7);"""
 
-const DefaultMaxConnections = 5
+const MaxNumConns = 5 #TODO: we may need to set that from app args (maybe?)
 
 proc new*(T: type PostgresDriver,
           dbUrl: string,
-          maxConnections: int = DefaultMaxConnections,
+          maxConnections: int = MaxNumConns,
           onErrAction: OnErrHandler = nil):
           ArchiveDriverResult[T] =
 


### PR DESCRIPTION
## Description
During _Postgres_ performance analysis I realized that we have this duplicated `const` that can lead into a confusion.

This PR will simplify that.

