### PR TITLE
chore: Extend temporary pr images validity to 30 days

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -59,7 +59,7 @@ jobs:
           echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
           docker login -u ${QUAY_USER} -p ${QUAY_PASSWORD} quay.io
-          docker build -t ${IMAGE} -f docker/binaries/Dockerfile.bn.amd64 --label quay.expires-after=7d .
+          docker build -t ${IMAGE} -f docker/binaries/Dockerfile.bn.amd64 --label quay.expires-after=30d .
           docker push ${IMAGE}
         env:
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Simple PR to extend the validity of the temporary images that are generated when a PR is submitted.

Those images are temporarily stored in: https://quay.io/repository/wakuorg/nwaku-pr?tab=tags

( Thanks @vpavlin for the hint on how to achieve this ! )