### PR TITLE
chore(rest): improved message cache logic

### DIFF
--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -229,11 +229,11 @@ when isMainModule:
 
     # Install enabled API handlers:
     if conf.relay:
-      let cache = MessageCache[string].init(capacity=30)
+      let cache = MessageCache.init(capacity=30)
       installRelayApiHandlers(node, rpcServer, cache)
 
     if conf.filter:
-      let messageCache = filter_api.MessageCache.init(capacity=30)
+      let messageCache = MessageCache.init(capacity=30)
       installFilterApiHandlers(node, rpcServer, messageCache)
 
     if conf.store:

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -653,18 +653,17 @@ proc startRestServer(app: App, address: ValidIpAddress, port: Port, conf: WakuNo
 
   ## Relay REST API
   if conf.relay:
-    let cache = MessageCache[string].init(capacity=conf.restRelayCacheCapacity)
+    let cache = MessageCache.init(int(conf.restRelayCacheCapacity))
 
     let handler = messageCacheHandler(cache)
-    let autoHandler = autoMessageCacheHandler(cache)
 
     for pubsubTopic in conf.pubsubTopics:
-      cache.subscribe(pubsubTopic)
+      cache.pubsubSubscribe(pubsubTopic)
       app.node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(handler))
 
     for contentTopic in conf.contentTopics:
-      cache.subscribe(contentTopic)
-      app.node.subscribe((kind: ContentSub, topic: contentTopic), some(autoHandler))
+      cache.contentSubscribe(contentTopic)
+      app.node.subscribe((kind: ContentSub, topic: contentTopic), some(handler))
 
     installRelayApiHandlers(server.router, app.node, cache)
   else:
