### PR TITLE
feat: adding filter data admin endpoint (REST)

### DIFF
--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -136,44 +136,6 @@ suite "Waku v2 Rest API - Admin":
       ($getRes.data).contains(expectedFilterData2)
       ($getRes.data).contains(expectedFilterData3)
 
-  asyncTest "Get filter data":
-    await allFutures(node1.mountFilter(), node2.mountFilterClient(), node3.mountFilterClient())
-
-    let
-      contentFiltersNode2 = @[DefaultContentTopic, ContentTopic("2"), ContentTopic("3")]
-      contentFiltersNode3 = @[ContentTopic("3"), ContentTopic("4")]
-      pubsubTopicNode2 = DefaultPubsubTopic
-      pubsubTopicNode3 = PubsubTopic("/waku/2/custom-waku/proto")
-
-      expectedFilterData2 = fmt"(peerId: ""{$peerInfo2}"", filterCriteria:" &
-        fmt" @[(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[0]}""), " &
-        fmt"(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[1]}""), " &
-        fmt"(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[2]}"")]"
-
-      expectedFilterData3 = fmt"(peerId: ""{$peerInfo3}"", filterCriteria:" &
-        fmt" @[(pubsubTopic: ""{pubsubTopicNode3}"", contentTopic: ""{contentFiltersNode3[0]}""), " &
-        fmt"(pubsubTopic: ""{pubsubTopicNode3}"", contentTopic: ""{contentFiltersNode3[1]}"")]"
-
-    let
-      subscribeResponse2 = await node2.wakuFilterClient.subscribe(
-        peerInfo1, pubsubTopicNode2, contentFiltersNode2
-      )
-      subscribeResponse3 = await node3.wakuFilterClient.subscribe(
-        peerInfo1, pubsubTopicNode3, contentFiltersNode3
-      )
-
-    assert subscribeResponse2.isOk(), $subscribeResponse2.error
-    assert subscribeResponse3.isOk(), $subscribeResponse3.error
-
-    let getRes = await client.getFilterSubscriptions()
-
-    check:
-      getRes.status == 200
-      $getRes.contentType == $MIMETYPE_JSON
-      getRes.data.len() == 2
-      ($getRes.data).contains(expectedFilterData2)
-      ($getRes.data).contains(expectedFilterData3)
-
   asyncTest "Get filter data - no filter subscribers":
     await node1.mountFilter()
 
@@ -185,9 +147,8 @@ suite "Waku v2 Rest API - Admin":
       getRes.data.len() == 0
 
   asyncTest "Get filter data - filter not mounted":
-    let getRes = await client.getFilterSubscriptions()
-    
+    let getRes = await client.getFilterSubscriptionsFilterNotMounted()
+
     check:
-      getRes.status == 200
-      $getRes.contentType == $MIMETYPE_JSON
-      getRes.data.len() == 0
+      getRes.status == 400
+      getRes.data == "Error: Filter Protocol is not mounted to the node"

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -106,24 +106,24 @@ suite "Waku v2 Rest API - Admin":
       contentFiltersNode3 = @[ContentTopic("3"), ContentTopic("4")]
       pubsubTopicNode2 = DefaultPubsubTopic
       pubsubTopicNode3 = PubsubTopic("/waku/2/custom-waku/proto")
-      
+
       expectedFilterData2 = fmt"(peerId: ""{$peerInfo2}"", filterCriteria:" &
-        fmt" ""@[(\""{pubsubTopicNode2}\"", \""{contentFiltersNode2[0]}\""), " & 
-        fmt"(\""{pubsubTopicNode2}\"", \""{contentFiltersNode2[1]}\""), " &
-        fmt"(\""{pubsubTopicNode2}\"", \""{contentFiltersNode2[2]}\"")]"")"
+        fmt" @[(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[0]}""), " &
+        fmt"(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[1]}""), " &
+        fmt"(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[2]}"")]"
 
       expectedFilterData3 = fmt"(peerId: ""{$peerInfo3}"", filterCriteria:" &
