### PR TITLE
chore: postres driver allow setting the max number of connection from a parameter

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -491,6 +491,7 @@ proc setupProtocols(node: WakuNode,
     let archiveDriverRes = ArchiveDriver.new(conf.storeMessageDbUrl,
                                              conf.storeMessageDbVacuum,
                                              conf.storeMessageDbMigration,
+                                             conf.storeMaxNumDbConnections,
                                              onErrAction)
     if archiveDriverRes.isErr():
       return err("failed to setup archive driver: " & archiveDriverRes.error)

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -273,6 +273,11 @@ type
         defaultValue: true,
         name: "store-message-db-migration" }: bool
 
+      storeMaxNumDbConnections* {.
+        desc: "Maximum number of simultaneous Postgres connections.",
+        defaultValue: 50,
+        name: "store-max-num-db-connections" }: int
+
       ## Filter config
 
       filter* {.

--- a/waku/waku_archive/driver/builder.nim
+++ b/waku/waku_archive/driver/builder.nim
@@ -28,12 +28,14 @@ proc new*(T: type ArchiveDriver,
           url: string,
           vacuum: bool,
           migrate: bool,
+          maxNumConn: int,
           onErrAction: OnErrHandler):
           Result[T, string] =
   ## url - string that defines the database
   ## vacuum - if true, a cleanup operation will be applied to the database
   ## migrate - if true, the database schema will be updated
-  ## onErrAction - called if, e.g., the connection with db got lost forever
+  ## maxNumConn - defines the maximum number of connections to handle simultaneously (Postgres)
+  ## onErrAction - called if, e.g., the connection with db got lost
 
   let dbUrlValidationRes = dburl.validateDbUrl(url)
   if dbUrlValidationRes.isErr():
@@ -81,7 +83,9 @@ proc new*(T: type ArchiveDriver,
 
   of "postgres":
     when defined(postgres):
-      let res = PostgresDriver.new(dbUrl = url, onErrAction = onErrAction)
+      let res = PostgresDriver.new(dbUrl = url,
+                                   maxConnections = maxNumConn,
+                                   onErrAction = onErrAction)
       if res.isErr():
         return err("failed to init postgres archive driver: " & res.error)
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -84,7 +84,7 @@ const SelectWithCursorAscStmtDef =
           storedAt <= $6
     ORDER BY storedAt ASC LIMIT $7;"""
 
-const DefaultMaxNumConns = 50 #TODO: we may need to set that from app args (maybe?)
+const DefaultMaxNumConns = 50
 
 proc new*(T: type PostgresDriver,
           dbUrl: string,


### PR DESCRIPTION
# Description
It is more handy to be able to easily change the maximum number of _PostgreSQL_ connections a _nwaku_ node can handle simultaneously.

# Changes

- [x] New `wakunode2` parameter: store-max-num-db-connections

