### PR TITLE
feat: discv5 filter peer by capability 

### DIFF
--- a/tests/test_waku_discv5.nim
+++ b/tests/test_waku_discv5.nim
@@ -320,6 +320,7 @@ procSuite "Waku Discovery v5":
 
       var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)
       require builder.withWakuRelaySharding(shardsTopics).isOk()
+      builder.withWakuCapabilities(Relay)
 
       let recordRes = builder.build()
       require recordRes.isOk()
@@ -338,6 +339,7 @@ procSuite "Waku Discovery v5":
 
       var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)
       require builder.withWakuRelaySharding(shardsTopics).isOk()
+      builder.withWakuCapabilities(Relay)
 
       let recordRes = builder.build()
       require recordRes.isOk()
@@ -356,6 +358,7 @@ procSuite "Waku Discovery v5":
 
       var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)
       require builder.withWakuRelaySharding(shardsTopics).isOk()
+      builder.withWakuCapabilities(Relay)
 
       let recordRes = builder.build()
       require recordRes.isOk()


### PR DESCRIPTION
# Description
RFC#31 specify that discv5 must filter out ENRs that don't have `waku2` field or empty capability list.

# Changes
- [x] Filter predicate now reject peers with empty capability list.
- [x] Fixed test
- [x] Refactor `shardingPredicate` proc

Closes #2179