### PR TITLE
chore: group_manager.nim more except detail when cant connect eth client

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -403,7 +403,8 @@ method init*(g: OnchainGroupManager): Future[void] {.async.} =
   try:
     ethRpc = await newWeb3(g.ethClientUrl)
   except CatchableError:
-    raise newException(ValueError, "could not connect to the Ethereum client")
+    let errMsg = "could not connect to the Ethereum client: " & getCurrentExceptionMsg()
+    raise newException(ValueError, errMsg)
 
   # Set the chain id
   let chainId = await ethRpc.provider.eth_chainId()


### PR DESCRIPTION
## Description
Simple PR to add a little bit more detail when exception occurs while trying to connect to eth client (running the 
https://github.com/waku-org/nwaku-compose/blob/master/register_rln.sh script)

## Changes
- [x] group_manager.nim more exception detail when can't connect eth client.
