### PR TITLE
chore: Optimize postgres - prepared statements in select

### DIFF
--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -203,3 +203,5 @@ suite "Postgres driver":
     putRes = await driver.put(DefaultPubsubTopic,
                               msg2, computeDigest(msg2, DefaultPubsubTopic), msg2.timestamp)
     require not putRes.isOk()
+
+    (await driver.close()).expect("driver to close")

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -138,7 +138,7 @@ proc waitQueryToFinish(db: DbConn,
     if success != 1:
       let checkRes = db.check()
       if checkRes.isErr():
-        return err("failed pqconsumeInput: " & checkRes.error)
+        return err("failed pqconsumeInput: " & $checkRes.error)
 
       return err("failed pqconsumeInput: unknown reason")
 
@@ -149,6 +149,10 @@ proc waitQueryToFinish(db: DbConn,
     let pqResult = db.pqgetResult()
 
     if pqResult == nil:
+      let checkRes = db.check()
+      if checkRes.isErr():
+        return err("error in query: " & $checkRes.error)
+
       return ok() # reached the end of the results
 
     if not rowCallback.isNil():

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -53,9 +53,8 @@ proc sendQuery(db: DbConn,
   ## This proc can be used directly for queries that don't retrieve values back.
 
   if db.status != CONNECTION_OK:
-    let checkRes = db.check()
-    if checkRes.isErr():
-      return err("failed to connect to database: " & checkRes.error)
+    db.check().isOkOr:
+      return err("failed to connect to database: " & $error)
 
     return err("unknown reason")
 
@@ -68,9 +67,8 @@ proc sendQuery(db: DbConn,
 
   let success = db.pqsendQuery(cstring(wellFormedQuery))
   if success != 1:
-    let checkRes = db.check()
-    if checkRes.isErr():
-      return err("failed pqsendQuery: " & checkRes.error)
+    db.check().isOkOr:
+      return err("failed pqsendQuery: " & $error)
 
     return err("failed pqsendQuery: unknown reason")
 
@@ -91,9 +89,8 @@ proc sendQueryPrepared(
     return err("lengths discrepancies in sendQueryPrepared: " & $lengthsErrMsg)
 
   if db.status != CONNECTION_OK:
-    let checkRes = db.check()
-    if checkRes.isErr():
-      return err("failed to connect to database: " & checkRes.error)
+    db.check().isOkOr:
+      return err("failed to connect to database: " & $error)
 
     return err("unknown reason")
 
@@ -111,9 +108,8 @@ proc sendQueryPrepared(
                                        unsafeAddr paramFormats[0],
                                        ResultFormat)
   if success != 1:
-    let checkRes = db.check()
-    if checkRes.isErr():
-      return err("failed pqsendQueryPrepared: " & checkRes.error)
+    db.check().isOkOr:
+      return err("failed pqsendQueryPrepared: " & $error)
 
     return err("failed pqsendQueryPrepared: unknown reason")
 
@@ -136,9 +132,8 @@ proc waitQueryToFinish(db: DbConn,
     let success = db.pqconsumeInput()
 
     if success != 1:
-      let checkRes = db.check()
-      if checkRes.isErr():
-        return err("failed pqconsumeInput: " & $checkRes.error)
+      db.check().isOkOr:
+        return err("failed pqconsumeInput: " & $error)
 
       return err("failed pqconsumeInput: unknown reason")
 
@@ -149,9 +144,8 @@ proc waitQueryToFinish(db: DbConn,
     let pqResult = db.pqgetResult()
 
     if pqResult == nil:
-      let checkRes = db.check()
-      if checkRes.isErr():
-        return err("error in query: " & $checkRes.error)
+      db.check().isOkOr:
+        return err("error in query: " & $error)
 
       return ok() # reached the end of the results
 

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -1,9 +1,5 @@
-when (NimMajor, NimMinor) < (1, 4):
-  {.push raises: [Defect,DbError].}
-else:
-  {.push raises: [ValueError,DbError].}
-
 import
+  std/[times, strutils, strformat],
   stew/results,
   chronos
 
@@ -12,6 +8,17 @@ include db_postgres
 type DataProc* = proc(result: ptr PGresult) {.closure, gcsafe.}
 
 ## Connection management
+
+proc isBusy*(db: DbConn): bool =
+  try:
+    return db.pqisBusy() == 1
+  except ValueError,DbError:
+    return true
+
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect,DbError].}
+else:
+  {.push raises: [ValueError,DbError].}
 
 proc check*(db: DbConn): Result[void, string] =
 
@@ -75,15 +82,59 @@ proc sendQuery(db: DbConn,
 
   return ok()
 
+proc sendQueryPrepared(
+               db: DbConn,
+               stmtName: string,
+               paramValues: openArray[string],
+               paramLengths: openArray[int32],
+               paramFormats: openArray[int32]):
+               Result[void, string] =
+  ## This proc can be used directly for queries that don't retrieve values back.
+
+  if paramValues.len != paramLengths.len or paramValues.len != paramFormats.len or
+     paramLengths.len != paramFormats.len:
+    let lengthsErrMsg = $paramValues.len & " " & $paramLengths.len & " " & $paramFormats.len
+    return err("lengths discrepancies in sendQueryPrepared: " & $lengthsErrMsg)
+
+  if db.status != CONNECTION_OK:
+    let checkRes = db.check()
+    if checkRes.isErr():
+      return err("failed to connect to database: " & checkRes.error)
+
+    return err("unknown reason")
+
+  var cstrArrayParams = allocCStringArray(paramValues)
+  defer: deallocCStringArray(cstrArrayParams)
+
+  let nParams = cast[int32](paramValues.len)
+
+  const ResultFormat = 0 ## 0 for text format, 1 for binary format.
+
+  let success = db.pqsendQueryPrepared(stmtName,
+                                       nParams,
+                                       cstrArrayParams,
+                                       unsafeAddr paramLengths[0],
+                                       unsafeAddr paramFormats[0],
+                                       ResultFormat)
+  if success != 1:
+    let checkRes = db.check()
+    if checkRes.isErr():
+      return err("failed pqsendQueryPrepared: " & checkRes.error)
+
+    return err("failed pqsendQueryPrepared: unknown reason")
+
+  return ok()
+
 proc waitQueryToFinish(db: DbConn,
                        rowCallback: DataProc = nil):
                        Future[Result[void, string]] {.async.} =
   ## The 'rowCallback' param is != nil when the underlying query wants to retrieve results (SELECT.)
   ## For other queries, like "INSERT", 'rowCallback' should be nil.
 
-  while true:
+  while db.isBusy():
 
     let success = db.pqconsumeInput()
+
     if success != 1:
       let checkRes = db.check()
       if checkRes.isErr():
@@ -91,11 +142,12 @@ proc waitQueryToFinish(db: DbConn,
 
       return err("failed pqconsumeInput: unknown reason")
 
-    if db.pqisBusy() == 1:
-      await sleepAsync(timer.milliseconds(0)) # Do not block the async runtime
-      continue
+    await sleepAsync(timer.milliseconds(0)) # Do not block the async runtime
 
+  ## Now retrieve the result
+  while true:
     let pqResult = db.pqgetResult()
+
     if pqResult == nil:
       # Check if its a real error or just end of results
       let checkRes = db.check()
@@ -120,5 +172,21 @@ proc dbConnQuery*(db: DbConn,
 
   (await db.waitQueryToFinish(rowCallback)).isOkOr:
     return err("error in dbConnQuery calling waitQueryToFinish: " & $error)
+
+  return ok()
+
+proc dbConnQueryPrepared*(db: DbConn,
+                          stmtName: string,
+                          paramValues: seq[string],
+                          paramLengths: seq[int32],
+                          paramFormats: seq[int32],
+                          rowCallback: DataProc):
+                          Future[Result[void, string]] {.async, gcsafe.} =
+
+  db.sendQueryPrepared(stmtName, paramValues , paramLengths, paramFormats).isOkOr:
+    return err("error in dbConnQueryPrepared calling sendQuery: " & $error)
+
+  (await db.waitQueryToFinish(rowCallback)).isOkOr:
+    return err("error in dbConnQueryPrepared calling waitQueryToFinish: " & $error)
 
   return ok()

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -4,8 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[strformat,nre,options,sequtils,strutils,
-  strformat],
+  std/[nre,options,sequtils,strutils,times],
   stew/[results,byteutils],
   db_postgres,
   postgres,
@@ -345,7 +344,7 @@ proc getMessagesPreparedStmt(s: PostgresDriver,
                                    int32(limit.len)],
                                  @[int32(0), int32(0), int32(0), int32(0),
                                    int32(0), int32(0), int32(0)],
-                                 rowCallback)
+                                  rowCallback)
     ).isOkOr:
       return err("failed to run query with cursor: " & $error)
 
@@ -365,7 +364,7 @@ proc getMessagesPreparedStmt(s: PostgresDriver,
                                    int32(endTimeStr.len),
                                    int32(limit.len)],
                                  @[int32(0), int32(0), int32(0), int32(0), int32(0)],
-                                 rowCallback)
+                                  rowCallback)
     ).isOkOr:
       return err("failed to run query without cursor: " & $error)
 
@@ -382,9 +381,9 @@ method getMessages*(s: PostgresDriver,
                     Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
 
   if contentTopicSeq.len > 0 and
-     pubsubTopic.isSome() and
-     startTime.isSome() and
-     endTime.isSome():
+    pubsubTopic.isSome() and
+    startTime.isSome() and
+    endTime.isSome():
 
     ## Considered the most common query. Therefore, we use prepared statements to optimize it.
     return await s.getMessagesPreparedStmt(contentTopicSeq.join(","),

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -9,7 +9,8 @@ import
   stew/[results,byteutils],
   db_postgres,
   postgres,
-  chronos
+  chronos,
+  chronicles
 import
   ../../../waku_core,
   ../../common,


### PR DESCRIPTION
# Description
The [prepared statements](https://www.postgresql.org/docs/current/sql-prepare.html#:~:text=A%20prepared%20statement%20is%20a,statement%20is%20planned%20and%20executed.) is a mechanism that allows saving time for common queries.

We are applying that approach for the "select" queries, i.e. queries that come from the _Store_ protocol requests. Notice that we were already applying this in "insert" operations.

With that, we enhance the performance of "select" queries. However, bear in mind that there is an underlying time consumption when performing concurrent queries. I've added a long comment about that in `dbconn.nim`.

# Changes

- [x] Use of prepared statements in select queries. 

## Issue
https://github.com/waku-org/nwaku/issues/1842