### PR TITLE
chore: peer_manager.nim - better feedback if can't dial peer with WakuMetadaCodec

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -331,7 +331,7 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
         try:
           conn = await pm.switch.dial(peerId, WakuMetadataCodec)
         except CatchableError:
-          reason = "waku metadata codec not supported"
+          reason = "waku metadata codec not supported: " & getCurrentExceptionMsg()
           break wakuMetadata
 
         # request metadata from connecting peer


### PR DESCRIPTION
Very simple PR to have better insight if the dial against a node supposed to support the "WakuMetadataCodec".

