### PR TITLE
fix: sqlite limited delete query bug

### DIFF
--- a/waku/waku_archive/driver/sqlite_driver/queries.nim
+++ b/waku/waku_archive/driver/sqlite_driver/queries.nim
@@ -181,9 +181,9 @@ proc deleteMessagesOlderThanTimestamp*(db: SqliteDatabase, ts: int64):
 ## Delete oldest messages not within limit
 
 proc deleteOldestMessagesNotWithinLimitQuery(table: string, limit: int): SqlQueryStr =
-  "DELETE FROM " & table & " WHERE id NOT IN (" &
-  " SELECT id FROM " & table &
-  " ORDER BY storedAt DESC" &
+  "DELETE FROM " & table & " WHERE (storedAt, id, pubsubTopic) NOT IN (" &
+  " SELECT storedAt, id, pubsubTopic FROM " & table &
+  " ORDER BY storedAt DESC, id DESC" &
   " LIMIT " & $limit &
   ");"
 


### PR DESCRIPTION
# Description
Observed a bug while testing the retention policy where the database, if filled beyond its size limit, reaches a point where the deletion query `proc deleteOldestMessagesNotWithinLimitQuery(table: string, limit: int): SqlQueryStr = `ceases to function. The database size remains unchanged, leading to an endless loop in the deletion process, especially when the deletion is expected to be achieved via a loop.

This impacts the retention policy process. Turns out that the sqlite DB query assumes that the `id` column alone can uniquely identify rows in the table. If two different rows have the same `id` but different `storedAt` values, then using only `id` in the subquery may not produce the intended results. Given the schema has a composite primary key (`storedAt, id, pubsubTopic`), just checking against id might not be precise enough.

For the size-based retention policy, there isn't a direct correlation between the database's size and its number of rows. Also, deletion based on page count isn't feasible. To manage database size effectively:

Ascertain the total number of messages/rows.
Delete 20% of the messages and then perform a database Vacuum.
Confirm if the adjusted database size aligns with the intended target size.
If not, iterate the process.

So in this process, if the database size increases beyond a limit then a forever loop is encountered. 


# Changes

Only the query has been modified.

- [x] Able to delete the outdated database rows correctly


<!--
## How to test

1.
1.
1.

-->



## Issue

#1885 
