### PR TITLE
chore: archive - move error to trace level when insert row fails

### DIFF
--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -111,7 +111,7 @@ proc handleMessage*(w: WakuArchive,
 
     let putRes = await w.driver.put(pubsubTopic, msg, msgDigest, msgHash, msgReceivedTime)
     if putRes.isErr():
-      error "failed to insert message", err=putRes.error
+      trace "failed to insert message", err=putRes.error
       waku_archive_errors.inc(labelValues = [insertFailure])
 
   let insertDuration = getTime().toUnixFloat() - insertStartTime

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -111,7 +111,10 @@ proc handleMessage*(w: WakuArchive,
 
     let putRes = await w.driver.put(pubsubTopic, msg, msgDigest, msgHash, msgReceivedTime)
     if putRes.isErr():
-      trace "failed to insert message", err=putRes.error
+      if "duplicate key value violates unique constraint" in putRes.error:
+        trace "failed to insert message", err=putRes.error
+      else:
+        debug "failed to insert message", err=putRes.error
       waku_archive_errors.inc(labelValues = [insertFailure])
 
   let insertDuration = getTime().toUnixFloat() - insertStartTime


### PR DESCRIPTION
## Description

That is helpful to prevent the node to spam the logs when it shares connection to the same Postgres database with other nodes, in which case the following log appears too much:

topics="waku archive" tid=1 file=archive.nim:113 err="error in runStmt: error in dbConnQueryPrepared calling waitQueryToFinish: error in query: ERROR: duplicate key value violates unique constraint "messageindex" DETAIL: Key
(messagehash)=(88f4ee115eef6f233a7dceaf975f03946e18666adda877e38d61be98add934e8) already exists. "

