### PR TITLE
chore: peer_manager.nim - add protection to avoid crashes if wakuMetadata is nil

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -438,8 +438,7 @@ proc setupProtocols(node: WakuNode,
         conf.topics
 
     try:
-      await mountRelay(node, pubsubTopics, peerExchangeHandler = peerExchangeHandler,
-                       metadataClusterId = conf.clusterId)
+      await mountRelay(node, pubsubTopics, peerExchangeHandler = peerExchangeHandler)
     except CatchableError:
       return err("failed to mount waku relay protocol: " & getCurrentExceptionMsg())
 
@@ -567,6 +566,12 @@ proc setupProtocols(node: WakuNode,
         node.peerManager.addServicePeer(peerExchangeNode.value, WakuPeerExchangeCodec)
       else:
         return err("failed to set node waku peer-exchange peer: " & peerExchangeNode.error)
+
+  # waku metadata protocol
+  if conf.relay or conf.filter or conf.lightpush:
+    node.mountMetadata(conf.clusterId).isOkOr:
+      error "failed to mount waku metadata protocol", error=error
+      return
 
   return ok()
 

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -410,9 +410,6 @@ proc setupProtocols(node: WakuNode,
   ## Optionally include persistent message storage.
   ## No protocols are started yet.
 
-  node.mountMetadata(conf.clusterId).isOkOr:
-    return err("failed to mount waku metadata protocol: " & error)
-
   # Mount relay on all nodes
   var peerExchangeHandler = none(RoutingRecordsHandler)
   if conf.relayPeerExchange:
@@ -441,7 +438,8 @@ proc setupProtocols(node: WakuNode,
         conf.topics
 
     try:
-      await mountRelay(node, pubsubTopics, peerExchangeHandler = peerExchangeHandler)
+      await mountRelay(node, pubsubTopics, peerExchangeHandler = peerExchangeHandler,
+                       metadataClusterId = conf.clusterId)
     except CatchableError:
       return err("failed to mount waku relay protocol: " & getCurrentExceptionMsg())
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -369,11 +369,7 @@ proc startRelay*(node: WakuNode) {.async.} =
 
 proc mountRelay*(node: WakuNode,
                  pubsubTopics: seq[string] = @[],
-                 peerExchangeHandler = none(RoutingRecordsHandler),
-                 metadataClusterId: uint32 = 1) {.async, gcsafe.} =
-
-  ## metadataClusterId: Param needed by the WakuMetadata protocol.
-  ##                    Defaults to 1 to indicate The Waku Network, aka TWN.
+                 peerExchangeHandler = none(RoutingRecordsHandler)) {.async, gcsafe.} =
 
   if not node.wakuRelay.isNil():
     error "wakuRelay already mounted, skipping"
@@ -404,13 +400,6 @@ proc mountRelay*(node: WakuNode,
   # Subscribe to topics
   for pubsubTopic in pubsubTopics:
     node.subscribe((kind: PubsubSub, topic: pubsubTopic))
-
-  ## Mount the WakuMetadata protocol
-  ## Notice that we mount the WakuMetadata at this point because there couldn't exist
-  ## WakuRelay without WakuMetadata.
-  node.mountMetadata(metadataClusterId).isOkOr:
-    error "failed to mount waku metadata protocol", error=error
-    return
 
 ## Waku filter
 


### PR DESCRIPTION
Simple PR to avoid crashes if `wakuMetadata` is not properly set