### PR TITLE
fix: postgres_driver.nim: restrict getMessages prepared stmt to query with 1 content topic

### DIFF
--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -388,7 +388,7 @@ method getMessages*(s: PostgresDriver,
                     ascendingOrder = true):
                     Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
 
-  if contentTopicSeq.len > 0 and
+  if contentTopicSeq.len == 1 and
     pubsubTopic.isSome() and
     startTime.isSome() and
     endTime.isSome():


### PR DESCRIPTION
## Description

Before this commit, the following execution of a prepared statement returned nothing even though the database had 2 rows to be returned:

```
nwaku-db-1  | 2023-12-14 12:55:17.575 UTC [73] LOG:  execute SelectWithoutCursorAsc: SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id FROM messages
nwaku-db-1  | 	    WHERE contentTopic IN ($1) AND
nwaku-db-1  | 	          pubsubTopic = $2 AND
nwaku-db-1  | 	          storedAt >= $3 AND
nwaku-db-1  | 	          storedAt <= $4
nwaku-db-1  | 	    ORDER BY storedAt ASC LIMIT $5;
nwaku-db-1  | 2023-12-14 12:55:17.575 UTC [73] DETAIL:  parameters: $1 =
'my/ctopic/1,my/ctopic/2', $2 = '/waku/2/default-waku/proto', $3 =
'1702552968570786800', $4 = '1702552968585347557', $5 = '101'
```

The reason why it is not returning anything is that the 'IN' statement doesn't work when using prepared statements with multiple items. It only works when the 'IN' content, i.e. $1, contains one single item.

## Issue

closes https://github.com/waku-org/nwaku/issues/2288
