### PR TITLE
chore: deterministic message hash algorithm updated

### DIFF
--- a/tests/waku_core/test_message_digest.nim
+++ b/tests/waku_core/test_message_digest.nim
@@ -17,15 +17,17 @@ suite "Waku Message - Deterministic hashing":
     ##  waku_message.payload = 0x010203045445535405060708
     ##  waku_message.content_topic = 0x2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f
     ##  waku_message.meta = <empty>
+    ##  waku_message.ts = 0x175789bfa23f8400
     ##
-    ##  message_hash = 0x87619d05e563521d9126749b45bd4cc2430df0607e77e23572d874ed9c1aaa62
+    ##  message_hash = 0xa2554498b31f5bcdfcbf7fa58ad1c2d45f0254f3f8110a85588ec3cf10720fd8
 
     ## Given
     let pubsubTopic = DefaultPubsubTopic  # /waku/2/default-waku/proto
     let message = fakeWakuMessage(
         contentTopic = DefaultContentTopic,  # /waku/2/default-content/proto
         payload = "\x01\x02\x03\x04TEST\x05\x06\x07\x08".toBytes(),
-        meta = newSeq[byte]()
+        meta = newSeq[byte](),
+        ts = getNanosecondTime(1681964442) # Apr 20 2023 04:20:42
       )
 
     ## When
@@ -37,7 +39,8 @@ suite "Waku Message - Deterministic hashing":
       byteutils.toHex(message.contentTopic.toBytes()) == "2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f"
       byteutils.toHex(message.payload) == "010203045445535405060708"
       byteutils.toHex(message.meta) == ""
-      messageHash.toHex() == "87619d05e563521d9126749b45bd4cc2430df0607e77e23572d874ed9c1aaa62"
+      byteutils.toHex(toBytesFromInt64(int64(message.timestamp))) == "175789bfa23f8400"
+      messageHash.toHex() == "a2554498b31f5bcdfcbf7fa58ad1c2d45f0254f3f8110a85588ec3cf10720fd8"
 
   test "digest computation - meta field (12 bytes)":
     ## Test vector:
@@ -46,15 +49,17 @@ suite "Waku Message - Deterministic hashing":
     ##  waku_message.payload = 0x010203045445535405060708
     ##  waku_message.content_topic = 0x2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f
     ##  waku_message.meta = 0x73757065722d736563726574
+    ##  waku_message.ts = 0x175789bfa23f8400
     ##
-    ##  message_hash = 0x4fdde1099c9f77f6dae8147b6b3179aba1fc8e14a7bf35203fc253ee479f135f
+    ##  message_hash = 0x64cce733fed134e83da02b02c6f689814872b1a0ac97ea56b76095c3c72bfe05
 
     ## Given
     let pubsubTopic = DefaultPubsubTopic  # /waku/2/default-waku/proto
     let message = fakeWakuMessage(
         contentTopic = DefaultContentTopic,  # /waku/2/default-content/proto
         payload = "\x01\x02\x03\x04TEST\x05\x06\x07\x08".toBytes(),
-        meta = "\x73\x75\x70\x65\x72\x2d\x73\x65\x63\x72\x65\x74".toBytes()
+        meta = "\x73\x75\x70\x65\x72\x2d\x73\x65\x63\x72\x65\x74".toBytes(),
+        ts = getNanosecondTime(1681964442) # Apr 20 2023 04:20:42
       )
 
     ## When
@@ -66,7 +71,8 @@ suite "Waku Message - Deterministic hashing":
       byteutils.toHex(message.contentTopic.toBytes()) == "2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f"
       byteutils.toHex(message.payload) == "010203045445535405060708"
       byteutils.toHex(message.meta) == "73757065722d736563726574"
-      messageHash.toHex() == "4fdde1099c9f77f6dae8147b6b3179aba1fc8e14a7bf35203fc253ee479f135f"
+      byteutils.toHex(toBytesFromInt64(int64(message.timestamp))) == "175789bfa23f8400"
+      messageHash.toHex() == "64cce733fed134e83da02b02c6f689814872b1a0ac97ea56b76095c3c72bfe05"
 
   test "digest computation - meta field (64 bytes)":
     ## Test vector:
@@ -75,15 +81,17 @@ suite "Waku Message - Deterministic hashing":
     ##  waku_message.payload = 0x010203045445535405060708
     ##  waku_message.content_topic = 0x2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f
     ##  waku_message.meta = 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f
