### PR TITLE
fix(tests): Compilation failure fix.

### DIFF
--- a/tests/node/test_wakunode_filter.nim
+++ b/tests/node/test_wakunode_filter.nim
@@ -1,27 +1,38 @@
 {.used.}  
 
 import
-  std/[options, tables, sequtils],
+  std/[
+    options, 
+    tables, 
+    sequtils
+  ],
   stew/shims/net as stewNet,
   testutils/unittests,
   chronos,
   chronicles,
   os,
-  libp2p/peerstore,
-  libp2p/crypto/crypto
+  libp2p/[
+    peerstore, 
+    crypto/crypto
+  ]
 
 import
-  ../../../waku/waku_core,
-  ../../../waku/node/peer_manager,
-  ../../../waku/node/waku_node,
-  ../../../waku/waku_filter_v2,
-  ../../../waku/waku_filter_v2/client,
-  ../../../waku/waku_filter_v2/subscriptions,
-  ../testlib/common,
-  ../testlib/wakucore,
-  ../testlib/wakunode,
-  ../testlib/testasync,
-  ../testlib/futures
+  ../../../waku/[
+    waku_core,
+    node/peer_manager,
+    node/waku_node,
+    waku_filter_v2,
+    waku_filter_v2/client,
+    waku_filter_v2/subscriptions
+  ],
+  ../testlib/[
+    common,
+    wakucore,
+    wakunode,
+    testasync,
+    futures,
+    testutils
+  ]
 
 let FUTURE_TIMEOUT = 1.seconds
 
@@ -185,7 +196,7 @@ suite "Waku Filter - End to End":
     # And the client node reboots
     waitFor client.stop()
     waitFor client.start()
-    client.mountFilterClient()
+    discard client.mountFilterClient()
 
     # When a message is sent to the subscribed content topic, via Relay
     let msg = fakeWakuMessage(contentTopic=contentTopic)

--- a/tests/waku_relay/test_protocol.nim
+++ b/tests/waku_relay/test_protocol.nim
@@ -239,7 +239,7 @@ suite "Waku Relay":
 
     asyncTest "Refreshing subscription":
       # Given a subscribed node
-      node.subscribe(pubsubTopic, simpleFutureHandler)
+      discard node.subscribe(pubsubTopic, simpleFutureHandler)
       check:
         node.isSubscribed(pubsubTopic)
         node.subscribedTopics == pubsubTopicSeq
@@ -252,7 +252,7 @@ suite "Waku Relay":
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(topic: PubsubTopic, message: WakuMessage) {.async, gcsafe.} =
         otherHandlerFuture.complete((topic, message))
-      node.subscribe(pubsubTopic, otherSimpleFutureHandler)
+      discard node.subscribe(pubsubTopic, otherSimpleFutureHandler)
       check:
         node.isSubscribed(pubsubTopic)
         node.subscribedTopics == pubsubTopicSeq
@@ -297,14 +297,14 @@ suite "Waku Relay":
         otherHandlerFuture.complete((topic, message))
 
       otherNode.addValidator(pubsubTopic, len4Validator)
-      otherNode.subscribe(pubsubTopic, otherSimpleFutureHandler)
+      discard otherNode.subscribe(pubsubTopic, otherSimpleFutureHandler)
       await sleepAsync(500.millis)
       check:
         otherNode.isSubscribed(pubsubTopic)
 
       # Given a subscribed node with a validator
       node.addValidator(pubsubTopic, len4Validator)
-      node.subscribe(pubsubTopic, simpleFutureHandler)
+      discard node.subscribe(pubsubTopic, simpleFutureHandler)
       await sleepAsync(500.millis)
       check:
         node.isSubscribed(pubsubTopic)
@@ -784,7 +784,7 @@ suite "Waku Relay":
 
     asyncTest "Single Node with Single Pubsub Topic":
       # Given a node subscribed to a pubsub topic
-      node.subscribe(pubsubTopic, simpleFutureHandler)
+      discard node.subscribe(pubsubTopic, simpleFutureHandler)
       check node.subscribedTopics == pubsubTopicSeq
 
       # When unsubscribing from all pubsub topics


### PR DESCRIPTION
# Description
There were some missing keywords that slipped by in recent PRs, making compilation fail. This PR adds those keywords.
There are still some issues within the tests, meaning: 
- Some tests are failing.
- Some tests are not being run.

I'm checking those right as I finish publishing this PR but, if you consider it a good idea, we can merge this in the meantime, so other PRs' jobs are not blocked.


# Changes
- [X] Add missing keywords.