### PR TITLE
fix: setting connectivity loop interval to 15 seconds

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -54,7 +54,7 @@ const
   MaxParallelDials = 10
 
   # Delay between consecutive relayConnectivityLoop runs
-  ConnectivityLoopInterval = chronos.minutes(1)
+  ConnectivityLoopInterval = chronos.seconds(15)
 
   # How often the peer store is pruned
   PrunePeerStoreInterval = chronos.minutes(10)


### PR DESCRIPTION
# Description
After changing the connectivity loop interval from 15 seconds to 1 minute, the node is taking long to find peers at startup. Reverting the change and returning to 15 seconds intervals.

# Changes

<!-- List of detailed changes -->

- [x] setting connectivity loop interval to 15 seconds

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #2299 
