### PR TITLE
fix(relay): subscribe only once to a pubsub topic

### DIFF
--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -235,11 +235,11 @@ proc subscribe*(w: WakuRelay, pubsubTopic: PubsubTopic, handler: WakuRelayHandle
     procCall GossipSub(w).addValidator(pubSubTopic, w.generateOrderedValidator())
     w.validatorInserted[pubSubTopic] = true
 
-  # set this topic parameters for scoring
-  w.topicParams[pubsubTopic] = TopicParameters
+    # set this topic parameters for scoring
+    w.topicParams[pubsubTopic] = TopicParameters
 
-  # subscribe to the topic with our wrapped handler
-  procCall GossipSub(w).subscribe(pubsubTopic, wrappedHandler)
+    # subscribe to the topic with our wrapped handler
+    procCall GossipSub(w).subscribe(pubsubTopic, wrappedHandler)
 
   return wrappedHandler
 


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
Multiple WakuRelay.subscribe's resulted in a segfault in the nim-libp2p lib

# Changes

<!-- List of detailed changes -->

- [x] Subscribes to a topic only if it hasn't before

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #2114

