### PR TITLE
feat: postgres vacuum enabled with test case

### DIFF
--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -17,7 +17,6 @@ import
   ./waku_archive/test_driver_queue,
   ./waku_archive/test_driver_sqlite_query,
   ./waku_archive/test_driver_sqlite,
-  ./waku_archive/test_retention_policy,
   ./waku_archive/test_waku_archive
 
 const os* {.strdefine.} = ""
@@ -27,6 +26,7 @@ when os == "Linux" and
   defined(postgres):
   import
     ./waku_archive/test_driver_postgres_query,
+    ./waku_archive/test_retention_policy,
     ./waku_archive/test_driver_postgres
 
 # Waku store test suite

--- a/tests/waku_archive/test_retention_policy.nim
+++ b/tests/waku_archive/test_retention_policy.nim
@@ -11,7 +11,7 @@ import
   ../../../waku/waku_core,
   ../../../waku/waku_core/message/digest,
   ../../../waku/waku_archive,
-    ../../../waku/waku_archive/driver/postgres_driver,
+  ../../../waku/waku_archive/driver/postgres_driver,
   ../../../waku/waku_archive/retention_policy,
   ../../../waku/waku_archive/retention_policy/retention_policy_capacity,
   ../../../waku/waku_archive/retention_policy/retention_policy_size,
@@ -57,9 +57,8 @@ suite "Waku Archive - Retention policy":
     ## Then
     let numMessages = (waitFor driver.getMessagesCount()).tryGet()
     check:
-      # Expected number of messages is 120 because
-      # (capacity = 100) + (half of the overflow window = 15) + (5 messages added after after the last delete)
-      # the window size changes when changing `const maxStoreOverflow = 1.3 in sqlite_store
+      # Expected number of messages is 115 because
+      # (capacity = 100) + (half of the overflow window = 15)
       numMessages == 115
 
     ## Cleanup
@@ -68,52 +67,51 @@ suite "Waku Archive - Retention policy":
   test "size retention policy - windowed message deletion":
     ## Given
     let driver = newTestPostgresDriver()
-    let dbEngine = driver.getDbType()
 
     # make sure that the db is empty to before test begins
     let storedMsg = (waitFor driver.getAllMessages()).tryGet()
-    # if there are messages in db, empty them
+    # if there are messages in db, delete them before the test begins
     if storedMsg.len > 0:
       let now = getNanosecondTime(getTime().toUnixFloat())
       require (waitFor driver.deleteMessagesOlderThanTimestamp(ts=now)).isOk()  
       require (waitFor driver.performVacuum()).isOk()
 
-    # in bytes
-    let sizeLimit:int64 = 10422851
-    let excess = 800
+    # get the minimum/empty size of the database
+    let sizeLimit = int64((waitFor driver.getDatabaseSize()).tryGet())
+    let num_messages = 100
+    let retryLimit = 4
 
     let retentionPolicy: RetentionPolicy = SizeRetentionPolicy.init(size=sizeLimit)
     var putFutures = newSeq[Future[ArchiveDriverResult[void]]]()
 
     ## When
-    ##
-
-    # create a number of messages so that the size of the DB overshoots
-    for i in 1..excess:
-        let msg = fakeWakuMessage(payload= @[byte (i*10)], contentTopic=DefaultContentTopic, ts=Timestamp(i))
-        putFutures.add(driver.put(DefaultPubsubTopic, msg, computeDigest(msg), computeMessageHash(DefaultPubsubTopic, msg), msg.timestamp))
+    # create a number of messages to increase DB size
+    for i in 1..num_messages:
+      let msg = fakeWakuMessage(payload= @[byte i], contentTopic=DefaultContentTopic, ts=Timestamp(i))
+      putFutures.add(driver.put(DefaultPubsubTopic, msg, computeDigest(msg), computeMessageHash(DefaultPubsubTopic, msg), msg.timestamp))
 
     # waitFor is used to synchronously wait for the futures to complete.
     discard waitFor allFinished(putFutures)
+    sleep(150)
 
     ## Then
     # calculate the current database size
-    var sizeDB = int64((waitFor driver.getDatabaseSize()).tryGet())
+    let sizeBeforeRetPolicy = int64((waitFor driver.getDatabaseSize()).tryGet())
+    var sizeAfterRetPolicy:int64 = sizeBeforeRetPolicy
+    var retryCounter = 0
 
-    if (sizeDB < sizeLimit):
-      # we put a warning/debug that the size of the DB is less than the limit already
-      echo ("WARNING: DB size is less than the limit. This test may not work as expected")
+    while (sizeAfterRetPolicy >= sizeBeforeRetPolicy)  and (retryCounter < retryLimit):
+      # execute the retention policy
+      require (waitFor retentionPolicy.execute(driver)).isOk()
 