-        fmt" ""@[(\""{pubsubTopicNode3}\"", \""{contentFiltersNode3[0]}\""), " & 
-        fmt"(\""{pubsubTopicNode3}\"", \""{contentFiltersNode3[1]}\"")]"")"
-    
-    let 
-        subscribeResponse2 = await node2.wakuFilterClient.subscribe(
-          peerInfo1, pubsubTopicNode2, contentFiltersNode2
-        )
-        subscribeResponse3 = await node3.wakuFilterClient.subscribe(
-          peerInfo1, pubsubTopicNode3, contentFiltersNode3
-        )
-    
+        fmt" @[(pubsubTopic: ""{pubsubTopicNode3}"", contentTopic: ""{contentFiltersNode3[0]}""), " &
+        fmt"(pubsubTopic: ""{pubsubTopicNode3}"", contentTopic: ""{contentFiltersNode3[1]}"")]"
+
+    let
+      subscribeResponse2 = await node2.wakuFilterClient.subscribe(
+        peerInfo1, pubsubTopicNode2, contentFiltersNode2
+      )
+      subscribeResponse3 = await node3.wakuFilterClient.subscribe(
+        peerInfo1, pubsubTopicNode3, contentFiltersNode3
+      )
+
     assert subscribeResponse2.isOk(), $subscribeResponse2.error
     assert subscribeResponse3.isOk(), $subscribeResponse3.error
 

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/sequtils,
+  std/[sequtils,strformat],
   stew/shims/net,
   testutils/unittests,
   presto, presto/client as presto_client,
@@ -10,6 +10,7 @@ import
 import
   ../../waku/waku_core,
   ../../waku/waku_node,
+  ../../waku/waku_filter_v2/client,
   ../../waku/node/peer_manager,
   ../../waku/waku_api/rest/server,
   ../../waku/waku_api/rest/client,
@@ -26,6 +27,7 @@ suite "Waku v2 Rest API - Admin":
   var node1 {.threadvar.}: WakuNode
   var node2 {.threadvar.}: WakuNode
   var node3 {.threadvar.}: WakuNode
+  var peerInfo1 {.threadvar.}: RemotePeerInfo
   var peerInfo2 {.threadvar.}: RemotePeerInfo
   var peerInfo3 {.threadvar.}: RemotePeerInfo
   var restServer {.threadvar.}: RestServerRef
@@ -33,6 +35,7 @@ suite "Waku v2 Rest API - Admin":
 
   asyncSetup:
     node1 = newTestWakuNode(generateSecp256k1Key(), parseIpAddress("127.0.0.1"), Port(60600))
+    peerInfo1 = node1.switch.peerInfo
     node2 = newTestWakuNode(generateSecp256k1Key(), parseIpAddress("127.0.0.1"), Port(60602))
     peerInfo2 = node2.switch.peerInfo
     node3 = newTestWakuNode(generateSecp256k1Key(), parseIpAddress("127.0.0.1"), Port(60604))
@@ -94,3 +97,41 @@ suite "Waku v2 Rest API - Admin":
       getRes.status == 200
       $getRes.contentType == $MIMETYPE_JSON
       getRes.data.len() == 0
+
+  asyncTest "Get filter data":
+    await allFutures(node1.mountFilter(), node2.mountFilterClient(), node3.mountFilterClient())
+
+    let
+      contentFiltersNode2 = @[DefaultContentTopic, ContentTopic("2"), ContentTopic("3")]
+      contentFiltersNode3 = @[ContentTopic("3"), ContentTopic("4")]
+      pubsubTopicNode2 = DefaultPubsubTopic
+      pubsubTopicNode3 = PubsubTopic("/waku/2/custom-waku/proto")
+      
+      expectedFilterData2 = fmt"(peerId: ""{$peerInfo2}"", filterCriteria:" &
+        fmt" ""@[(\""{pubsubTopicNode2}\"", \""{contentFiltersNode2[0]}\""), " & 
+        fmt"(\""{pubsubTopicNode2}\"", \""{contentFiltersNode2[1]}\""), " &
+        fmt"(\""{pubsubTopicNode2}\"", \""{contentFiltersNode2[2]}\"")]"")"
+
+      expectedFilterData3 = fmt"(peerId: ""{$peerInfo3}"", filterCriteria:" &
+        fmt" ""@[(\""{pubsubTopicNode3}\"", \""{contentFiltersNode3[0]}\""), " & 
+        fmt"(\""{pubsubTopicNode3}\"", \""{contentFiltersNode3[1]}\"")]"")"
+    
+    let 
+        subscribeResponse2 = await node2.wakuFilterClient.subscribe(
+          peerInfo1, pubsubTopicNode2, contentFiltersNode2
+        )
+        subscribeResponse3 = await node3.wakuFilterClient.subscribe(
+          peerInfo1, pubsubTopicNode3, contentFiltersNode3
+        )
+    
+    assert subscribeResponse2.isOk(), $subscribeResponse2.error
+    assert subscribeResponse3.isOk(), $subscribeResponse3.error
+
+    let getRes = await client.getFilterData()
+
+    check:
+      getRes.status == 200
+      $getRes.contentType == $MIMETYPE_JSON
+      getRes.data.len() == 2
+      ($getRes.data).contains(expectedFilterData2)
+      ($getRes.data).contains(expectedFilterData3)

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -127,7 +127,7 @@ suite "Waku v2 Rest API - Admin":
     assert subscribeResponse2.isOk(), $subscribeResponse2.error
     assert subscribeResponse3.isOk(), $subscribeResponse3.error
 
