### PR TITLE
bug: extended Postgres code to support retention policy + refactoring

### DIFF
--- a/tests/waku_archive/test_retention_policy.nim
+++ b/tests/waku_archive/test_retention_policy.nim
@@ -92,9 +92,7 @@ suite "Waku Archive - Retention policy":
 
     ## Then
     # calculate the current database size
-    let pageSize = (waitFor driver.getPagesSize()).tryGet()
-    let pageCount = (waitFor driver.getPagesCount()).tryGet()
-    let sizeDB = float(pageCount * pageSize) / (1024.0 * 1024.0)
+    let sizeDB = float((waitFor driver.getDatabasesSize()).tryGet()) / (1024.0)
 
     # NOTE: since vacuumin is done manually, this needs to be revisited if vacuuming done automatically
 

--- a/waku/common/databases/db_sqlite.nim
+++ b/waku/common/databases/db_sqlite.nim
@@ -295,6 +295,22 @@ proc getPageCount*(db: SqliteDatabase): DatabaseResult[int64] =
 
   return ok(count)
 
+proc getDatabaseSize*(db: SqliteDatabase): DatabaseResult[int64] =
+  # get the database page size
+  var pageSize = ?db.getPageSize()
+  # change the page size from bytes to Kilo bytes
+  pageSize = int64(pageSize div 1024)
+  
+  if pageSize == 0:
+    return err("failed to get page size ")
+
+  # get the database page count
+  let pageCount = ?db.getPageCount()
+
+  let databaseSize = (pageSize * pageCount)
+
+  return ok(databaseSize)
+
 proc gatherSqlitePageStats*(db: SqliteDatabase):
                             DatabaseResult[(int64, int64, int64)] =
   let

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -52,6 +52,9 @@ method getPagesCount*(driver: ArchiveDriver):
 method getPagesSize*(driver: ArchiveDriver):
                          Future[ArchiveDriverResult[int64]] {.base, async.} = discard
 
+method getDatabasesSize*(driver: ArchiveDriver):
+                         Future[ArchiveDriverResult[int64]] {.base, async.} = discard
+
 method performVacuum*(driver: ArchiveDriver):
               Future[ArchiveDriverResult[void]] {.base, async.} = discard
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -434,6 +434,16 @@ proc getInt(s: PostgresDriver,
 
   return ok(retInt)
 
+method getDatabasesSize*(s: PostgresDriver):
+                         Future[ArchiveDriverResult[int64]] {.async.} =
+
+  let intRes = await s.getInt("SELECT pg_database_size(current_database())")
+  if intRes.isErr():
+    return err("error in getMessagesCount: " & intRes.error)
+
+  let databaseSize: int64 = int64(float(intRes.get())/1024.0)
+  return ok(databaseSize)
+
 method getMessagesCount*(s: PostgresDriver):
                          Future[ArchiveDriverResult[int64]] {.async.} =
 

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -289,6 +289,10 @@ method getPagesSize*(driver: QueueDriver):
                          Future[ArchiveDriverResult[int64]] {.async} =
   return ok(int64(driver.len()))
 
+method getDatabasesSize*(driver: QueueDriver):
+                         Future[ArchiveDriverResult[int64]] {.async} =
+  return ok(int64(driver.len()))
+
 method performVacuum*(driver: QueueDriver):
               Future[ArchiveDriverResult[void]] {.async.} =
   return err("interface method not implemented")

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -120,6 +120,10 @@ method getPagesSize*(s: SqliteDriver):
                          Future[ArchiveDriverResult[int64]] {.async.} =
   return s.db.getPageSize()
 
+method getDatabasesSize*(s: SqliteDriver):
+                         Future[ArchiveDriverResult[int64]] {.async.} =
+  return s.db.getDatabaseSize()
+
 method performVacuum*(s: SqliteDriver):
                          Future[ArchiveDriverResult[void]] {.async.} =
   return s.db.performSqliteVacuum()

--- a/waku/waku_archive/retention_policy/retention_policy_size.nim
+++ b/waku/waku_archive/retention_policy/retention_policy_size.nim
@@ -42,21 +42,12 @@ method execute*(p: SizeRetentionPolicy,
                 driver: ArchiveDriver):
                 Future[RetentionPolicyResult[void]] {.async.} =
   ## when db size overshoots the database limit, shread 20% of outdated messages 
-
-  # get page size of database
-  let pageSizeRes = await driver.getPagesSize()
-  let pageSize: int64 = int64(pageSizeRes.valueOr(0) div 1024)
-
-  if pageSize == 0:
-    return err("failed to get Page size: " & pageSizeRes.error)
-
-  # to get the size of the database, pageCount and PageSize is required
-  # get page count in "messages" database
-  let pageCount = (await driver.getPagesCount()).valueOr:
-    return err("failed to get Pages count: " & $error)
+  # get size of database
+  let dbSize = (await driver.getDatabasesSize()).valueOr:
+    return err("failed to get database size: " & $error)
 
   # database size in megabytes (Mb)
-  let totalSizeOfDB: float = float(pageSize * pageCount)/1024.0
+  let totalSizeOfDB: float = float(dbSize)/1024.0
 
   if totalSizeOfDB < p.sizeLimit:
     return ok()


### PR DESCRIPTION
# Description

The bug was caused due to Postgres not supporting the SQLite like functionality on the retention policy. Changes introduce Postgres to calculate the database size. Also, some refactoring for a cleaner code interface.

# Changes

<!-- List of detailed changes -->

- [x] Postgres supporting retention policy updates.
- [x] Waku store node running with Postgres using size-based retention policy.

<!--
## How to test

1.
1.
1.

-->



## Issue

closes #2242 