### PR TITLE
chore: waku_store/common.nim: correct ret code in PEER_DIAL_FAILURE

### DIFF
--- a/waku/waku_store/common.nim
+++ b/waku/waku_store/common.nim
@@ -63,10 +63,10 @@ type
 
   HistoryErrorKind* {.pure.} = enum
     UNKNOWN = uint32(000)
-    PEER_DIAL_FAILURE = uint32(200)
     BAD_RESPONSE = uint32(300)
     BAD_REQUEST = uint32(400)
     SERVICE_UNAVAILABLE = uint32(503)
+    PEER_DIAL_FAILURE = uint32(504)
 
   HistoryError* = object
     case kind*: HistoryErrorKind


### PR DESCRIPTION
## Description
Simple PR to have proper return error codes in Store protocol.
This is inspired by the following comment: https://github.com/waku-org/nwaku/pull/2236#pullrequestreview-1744220535

