### PR TITLE
chore: libwaku - avoid using waku_init. Only use waku_new to create node and context

### DIFF
--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -267,8 +267,6 @@ int main(int argc, char** argv) {
         show_help_and_exit();
     }
 
-    ctx = waku_init(event_handler, userData);
-
     char jsonConfig[2048];
     snprintf(jsonConfig, 2048, "{ \
                                     \"host\": \"%s\",    \
@@ -288,13 +286,14 @@ int main(int argc, char** argv) {
                                     cfgNode.storeRetentionPolicy,
                                     cfgNode.storeMaxNumDbConnections);
 
+    ctx = waku_new(jsonConfig, event_handler, userData);
+
     WAKU_CALL( waku_default_pubsub_topic(&ctx, print_default_pubsub_topic, userData) );
     WAKU_CALL( waku_version(&ctx, print_waku_version, userData) );
 
     printf("Bind addr: %s:%u\n", cfgNode.host, cfgNode.port);
     printf("Waku Relay enabled: %s\n", cfgNode.relay == 1 ? "YES": "NO");
 
-    WAKU_CALL( waku_new(&ctx, jsonConfig, event_handler, userData) );
     waku_set_event_callback(event_handler, userData);
     waku_start(&ctx, event_handler, userData);
 

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -17,13 +17,10 @@ extern "C" {
 
 typedef void (*WakuCallBack) (int callerRet, const char* msg, size_t len);
 
-// Initializes the waku library and returns a pointer to the Context.
-void* waku_init(WakuCallBack callback,
-                void* userData);
-
 // Creates a new instance of the waku node.
 // Sets up the waku node from the given configuration.
-int waku_new(void* ctx,
+// Returns a pointer to the Context needed by the rest of the API functions.
+void* waku_new(
              const char* configJson,
              WakuCallBack callback,
              void* userData);


### PR DESCRIPTION
## Description
This PR aims to simplify the creation of `waku` node and context, in C-bindings libwaku.
This is motivated by the following comment: https://github.com/waku-org/go-waku/pull/929#discussion_r1419857779

# Changes

- [x] libwaku simplification. Only `waku_new` is needed to create the node/context. 
- [x] Adaptation of the simple cwaku_example, according to the previous point.
