### PR TITLE
fix: update num-msgs archive metrics every minute and not only at the beginning

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -751,14 +751,6 @@ proc mountArchive*(node: WakuNode,
     return err("error in mountArchive: " & wakuArchiveRes.error)
 
   node.wakuArchive = wakuArchiveRes.get()
-
-  try:
-    let reportMetricRes = waitFor node.wakuArchive.reportStoredMessagesMetric()
-    if reportMetricRes.isErr():
-      return err("error in mountArchive: " & reportMetricRes.error)
-  except CatchableError:
-    return err("exception in mountArchive: " & getCurrentExceptionMsg())
-
   asyncSpawn node.wakuArchive.start()
   return ok()
 


### PR DESCRIPTION
## Description
This issue was reported/detected by @richard-ramos 
There was a problem that the archive metrics (number of archived messages) were not properly updated regularly.

With this, we update the metrics every minute