-    let getRes = await client.getFilterData()
+    let getRes = await client.getFilterSubscriptions()
 
     check:
       getRes.status == 200
@@ -165,7 +165,7 @@ suite "Waku v2 Rest API - Admin":
     assert subscribeResponse2.isOk(), $subscribeResponse2.error
     assert subscribeResponse3.isOk(), $subscribeResponse3.error
 
-    let getRes = await client.getFilterData()
+    let getRes = await client.getFilterSubscriptions()
 
     check:
       getRes.status == 200
@@ -177,7 +177,7 @@ suite "Waku v2 Rest API - Admin":
   asyncTest "Get filter data - no filter subscribers":
     await node1.mountFilter()
 
-    let getRes = await client.getFilterData()
+    let getRes = await client.getFilterSubscriptions()
 
     check:
       getRes.status == 200
@@ -185,7 +185,7 @@ suite "Waku v2 Rest API - Admin":
       getRes.data.len() == 0
 
   asyncTest "Get filter data - filter not mounted":
-    let getRes = await client.getFilterData()
+    let getRes = await client.getFilterSubscriptions()
     
     check:
       getRes.status == 200

--- a/waku/waku_api/rest/admin/client.nim
+++ b/waku/waku_api/rest/admin/client.nim
@@ -33,3 +33,7 @@ proc getPeers*():
 proc postPeers*(body: seq[string]):
       RestResponse[string]
       {.rest, endpoint: "/admin/v1/peers", meth: HttpMethod.MethodPost.}
+
+proc getFilterData*():
+    RestResponse[seq[tuple[peerId: string, filterCriteria: string]]]
+    {.rest, endpoint: "/admin/v1/filter", meth: HttpMethod.MethodGet.}

--- a/waku/waku_api/rest/admin/client.nim
+++ b/waku/waku_api/rest/admin/client.nim
@@ -34,6 +34,6 @@ proc postPeers*(body: seq[string]):
       RestResponse[string]
       {.rest, endpoint: "/admin/v1/peers", meth: HttpMethod.MethodPost.}
 
-proc getFilterData*():
+proc getFilterSubscriptions*():
     RestResponse[seq[FilterSubscription]]
-    {.rest, endpoint: "/admin/v1/filter", meth: HttpMethod.MethodGet.}
+    {.rest, endpoint: "/admin/v1/filter/subscriptions", meth: HttpMethod.MethodGet.}

--- a/waku/waku_api/rest/admin/client.nim
+++ b/waku/waku_api/rest/admin/client.nim
@@ -37,3 +37,7 @@ proc postPeers*(body: seq[string]):
 proc getFilterSubscriptions*():
     RestResponse[seq[FilterSubscription]]
     {.rest, endpoint: "/admin/v1/filter/subscriptions", meth: HttpMethod.MethodGet.}
+
+proc getFilterSubscriptionsFilterNotMounted*():
+    RestResponse[string]
+    {.rest, endpoint: "/admin/v1/filter/subscriptions", meth: HttpMethod.MethodGet.}

--- a/waku/waku_api/rest/admin/client.nim
+++ b/waku/waku_api/rest/admin/client.nim
@@ -35,5 +35,5 @@ proc postPeers*(body: seq[string]):
       {.rest, endpoint: "/admin/v1/peers", meth: HttpMethod.MethodPost.}
 
 proc getFilterData*():
