### PR TITLE
fix: rln_keystore_generator asks for creating credentials folder if doesn't exist

### DIFF
--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -4,9 +4,10 @@ else:
   {.push raises: [].}
 
 import
+  os,
   chronicles,
   stew/[results],
-  std/tempfiles
+  std/[tempfiles,strutils]
 
 import
   ../../waku/waku_keystore,
@@ -91,6 +92,11 @@ when isMainModule:
     treeIndex: groupManager.membershipIndex.get(),
     identityCredential: credential,
   )
+
+  let baseDir = conf.rlnRelayCredPath.splitFile().dir
+  if baseDir.len > 0 and not existsDir(baseDir):
+    info "Creating credentials keystore folder", dir=baseDir
+    createDir(baseDir)
 
   let persistRes = addMembershipCredentials(conf.rlnRelayCredPath,
                                             keystoreCred,

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -31,6 +31,12 @@ when isMainModule:
 
   trace "configuration", conf = $conf
 
+  let baseDir = conf.rlnRelayCredPath.splitFile().dir
+  if baseDir.len > 0 and not existsDir(baseDir):
+    let errMsg = "The next folder doesn't exist: " & baseDir
+    error "failure missing credentials folder", error=errMsg
+    quit(1)
+
   # 2. initialize rlnInstance
   let rlnInstanceRes = createRLNInstance(d=20,
                                          tree_path = genTempPath("rln_tree", "rln_keystore_generator"))
@@ -92,11 +98,6 @@ when isMainModule:
     treeIndex: groupManager.membershipIndex.get(),
     identityCredential: credential,
   )
-
-  let baseDir = conf.rlnRelayCredPath.splitFile().dir
-  if baseDir.len > 0 and not existsDir(baseDir):
-    info "Creating credentials keystore folder", dir=baseDir
-    createDir(baseDir)
 
   let persistRes = addMembershipCredentials(conf.rlnRelayCredPath,
                                             keystoreCred,


### PR DESCRIPTION
# Description
The `rln_keystore_generator` tool stores the user credentials in a file passed by the `rln-relay-cred-path` param.
If the users passes a path which folder doesn't exist, then the next error appears and the credentials aren't properly stored:

```
ERR 2023-11-08 17:25:50.598+01:00 failed to persist credentials              topics="rln_keystore_generator" tid=240725 file=rln_keystore_generator.nim:100 error="keystore error: OS specific error: Cannot open file for writing"
```

This PR enhances that situation by ending the app immediately and informing the user that the credentials folder doesn't exist.

# Changes

- [x] rln_keystore_generator informs the user when the credential folder doesn't exist and ends.
