### PR TITLE
feat: messageHash attribute added in SQLite + testcase

### DIFF
--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -87,7 +87,7 @@ suite "Postgres driver":
     require:
       storedMsg.len == 1
       storedMsg.all do (item: auto) -> bool:
-        let (pubsubTopic, actualMsg, digest, storeTimestamp) = item
+        let (pubsubTopic, actualMsg, digest, messageHash, storeTimestamp) = item
         actualMsg.contentTopic == contentTopic and
         pubsubTopic == DefaultPubsubTopic and
         toHex(computedDigest.data) == toHex(digest) and

--- a/tests/waku_archive/test_driver_sqlite.nim
+++ b/tests/waku_archive/test_driver_sqlite.nim
@@ -60,7 +60,7 @@ suite "SQLite driver":
     check:
       storedMsg.len == 1
       storedMsg.all do (item: auto) -> bool:
-        let (pubsubTopic, msg, digest, storeTimestamp) = item
+        let (pubsubTopic, msg, digest, messageHash, storeTimestamp) = item
         msg.contentTopic == contentTopic and
         pubsubTopic == DefaultPubsubTopic
 

--- a/tests/waku_archive/test_driver_sqlite_query.nim
+++ b/tests/waku_archive/test_driver_sqlite_query.nim
@@ -448,7 +448,8 @@ suite "SQLite driver - query by pubsub topic":
 
     check:
       # there needs to be two messages
-      storedMsg.len > 0 and storedMsg.len == 2
+      storedMsg.len > 0
+      storedMsg.len == 2
 
       # get the individual messages and message hash values
       @[storedMsg[0]].all do (item1: auto) -> bool:

--- a/tests/waku_archive/test_retention_policy.nim
+++ b/tests/waku_archive/test_retention_policy.nim
@@ -147,7 +147,7 @@ suite "Waku Archive - Retention policy":
     check:
       storedMsg.len == capacity
       storedMsg.all do (item: auto) -> bool:
-        let (pubsubTopic, msg, digest, storeTimestamp) = item
+        let (pubsubTopic, msg, digest, messageHash, storeTimestamp) = item
         msg.contentTopic == contentTopic and
         pubsubTopic == DefaultPubsubTopic
 

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -163,7 +163,7 @@ proc findMessages*(w: WakuArchive, query: ArchiveQuery): Future[ArchiveResult] {
     ## Build last message cursor
     ## The cursor is built from the last message INCLUDED in the response
     ## (i.e. the second last message in the rows list)
-    let (pubsubTopic, message, digest, storeTimestamp) = rows[^2]
+    let (pubsubTopic, message, digest, messageHash, storeTimestamp) = rows[^2]
 
     # TODO: Improve coherence of MessageDigest type
     let messageDigest = block:

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -18,7 +18,7 @@ type
   ArchiveDriver* = ref object of RootObj
   OnErrHandler* = proc(errMsg: string) {.gcsafe, closure.}
 
-type ArchiveRow* = (PubsubTopic, WakuMessage, seq[byte], Timestamp)
+type ArchiveRow* = (PubsubTopic, WakuMessage, seq[byte], seq[byte], Timestamp)
 
 # ArchiveDriver interface
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -138,6 +138,7 @@ proc toArchiveRow(r: Row): ArchiveDriverResult[ArchiveRow] =
   return ok((pubSubTopic,
              wakuMessage,
              @(digest.toOpenArrayByte(0, digest.high)),
+             @(digest.toOpenArrayByte(0, digest.high)),
              storedAt))
 
 method getAllMessages*(s: PostgresDriver):

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -138,7 +138,7 @@ proc getPage(driver: QueueDriver,
 
       numberOfItems += 1
 
-      outSeq.add((key.pubsubTopic, data.msg, @(key.digest.data), key.receiverTime))
+      outSeq.add((key.pubsubTopic, data.msg, @(key.digest.data), @(key.digest.data), key.receiverTime))
 
     currentEntry = if forward: w.next()
                    else: w.prev()

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -66,6 +66,7 @@ method put*(s: SqliteDriver,
   ## Inserts a message into the store
   let res = s.insertStmt.exec((
     @(digest.data),                # id
+    @(digest.data),                # messageHash
     receivedTime,                  # storedAt
     toBytes(message.contentTopic), # contentTopic
     message.payload,               # payload


### PR DESCRIPTION
# Description

`messageHash` attributed added to SQLite, which aims to remove the `id` attribute in upcoming PRs. An associated test case also added. 

migration scripts will be changed after the deletion of `id` attribute in upcoming PRs.

# Changes

<!-- List of detailed changes -->

- [x] `messageHash` attribute added
- [x] added test case to test the `messageHash` attribute

<!--
## How to test

1.
1.
1.

-->



## Issue

#2112 
