### PR TITLE
fix: lightpush rest 

### DIFF
--- a/waku/waku_api/rest/lightpush/handlers.nim
+++ b/waku/waku_api/rest/lightpush/handlers.nim
@@ -75,14 +75,14 @@ proc installLightPushRequestHandler*(
     let req: PushRequest = decodedBody.value()
     
     let msg = req.message.toWakuMessage().valueOr:
-      return RestApiResponse.badRequest("Invalid message: {msg.error}")
+      return RestApiResponse.badRequest("Invalid message: " & $error)
 
     let peer = node.peerManager.selectPeer(WakuLightPushCodec).valueOr:
       let handler = discHandler.valueOr:
         return NoPeerNoDiscoError
 
       let peerOp = (await handler()).valueOr:
-        return RestApiResponse.internalServerError($error)
+        return RestApiResponse.internalServerError("No value in peerOp: " & $error)
 
       peerOp.valueOr:
         return NoPeerNoneFoundError

--- a/waku/waku_api/rest/lightpush/openapi.yaml
+++ b/waku/waku_api/rest/lightpush/openapi.yaml
@@ -76,7 +76,7 @@ components:
     PushRequest:
       type: object
       properties:
-        pusbsubTopic:
+        pubsubTopic:
           $ref: '#/components/schemas/PubsubTopic'
         message:
           $ref: '#/components/schemas/WakuMessage'


### PR DESCRIPTION
## Description
This PR aims to enhance the `lightpush rest` API a little.

This was detected by @weboko. Thanks for spotting it !

## Changes

- [x] Fix error response
- [x] Fix typo in openapi.yaml definition

## Future notes
- We need to review all the open API definitions and make sure all the cases work as expected.
- Important to define examples of how to use each API. Maybe something that can be written within each open API.
- It is not very handy to import openapi.yaml file into _Postman_. The parameter types are not properly described. For example, in the case of `lightpush`, we should make it clear that the `payload` should be base64-encoded. On the other hand, the numeric fields are imported (in Postman) as `"<number>"` but that confuses a little and it should be `<number>` instead, or having an example would help.