-    RestResponse[seq[tuple[peerId: string, filterCriteria: string]]]
+    RestResponse[seq[FilterSubscription]]
     {.rest, endpoint: "/admin/v1/filter", meth: HttpMethod.MethodGet.}

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -114,12 +114,18 @@ proc installAdminV1PostPeersHandler(router: var RestRouter, node: WakuNode) =
 proc installAdminV1GetFilterHandler(router: var RestRouter, node: WakuNode) =
   router.api(MethodGet, ROUTE_ADMIN_V1_FILTER) do () -> RestApiResponse:
     
-    var subscriptions: seq[tuple[peerId: string, filterCriteria: string]] = @[]
+    var subscriptions: seq[FilterSubscription] = @[]
 
     if not node.wakuFilter.isNil():
 
+      var filterCriteria: seq[FilterTopic]
+
       for (peerId, criteria) in node.wakuFilter.subscriptions.pairs():
-        subscriptions.add(($peerId, $criteria.toSeq()))
+      
+        filterCriteria = criteria.toSeq().mapIt(FilterTopic(pubsubTopic: it[0],
+          contentTopic: it[1]))
+
+        subscriptions.add(FilterSubscription(peerId: $peerId, filterCriteria: filterCriteria))
 
     let resp = RestApiResponse.jsonResponse(subscriptions, status=Http200)
     if resp.isErr():

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -121,8 +121,6 @@ proc installAdminV1GetFilterHandler(router: var RestRouter, node: WakuNode) =
       for (peerId, criteria) in node.wakuFilter.subscriptions.pairs():
         subscriptions.add(($peerId, $criteria))
 
-      echo subscriptions
-
     let resp = RestApiResponse.jsonResponse(subscriptions, status=Http200)
     if resp.isErr():
       error "An error ocurred while building the json respose: ", error=resp.error

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -113,7 +113,10 @@ proc installAdminV1PostPeersHandler(router: var RestRouter, node: WakuNode) =
 
 proc installAdminV1GetFilterSubsHandler(router: var RestRouter, node: WakuNode) =
   router.api(MethodGet, ROUTE_ADMIN_V1_FILTER_SUBS) do () -> RestApiResponse:
-    
+
+    if node.wakuFilter.isNil():
+      return RestApiResponse.badRequest("Error: Filter Protocol is not mounted to the node")
+
     var subscriptions: seq[FilterSubscription] = @[]
 
     if not node.wakuFilter.isNil():
@@ -121,7 +124,6 @@ proc installAdminV1GetFilterSubsHandler(router: var RestRouter, node: WakuNode) 
       var filterCriteria: seq[FilterTopic]
 
       for (peerId, criteria) in node.wakuFilter.subscriptions.pairs():
-      
         filterCriteria = criteria.toSeq().mapIt(FilterTopic(pubsubTopic: it[0],
           contentTopic: it[1]))
 

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -119,7 +119,7 @@ proc installAdminV1GetFilterHandler(router: var RestRouter, node: WakuNode) =
     if not node.wakuFilter.isNil():
 
       for (peerId, criteria) in node.wakuFilter.subscriptions.pairs():
-        subscriptions.add(($peerId, $criteria))
+        subscriptions.add(($peerId, $criteria.toSeq()))
 
     let resp = RestApiResponse.jsonResponse(subscriptions, status=Http200)
     if resp.isErr():

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -117,17 +117,15 @@ proc installAdminV1GetFilterSubsHandler(router: var RestRouter, node: WakuNode) 
     if node.wakuFilter.isNil():
       return RestApiResponse.badRequest("Error: Filter Protocol is not mounted to the node")
 
-    var subscriptions: seq[FilterSubscription] = @[]
+    var
+      subscriptions: seq[FilterSubscription] = @[]
+      filterCriteria: seq[FilterTopic]
 
-    if not node.wakuFilter.isNil():
+    for (peerId, criteria) in node.wakuFilter.subscriptions.pairs():
+      filterCriteria = criteria.toSeq().mapIt(FilterTopic(pubsubTopic: it[0],
+        contentTopic: it[1]))
 
