### PR TITLE
chore(networking): lower dhigh to limit amplification factor

### DIFF
--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -72,7 +72,7 @@ const GossipsubParameters = GossipSubParams(
 
     d: 6,
     dLow: 4,
-    dHigh: 12,
+    dHigh: 8,
     dScore: 6,
     dOut: 3,
     dLazy: 6,
@@ -174,8 +174,8 @@ proc new*(T: type WakuRelay, switch: Switch): WakuRelayResult[T] =
 
   return ok(w)
 
-proc addValidator*(w: WakuRelay, 
-                   topic: varargs[string], 
+proc addValidator*(w: WakuRelay,
+                   topic: varargs[string],
                    handler: WakuValidatorHandler) {.gcsafe.} =
   for t in topic:
     w.wakuValidators.mgetOrPut(t, @[]).add(handler)
@@ -196,7 +196,7 @@ proc subscribedTopics*(w: WakuRelay): seq[PubsubTopic] =
 
 proc generateOrderedValidator*(w: WakuRelay): auto {.gcsafe.} =
   # rejects messages that are not WakuMessage
-  let wrappedValidator = proc(pubsubTopic: string, 
+  let wrappedValidator = proc(pubsubTopic: string,
                               message: messages.Message): Future[ValidationResult] {.async.} =
     # can be optimized by checking if the message is a WakuMessage without allocating memory
     # see nim-libp2p protobuf library
@@ -245,7 +245,7 @@ proc subscribe*(w: WakuRelay, pubsubTopic: PubsubTopic, handler: WakuRelayHandle
 
 proc unsubscribeAll*(w: WakuRelay, pubsubTopic: PubsubTopic) =
   ## Unsubscribe all handlers on this pubsub topic
-  
+
   debug "unsubscribe all", pubsubTopic=pubsubTopic
 
   procCall GossipSub(w).unsubscribeAll(pubsubTopic)
@@ -253,7 +253,7 @@ proc unsubscribeAll*(w: WakuRelay, pubsubTopic: PubsubTopic) =
 
 proc unsubscribe*(w: WakuRelay, pubsubTopic: PubsubTopic, handler: TopicHandler) =
   ## Unsubscribe this handler on this pubsub topic
-  
+
   debug "unsubscribe", pubsubTopic=pubsubTopic
 
   procCall GossipSub(w).unsubscribe(pubsubTopic, handler)


### PR DESCRIPTION
This PR lowers gossipsub's `Dhigh` value so that nodes have a more predictable amplification factor (in terms of bandwidth). Before `4 to 12` now `4 to 8`.

Used [this tool](https://github.com/waku-org/research/tree/master/rln-delay-simulations) to run simulations using 1000 nodes and propagation time should not be affected, since average `D` in the network stays the same.

**before**: mean of D among 1000 randomly connected nodes 6.129. Message latency average 509 ms (8991 samples).
```
Statistics. mean=6.129 max=12 min=4
Statistics. mean=509.4595706817929 max=695 min=263
```

**after this PR**: mean of D among 1000 randomly connected nodes 6.124. Message latency average 506 ms  (8991 samples). But with the main difference that max D is `8` instead of `12`.
```
Statistics. mean=6.124 max=8 min=4
Statistics. mean=506.74274274274273 max=677 min=263
```

In other words, it shouldn't affect the network performance, but it will decrease bandwidth consumption in some nodes by around 30% (12 -> 8)

**note**: In the future we may want to lower both Dlow/Dhigh even more, to limit bandwidth consumption, or at least to some "profiles". But this indeed has an impact in propagation delay. More https://github.com/waku-org/research/issues/44
