### PR TITLE
chore: adding postgres flag to manual docker job instructions

### DIFF
--- a/docs/contributors/release-process.md
+++ b/docs/contributors/release-process.md
@@ -76,7 +76,7 @@ Ensure all items in this list are ticked:
   > - `MAKE_TARGET`: `wakunode2`
   > - `IMAGE_TAG`: the release tag (e.g. `v0.16.0`)
   > - `IMAGE_NAME`: `wakuorg/nwaku`
-  > - `NIMFLAGS`: `--colors:off -d:disableMarchNative -d:chronicles_colors:none`
+  > - `NIMFLAGS`: `--colors:off -d:disableMarchNative -d:chronicles_colors:none -d:postgres`
   > - `GIT_REF` the release tag (e.g. `v0.16.0`)
 3. Deploy the release to appropriate fleets:
    - Inform clients


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Include Postgres compilation flag to the `docker-manual` job parameters for releases in order for the uploaded image to support Postgres.

# Changes

<!-- List of detailed changes -->

- [x] Added the `-d:postgres` to `NIMFLAGS` on the release instructions

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->