### PR TITLE
chore: removing automatic vacuuming from retention policy code

### DIFF
--- a/tests/waku_archive/test_retention_policy.nim
+++ b/tests/waku_archive/test_retention_policy.nim
@@ -70,11 +70,6 @@ suite "Waku Archive - Retention policy":
     let retentionPolicy: RetentionPolicy = SizeRetentionPolicy.init(size=sizeLimit)
     var putFutures = newSeq[Future[ArchiveDriverResult[void]]]()
 
-    # variables to check the db size
-    var pageSize = (waitFor driver.getPagesSize()).tryGet()
-    var pageCount = (waitFor driver.getPagesCount()).tryGet()
-    var sizeDB = float(pageCount * pageSize) / (1024.0 * 1024.0)
-
     # make sure that the db is empty to before test begins
     let storedMsg = (waitFor driver.getAllMessages()).tryGet()
     # if there are messages in db, empty them
@@ -95,9 +90,9 @@ suite "Waku Archive - Retention policy":
 
     ## Then
     # calculate the current database size
-    pageSize = (waitFor driver.getPagesSize()).tryGet()
-    pageCount = (waitFor driver.getPagesCount()).tryGet()
-    sizeDB = float(pageCount * pageSize) / (1024.0 * 1024.0)
+    let pageSize = (waitFor driver.getPagesSize()).tryGet()
+    let pageCount = (waitFor driver.getPagesCount()).tryGet()
+    let sizeDB = float(pageCount * pageSize) / (1024.0 * 1024.0)
 
     # NOTE: since vacuumin is done manually, this needs to be revisited if vacuuming done automatically
 

--- a/waku/waku_archive/retention_policy/retention_policy_capacity.nim
+++ b/waku/waku_archive/retention_policy/retention_policy_capacity.nim
@@ -75,10 +75,4 @@ method execute*(p: CapacityRetentionPolicy,
   if res.isErr():
     return err("deleting oldest messages failed: " & res.error)
 
-  # vacuum to get the deleted pages defragments to save storage space
-  # this will resize the database size
-  let resVaccum = await driver.performVacuum()
-  if resVaccum.isErr():
-    return err("vacuumming failed: " & resVaccum.error)
-
   return ok()

--- a/waku/waku_archive/retention_policy/retention_policy_size.nim
+++ b/waku/waku_archive/retention_policy/retention_policy_size.nim
@@ -50,36 +50,32 @@ method execute*(p: SizeRetentionPolicy,
   if pageSize == 0:
     return err("failed to get Page size: " & pageSizeRes.error)
 
-  # keep deleting until the current db size falls within size limit 
-  while true:
-    # to get the size of the database, pageCount and PageSize is required
-    # get page count in "messages" database
-    let pageCount = (await driver.getPagesCount()).valueOr:
-      return err("failed to get Pages count: " & $error)
+  # to get the size of the database, pageCount and PageSize is required
+  # get page count in "messages" database
+  let pageCount = (await driver.getPagesCount()).valueOr:
+    return err("failed to get Pages count: " & $error)
 
-    # database size in megabytes (Mb)
-    let totalSizeOfDB: float = float(pageSize * pageCount)/1024.0
+  # database size in megabytes (Mb)
+  let totalSizeOfDB: float = float(pageSize * pageCount)/1024.0
 
-    if totalSizeOfDB < p.sizeLimit:
-      break
+  if totalSizeOfDB < p.sizeLimit:
+    return ok()
 
-    # to shread/delete messsges, get the total row/message count
-    let numMessagesRes = await driver.getMessagesCount()
-    if numMessagesRes.isErr():
-      return err("failed to get messages count: " & numMessagesRes.error)
-    let numMessages = numMessagesRes.value
+  # to shread/delete messsges, get the total row/message count
+  let numMessagesRes = await driver.getMessagesCount()
+  if numMessagesRes.isErr():
+    return err("failed to get messages count: " & numMessagesRes.error)
+  let numMessages = numMessagesRes.value
 
-    # 80% of the total messages are to be kept, delete others
-    let pageDeleteWindow = int(float(numMessages) * DeleteLimit)
+  # NOTE: Using SQLite vacuuming is done manually, we delete a percentage of rows
+  # if vacumming is done automatically then we aim to check DB size periodially for efficient
+  # retention policy implementation.
 
-    let res = await driver.deleteOldestMessagesNotWithinLimit(limit=pageDeleteWindow)
-    if res.isErr():
-        return err("deleting oldest messages failed: " & res.error)
-    
-    # vacuum to get the deleted pages defragments to save storage space
-    # this will resize the database size
-    let resVaccum = await driver.performVacuum()
-    if resVaccum.isErr():
-      return err("vacuumming failed: " & resVaccum.error)
+  # 80% of the total messages are to be kept, delete others
+  let pageDeleteWindow = int(float(numMessages) * DeleteLimit)
+
+  let res = await driver.deleteOldestMessagesNotWithinLimit(limit=pageDeleteWindow)
+  if res.isErr():
+    return err("deleting oldest messages failed: " & res.error)
 
   return ok()


### PR DESCRIPTION
# Description
As discussed in #2226, the automatic vacuuming is removed from the retention policy code.

# Changes

<!-- List of detailed changes -->

- [x] vacuuming code removed from retention policy
- [x] associated testcase updated

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #2226 