### PR TITLE
fix: build failure on testwaku

### DIFF
--- a/tests/testlib/sequtils.nim
+++ b/tests/testlib/sequtils.nim
@@ -1,5 +1,2 @@
 proc toString*(bytes: seq[byte]): string =
   cast[string](bytes)
-
-proc toBytes*(str: string): seq[byte] =
-  cast[seq[byte]](str)


### PR DESCRIPTION
# Description
test(peer-connection-managenent): Functional Tests (#2321) @ e9d083b2 introduced build error through ambigous function call, testwaku build failed on master.

It turned out, some commits ago a new - duplicated toBytes proc was introduced that makes build fail for testwaku.
Removed it and checked that all tests on master no runs fine.

# Changes

<!-- List of detailed changes -->

- [X ] tests/testlib/sequtils.nim removed unnecessary toBytes
