### PR TITLE
chore: including content topics on FilterSubscribeRequest logs

### DIFF
--- a/waku/waku_filter_v2/rpc.nim
+++ b/waku/waku_filter_v2/rpc.nim
@@ -76,7 +76,8 @@ proc `$`*(err: FilterSubscribeResponse): string =
   "FilterSubscribeResponse of req:" & err.requestId & " [" & $err.statusCode & "] " & $err.statusDesc
 
 proc `$`*(req: FilterSubscribeRequest): string =
-  "FilterSubscribeRequest of req:" & req.requestId & " [" & $req.filterSubscribeType & "] " & $req.pubsubTopic
+  "FilterSubscribeRequest of req:" & req.requestId & " [" & $req.filterSubscribeType & 
+    "] pubsubTopic:" & $req.pubsubTopic & " contentTopics:" & $req.contentTopics
 
 proc `$`*(t: FilterSubscribeType): string =
   result = case t:


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Currently, when receiving a Filter subscription request, the content topics subscribed to were not getting logged.
Modified the logging so content topics are included.

# Changes

<!-- List of detailed changes -->

- [x] added content topics to `FilterSubscribeRequest` prints

<img width="947" alt="logging-filterequest" src="https://github.com/waku-org/nwaku/assets/101006718/ac6b76d2-a36c-48c5-b40a-8621a9e3cd43">
<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->