### PR TITLE
fix(examples): Set `record` to the Waku Node Builder as it is required.

### DIFF
--- a/examples/publisher.nim
+++ b/examples/publisher.nim
@@ -43,8 +43,18 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
         ip = parseIpAddress("0.0.0.0")
         flags = CapabilitiesBitfield.init(lightpush = false, filter = false, store = false, relay = true)
 
+    var enrBuilder = EnrBuilder.init(nodeKey)
+
+    let recordRes = enrBuilder.build()
+    let record =
+      if recordRes.isErr():
+        error "failed to create enr record", error=recordRes.error
+        quit(QuitFailure)
+      else: recordRes.get()
+
     var builder = WakuNodeBuilder.init()
     builder.withNodeKey(nodeKey)
+    builder.withRecord(record)
     builder.withNetworkConfigurationDetails(ip, Port(wakuPort)).tryGet()
     let node = builder.build().tryGet()
 
@@ -62,7 +72,7 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
 
     # assumes behind a firewall, so not care about being discoverable
     let wakuDiscv5 = WakuDiscoveryV5.new(
-      node.rng, 
+      node.rng,
       discv5Conf,
       some(node.enr),
       some(node.peerManager),

--- a/examples/subscriber.nim
+++ b/examples/subscriber.nim
@@ -38,8 +38,18 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
         ip = parseIpAddress("0.0.0.0")
         flags = CapabilitiesBitfield.init(lightpush = false, filter = false, store = false, relay = true)
 
+    var enrBuilder = EnrBuilder.init(nodeKey)
+
+    let recordRes = enrBuilder.build()
+    let record =
+      if recordRes.isErr():
+        error "failed to create enr record", error=recordRes.error
+        quit(QuitFailure)
+      else: recordRes.get()
+
     var builder = WakuNodeBuilder.init()
     builder.withNodeKey(nodeKey)
+    builder.withRecord(record)
     builder.withNetworkConfigurationDetails(ip, Port(wakuPort)).tryGet()
     let node = builder.build().tryGet()
 
@@ -57,7 +67,7 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
 
     # assumes behind a firewall, so not care about being discoverable
     let wakuDiscv5 = WakuDiscoveryV5.new(
-      node.rng, 
+      node.rng,
       discv5Conf,
       some(node.enr),
       some(node.peerManager),


### PR DESCRIPTION
# Description
I followed the instructions in the [examples](https://github.com/waku-org/nwaku/tree/master/examples) readme. After running `make example2`, everything appeared to be in order. However, when executing `./build/subscriber`, I encountered the following message:
```
NTC 2024-01-02 16:50:37.824+02:00 starting subscriber                        tid=132009 file=subscriber.nim:35 wakuPort=50000 discv5Port=8000
/some/nice/path/nwaku/examples/subscriber.nim(102) subscriber
/some/nice/path/nwaku/vendor/nim-chronos/chronos/internal/asyncfutures.nim(660) cb
Error: unhandled exception: Asynchronous task [setupAndSubscribe() at subscriber.nim:34] finished with an exception "LPError"!
Message: node record is required
Stack trace: /some/nice/path/nwaku/examples/subscriber.nim(102) subscriber
/some/nice/path/nwaku/examples/subscriber.nim(34) setupAndSubscribe
/some/nice/path/nwaku/vendor/nim-chronos/chronos/internal/asyncfutures.nim(378) futureContinue
/some/nice/path/nwaku/examples/subscriber.nim(44) setupAndSubscribe
/some/nice/path/nwaku/vendor/nim-results/results.nim(840) tryValue
 [FutureDefect]
 ```
The error indicated that a "node record is required," so I addressed this by setting it to the Waku Node Builder object. After rebuilding and restarting both the `subscriber` and `publisher`, everything seems to be working correctly.

# Changes
- [x] Create `enr record` and set it to Waku Node Builder object in the examples

## How to test

1. Follow the [examples](https://github.com/waku-org/nwaku/tree/master/examples) readme.

## Issue

closes #2327
