### PR TITLE
fix: Properly divide num_bytes by 1024 to get KB

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -193,7 +193,7 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
       receivedTime=getNowInNanosecondTime(),
       payloadSizeBytes=msg.payload.len
 
-    let msgSizeKB = msg.payload.len/1000
+    let msgSizeKB = msg.payload.len/1024
 
     waku_node_messages.inc(labelValues = ["relay"])
     waku_histogram_message_size.observe(msgSizeKB)


### PR DESCRIPTION
# Description

Fix conversion from bytes to kilobytes in `waku_histogram_message_size.observe(msgSizeKB)`