### PR TITLE
chore: Enhance rest request error handling

### DIFF
--- a/waku/waku_api/rest/server.nim
+++ b/waku/waku_api/rest/server.nim
@@ -59,7 +59,8 @@ proc getRouter(allowedOrigin: Option[string]): RestRouter =
 proc init*(T: type RestServerRef,
               ip: ValidIpAddress, port: Port,
               allowedOrigin=none(string),
-              conf=RestServerConf.default()): RestServerResult[T] =
+              conf=RestServerConf.default(),
+              requestErrorHandler: RestRequestErrorHandler = nil): RestServerResult[T] =
   let address = initTAddress(ip, port)
   let serverFlags = {
     HttpServerFlags.QueryCommaSeparatedArray,
@@ -82,7 +83,8 @@ proc init*(T: type RestServerRef,
       serverFlags = serverFlags,
       httpHeadersTimeout = headersTimeout,
       maxHeadersSize = maxHeadersSize,
-      maxRequestBodySize = maxRequestBodySize
+      maxRequestBodySize = maxRequestBodySize,
+      requestErrorHandler = requestErrorHandler
     )
   except CatchableError:
     return err(getCurrentExceptionMsg())
@@ -92,5 +94,7 @@ proc init*(T: type RestServerRef,
 
 proc newRestHttpServer*(ip: ValidIpAddress, port: Port,
                         allowedOrigin=none(string),
-                        conf=RestServerConf.default()): RestServerResult[RestServerRef] =
-  RestServerRef.init(ip, port, allowedOrigin, conf)
+                        conf=RestServerConf.default(),
+                        requestErrorHandler: RestRequestErrorHandler = nil):
+                    RestServerResult[RestServerRef] =
+  RestServerRef.init(ip, port, allowedOrigin, conf, requestErrorHandler)


### PR DESCRIPTION
# Description
Issue https://github.com/waku-org/nwaku/issues/2135
describes the case when intentionally we do not install certain endpoints.
In such cases we shall report nicely that the offered endpoint is missing due configuration not by error.

# Changes
- [x] Eugen enhance HttpServer and RestHttpServer with an error callback hook on request.
- [x] nim-presto version is elevated to new commit (we had been in the HEAD of master, after new feature implemented we got to the HEAD now again.
- [x] requestErrorHandler added for wakunode2 app.nim for RestServer.
- [x] Error handler takes care of intentionally not installed endpoints.

## How to test

1. run: wakunode2 --relay --filter --lightpush --rest=true --rest-port=11111
2. run: curl -i -X GET "http://127.0.0.1:11111/filter/v2/subscriptions/111" -H "accept: application/json"
3. Check response, it shall tell the endpoint is not installed, configuration shall be checked.
4. curl -i -X GET "http://127.0.0.1:11111/admin/v1/peers" -H "accept: application/json"
5. Response shall be Http200 and may list connected peers or may return empty list.
6. curl -i -X GET "http://127.0.0.1:11111/aaaadmin/v1/peers" -H "accept: application/json"
7. Response shall be Http400 but with bad request message
8. run ./wakunode2 --relay --filternode=/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2HAm8n7MSAr59Mae7K7WoKiyqtKstJhh5RvvGWYx1ZDJ4HGQ --rest=true --rest-port=11112
9. run: curl -i -X GET "http://127.0.0.1:11112/filter/v2/subscriptions/111" -H "accept: application/json"
10. Response shall be Http200 with json response from filter service.
 
## Issue
https://github.com/waku-org/nwaku/issues/2135