### PR TITLE
fix: waku_filter_v2/common: PEER_DIAL_FAILURE ret code change: 200 -> 504

### DIFF
--- a/waku/waku_filter_v2/common.nim
+++ b/waku/waku_filter_v2/common.nim
@@ -13,7 +13,7 @@ const
 type
   FilterSubscribeErrorKind* {.pure.} = enum
     UNKNOWN = uint32(000)
-    PEER_DIAL_FAILURE = uint32(200) # TODO shouldn't this be an error code, e.g. 504 Gateway Timeout?
+    PEER_DIAL_FAILURE = uint32(504)
     BAD_RESPONSE = uint32(300)
     BAD_REQUEST = uint32(400)
     NOT_FOUND = uint32(404)

--- a/waku/waku_filter_v2/common.nim
+++ b/waku/waku_filter_v2/common.nim
@@ -13,11 +13,11 @@ const
 type
   FilterSubscribeErrorKind* {.pure.} = enum
     UNKNOWN = uint32(000)
-    PEER_DIAL_FAILURE = uint32(504)
     BAD_RESPONSE = uint32(300)
     BAD_REQUEST = uint32(400)
     NOT_FOUND = uint32(404)
     SERVICE_UNAVAILABLE = uint32(503)
+    PEER_DIAL_FAILURE = uint32(504)
 
   FilterSubscribeError* = object
     case kind*: FilterSubscribeErrorKind


### PR DESCRIPTION
Changing the return code to a more meaningful value when `PEER_DIAL_FAILURE` happens.