### PR TITLE
fix(rest): properly check if rln is used

### DIFF
--- a/waku/waku_api/jsonrpc/relay/handlers.nim
+++ b/waku/waku_api/jsonrpc/relay/handlers.nim
@@ -118,7 +118,7 @@ proc installRelayApiHandlers*(node: WakuNode, server: RpcServer, cache: MessageC
         raise newException(ValueError, "Failed to publish: unknown RLN proof validation result")
 
     # if we reach here its either a non-RLN message or a RLN message with a valid proof
-    debug "Publishing message", pubSubTopic=pubsubTopic, rln=defined(rln)
+    debug "Publishing message", pubSubTopic=pubsubTopic, rln=not node.wakuRlnRelay.isNil()
     let publishFut = node.publish(some(pubsubTopic), message)
     if not await publishFut.withTimeout(futTimeout):
       raise newException(ValueError, "Failed to publish: timed out")
@@ -217,7 +217,7 @@ proc installRelayApiHandlers*(node: WakuNode, server: RpcServer, cache: MessageC
         raise newException(ValueError, "Failed to publish: unknown RLN proof validation result")
 
     # if we reach here its either a non-RLN message or a RLN message with a valid proof
-    debug "Publishing message", contentTopic=message.contentTopic, rln=defined(rln)
+    debug "Publishing message", contentTopic=message.contentTopic, rln=not node.wakuRlnRelay.isNil()
     let publishFut = node.publish(none(PubsubTopic), message)
     if not await publishFut.withTimeout(futTimeout):
       raise newException(ValueError, "Failed to publish: timed out")

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -304,7 +304,7 @@ proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: Mes
         return RestApiResponse.internalServerError("Failed to publish: unknown RLN proof validation result")
 
     # if we reach here its either a non-RLN message or a RLN message with a valid proof
-    debug "Publishing message", contentTopic=message.contentTopic, rln=defined(rln)
+    debug "Publishing message", contentTopic=message.contentTopic, rln=not node.wakuRlnRelay.isNil()
     if not (waitFor node.publish(none(PubSubTopic), message).withTimeout(futTimeout)):
       error "Failed to publish message to topic", contentTopic=message.contentTopic
       return RestApiResponse.internalServerError("Failed to publish: timedout")

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -174,7 +174,7 @@ proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: Mes
         return RestApiResponse.internalServerError("Failed to publish: unknown RLN proof validation result")
 
     # if we reach here its either a non-RLN message or a RLN message with a valid proof
-    debug "Publishing message", pubSubTopic=pubSubTopic, rln=defined(rln)
+    debug "Publishing message", pubSubTopic=pubSubTopic, rln=not node.wakuRlnRelay.isNil()
     if not (waitFor node.publish(some(pubSubTopic), message).withTimeout(futTimeout)):
       error "Failed to publish message to topic", pubSubTopic=pubSubTopic
       return RestApiResponse.internalServerError("Failed to publish: timedout")


### PR DESCRIPTION
# Description

Fixing leftover check for `define(rln)` from when RLN was compiled in conditionally.

Using the option to get a boolean instead

# Changes

<!-- List of detailed changes -->

- [ ] ...
- [ ] ...

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->