### PR TITLE
chore: ip colocation is parameterizable. If set to 0, it is disabled

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -303,6 +303,7 @@ proc initNode(conf: WakuNodeConf,
       sendSignedPeerRecord = conf.relayPeerExchange, # We send our own signed peer record when peer exchange enabled
       agentString = some(conf.agentString)
   )
+  builder.withColocationLimit(conf.colocationLimit)
   builder.withPeerManagerConfig(maxRelayPeers = conf.maxRelayPeers)
 
   node = ? builder.build().mapErr(proc (err: string): string = "failed to create waku node instance: " & err)

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -17,7 +17,8 @@ import
   ../../waku/common/confutils/envvar/defs as confEnvvarDefs,
   ../../waku/common/confutils/envvar/std/net as confEnvvarNet,
   ../../waku/common/logging,
-  ../../waku/waku_enr
+  ../../waku/waku_enr,
+  ../../waku/node/peer_manager
 
 export
   confTomlDefs,
@@ -142,6 +143,11 @@ type
         desc: "Maximum allowed number of libp2p connections."
         defaultValue: 50
         name: "max-connections" }: uint16
+
+      colocationLimit* {.
+        desc: "Max num allowed peers from the same IP. Set it to 0 to remove the limitation."
+        defaultValue: defaultColocationLimit()
+        name: "ip-colocation-limit" }: int
 
       maxRelayPeers* {.
         desc: "Maximum allowed number of relay peers."
@@ -523,6 +529,9 @@ proc defaultListenAddress*(): IpAddress =
   # TODO: How should we select between IPv4 and IPv6
   # Maybe there should be a config option for this.
   (static parseIpAddress("0.0.0.0"))
+
+proc defaultColocationLimit*(): int =
+  return DefaultColocationLimit
 
 proc parseCmdArg*(T: type Port, p: string): T =
   try:

--- a/waku/node/builder.nim
+++ b/waku/node/builder.nim
@@ -35,6 +35,7 @@ type
 
     # Peer manager config
     maxRelayPeers: Option[int]
+    colocationLimit: int
 
     # Libp2p switch
     switchMaxConnections: Option[int]
@@ -107,7 +108,9 @@ proc withPeerManagerConfig*(builder: var WakuNodeBuilder,
                             maxRelayPeers = none(int)) =
   builder.maxRelayPeers = maxRelayPeers
 
-
+proc withColocationLimit*(builder: var WakuNodeBuilder,
+                          colocationLimit: int) =
+  builder.colocationLimit = colocationLimit
 
 ## Waku switch
 
@@ -170,6 +173,7 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
     switch = switch,
     storage = builder.peerStorage.get(nil),
     maxRelayPeers = builder.maxRelayPeers,
+    colocationLimit = builder.colocationLimit,
   )
 
   var node: WakuNode


### PR DESCRIPTION

## Description
The "ip colocation" concept refers to the maximum allowed peers from the same IP address. We allow disable this limit when the node works behing a reverse proxy.

## How to test

1. Run one node with `ip-colocation-limit` set to 0.
2. The node set in 1. can accept multiple connections from nodes run locally (127.0.0.1)

---

1. Run one node with `ip-colocation-limit` set to 2.
2. The node set in 1. only accepts two peers from 127.0.0.1.

:information_source:  in both cases remember to set `rest-admin = true` so that you can check the peers with `curl -X GET 127.0.0.1:8645/admin/v1/peers`.

## Issue

closes https://github.com/waku-org/nwaku/issues/2306
