### PR TITLE
chore: reverting shard aware connections

### DIFF
--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -282,7 +282,7 @@ procSuite "Peer Manager":
 
     await node3.mountRelay()
 
-    await node3.peerManager.manageRelayPeers()
+    await node3.peerManager.connectToRelayPeers()
 
     await sleepAsync(chronos.milliseconds(500))
 
@@ -432,7 +432,7 @@ procSuite "Peer Manager":
     nodes[0].peerManager.addPeer(peerInfos[3])
 
     # Connect to relay peers
-    await nodes[0].peerManager.manageRelayPeers()
+    await nodes[0].peerManager.connectToRelayPeers()
 
     check:
       # Peerstore track all three peers


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Reverting sharded peer management to allow shard-agnostic connections. This feature has been the root cause of different bugs and misunderstanding, so postponing it for the next release when it will have more maturity and better adoption.

# Changes

<!-- List of detailed changes -->

- [x] replaced `manageRelayPeers()` for its previous version `connectToRelayPeers()`
- [x] changed connection loop interval from 1 minute to 15 seconds 

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->