### PR TITLE
chore: Optimize postgres - use of rowCallback approach

### DIFF
--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -109,31 +109,17 @@ proc waitQueryToFinish(db: DbConn,
 
     pqclear(pqResult)
 
-proc exec*(db: DbConn,
-           query: SqlQuery,
-           args: seq[string]):
-           Future[Result[void, string]] {.async, gcsafe.} =
+proc dbConnQuery*(db: DbConn,
+                  query: SqlQuery,
+                  args: seq[string],
+                  rowCallback: DataProc):
+                  Future[Result[void, string]] {.async, gcsafe.} =
   ## Runs the SQL getting results.
 
   (await db.sendQuery(query, args)).isOkOr:
-    return err("error in exec calling sendQuery: " & $error)
-
-  (await db.waitQueryToFinish()).isOkOr:
-    return err("error in exec calling waitQueryToFinish: " & $error)
-
-  return ok()
-
-proc getRows*(db: DbConn,
-              query: SqlQuery,
-              args: seq[string],
-              rowCallback: DataProc):
-              Future[Result[void, string]] {.async, gcsafe.} =
-  ## Runs the SQL getting results.
-
-  (await db.sendQuery(query, args)).isOkOr:
-    return err("error calling sendQuery: " & $error)
+    return err("error in dbConnQuery calling sendQuery: " & $error)
 
   (await db.waitQueryToFinish(rowCallback)).isOkOr:
-    return err("error calling waitQueryToFinish: " & $error)
+    return err("error in dbConnQuery calling waitQueryToFinish: " & $error)
 
   return ok()

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -114,7 +114,6 @@ proc dbConnQuery*(db: DbConn,
                   args: seq[string],
                   rowCallback: DataProc):
                   Future[Result[void, string]] {.async, gcsafe.} =
-  ## Runs the SQL getting results.
 
   (await db.sendQuery(query, args)).isOkOr:
     return err("error in dbConnQuery calling sendQuery: " & $error)

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -9,6 +9,8 @@ import
 
 include db_postgres
 
+type DataProc* = proc(result: ptr PGresult) {.closure, gcsafe.}
+
 ## Connection management
 
 proc check*(db: DbConn): Result[void, string] =
@@ -43,11 +45,11 @@ proc open*(connString: string):
 
   ok(conn)
 
-proc rows*(db: DbConn,
-           query: SqlQuery,
-           args: seq[string]):
-           Future[Result[seq[Row], string]] {.async.} =
-  ## Runs the SQL getting results.
+proc sendQuery(db: DbConn,
+               query: SqlQuery,
+               args: seq[string]):
+               Future[Result[void, string]] {.async.} =
+  ## This proc can be used directly for queries that don't retrieve values back.
 
   if db.status != CONNECTION_OK:
     let checkRes = db.check()
@@ -71,7 +73,13 @@ proc rows*(db: DbConn,
 
     return err("failed pqsendQuery: unknown reason")
 
-  var ret = newSeq[Row](0)
+  return ok()
+
+proc waitQueryToFinish(db: DbConn,
+                       rowCallback: DataProc = nil):
+                       Future[Result[void, string]] {.async.} =
+  ## The 'rowCallback' param is != nil when the underlying query wants to retrieve results (SELECT.)
+  ## For other queries, like "INSERT", 'rowCallback' should be nil.
 
   while true:
 
@@ -84,22 +92,48 @@ proc rows*(db: DbConn,
       return err("failed pqconsumeInput: unknown reason")
 
     if db.pqisBusy() == 1:
-      await sleepAsync(0.milliseconds) # Do not block the async runtime
+      await sleepAsync(timer.milliseconds(0)) # Do not block the async runtime
       continue
 
-    var pqResult = db.pqgetResult()
+    let pqResult = db.pqgetResult()
     if pqResult == nil:
       # Check if its a real error or just end of results
       let checkRes = db.check()
       if checkRes.isErr():
         return err("error in rows: " & checkRes.error)
 
-      return ok(ret) # reached the end of the results
+      return ok() # reached the end of the results
 
-    var cols = pqResult.pqnfields()
-    var row = cols.newRow()
-    for i in 0'i32 .. pqResult.pqNtuples() - 1:
-      pqResult.setRow(row, i, cols) # puts the value in the row
-      ret.add(row)
+    if not rowCallback.isNil():
+      rowCallback(pqResult)
 
     pqclear(pqResult)
+
+proc exec*(db: DbConn,
+           query: SqlQuery,
+           args: seq[string]):
+           Future[Result[void, string]] {.async, gcsafe.} =
+  ## Runs the SQL getting results.
+
+  (await db.sendQuery(query, args)).isOkOr:
+    return err("error in exec calling sendQuery: " & $error)
+
+  (await db.waitQueryToFinish()).isOkOr:
+    return err("error in exec calling waitQueryToFinish: " & $error)
+
+  return ok()
+
+proc getRows*(db: DbConn,
+              query: SqlQuery,
+              args: seq[string],
+              rowCallback: DataProc):
+              Future[Result[void, string]] {.async, gcsafe.} =
+  ## Runs the SQL getting results.
+
+  (await db.sendQuery(query, args)).isOkOr:
+    return err("error calling sendQuery: " & $error)
+
+  (await db.waitQueryToFinish(rowCallback)).isOkOr:
+    return err("error calling waitQueryToFinish: " & $error)
+
+  return ok()

--- a/waku/common/databases/db_postgres/pgasyncpool.nim
+++ b/waku/common/databases/db_postgres/pgasyncpool.nim
@@ -8,14 +8,10 @@ else:
 import
   std/[sequtils,nre, strformat],
   stew/results,
-  chronicles,
   chronos
 import
   ./dbconn,
   ../common
-
-logScope:
-  topics = "postgres asyncpool"
 
 type PgAsyncPoolState {.pure.} = enum
     Closed,

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -7,7 +7,9 @@ import
   std/[strformat,nre,options,strutils],
   stew/[results,byteutils],
   db_postgres,
-  chronos
+  postgres,
+  chronos,
+  chronicles
 import
   ../../../waku_core,
   ../../common,
@@ -96,6 +98,51 @@ proc reset*(s: PostgresDriver): Future[ArchiveDriverResult[void]] {.async.} =
   let ret = await s.deleteMessageTable()
   return ret
 
+proc rowCallbackImpl(pqResult: ptr PGresult,
+                     outRows: var seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp)]) =
+  ## Proc aimed to contain the logic of the callback passed to the `psasyncpool`.
+  ## That callback is used in "SELECT" queries.
+  ##
+  ## pqResult - contains the query results
+  ## outRows - seq of Store-rows. This is populated from the info contained in pqResult
+
+  let numFields = pqResult.pqnfields()
+  if numFields != 7:
+    error "Wrong number of fields"
+    return
+
+  for iRow in 0..<pqResult.pqNtuples():
+
+    var wakuMessage: WakuMessage
+    var timestamp: Timestamp
+    var version: uint
+    var pubSubTopic: string
+    var contentTopic: string
+    var storedAt: int64
+    var digest: string
+    var payload: string
+
+    try:
+      storedAt = parseInt( $(pqgetvalue(pqResult, iRow, 0)) )
+      contentTopic = $(pqgetvalue(pqResult, iRow, 1))
+      payload = parseHexStr( $(pqgetvalue(pqResult, iRow, 2)) )
+      pubSubTopic = $(pqgetvalue(pqResult, iRow, 3))
+      version = parseUInt( $(pqgetvalue(pqResult, iRow, 4)) )
+      timestamp = parseInt( $(pqgetvalue(pqResult, iRow, 5)) )
+      digest = parseHexStr( $(pqgetvalue(pqResult, iRow, 6)) )
+    except ValueError:
+      error "could not parse correctly", error = getCurrentExceptionMsg()
+
+    wakuMessage.timestamp = timestamp
+    wakuMessage.version = uint32(version)
+    wakuMessage.contentTopic = contentTopic
+    wakuMessage.payload = @(payload.toOpenArrayByte(0, payload.high))
+
+    outRows.add((pubSubTopic,
+                 wakuMessage,
+                 @(digest.toOpenArrayByte(0, digest.high)),
+                 storedAt))
+
 method put*(s: PostgresDriver,
             pubsubTopic: PubsubTopic,
             message: WakuMessage,
@@ -113,60 +160,23 @@ method put*(s: PostgresDriver,
                                        $message.timestamp])
   return ret
 
-proc toArchiveRow(r: Row): ArchiveDriverResult[ArchiveRow] =
-  # Converts a postgres row into an ArchiveRow
-
-  var wakuMessage: WakuMessage
-  var timestamp: Timestamp
-  var version: uint
-  var pubSubTopic: string
-  var contentTopic: string
-  var storedAt: int64
-  var digest: string
-  var payload: string
-
-  try:
-    storedAt = parseInt(r[0])
-    contentTopic = r[1]
-    payload = parseHexStr(r[2])
-    pubSubTopic = r[3]
-    version = parseUInt(r[4])
-    timestamp = parseInt(r[5])
-    digest = parseHexStr(r[6])
-  except ValueError:
-    return err("could not parse timestamp")
-
-  wakuMessage.timestamp = timestamp
-  wakuMessage.version = uint32(version)
-  wakuMessage.contentTopic = contentTopic
-  wakuMessage.payload = @(payload.toOpenArrayByte(0, payload.high))
-
-  return ok((pubSubTopic,
-             wakuMessage,
-             @(digest.toOpenArrayByte(0, digest.high)),
-             storedAt))
-
 method getAllMessages*(s: PostgresDriver):
                        Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   ## Retrieve all messages from the store.
 
-  let rowsRes = await s.readConnPool.query("""SELECT storedAt, contentTopic,
+  var rows: seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp)]
+  proc rowCallback(pqResult: ptr PGresult) =
+    rowCallbackImpl(pqResult, rows)
+
+  (await s.readConnPool.query("""SELECT storedAt, contentTopic,
                                        payload, pubsubTopic, version, timestamp,
                                        id FROM messages ORDER BY storedAt ASC""",
-                                       newSeq[string](0))
+                                       newSeq[string](0),
+                                       rowCallback
+                              )).isOkOr:
+    return err("failed in query: " & $error)
 
-  if rowsRes.isErr():
-    return err("failed in query: " & rowsRes.error)
-
-  var results: seq[ArchiveRow]
-  for r in rowsRes.value:
-    let rowRes = r.toArchiveRow()
-    if rowRes.isErr():
-      return err("failed to extract row")
-
-    results.add(rowRes.get())
-
-  return ok(results)
+  return ok(rows)
 
 method getMessages*(s: PostgresDriver,
                     contentTopic: seq[ContentTopic] = @[],
@@ -177,6 +187,7 @@ method getMessages*(s: PostgresDriver,
                     maxPageSize = DefaultPageSize,
                     ascendingOrder = true):
                     Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
+
   var query = """SELECT storedAt, contentTopic, payload,
   pubsubTopic, version, timestamp, id FROM messages"""
   var statements: seq[string]
@@ -220,43 +231,38 @@ method getMessages*(s: PostgresDriver,
   query &= " LIMIT ?"
   args.add($maxPageSize)
 
-  let rowsRes = await s.readConnPool.query(query, args)
-  if rowsRes.isErr():
-    return err("failed to run query: " & rowsRes.error)
+  var rows: seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp)]
+  proc rowCallback(pqResult: ptr PGresult) =
+    rowCallbackImpl(pqResult, rows)
 
-  var results: seq[ArchiveRow]
-  for r in rowsRes.value:
-    let rowRes = r.toArchiveRow()
-    if rowRes.isErr():
-      return err("failed to extract row: " & rowRes.error)
+  (await s.readConnPool.query(query, args, rowCallback)).isOkOr:
+    return err("failed to run query: " & $error)
 
-    results.add(rowRes.get())
-
-  return ok(results)
+  return ok(rows)
 
 proc getInt(s: PostgresDriver,
             query: string):
             Future[ArchiveDriverResult[int64]] {.async.} =
   # Performs a query that is expected to return a single numeric value (int64)
 
-  let rowsRes = await s.readConnPool.query(query)
-  if rowsRes.isErr():
-    return err("failed in getRow: " & rowsRes.error)
-
-  let rows = rowsRes.get()
-  if rows.len != 1:
-    return err("failed in getRow. Expected one row but got " & $rows.len)
-
-  let fields = rows[0]
-  if fields.len != 1:
-    return err("failed in getRow: Expected one field but got " & $fields.len)
-
   var retInt = 0'i64
-  try:
-    if fields[0] != "":
-      retInt = parseInt(fields[0])
-  except ValueError:
-    return err("exception in getRow, parseInt: " & getCurrentExceptionMsg())
+  proc rowCallback(pqResult: ptr PGresult) =
+    if pqResult.pqnfields() != 1:
+      error "Wrong number of fields in getInt"
+      return
+
+    if pqResult.pqNtuples() != 1:
+      error "Wrong number of rows in getInt"
+      return
+
+    try:
+      retInt = parseInt( $(pqgetvalue(pqResult, 0, 0)) )
+    except ValueError:
+      error "exception in getInt, parseInt", error = getCurrentExceptionMsg()
+      return
+
+  (await s.readConnPool.query(query, newSeq[string](0), rowCallback)).isOkOr:
+    return err("failed in getRow: " & $error)
 
   return ok(retInt)
 
@@ -334,11 +340,16 @@ proc sleep*(s: PostgresDriver, seconds: int):
   # This is for testing purposes only. It is aimed to test the proper
   # implementation of asynchronous requests. It merely triggers a sleep in the
   # database for the amount of seconds given as a parameter.
+
+  proc rowCallback(result: ptr PGresult) =
+    ## We are not interested in any value in this case
+    discard
+
   try:
     let params = @[$seconds]
-    let sleepRes = await s.writeConnPool.query("SELECT pg_sleep(?)", params)
-    if sleepRes.isErr():
-      return err("error in postgres_driver sleep: " & sleepRes.error)
+    (await s.writeConnPool.query("SELECT pg_sleep(?)", params, rowCallback)).isOkOr:
+      return err("error in postgres_driver sleep: " & $error)
+
   except DbError:
     # This always raises an exception although the sleep works
     return err("exception sleeping: " & getCurrentExceptionMsg())

--- a/waku/waku_archive/driver/postgres_driver/postgres_healthcheck.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_healthcheck.nim
@@ -21,7 +21,7 @@ proc checkConnectivity*(connPool: PgAsyncPool,
 
   while true:
 
-    (await connPool.exec(HealthCheckQuery)).isOkOr:
+    (await connPool.pgQuery(HealthCheckQuery)).isOkOr:
 
       ## The connection failed once. Let's try reconnecting for a while.
       ## Notice that the 'exec' proc tries to establish a new connection.
@@ -33,7 +33,7 @@ proc checkConnectivity*(connPool: PgAsyncPool,
 
         var numTrial = 0
         while numTrial < MaxNumTrials:
-          let res = await connPool.exec(HealthCheckQuery)
+          let res = await connPool.pgQuery(HealthCheckQuery)
           if res.isOk():
             ## Connection resumed. Let's go back to the normal healthcheck.
             break errorBlock


### PR DESCRIPTION
# Description
This represents a quite important time reduction in _Postgres_ queries. However, still slower than _SQLite_.
The main issue happened because the we were processing the obtained rows multiple times, and there were an overhead due to changing the rows objects from one type to another.
In this PR we aim to reduce the type conversion overhead by providing a `rowCallback(result: ptr PGresult)` to the `dbconn` object.

( Thanks to @NagyZoltanPeter for the help to achieve that. )

# Changes

- [x] Use of `rowCalback` to retrieve rows in a more direct way.
- [x] Change logic on how to retrieve the first free connection - waku/common/databases/db_postgres/pgasyncpool.nim

## Issue

https://github.com/waku-org/nwaku/issues/1842