-    require (waitFor retentionPolicy.execute(driver)).isOk()
-
-    # get the updated DB size post vacuum
-    sizeDB = int64((waitFor driver.getDatabaseSize()).tryGet())
+      # get the updated DB size post vacuum
+      sizeAfterRetPolicy = int64((waitFor driver.getDatabaseSize()).tryGet())
+      retryCounter += 1
+      sleep(150)
 
     check:
-      # size of the database is used to check if the storage limit has been preserved
-      # check the current database size with the limitSize provided by the user
-      # it should be lower
-      sizeDB <= sizeLimit
+      # check if the size of the database has been reduced after executing the retention policy
+      sizeAfterRetPolicy < sizeBeforeRetPolicy
 
     ## Cleanup
     (waitFor driver.close()).expect("driver to close")

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -43,6 +43,9 @@ method getMessages*(driver: ArchiveDriver,
                     ascendingOrder = true):
                     Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async.} = discard
 
+method getDbType*(driver: ArchiveDriver): string {.base, raises: [ValueError].} =
+    raise newException(ValueError, "Database type method not implemented in subclass")
+
 method getMessagesCount*(driver: ArchiveDriver):
                          Future[ArchiveDriverResult[int64]] {.base, async.} = discard
 

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -85,7 +85,7 @@ proc new*(T: type QueueDriver, capacity: int = QueueDriverDefaultMaxCapacity): T
   return QueueDriver(items: items, capacity: capacity)
 
 method getDbType*(driver: QueueDriver): string =
-    return "sqlite"
+    return "queue"
 
 proc contains*(driver: QueueDriver, index: Index): bool =
   ## Return `true` if the store queue already contains the `index`, `false` otherwise.

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -84,6 +84,9 @@ proc new*(T: type QueueDriver, capacity: int = QueueDriverDefaultMaxCapacity): T
   var items = SortedSet[Index, IndexedWakuMessage].init()
   return QueueDriver(items: items, capacity: capacity)
 
+method getDbType*(driver: QueueDriver): string =
+    return "sqlite"
+
 proc contains*(driver: QueueDriver, index: Index): bool =
   ## Return `true` if the store queue already contains the `index`, `false` otherwise.
   driver.items.eq(index).isOk()

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -47,6 +47,9 @@ type SqliteDriver* = ref object of ArchiveDriver
     db: SqliteDatabase
     insertStmt: SqliteStmt[InsertMessageParams, void]
 
+method getDbType*(s: SqliteDriver): string =
+    return "sqlite"
+
 proc new*(T: type SqliteDriver, db: SqliteDatabase): ArchiveDriverResult[T] =
 
   # Database initialization

--- a/waku/waku_archive/retention_policy/retention_policy_capacity.nim
+++ b/waku/waku_archive/retention_policy/retention_policy_capacity.nim
@@ -71,4 +71,12 @@ method execute*(p: CapacityRetentionPolicy,
   (await driver.deleteOldestMessagesNotWithinLimit(limit=p.capacity + p.deleteWindow)).isOkOr:
     return err("deleting oldest messages failed: " & error)
 
+  # perform vacuum
+  let resVaccum = await driver.performVacuum()
+  if resVaccum.isErr():
+    return err("vacuumming failed: " & resVaccum.error)
+
+    # sleep to give it some time to complete vacuuming
+  await sleepAsync(350)
+  
   return ok()

--- a/waku/waku_archive/retention_policy/retention_policy_time.nim
+++ b/waku/waku_archive/retention_policy/retention_policy_time.nim
@@ -49,4 +49,12 @@ method execute*(p: TimeRetentionPolicy,
   if res.isErr():
     return err("failed to delete oldest messages: " & res.error)
 
+   # perform vacuum
+  let resVaccum = await driver.performVacuum()
+  if resVaccum.isErr():
+    return err("vacuumming failed: " & resVaccum.error)
+
+    # sleep to give it some time to complete vacuuming
+  await sleepAsync(350)
+  
   return ok()


### PR DESCRIPTION
# Description
With this change, Waku Store protocol now supports retention policy on PostgreSQL. Outdated messages are deleted and DB enters a non-blocking VACUUM state. Effectively it reduces the size of the DB on disk while allowing parallel read/write operation on database.

# Changes

Apart from vacuum functionality in PostgreSQL database, I have extended the ArchiveDriver so that using the driver one can know which type of Database driver it is currently using i.e. Sqlite or Postgres or in-memory (Queue driver) etc. It was required to disable SQLite-based vacuuming smoothly.

Retention policy test cases have also been updated to support Postgres instead of SQLite. We make this choice since SQLite Vacuum process blocks the read/write operations, so it is decided to do Vacuum manually on Waku nodes/client running SQLite as store archive.

Changed the Size based retention policy test case such that it fulfills the purpose that after performing the vacuum, DB size is reduced.

- [x] Postgres Vacuum function created
- [x] SQLite focused retention policy test cases replaced by Postgres
- [x] Vacuum function added after each type of retention policy 
- [x] ArchiveDriver extended to support database type feature

<!--
## How to test

1.
1.
1.

-->


## Issue
closes #1885 