+    ##  waku_message.ts = 0x175789bfa23f8400
     ##
-    ##  message_hash = 0xc32ed3b51f0c432be1c7f50880110e1a1a60f6067cd8193ca946909efe1b26ad
+    ##  message_hash = 0x7158b6498753313368b9af8f6e0a0a05104f68f972981da42a43bc53fb0c1b27"
 
     ## Given
     let pubsubTopic = DefaultPubsubTopic  # /waku/2/default-waku/proto
     let message = fakeWakuMessage(
       contentTopic = DefaultContentTopic,  # /waku/2/default-content/proto
       payload = "\x01\x02\x03\x04TEST\x05\x06\x07\x08".toBytes(),
-      meta = toSeq(0.byte..63.byte)
+      meta = toSeq(0.byte..63.byte),
+      ts = getNanosecondTime(1681964442) # Apr 20 2023 04:20:42
     )
 
     ## When
@@ -95,7 +103,8 @@ suite "Waku Message - Deterministic hashing":
       byteutils.toHex(message.contentTopic.toBytes()) == "2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f"
       byteutils.toHex(message.payload) == "010203045445535405060708"
       byteutils.toHex(message.meta) == "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
-      messageHash.toHex() == "c32ed3b51f0c432be1c7f50880110e1a1a60f6067cd8193ca946909efe1b26ad"
+      byteutils.toHex(toBytesFromInt64(int64(message.timestamp))) == "175789bfa23f8400"
+      messageHash.toHex() == "7158b6498753313368b9af8f6e0a0a05104f68f972981da42a43bc53fb0c1b27"
 
   test "digest computation - zero length payload":
     ## Test vector:
@@ -104,15 +113,17 @@ suite "Waku Message - Deterministic hashing":
     ##  waku_message.payload = []
     ##  waku_message.content_topic = 0x2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f
     ##  waku_message.meta = 0x73757065722d736563726574
+    ##  waku_message.ts = 0x175789bfa23f8400
     ##
-    ##  message_hash = 0xe1a9596237dbe2cc8aaf4b838c46a7052df6bc0d42ba214b998a8bfdbe8487d6
+    ##  message_hash = 0x483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4
 
     ## Given
     let pubsubTopic = DefaultPubsubTopic  # /waku/2/default-waku/proto
     let message = fakeWakuMessage(
         contentTopic = DefaultContentTopic,  # /waku/2/default-content/proto
         payload = newSeq[byte](),
-        meta = "\x73\x75\x70\x65\x72\x2d\x73\x65\x63\x72\x65\x74".toBytes()
+        meta = "\x73\x75\x70\x65\x72\x2d\x73\x65\x63\x72\x65\x74".toBytes(),
+        ts = getNanosecondTime(1681964442) # Apr 20 2023 04:20:42
       )
 
     ## When
@@ -120,8 +131,9 @@ suite "Waku Message - Deterministic hashing":
 
     ## Then
     check:
-      messageHash.toHex() == "e1a9596237dbe2cc8aaf4b838c46a7052df6bc0d42ba214b998a8bfdbe8487d6"
+      messageHash.toHex() == "483ea950cb63f9b9d6926b262bb36194d3f40a0463ce8446228350bd44e96de4"
 