@@ -675,10 +674,10 @@ proc startRestServer(app: App, address: ValidIpAddress, port: Port, conf: WakuNo
      app.node.wakuFilterClient != nil and
      app.node.wakuFilterClientLegacy != nil:
 
-    let legacyFilterCache = rest_legacy_filter_api.MessageCache.init()
+    let legacyFilterCache = MessageCache.init()
     rest_legacy_filter_api.installLegacyFilterRestApiHandlers(server.router, app.node, legacyFilterCache)
 
-    let filterCache = rest_filter_api.MessageCache.init()
+    let filterCache = MessageCache.init()
 
     let filterDiscoHandler = 
       if app.wakuDiscv5.isSome():
@@ -731,23 +730,22 @@ proc startRpcServer(app: App, address: ValidIpAddress, port: Port, conf: WakuNod
   installDebugApiHandlers(app.node, server)
 
   if conf.relay:
-    let cache = MessageCache[string].init(capacity=30)
+    let cache = MessageCache.init(capacity=50)
 
     let handler = messageCacheHandler(cache)
-    let autoHandler = autoMessageCacheHandler(cache)
 
     for pubsubTopic in conf.pubsubTopics:
-      cache.subscribe(pubsubTopic)
+      cache.pubsubSubscribe(pubsubTopic)
       app.node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(handler))
 
     for contentTopic in conf.contentTopics:
-      cache.subscribe(contentTopic)
-      app.node.subscribe((kind: ContentSub, topic: contentTopic), some(autoHandler))
+      cache.contentSubscribe(contentTopic)
+      app.node.subscribe((kind: ContentSub, topic: contentTopic), some(handler))
 
     installRelayApiHandlers(app.node, server, cache)
 
   if conf.filternode != "":
-    let filterMessageCache = rpc_filter_api.MessageCache.init(capacity=30)
+    let filterMessageCache = MessageCache.init(capacity=50)
     installFilterApiHandlers(app.node, server, filterMessageCache)
 
   installStoreApiHandlers(app.node, server)

--- a/tests/test_message_cache.nim
+++ b/tests/test_message_cache.nim
@@ -12,9 +12,10 @@ import
 suite "MessageCache":
   setup:
     ## Given
+    let capacity = 3
     let testPubsubTopic = DefaultPubsubTopic
     let testContentTopic = DefaultContentTopic
-    let cache = MessageCache.init(3)
+    let cache = MessageCache.init(capacity)
 
   test "subscribe to topic":
     ## When
@@ -128,7 +129,7 @@ suite "MessageCache":
     var testMessages = @[fakeWakuMessage(toBytes("MSG-1"))]
 
     # Prevent duplicate messages timestamp
-    for i in 0..4:
+    for i in 0..<5:
       var msg = fakeWakuMessage(toBytes("MSG-1"))
 
       while msg.timestamp <= testMessages[i].timestamp:
@@ -136,20 +137,20 @@ suite "MessageCache":
 
       testMessages.add(msg)
 
-    let testSet = toHashSet(testMessages)
-
     cache.pubsubSubscribe(testPubsubTopic)
 
     ## When
-    for msg in testSet:
+    for msg in testMessages:
       cache.addMessage(testPubsubTopic, msg)
 
     ## Then
     let messages = cache.getMessages(testPubsubTopic).tryGet()
     let messageSet = toHashSet(messages)
 
+    let testSet = toHashSet(testMessages)
+
     check:
-      messageSet.len == 3
+      messageSet.len == capacity
       messageSet < testSet
       testMessages[0] notin messages
 

--- a/tests/test_message_cache.nim
+++ b/tests/test_message_cache.nim
@@ -1,153 +1,216 @@
 {.used.}
 
 import
+  std/sets,
   stew/[results, byteutils],
-  testutils/unittests,
-  chronicles
+  testutils/unittests
 import
   ../../waku/waku_core,
   ../../waku/waku_api/message_cache,
-  ./testlib/common,
   ./testlib/wakucore
 
-
-type TestMessageCache = MessageCache[(PubsubTopic, ContentTopic)]
-
 suite "MessageCache":
-  test "subscribe to topic":
+  setup:
     ## Given
-    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
-    let cache = TestMessageCache.init()
+    let testPubsubTopic = DefaultPubsubTopic
+    let testContentTopic = DefaultContentTopic
+    let cache = MessageCache.init(3)
 
+  test "subscribe to topic":
     ## When
-    cache.subscribe(testTopic)
+    cache.pubsubSubscribe(testPubsubTopic)
+    cache.pubsubSubscribe(testPubsubTopic)
+
+    # idempotence of subscribe is also tested
+    cache.contentSubscribe(testContentTopic)
+    cache.contentSubscribe(testContentTopic)
 
     ## Then
     check:
-      cache.isSubscribed(testTopic)
-
+      cache.isPubsubSubscribed(testPubsubTopic)
+      cache.isContentSubscribed(testContentTopic)
+      cache.pubsubTopicCount() == 1
+      cache.contentTopicCount() == 1
 
   test "unsubscribe from topic":
-    ## Given
-    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
-    let cache = TestMessageCache.init()
-
     # Init cache content
-    cache.subscribe(testTopic)
+    cache.pubsubSubscribe(testPubsubTopic)
+    cache.contentSubscribe(testContentTopic)
+
+    cache.pubsubSubscribe("AnotherPubsubTopic")
+    cache.contentSubscribe("AnotherContentTopic")
 
     ## When
-    cache.unsubscribe(testTopic)
+    cache.pubsubUnsubscribe(testPubsubTopic)
+    cache.contentUnsubscribe(testContentTopic)
 
     ## Then
     check:
-      not cache.isSubscribed(testTopic)
-
+      not cache.isPubsubSubscribed(testPubsubTopic)
+      not cache.isContentSubscribed(testContentTopic)
+      cache.pubsubTopicCount() == 1
+      cache.contentTopicCount() == 1
 
   test "get messages of a subscribed topic":
     ## Given
-    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessage = fakeWakuMessage()
-    let cache = TestMessageCache.init()
 
     # Init cache content
-    cache.subscribe(testTopic)
-    cache.addMessage(testTopic, testMessage)
+    cache.pubsubSubscribe(testPubsubTopic)
+    cache.addMessage(testPubsubTopic, testMessage)
 
     ## When
-    let res = cache.getMessages(testTopic)
+    let res = cache.getMessages(testPubsubTopic)
 
     ## Then
     check:
       res.isOk()
       res.get() == @[testMessage]
 
-
   test "get messages with clean flag shoud clear the messages cache":
     ## Given
-    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessage = fakeWakuMessage()
-    let cache = TestMessageCache.init()
 
     # Init cache content
-    cache.subscribe(testTopic)
-    cache.addMessage(testTopic, testMessage)
+    cache.pubsubSubscribe(testPubsubTopic)
+    cache.addMessage(testPubsubTopic, testMessage)
 
     ## When
-    var res = cache.getMessages(testTopic, clear=true)
+    var res = cache.getMessages(testPubsubTopic, clear=true)
     require(res.isOk())
 
-    res = cache.getMessages(testTopic)
+    res = cache.getMessages(testPubsubTopic)
 
     ## Then
     check:
       res.isOk()
       res.get().len == 0
 
-
   test "get messages of a non-subscribed topic":
-    ## Given
-    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
-    let cache = TestMessageCache.init()
-
     ## When
-    let res = cache.getMessages(testTopic)
+    cache.pubsubSubscribe(PubsubTopic("dummyPubsub"))
+    let res = cache.getMessages(testPubsubTopic)
 
     ## Then
     check:
       res.isErr()
-      res.error() == "Not subscribed to topic"
-
+      res.error() == "not subscribed to this pubsub topic"
 
   test "add messages to subscribed topic":
     ## Given
-    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessage = fakeWakuMessage()
-    let cache = TestMessageCache.init()
 
-    cache.subscribe(testTopic)
+    cache.pubsubSubscribe(testPubsubTopic)
 
     ## When
-    cache.addMessage(testTopic, testMessage)
+    cache.addMessage(testPubsubTopic, testMessage)
 
     ## Then
-    let messages = cache.getMessages(testTopic).tryGet()
+    let messages = cache.getMessages(testPubsubTopic).tryGet()
     check:
       messages == @[testMessage]
 
-
   test "add messages to non-subscribed topic":
     ## Given
-    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
     let testMessage = fakeWakuMessage()
-    let cache = TestMessageCache.init()
 
     ## When
-    cache.addMessage(testTopic, testMessage)
+    cache.addMessage(testPubsubTopic, testMessage)
 
     ## Then
-    let res = cache.getMessages(testTopic)
+    let res = cache.getMessages(testPubsubTopic)
     check:
      res.isErr()
-     res.error() == "Not subscribed to topic"
-
+     res.error() == "not subscribed to any pubsub topics"
 
   test "add messages beyond the capacity":
     ## Given
-    let testTopic = (PubsubTopic("test-pubsub-topic"), ContentTopic("test-content-topic"))
-    let testMessages = @[
-      fakeWakuMessage(toBytes("MSG-1")),
-      fakeWakuMessage(toBytes("MSG-2")),
-      fakeWakuMessage(toBytes("MSG-3"))
-    ]
+    var testMessages = @[fakeWakuMessage(toBytes("MSG-1"))]
 
-    let cache = TestMessageCache.init(capacity = 2)
-    cache.subscribe(testTopic)
+    # Prevent duplicate messages timestamp
+    for i in 0..4:
+      var msg = fakeWakuMessage(toBytes("MSG-1"))
+
+      while msg.timestamp <= testMessages[i].timestamp:
+        msg = fakeWakuMessage(toBytes("MSG-1"))
+
+      testMessages.add(msg)
+
+    let testSet = toHashSet(testMessages)
+
+    cache.pubsubSubscribe(testPubsubTopic)
 
     ## When
-    for msg in testMessages:
-      cache.addMessage(testTopic, msg)
+    for msg in testSet:
+      cache.addMessage(testPubsubTopic, msg)
 
     ## Then
-    let messages = cache.getMessages(testTopic).tryGet()
+    let messages = cache.getMessages(testPubsubTopic).tryGet()
+    let messageSet = toHashSet(messages)
+
     check:
-      messages == testMessages[1..2]
+      messageSet.len == 3
+      messageSet < testSet
+      testMessages[0] notin messages
+
+  test "get messages on pubsub via content topics":
+    cache.pubsubSubscribe(testPubsubTopic)
+
+    let fakeMessage = fakeWakuMessage()
+
+    cache.addMessage(testPubsubTopic, fakeMessage)
+
+    let getRes = cache.getAutoMessages(DefaultContentTopic)
+
+    check:
+      getRes.isOk
+      getRes.get() == @[fakeMessage]
+  
+  test "add same message twice":
+    cache.pubsubSubscribe(testPubsubTopic)
+
+    let fakeMessage = fakeWakuMessage()
+
+    cache.addMessage(testPubsubTopic, fakeMessage)
+    cache.addMessage(testPubsubTopic, fakeMessage)
+
+    check:
+      cache.messagesCount() == 1
+
+  test "unsubscribing remove messages":
+    let topic0 = "PubsubTopic0"
+    let topic1 = "PubsubTopic1"
+    let topic2 = "PubsubTopic2"
+
+    let fakeMessage0 = fakeWakuMessage(toBytes("MSG-0"))
+    let fakeMessage1 = fakeWakuMessage(toBytes("MSG-1"))
+    let fakeMessage2 = fakeWakuMessage(toBytes("MSG-2"))
+
+    cache.pubsubSubscribe(topic0)
+    cache.pubsubSubscribe(topic1)
+    cache.pubsubSubscribe(topic2)
+    cache.contentSubscribe("ContentTopic0")
+
+    cache.addMessage(topic0, fakeMessage0)
+    cache.addMessage(topic1, fakeMessage1)
+    cache.addMessage(topic2, fakeMessage2)
+
+    cache.pubsubUnsubscribe(topic0)
+
+    # at this point, fakeMessage0 is only ref by DefaultContentTopic
+
+    let res = cache.getAutoMessages(DefaultContentTopic)
+
+    check:
+      res.isOk()
+      res.get().len == 3
+      cache.isPubsubSubscribed(topic0) == false
+      cache.isPubsubSubscribed(topic1) == true
+      cache.isPubsubSubscribed(topic2) == true
+
+    cache.contentUnsubscribe(DefaultContentTopic)
+
+    # msg0 was delete because no refs
+
+    check:
+      cache.messagesCount() == 2

--- a/tests/wakunode_jsonrpc/test_jsonrpc_filter.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_filter.nim
@@ -4,8 +4,6 @@ import
   std/options,
   stew/shims/net as stewNet,
   testutils/unittests,
-  chronicles,
-  libp2p/crypto/crypto,
   json_rpc/[rpcserver, rpcclient]
 import
   ../../../waku/waku_core,
@@ -19,11 +17,6 @@ import
   ../../../waku/waku_filter/client,
   ../testlib/wakucore,
   ../testlib/wakunode
-
-
-proc newTestMessageCache(): filter_api.MessageCache =
-  filter_api.MessageCache.init(capacity=30)
-
 
 procSuite "Waku v2 JSON-RPC API - Filter":
   let
@@ -49,7 +42,8 @@ procSuite "Waku v2 JSON-RPC API - Filter":
       ta = initTAddress(bindIp, rpcPort)
       server = newRpcHttpServer([ta])
 
-    installFilterApiHandlers(node2, server, newTestMessageCache())
+    let cache = MessageCache.init(capacity=30)
+    installFilterApiHandlers(node2, server, cache)
     server.start()
 
     let client = newRpcHttpClient()

--- a/tests/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -4,7 +4,6 @@ import
   std/[options, sequtils, tempfiles],
   stew/shims/net as stewNet,
   testutils/unittests,
-  chronicles,
   libp2p/crypto/crypto,
   json_rpc/[rpcserver, rpcclient]
 import
@@ -15,10 +14,8 @@ import
   ../../../waku/waku_node,
   ../../../waku/waku_api/jsonrpc/relay/handlers as relay_api,
   ../../../waku/waku_api/jsonrpc/relay/client as relay_api_client,
-  ../../../waku/waku_core,
   ../../../waku/waku_relay,
   ../../../waku/waku_rln_relay,
-  ../testlib/common,
   ../testlib/wakucore,
   ../testlib/wakunode
 
@@ -37,7 +34,7 @@ suite "Waku v2 JSON-RPC API - Relay":
       ta = initTAddress(ValidIpAddress.init("0.0.0.0"), rpcPort)
       server = newRpcHttpServer([ta])
 
-    let cache = MessageCache[string].init(capacity=30)
+    let cache = MessageCache.init(capacity=30)
     installRelayApiHandlers(node, server, cache)
     server.start()
 
@@ -111,7 +108,7 @@ suite "Waku v2 JSON-RPC API - Relay":
       ta = initTAddress(ValidIpAddress.init("0.0.0.0"), rpcPort)
       server = newRpcHttpServer([ta])
 
-    let cache = MessageCache[string].init(capacity=30)
+    let cache = MessageCache.init(capacity=30)
     installRelayApiHandlers(srcNode, server, cache)
     server.start()
 
@@ -181,7 +178,7 @@ suite "Waku v2 JSON-RPC API - Relay":
       ta = initTAddress(ValidIpAddress.init("0.0.0.0"), rpcPort)
       server = newRpcHttpServer([ta])
 
-    let cache = MessageCache[string].init(capacity=30)
+    let cache = MessageCache.init(capacity=30)
     installRelayApiHandlers(dstNode, server, cache)
     server.start()
 
@@ -244,7 +241,7 @@ suite "Waku v2 JSON-RPC API - Relay":
       ta = initTAddress(ValidIpAddress.init("0.0.0.0"), rpcPort)
       server = newRpcHttpServer([ta])
 
-    let cache = MessageCache[string].init(capacity=30)
+    let cache = MessageCache.init(capacity=30)
     installRelayApiHandlers(dstNode, server, cache)
     server.start()
 

--- a/waku/waku_api/handlers.nim
+++ b/waku/waku_api/handlers.nim
@@ -40,11 +40,6 @@ proc defaultDiscoveryHandler*(discv5: WakuDiscoveryV5, cap: Capabilities): Disco
 
 ### Message Cache
 
-proc messageCacheHandler*(cache: MessageCache[string]): WakuRelayHandler =
+proc messageCacheHandler*(cache: MessageCache): WakuRelayHandler =
   return proc(pubsubTopic: string, msg: WakuMessage): Future[void] {.async, closure.} =
-    cache.addMessage(PubSubTopic(pubsubTopic), msg)
-
-proc autoMessageCacheHandler*(cache: MessageCache[string]): WakuRelayHandler =
-  return proc(pubsubTopic: string, msg: WakuMessage): Future[void] {.async, closure.} =
-    if cache.isSubscribed(msg.contentTopic):
-      cache.addMessage(msg.contentTopic, msg)
+    cache.addMessage(pubsubTopic, msg)

--- a/waku/waku_api/message_cache.nim
+++ b/waku/waku_api/message_cache.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[sequtils, sugar, algorithm],
+  std/[sequtils, sugar, algorithm, options],
   stew/results,
   chronicles,
   chronos,
@@ -239,14 +239,11 @@ proc getMessages*(
   if self.pubsubTopics.len == 0:
     return err("not subscribed to any pubsub topics")
 
-  var pubsubIdx = -1
-  for i, topic in self.pubsubTopics:
-    if topic == pubsubTopic:
-      pubsubIdx = i
-      break
-
-  if pubsubIdx == -1:
-    return err("not subscribed to this pubsub topic")
+  let pubsubIdxOp = self.pubsubSearch(pubsubTopic)
+  let pubsubIdx =
+    if pubsubIdxOp.isNone:
+      return err("not subscribed to this pubsub topic")
+    else: pubsubIdxOp.get()
 
   let msgIndices = collect:
     for (pId, mId) in self.pubsubIndex:
@@ -271,14 +268,11 @@ proc getAutoMessages*(
   if self.contentTopics.len == 0:
     return err("not subscribed to any content topics")
 
-  var contentIdx = -1
-  for i, topic in self.contentTopics:
-    if topic == contentTopic:
-      contentIdx = i
-      break
-
-  if contentIdx == -1:
-    return err("not subscribed to this content topic")
+  let contentIdxOp = self.contentSearch(contentTopic)
+  let contentIdx =
+    if contentIdxOp.isNone():
+      return err("not subscribed to this content topic")
+    else: contentIdxOp.get()
 
   let msgIndices = collect:
     for (cId, mId) in self.contentIndex:

--- a/waku/waku_api/message_cache.nim
+++ b/waku/waku_api/message_cache.nim
@@ -188,13 +188,16 @@ proc addMessage*(
   
   var oldestTime = int64.high
   var oldestMsg = int.high
-  for i, message in self.messages:
+  for i, message in self.messages.reversed:
     if message == msg:
       return
 
     if message.timestamp < oldestTime:
         oldestTime = message.timestamp
         oldestMsg = i
+
+  # reverse index
+  oldestMsg = self.messages.high - oldestMsg
 
   var pubsubIdxOp = self.pubsubSearch(pubsubTopic)
   var contentIdxOp = self.contentSearch(msg.contentTopic)

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -5,7 +5,7 @@ else:
 
 import
   std/sequtils,
-  stew/byteutils,
+  stew/[byteutils, results],
   chronicles,
   json_serialization,
   json_serialization/std/options,
@@ -26,18 +26,14 @@ import
 from std/times import getTime
 from std/times import toUnix
 
-
 export types
-
 
 logScope:
   topics = "waku node rest relay_api"
 
-
 ##### Topic cache
 
 const futTimeout* = 5.seconds # Max time to wait for futures
-
 
 #### Request handlers
 
@@ -47,10 +43,11 @@ const ROUTE_RELAY_AUTO_SUBSCRIPTIONSV1* = "/relay/v1/auto/subscriptions"
 const ROUTE_RELAY_AUTO_MESSAGESV1* = "/relay/v1/auto/messages/{contentTopic}"
 const ROUTE_RELAY_AUTO_MESSAGESV1_NO_TOPIC* = "/relay/v1/auto/messages"
 
-proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: MessageCache[string]) =
+proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: MessageCache) =
   router.api(MethodPost, ROUTE_RELAY_SUBSCRIPTIONSV1) do (contentBody: Option[ContentBody]) -> RestApiResponse:
-    # ## Subscribes a node to a list of PubSub topics
-    # debug "post_waku_v2_relay_v1_subscriptions"
+    ## Subscribes a node to a list of PubSub topics
+    
+    debug "post_waku_v2_relay_v1_subscriptions"
 
     # Check the request body
     if contentBody.isNone():
@@ -60,10 +57,10 @@ proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: Mes
       return error
 
     # Only subscribe to topics for which we have no subscribed topic handlers yet
-    let newTopics = req.filterIt(not cache.isSubscribed(it))
+    let newTopics = req.filterIt(not cache.isPubsubSubscribed(it))
 
     for pubsubTopic in newTopics:
-      cache.subscribe(pubsubTopic)
+      cache.pubsubSubscribe(pubsubTopic)
       node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(messageCacheHandler(cache)))
 
     return RestApiResponse.ok()
@@ -81,8 +78,8 @@ proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: Mes
 
     # Unsubscribe all handlers from requested topics
     for pubsubTopic in req:
-      node.unsubscribe((kind: PubsubUnsub, topic: pubsubTopic))
-      cache.unsubscribe(pubsubTopic)
+      cache.pubsubUnsubscribe(pubsubTopic)
+      node.unsubscribe((kind: PubsubUnsub, topic: pubsubTopic))      
 
     # Successfully unsubscribed from all requested topics
     return RestApiResponse.ok()
@@ -160,66 +157,54 @@ proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: Mes
   # Autosharding API
 
   router.api(MethodPost, ROUTE_RELAY_AUTO_SUBSCRIPTIONSV1) do (contentBody: Option[ContentBody]) -> RestApiResponse:
-    # ## Subscribes a node to a list of content topics
-    # debug "post_waku_v2_relay_v1_auto_subscriptions"
-
-    # Check the request body
-    if contentBody.isNone():
-      return RestApiResponse.badRequest()
+    ## Subscribes a node to a list of content topics.
+    
+    debug "post_waku_v2_relay_v1_auto_subscriptions"
 
     let req: seq[ContentTopic] = decodeRequestBody[seq[ContentTopic]](contentBody).valueOr:
       return error
 
     # Only subscribe to topics for which we have no subscribed topic handlers yet
-    let newTopics = req.filterIt(not cache.isSubscribed(it))
+    let newTopics = req.filterIt(not cache.isContentSubscribed(it))
 
     for contentTopic in newTopics:
-      cache.subscribe(contentTopic)
-      node.subscribe((kind: ContentSub, topic: contentTopic), some(autoMessageCacheHandler(cache)))
+      cache.contentSubscribe(contentTopic)
+      node.subscribe((kind: ContentSub, topic: contentTopic), some(messageCacheHandler(cache)))
 
     return RestApiResponse.ok()
 
   router.api(MethodDelete, ROUTE_RELAY_AUTO_SUBSCRIPTIONSV1) do (contentBody: Option[ContentBody]) -> RestApiResponse:
-    # ## Subscribes a node to a list of content topics
-    # debug "delete_waku_v2_relay_v1_auto_subscriptions"
-
-    # Check the request body
-    if contentBody.isNone():
-      return RestApiResponse.badRequest()
+    ## Unsubscribes a node from a list of content topics.
+    
+    debug "delete_waku_v2_relay_v1_auto_subscriptions"
 
     let req: seq[ContentTopic] = decodeRequestBody[seq[ContentTopic]](contentBody).valueOr:
       return error
 
-    # Unsubscribe all handlers from requested topics
     for contentTopic in req:
-      cache.unsubscribe(contentTopic)
+      cache.contentUnsubscribe(contentTopic)
       node.unsubscribe((kind: ContentUnsub, topic: contentTopic))
 
-    # Successfully unsubscribed from all requested topics
     return RestApiResponse.ok()
 
   router.api(MethodGet, ROUTE_RELAY_AUTO_MESSAGESV1) do (contentTopic: string) -> RestApiResponse:
-    # ## Returns all WakuMessages received on a content topic since the
-    # ## last time this method was called
-    # ## TODO: ability to specify a return message limit
-    # debug "get_waku_v2_relay_v1_auto_messages", topic=topic
+    ## Returns all WakuMessages received on a content topic since the
+    ## last time this method was called.
+    
+    debug "get_waku_v2_relay_v1_auto_messages", contentTopic=contentTopic
 
-    if contentTopic.isErr():
-      return RestApiResponse.badRequest()
-    let contentTopic = contentTopic.get()
+    let contentTopic = contentTopic.valueOr:
+      return RestApiResponse.badRequest($error)
 
-    let messages = cache.getMessages(contentTopic, clear=true)
-    if messages.isErr():
+    let messages = cache.getAutoMessages(contentTopic, clear=true).valueOr:
       debug "Not subscribed to topic", topic=contentTopic
-      return RestApiResponse.notFound()
+      return RestApiResponse.notFound(contentTopic)
 
-    let data = RelayGetMessagesResponse(messages.get().map(toRelayWakuMessage))
-    let resp = RestApiResponse.jsonResponse(data, status=Http200)
-    if resp.isErr():
-      debug "An error ocurred while building the json respose", error=resp.error
-      return RestApiResponse.internalServerError()
+    let data = RelayGetMessagesResponse(messages.map(toRelayWakuMessage))
 
-    return resp.get()
+    return RestApiResponse.jsonResponse(data, status=Http200).valueOr:
+      debug "An error ocurred while building the json respose", error = error
+      return RestApiResponse.internalServerError($error)
 
   router.api(MethodPost, ROUTE_RELAY_AUTO_MESSAGESV1_NO_TOPIC) do (contentBody: Option[ContentBody]) -> RestApiResponse:
     # Check the request body
@@ -237,25 +222,21 @@ proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: Mes
 
     # if RLN is mounted, append the proof to the message
     if not node.wakuRlnRelay.isNil():
-      # append the proof to the message
-      let success = node.wakuRlnRelay.appendRLNProof(message,
-                                                    float64(getTime().toUnix()))
-      if not success:
-        return RestApiResponse.internalServerError("Failed to publish: error appending RLN proof to message")
+      if not node.wakuRlnRelay.appendRLNProof(message, float64(getTime().toUnix())):
+        return RestApiResponse.internalServerError(
+          "Failed to publish: error appending RLN proof to message")
 
-      # validate the message before sending it
-      let result = node.wakuRlnRelay.validateMessageAndUpdateLog(message)
-      if result == MessageValidationResult.Invalid:
-        return RestApiResponse.internalServerError("Failed to publish: invalid RLN proof")
-      elif result == MessageValidationResult.Spam:
-        return RestApiResponse.badRequest("Failed to publish: limit exceeded, try again later")
-      elif result == MessageValidationResult.Valid:
-        debug "RLN proof validated successfully", contentTopic=message.contentTopic
-      else:
-        return RestApiResponse.internalServerError("Failed to publish: unknown RLN proof validation result")
+      case node.wakuRlnRelay.validateMessage(message):
+        of MessageValidationResult.Invalid:
+          return RestApiResponse.internalServerError("Failed to publish: invalid RLN proof")
+        of MessageValidationResult.Spam:
+          return RestApiResponse.badRequest("Failed to publish: limit exceeded, try again later")
+        of MessageValidationResult.Valid:
+          debug "RLN proof validated successfully", contentTopic=message.contentTopic
 
     # if we reach here its either a non-RLN message or a RLN message with a valid proof
     debug "Publishing message", contentTopic=message.contentTopic, rln=not node.wakuRlnRelay.isNil()
+    
     if not (waitFor node.publish(none(PubSubTopic), message).withTimeout(futTimeout)):
       error "Failed to publish message to topic", contentTopic=message.contentTopic
       return RestApiResponse.internalServerError("Failed to publish: timedout")


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
I refactored the message cache with the intent to allow fetching messages by pubsub OR content topic. Adding a message now add the missing topic either pubsub or content (still need to be subscribed to either). I also added a check to prevent duplicate messages.

The capacity is now TOTAL instead of PER topic.

# Changes

<!-- List of detailed changes -->

- [x] new message cache
- [x] updated APIs
- [x] new tests for new behaviour 

Tracking: #2201
Fix: #2192