-      var filterCriteria: seq[FilterTopic]
-
-      for (peerId, criteria) in node.wakuFilter.subscriptions.pairs():
-        filterCriteria = criteria.toSeq().mapIt(FilterTopic(pubsubTopic: it[0],
-          contentTopic: it[1]))
-
-        subscriptions.add(FilterSubscription(peerId: $peerId, filterCriteria: filterCriteria))
+      subscriptions.add(FilterSubscription(peerId: $peerId, filterCriteria: filterCriteria))
 
     let resp = RestApiResponse.jsonResponse(subscriptions, status=Http200)
     if resp.isErr():

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -31,7 +31,7 @@ logScope:
   topics = "waku node rest admin api"
 
 const ROUTE_ADMIN_V1_PEERS* = "/admin/v1/peers"
-const ROUTE_ADMIN_V1_FILTER* = "/admin/v1/filter"
+const ROUTE_ADMIN_V1_FILTER_SUBS* = "/admin/v1/filter/subscriptions"
 
 type PeerProtocolTuple = tuple[multiaddr: string, protocol: string, connected: bool]
 
@@ -111,8 +111,8 @@ proc installAdminV1PostPeersHandler(router: var RestRouter, node: WakuNode) =
 
     return RestApiResponse.ok()
 
-proc installAdminV1GetFilterHandler(router: var RestRouter, node: WakuNode) =
-  router.api(MethodGet, ROUTE_ADMIN_V1_FILTER) do () -> RestApiResponse:
+proc installAdminV1GetFilterSubsHandler(router: var RestRouter, node: WakuNode) =
+  router.api(MethodGet, ROUTE_ADMIN_V1_FILTER_SUBS) do () -> RestApiResponse:
     
     var subscriptions: seq[FilterSubscription] = @[]
 
@@ -137,4 +137,4 @@ proc installAdminV1GetFilterHandler(router: var RestRouter, node: WakuNode) =
 proc installAdminApiHandlers*(router: var RestRouter, node: WakuNode) =
   installAdminV1GetPeersHandler(router, node)
   installAdminV1PostPeersHandler(router, node)
-  installAdminV1GetFilterHandler(router, node)
+  installAdminV1GetFilterSubsHandler(router, node)

--- a/waku/waku_api/rest/admin/openapi.yaml
+++ b/waku/waku_api/rest/admin/openapi.yaml
@@ -65,6 +65,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FilterSubscription'
+        '400':
+          description: Filter Protocol is not mounted to the node
         '5XX':
           description: Unexpected error.
 

--- a/waku/waku_api/rest/admin/openapi.yaml
+++ b/waku/waku_api/rest/admin/openapi.yaml
@@ -49,6 +49,24 @@ paths:
           description: Cannot connect to one or more peers.
         '5XX':
           description: Unexpected error.
+  /admin/v1/filter:
+    get:
+      summary: Get filter protocol info
+      description: Retrieve information about the serving filter subscriptions
+      operationId: getFilterInfo
+      tags:
+        - admin
+      responses:
+        '200':
+          description: Information about subscribed filter peers and topics
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FilterSubscription'
+        '5XX':
+          description: Unexpected error.
 
 components:
   schemas:
@@ -72,3 +90,24 @@ components:
                 type: string
               connected:
                 type: boolean
+
+    FilterSubscription:
+      type: object
+      required:
+        - peerId
+        - filterCriteria
+      properties:
+        peerId:
+          type: string
+        filterCriteria:
+          type: array
+          items:
+            type: object
+            required:
+              - pubsubTopic
+              - contentTopic
+            properties:
+              pubsubTopic:
+                type: string
+              contentTopic:
+                type: string

--- a/waku/waku_api/rest/admin/openapi.yaml
+++ b/waku/waku_api/rest/admin/openapi.yaml
@@ -49,9 +49,9 @@ paths:
           description: Cannot connect to one or more peers.
         '5XX':
           description: Unexpected error.
-  /admin/v1/filter:
+  /admin/v1/filter/subscriptions:
     get:
-      summary: Get filter protocol info
+      summary: Get filter protocol subscribers
       description: Retrieve information about the serving filter subscriptions
       operationId: getFilterInfo
       tags:

--- a/waku/waku_api/rest/admin/types.nim
+++ b/waku/waku_api/rest/admin/types.nim
@@ -51,6 +51,20 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: WakuPeer)
   writer.writeField("protocols", value.protocols)
   writer.endRecord()
 
