### PR TITLE
feat: add new message_hash column

### DIFF
--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -100,7 +100,7 @@ proc handleMessage*(w: WakuArchive,
 
   block:
     let
-      msgDigest = computeDigest(msg)
+      msgDigest = computeDigest(msg, pubsubTopic)
       msgReceivedTime = if msg.timestamp > 0: msg.timestamp
                         else: getNanosecondTime(getTime().toUnixFloat())
 

--- a/waku/waku_archive/common.nim
+++ b/waku/waku_archive/common.nim
@@ -9,7 +9,8 @@ import
   stew/byteutils,
   nimcrypto/sha2
 import
-  ../waku_core
+  ../waku_core,
+  ../waku_core/topics
 
 
 ## Waku message digest
@@ -18,14 +19,16 @@ import
 
 type MessageDigest* = MDigest[256]
 
-proc computeDigest*(msg: WakuMessage): MessageDigest =
+proc computeDigest*(msg: WakuMessage, pubSubTopic: string = DefaultPubsubTopic): MessageDigest =
   var ctx: sha256
   ctx.init()
   defer: ctx.clear()
 
-  ctx.update(msg.contentTopic.toBytes())
+  ctx.update(pubSubTopic.toBytes())
   ctx.update(msg.payload)
-
+  ctx.update(msg.contentTopic.toBytes())
+  ctx.update(msg.meta)
+  
   # Computes the hash
   return ctx.finish()
 

--- a/waku/waku_archive/driver/queue_driver/index.nim
+++ b/waku/waku_archive/driver/queue_driver/index.nim
@@ -21,7 +21,7 @@ type Index* = object
 proc compute*(T: type Index, msg: WakuMessage, receivedTime: Timestamp, pubsubTopic: PubsubTopic): T =
   ## Takes a WakuMessage with received timestamp and returns its Index.
   let
-    digest = computeDigest(msg)
+    digest = computeDigest(msg, pubsubTopic)
     senderTime = msg.timestamp
 
   Index(

--- a/waku/waku_archive/driver/sqlite_driver/queries.nim
+++ b/waku/waku_archive/driver/sqlite_driver/queries.nim
@@ -71,8 +71,9 @@ proc createTableQuery(table: string): SqlQueryStr =
   " version INTEGER NOT NULL," &
   " timestamp INTEGER NOT NULL," &
   " id BLOB," &
+  " messageHash BLOB NOT NULL,"&
   " storedAt INTEGER NOT NULL," &
-  " CONSTRAINT messageIndex PRIMARY KEY (storedAt, id, pubsubTopic)" &
+  " CONSTRAINT messageIndex PRIMARY KEY (storedAt, messageHash)" &
   ") WITHOUT ROWID;"
 
 proc createTable*(db: SqliteDatabase): DatabaseResult[void] =
@@ -102,11 +103,11 @@ proc createHistoryQueryIndex*(db: SqliteDatabase): DatabaseResult[void] =
 
 
 ## Insert message
-type InsertMessageParams* = (seq[byte], Timestamp, seq[byte], seq[byte], seq[byte], int64, Timestamp)
+type InsertMessageParams* = (seq[byte], seq[byte], Timestamp, seq[byte], seq[byte], seq[byte], int64, Timestamp)
 
 proc insertMessageQuery(table: string): SqlQueryStr =
-  "INSERT INTO " & table & "(id, storedAt, contentTopic, payload, pubsubTopic, version, timestamp)" &
-  " VALUES (?, ?, ?, ?, ?, ?, ?);"
+  "INSERT INTO " & table & "(id, messageHash, storedAt, contentTopic, payload, pubsubTopic, version, timestamp)" &
+  " VALUES (?, ?, ?, ?, ?, ?, ?, ?);"
 
 proc prepareInsertMessageStmt*(db: SqliteDatabase): SqliteStmt[InsertMessageParams, void] =
   let query = insertMessageQuery(DbTable)
@@ -197,7 +198,7 @@ proc deleteOldestMessagesNotWithinLimit*(db: SqliteDatabase, limit: int):
 ## Select all messages
 
 proc selectAllMessagesQuery(table: string): SqlQueryStr =
-  "SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id" &
+  "SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id, messageHash" &
   " FROM " & table &
   " ORDER BY storedAt ASC"
 
@@ -280,7 +281,7 @@ proc selectMessagesWithLimitQuery(table: string, where: Option[string], limit: u
 
   var query: string
 
-  query = "SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id"
+  query = "SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id, messageHash"
   query &= " FROM " & table
 
   if where.isSome():

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -66,6 +66,7 @@ method put*(s: SqliteDriver,
   ## Inserts a message into the store
   let res = s.insertStmt.exec((
     @(digest.data),                # id
+    @(digest.data),                # messageHash
     receivedTime,                  # storedAt
     toBytes(message.contentTopic), # contentTopic
     message.payload,               # payload


### PR DESCRIPTION
# Description
Adding the message_hash (messageHash) as a new column in the Waku archive protocol. To compute the `messageHash`, we refer to [rfc_guide](https://rfc.vac.dev/spec/14/#deterministic-message-hashing). `computeDigest` function has been modified to support the conjunction of pubSubToic without breaking the existing test cases. In future PRs, the existing `id` attribute/column of the databases (SQLite and PostgreSQL) shall be removed with due testing and pagination support.

The change will help attain a message index type attribute which will be used in sync-related protocols for archive Waku node.

# Changes

<!-- List of detailed changes -->

- [x] The message_hash attribute should be present SQLite.
- [x] The message_hash attribute should be present Postgres.

<!--
## How to test

1.
1.
1.

-->



## Issue
#2112 
