### PR TITLE
chore: waku_thread_response.nim: use correct alloc() proc to allocate response correctly

### DIFF
--- a/library/waku_thread/inter_thread_communication/waku_thread_response.nim
+++ b/library/waku_thread/inter_thread_communication/waku_thread_response.nim
@@ -6,6 +6,8 @@
 import
   std/json,
   stew/results
+import
+  ../../alloc
 
 type
   ResponseType {.pure.} = enum
@@ -26,13 +28,11 @@ proc createShared*(T: type InterThreadResponse,
   if res.isOk():
     let value = res.get()
     ret[].respType = ResponseType.OK
-    ret[].content = cast[cstring](allocShared0(value.len + 1))
-    copyMem(ret[].content, unsafeAddr value, value.len + 1)
+    ret[].content = value.alloc()
   else:
     let error = res.error
     ret[].respType = ResponseType.ERR
-    ret[].content = cast[cstring](allocShared0(error.len + 1))
-    copyMem(ret[].content, unsafeAddr error, error.len + 1)
+    ret[].content = res.error.alloc()
   return ret
 
 proc process*(T: type InterThreadResponse,


### PR DESCRIPTION
# Description
Simple PR to properly allocate the string response.
Remember that this response is generated from the _Waku Thread_ and handled by the main thread.

# Changes

- [x] Use of well-defined `alloc()` proc to properly allocate a `cstring` from an `string` into the shared memory space.