+proc writeValue*(writer: var JsonWriter[RestJson], value: FilterTopic)
+  {.raises: [IOError].} =
+  writer.beginRecord()
+  writer.writeField("pubsubTopic", value.pubsubTopic)
+  writer.writeField("contentTopic", value.contentTopic)
+  writer.endRecord()
+
+proc writeValue*(writer: var JsonWriter[RestJson], value: FilterSubscription)
+  {.raises: [IOError].} =
+  writer.beginRecord()
+  writer.writeField("peerId", value.peerId)
+  writer.writeField("filterCriteria", value.filterCriteria)
+  writer.endRecord()
+
 proc readValue*(reader: var JsonReader[RestJson], value: var ProtocolState)
   {.gcsafe, raises: [SerializationError, IOError].} =
   var
@@ -109,6 +123,66 @@ proc readValue*(reader: var JsonReader[RestJson], value: var WakuPeer)
   value = WakuPeer(
       multiaddr: multiaddr.get(),
       protocols: protocols.get()
+    )
+
+proc readValue*(reader: var JsonReader[RestJson], value: var FilterTopic)
+  {.gcsafe, raises: [SerializationError, IOError].} =
+  var
+    pubsubTopic: Option[string]
+    contentTopic: Option[string]
+
+  for fieldName in readObjectFields(reader):
+    case fieldName
+    of "pubsubTopic":
+      if pubsubTopic.isSome():
+        reader.raiseUnexpectedField("Multiple `pubsubTopic` fields found", "FilterTopic")
+      pubsubTopic = some(reader.readValue(string))
+    of "contentTopic":
+      if contentTopic.isSome():
+        reader.raiseUnexpectedField("Multiple `contentTopic` fields found", "FilterTopic")
+      contentTopic = some(reader.readValue(string))
+    else:
+      unrecognizedFieldWarning()
+
+  if pubsubTopic.isNone():
+    reader.raiseUnexpectedValue("Field `pubsubTopic` is missing")
+
+  if contentTopic.isNone():
+    reader.raiseUnexpectedValue("Field `contentTopic` are missing")
+
+  value = FilterTopic(
+      pubsubTopic: pubsubTopic.get(),
+      contentTopic: contentTopic.get()
+    )
+
+proc readValue*(reader: var JsonReader[RestJson], value: var FilterSubscription)
+  {.gcsafe, raises: [SerializationError, IOError].} =
+  var
+    peerId: Option[string]
+    filterCriteria: Option[seq[FilterTopic]]
+
+  for fieldName in readObjectFields(reader):
+    case fieldName
+    of "peerId":
+      if peerId.isSome():
+        reader.raiseUnexpectedField("Multiple `peerId` fields found", "FilterSubscription")
+      peerId = some(reader.readValue(string))
+    of "filterCriteria":
+      if filterCriteria.isSome():
+        reader.raiseUnexpectedField("Multiple `filterCriteria` fields found", "FilterSubscription")
+      filterCriteria = some(reader.readValue(seq[FilterTopic]))
+    else:
+      unrecognizedFieldWarning()
+
+  if peerId.isNone():
+    reader.raiseUnexpectedValue("Field `peerId` is missing")
+
+  if filterCriteria.isNone():
+    reader.raiseUnexpectedValue("Field `filterCriteria` are missing")
+
+  value = FilterSubscription(
+      peerId: peerId.get(),
+      filterCriteria: filterCriteria.get()
     )
 
 ## Utility for populating WakuPeers and ProtocolState

--- a/waku/waku_api/rest/admin/types.nim
+++ b/waku/waku_api/rest/admin/types.nim
@@ -25,6 +25,16 @@ type
 
 type WakuPeers* = seq[WakuPeer]
 
+type
+  FilterTopic* = object
+    pubsubTopic*: string
+    contentTopic*: string 
+
+type
+  FilterSubscription* = object
+    peerId*: string
+    filterCriteria*: seq[FilterTopic]
+
 #### Serialization and deserialization
 
 proc writeValue*(writer: var JsonWriter[RestJson], value: ProtocolState)


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Adding admin REST endpoint to retrieve the serving node's subscriber filter clients and their subscribed pubsub and content topics.

Endpoint: GET /admin/v1/filter/subscriptions
# Changes

<!-- List of detailed changes -->

- [x] mounted endpoint to retrieve filter subscriber data
- [x] added unit test verifying its proper functioning
- [x] updated `openapi.yaml` documentation 

![image](https://github.com/waku-org/nwaku/assets/101006718/6c007678-0c4a-4547-962b-e288756c0a5f)




## Issue

closes #2290 