+  
   test "waku message - check meta size is enforced":
     # create message with meta size > 64 bytes (invalid)
     let message = fakeWakuMessage(

--- a/tests/waku_core/test_message_digest.nim
+++ b/tests/waku_core/test_message_digest.nim
@@ -3,6 +3,7 @@
 import
   std/sequtils,
   stew/byteutils,
+  stew/endians2,
   testutils/unittests
 import
   ../../../waku/waku_core,
@@ -39,7 +40,7 @@ suite "Waku Message - Deterministic hashing":
       byteutils.toHex(message.contentTopic.toBytes()) == "2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f"
       byteutils.toHex(message.payload) == "010203045445535405060708"
       byteutils.toHex(message.meta) == ""
-      byteutils.toHex(toBytesFromInt64(int64(message.timestamp))) == "175789bfa23f8400"
+      byteutils.toHex(toBytesBE(uint64(message.timestamp))) == "175789bfa23f8400"
       messageHash.toHex() == "a2554498b31f5bcdfcbf7fa58ad1c2d45f0254f3f8110a85588ec3cf10720fd8"
 
   test "digest computation - meta field (12 bytes)":
@@ -71,7 +72,7 @@ suite "Waku Message - Deterministic hashing":
       byteutils.toHex(message.contentTopic.toBytes()) == "2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f"
       byteutils.toHex(message.payload) == "010203045445535405060708"
       byteutils.toHex(message.meta) == "73757065722d736563726574"
-      byteutils.toHex(toBytesFromInt64(int64(message.timestamp))) == "175789bfa23f8400"
+      byteutils.toHex(toBytesBE(uint64(message.timestamp))) == "175789bfa23f8400"
       messageHash.toHex() == "64cce733fed134e83da02b02c6f689814872b1a0ac97ea56b76095c3c72bfe05"
 
   test "digest computation - meta field (64 bytes)":
@@ -103,7 +104,7 @@ suite "Waku Message - Deterministic hashing":
       byteutils.toHex(message.contentTopic.toBytes()) == "2f77616b752f322f64656661756c742d636f6e74656e742f70726f746f"
       byteutils.toHex(message.payload) == "010203045445535405060708"
       byteutils.toHex(message.meta) == "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
-      byteutils.toHex(toBytesFromInt64(int64(message.timestamp))) == "175789bfa23f8400"
+      byteutils.toHex(toBytesBE(uint64(message.timestamp))) == "175789bfa23f8400"
       messageHash.toHex() == "7158b6498753313368b9af8f6e0a0a05104f68f972981da42a43bc53fb0c1b27"
 
   test "digest computation - zero length payload":

--- a/waku/waku_core/message/digest.nim
+++ b/waku/waku_core/message/digest.nim
@@ -7,6 +7,7 @@ else:
 import
   std/sequtils,
   stew/byteutils,
+  stew/endians2,
   nimcrypto/sha2
 import
   ../topics,
@@ -22,15 +23,6 @@ type WakuMessageDigest* = array[32, byte]
 converter toBytesArray*(digest: MDigest[256]): WakuMessageDigest =
   digest.data
 
-converter toBytesFromInt64*(num: int64): seq[byte] =
-  var bytes: seq[byte] = newSeq[byte](8)  # Create a sequence for 8 bytes (int64)
-
-  # Extract and store each byte uinsg Big-endian method
-  for i in 0..<8:
-      bytes[i] = byte((num shr (56 - i * 8)) and 0xFF)
-
-  return bytes
-
 converter toBytes*(digest: MDigest[256]): seq[byte] =
   toSeq(digest.data)
 
@@ -44,6 +36,6 @@ proc digest*(pubsubTopic: PubsubTopic, msg: WakuMessage): WakuMessageDigest =
   ctx.update(msg.payload)
   ctx.update(msg.contentTopic.toBytes())
   ctx.update(msg.meta)
-  ctx.update((msg.timestamp).toBytesFromInt64())
+  ctx.update(toBytesBE(uint64(msg.timestamp)))
 
   return ctx.finish()  # Computes the hash

--- a/waku/waku_core/message/digest.nim
+++ b/waku/waku_core/message/digest.nim
@@ -22,6 +22,15 @@ type WakuMessageDigest* = array[32, byte]
 converter toBytesArray*(digest: MDigest[256]): WakuMessageDigest =
   digest.data
 
+converter toBytesFromInt64*(num: int64): seq[byte] =
+  var bytes: seq[byte] = newSeq[byte](8)  # Create a sequence for 8 bytes (int64)
+
+  # Extract and store each byte uinsg Big-endian method
+  for i in 0..<8:
+      bytes[i] = byte((num shr (56 - i * 8)) and 0xFF)
+
+  return bytes
+
 converter toBytes*(digest: MDigest[256]): seq[byte] =
   toSeq(digest.data)
 
@@ -35,5 +44,6 @@ proc digest*(pubsubTopic: PubsubTopic, msg: WakuMessage): WakuMessageDigest =
   ctx.update(msg.payload)
   ctx.update(msg.contentTopic.toBytes())
   ctx.update(msg.meta)
+  ctx.update((msg.timestamp).toBytesFromInt64())
 
   return ctx.finish()  # Computes the hash


### PR DESCRIPTION
# Description
As described in RFC related [change](https://github.com/vacp2p/rfc/pull/632), the deterministic message hash algorithm is updated. Waku message `timestamp` is added to the hash/digest computation. 

# Changes

<!-- List of detailed changes -->

- [x] hash/digest calculation updated 
- [x] related test cases updated 

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #2215 
