### PR TITLE
chore: continue on error for pre-release js-node jobs

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -98,21 +98,25 @@ jobs:
 
   js-waku-node:
     needs: build-docker-image
-    uses: waku-org/js-waku/.github/workflows/test-node.yml@master
-    with:
-      nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
-      test_type: node
-      debug: waku*
-    continue-on-error: true
-
+    steps:
+      - name: Run tests
+        uses: waku-org/js-waku/.github/workflows/test-node.yml@master
+        with:
+          nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
+          test_type: node
+          debug: waku*
+        continue-on-error: true
+  
   js-waku-node-optional:
     needs: build-docker-image
-    uses: waku-org/js-waku/.github/workflows/test-node.yml@master
-    with:
-      nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
-      test_type: node-optional
-      debug: waku*
-    continue-on-error: true
+    steps:
+      - name: Run tests
+        uses: waku-org/js-waku/.github/workflows/test-node.yml@master
+        with:
+          nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
+          test_type: node-optional
+          debug: waku*
+        continue-on-error: true
 
   create-release-candidate:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -103,6 +103,7 @@ jobs:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node
       debug: waku*
+    continue-on-error: true
 
   js-waku-node-optional:
     needs: build-docker-image
@@ -111,6 +112,7 @@ jobs:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node-optional
       debug: waku*
+    continue-on-error: true
 
   create-release-candidate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Allowing `js-node` jobs to fail for the pre-release workflow, so it does not become a blocker for releases.

# Changes

<!-- List of detailed changes -->

- [x] set `continue-on-error: true` for `js-node` pre-release jobs 

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->