### PR TITLE
chore: improve POST /relay/v1/auto/messages/{topic} error handling

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -212,7 +212,7 @@ proc publish(c: Chat, line: string) =
       # Attempt lightpush
       asyncSpawn c.node.lightpushPublish(some(DefaultPubsubTopic), message)
     else:
-      (await c.node.publish(some(DefaultPubsubTopic), message)).isOkOr:
+      (waitFor c.node.publish(some(DefaultPubsubTopic), message)).isOkOr:
         error "failed to publish message", error = error
 
 # TODO This should read or be subscribe handler subscribe

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -212,7 +212,8 @@ proc publish(c: Chat, line: string) =
       # Attempt lightpush
       asyncSpawn c.node.lightpushPublish(some(DefaultPubsubTopic), message)
     else:
-      asyncSpawn c.node.publish(some(DefaultPubsubTopic), message)
+      (await c.node.publish(some(DefaultPubsubTopic), message)).isOkOr:
+        error "failed to publish message", error = error
 
 # TODO This should read or be subscribe handler subscribe
 proc readAndPrint(c: Chat) {.async.} =

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -212,8 +212,11 @@ proc publish(c: Chat, line: string) =
       # Attempt lightpush
       asyncSpawn c.node.lightpushPublish(some(DefaultPubsubTopic), message)
     else:
-      (waitFor c.node.publish(some(DefaultPubsubTopic), message)).isOkOr:
-        error "failed to publish message", error = error
+      try:
+        (waitFor c.node.publish(some(DefaultPubsubTopic), message)).isOkOr:
+          error "failed to publish message", error = error
+      except CatchableError:
+        error "caught error publishing message: ", error = getCurrentExceptionMsg()      
 
 # TODO This should read or be subscribe handler subscribe
 proc readAndPrint(c: Chat) {.async.} =

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -208,14 +208,15 @@ proc publish(c: Chat, line: string) =
       # update the last epoch
       c.node.wakuRlnRelay.lastEpoch = proof.epoch
 
-    if not c.node.wakuLightPush.isNil():
-      # Attempt lightpush
-      asyncSpawn c.node.lightpushPublish(some(DefaultPubsubTopic), message)
-    else:
-      try:
+    try:
+      if not c.node.wakuLightPush.isNil():
+        # Attempt lightpush
+        (waitFor c.node.lightpushPublish(some(DefaultPubsubTopic), message)).isOkOr:
+          error "failed to publish lightpush message", error = error
+      else:
         (waitFor c.node.publish(some(DefaultPubsubTopic), message)).isOkOr:
           error "failed to publish message", error = error
-      except CatchableError:
+    except CatchableError:
         error "caught error publishing message: ", error = getCurrentExceptionMsg()      
 
 # TODO This should read or be subscribe handler subscribe

--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -96,7 +96,8 @@ proc toChat2(cmb: Chat2MatterBridge, jsonNode: JsonNode) {.async.} =
 
   chat2_mb_transfers.inc(labelValues = ["mb_to_chat2"])
 
-  await cmb.nodev2.publish(some(DefaultPubsubTopic), msg)
+  (await cmb.nodev2.publish(some(DefaultPubsubTopic), msg)).isOkOr:
+    error "failed to publish message", error = error
 
 proc toMatterbridge(cmb: Chat2MatterBridge, msg: WakuMessage) {.gcsafe, raises: [Exception].} =
   if cmb.seen.containsOrAdd(msg.payload.hash()):

--- a/examples/publisher.nim
+++ b/examples/publisher.nim
@@ -110,7 +110,10 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
                                 contentTopic: contentTopic,     # content topic to publish to
                                 ephemeral: true,                # tell store nodes to not store it
                                 timestamp: now())               # current timestamp
-      await node.publish(some(pubSubTopic), message)
+      
+      (await node.publish(some(pubSubTopic), message)).isOkOr:
+        error "failed to publish message", error = error
+      
       notice "published message", text = text, timestamp = message.timestamp, psTopic = pubSubTopic, contentTopic = contentTopic
       await sleepAsync(5000)
 

--- a/examples/publisher.nim
+++ b/examples/publisher.nim
@@ -116,7 +116,7 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
       if res.isOk:
         notice "published message", text = text, timestamp = message.timestamp, psTopic = pubSubTopic, contentTopic = contentTopic
       else:
-        error "failed to publish message", error = error
+        error "failed to publish message", error = res.error
       
       await sleepAsync(5000)
 

--- a/examples/publisher.nim
+++ b/examples/publisher.nim
@@ -111,10 +111,13 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
                                 ephemeral: true,                # tell store nodes to not store it
                                 timestamp: now())               # current timestamp
       
-      (await node.publish(some(pubSubTopic), message)).isOkOr:
+      let res = await node.publish(some(pubSubTopic), message)
+      
+      if res.isOk:
+        notice "published message", text = text, timestamp = message.timestamp, psTopic = pubSubTopic, contentTopic = contentTopic
+      else:
         error "failed to publish message", error = error
       
-      notice "published message", text = text, timestamp = message.timestamp, psTopic = pubSubTopic, contentTopic = contentTopic
       await sleepAsync(5000)
 
 when isMainModule:

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -70,7 +70,9 @@ suite "WakuNode":
     node2.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
     await sleepAsync(2000.millis)
 
-    await node1.publish(some(pubSubTopic), message)
+    var res = await node1.publish(some(pubSubTopic), message)
+    assert res.isOk(), $res.error
+
     await sleepAsync(2000.millis)
 
     check:

--- a/tests/test_wakunode_lightpush.nim
+++ b/tests/test_wakunode_lightpush.nim
@@ -55,7 +55,8 @@ suite "WakuNode - Lightpush":
     await sleepAsync(100.millis)
 
     ## When
-    await lightNode.lightpushPublish(some(DefaultPubsubTopic), message)
+    let res = await lightNode.lightpushPublish(some(DefaultPubsubTopic), message)
+    assert res.isOk(), $res.error
 
     ## Then
     check await completionFutRelay.withTimeout(5.seconds)

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -95,7 +95,8 @@ suite "WakuNode - Relay":
     node3.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
     await sleepAsync(500.millis)
 
-    await node1.publish(some(pubSubTopic), message)
+    var res = await node1.publish(some(pubSubTopic), message)
+    assert res.isOk(), $res.error
 
     ## Then
     check:
@@ -176,11 +177,15 @@ suite "WakuNode - Relay":
     node3.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
     await sleepAsync(500.millis)
 
-    await node1.publish(some(pubSubTopic), message1)
+    var res = await node1.publish(some(pubSubTopic), message1)
+    assert res.isOk(), $res.error
+    
     await sleepAsync(500.millis)
 
     # message2 never gets relayed because of the validator
-    await node1.publish(some(pubSubTopic), message2)
+    res = await node1.publish(some(pubSubTopic), message2)
+    assert res.isOk(), $res.error
+    
     await sleepAsync(500.millis)
 
     check:
@@ -257,7 +262,9 @@ suite "WakuNode - Relay":
     node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
     await sleepAsync(500.millis)
 
-    await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some(pubSubTopic), message)
+    assert res.isOk(), $res.error
+    
     await sleepAsync(500.millis)
 
 
@@ -298,7 +305,9 @@ suite "WakuNode - Relay":
     node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
     await sleepAsync(500.millis)
 
-    await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some(pubSubTopic), message)
+    assert res.isOk(), $res.error
+
     await sleepAsync(500.millis)
 
 
@@ -343,7 +352,9 @@ suite "WakuNode - Relay":
     node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
     await sleepAsync(500.millis)
 
-    await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some(pubSubTopic), message)
+    assert res.isOk(), $res.error
+
     await sleepAsync(500.millis)
 
     check:
@@ -383,7 +394,9 @@ suite "WakuNode - Relay":
     node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
     await sleepAsync(500.millis)
 
-    await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some(pubSubTopic), message)
+    assert res.isOk(), $res.error
+
     await sleepAsync(500.millis)
 
     check:
@@ -423,7 +436,9 @@ suite "WakuNode - Relay":
     node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
     await sleepAsync(500.millis)
 
-    await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some(pubSubTopic), message)
+    assert res.isOk(), $res.error
+    
     await sleepAsync(500.millis)
 
 

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -91,7 +91,7 @@ procSuite "WakuNode - RLN relay":
     ## node1 publishes a message with a rate limit proof, the message is then relayed to node2 which in turn
     ## verifies the rate limit proof of the message and relays the message to node3
     ## verification at node2 occurs inside a topic validator which is installed as part of the waku-rln-relay mount proc
-    await node1.publish(some(DefaultPubsubTopic), message)
+    discard await node1.publish(some(DefaultPubsubTopic), message)
     await sleepAsync(2000.millis)
 
 
@@ -165,8 +165,8 @@ procSuite "WakuNode - RLN relay":
 
     # publish 3 messages from node[0] (last 2 are spam, window is 10 secs)
     # publish 3 messages from node[1] (last 2 are spam, window is 10 secs)
-    for msg in messages1: await nodes[0].publish(some(pubsubTopics[0]), msg)
-    for msg in messages2: await nodes[1].publish(some(pubsubTopics[1]), msg)
+    for msg in messages1: discard await nodes[0].publish(some(pubsubTopics[0]), msg)
+    for msg in messages2: discard await nodes[1].publish(some(pubsubTopics[1]), msg)
 
     # wait for gossip to propagate
     await sleepAsync(5000.millis)
@@ -266,7 +266,7 @@ procSuite "WakuNode - RLN relay":
     ## attempts to verify the rate limit proof and fails hence does not relay the message to node3, thus the relayHandler of node3
     ## never gets called
     ## verification at node2 occurs inside a topic validator which is installed as part of the waku-rln-relay mount proc
-    await node1.publish(some(DefaultPubsubTopic), message)
+    discard await node1.publish(some(DefaultPubsubTopic), message)
     await sleepAsync(2000.millis)
 
     check:
@@ -378,11 +378,11 @@ procSuite "WakuNode - RLN relay":
     ## node2 should detect either of wm1 or wm2 as spam and not relay it
     ## node2 should relay wm3 to node3
     ## node2 should not relay wm4 because it has no valid rln proof
-    await node1.publish(some(DefaultPubsubTopic), wm1)
-    await node1.publish(some(DefaultPubsubTopic), wm2)
-    await node1.publish(some(DefaultPubsubTopic), wm3)
-    await node1.publish(some(DefaultPubsubTopic), wm4)
-    await sleepAsync(2000.millis)
+    discard await node1.publish(some(DefaultPubsubTopic), wm1)
+    discard await node1.publish(some(DefaultPubsubTopic), wm2)
+    discard await node1.publish(some(DefaultPubsubTopic), wm3)
+    discard await node1.publish(some(DefaultPubsubTopic), wm4)
+    discard await sleepAsync(2000.millis)
 
     let
       res1 = await completionFut1.withTimeout(10.seconds)
@@ -474,9 +474,9 @@ procSuite "WakuNode - RLN relay":
     node2.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic), some(relayHandler))
     await sleepAsync(2000.millis)
 
-    await node1.publish(some(DefaultPubsubTopic), wm1)
-    await node1.publish(some(DefaultPubsubTopic), wm2)
-    await node1.publish(some(DefaultPubsubTopic), wm3)
+    discard await node1.publish(some(DefaultPubsubTopic), wm1)
+    discard await node1.publish(some(DefaultPubsubTopic), wm2)
+    discard await node1.publish(some(DefaultPubsubTopic), wm3)
 
     let
       res1 = await completionFut1.withTimeout(10.seconds)

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -382,7 +382,7 @@ procSuite "WakuNode - RLN relay":
     discard await node1.publish(some(DefaultPubsubTopic), wm2)
     discard await node1.publish(some(DefaultPubsubTopic), wm3)
     discard await node1.publish(some(DefaultPubsubTopic), wm4)
-    discard await sleepAsync(2000.millis)
+    await sleepAsync(2000.millis)
 
     let
       res1 = await completionFut1.withTimeout(10.seconds)

--- a/tests/wakunode2/test_validators.nim
+++ b/tests/wakunode2/test_validators.nim
@@ -74,7 +74,7 @@ suite "WakuNode2 - Validators":
         # Include signature
         msg.meta = secretKey.sign(SkMessage(spamProtectedTopic.msgHash(msg))).toRaw()[0..63]
 
-        await nodes[i].publish(some(spamProtectedTopic), msg)
+        discard await nodes[i].publish(some(spamProtectedTopic), msg)
 
     # Wait for gossip
     await sleepAsync(2.seconds)
@@ -146,7 +146,7 @@ suite "WakuNode2 - Validators":
         # Sign the message with a wrong key
         msg.meta = wrongSecretKey.sign(SkMessage(spamProtectedTopic.msgHash(msg))).toRaw()[0..63]
 
-        await nodes[i].publish(some(spamProtectedTopic), msg)
+        discard await nodes[i].publish(some(spamProtectedTopic), msg)
 
     # Each node sends 5 messages that are not signed (total = 25)
     for i in 0..<5:
@@ -154,7 +154,7 @@ suite "WakuNode2 - Validators":
         let unsignedMessage = WakuMessage(
           payload: urandom(1*(10^3)), contentTopic: spamProtectedTopic,
           version: 2, timestamp: now(), ephemeral: true)
-        await nodes[i].publish(some(spamProtectedTopic), unsignedMessage)
+        discard await nodes[i].publish(some(spamProtectedTopic), unsignedMessage)
 
     # Each node sends 5 messages that dont contain timestamp (total = 25)
     for i in 0..<5:
@@ -162,7 +162,7 @@ suite "WakuNode2 - Validators":
         let unsignedMessage = WakuMessage(
           payload: urandom(1*(10^3)), contentTopic: spamProtectedTopic,
           version: 2, timestamp: 0, ephemeral: true)
-        await nodes[i].publish(some(spamProtectedTopic), unsignedMessage)
+        discard await nodes[i].publish(some(spamProtectedTopic), unsignedMessage)
 
     # Each node sends 5 messages way BEFORE than the current timestmap (total = 25)
     for i in 0..<5:
@@ -171,7 +171,7 @@ suite "WakuNode2 - Validators":
         let unsignedMessage = WakuMessage(
           payload: urandom(1*(10^3)), contentTopic: spamProtectedTopic,
           version: 2, timestamp: beforeTimestamp, ephemeral: true)
-        await nodes[i].publish(some(spamProtectedTopic), unsignedMessage)
+        discard await nodes[i].publish(some(spamProtectedTopic), unsignedMessage)
 
     # Each node sends 5 messages way LATER than the current timestmap (total = 25)
     for i in 0..<5:
@@ -180,7 +180,7 @@ suite "WakuNode2 - Validators":
         let unsignedMessage = WakuMessage(
           payload: urandom(1*(10^3)), contentTopic: spamProtectedTopic,
           version: 2, timestamp: afterTimestamp, ephemeral: true)
-        await nodes[i].publish(some(spamProtectedTopic), unsignedMessage)
+        discard await nodes[i].publish(some(spamProtectedTopic), unsignedMessage)
 
     # Wait for gossip
     await sleepAsync(4.seconds)
@@ -255,7 +255,7 @@ suite "WakuNode2 - Validators":
       let unsignedMessage = WakuMessage(
         payload: urandom(1*(10^3)), contentTopic: spamProtectedTopic,
         version: 2, timestamp: now(), ephemeral: true)
-      await nodes[0].publish(some(spamProtectedTopic), unsignedMessage)
+      discard await nodes[0].publish(some(spamProtectedTopic), unsignedMessage)
 
     # nodes[0] spams 50 wrongly signed messages (nodes[0] just knows of nodes[1])
     for j in 0..<50:
@@ -264,7 +264,7 @@ suite "WakuNode2 - Validators":
         version: 2, timestamp: now(), ephemeral: true)
       # Sign the message with a wrong key
       msg.meta = wrongSecretKey.sign(SkMessage(spamProtectedTopic.msgHash(msg))).toRaw()[0..63]
-      await nodes[0].publish(some(spamProtectedTopic), msg)
+      discard await nodes[0].publish(some(spamProtectedTopic), msg)
 
     # Wait for gossip
     await sleepAsync(2.seconds)

--- a/tests/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -198,7 +198,7 @@ suite "Waku v2 JSON-RPC API - Relay":
 
     ## When
     for msg in messages:
-      await srcNode.publish(some(pubSubTopic), msg)
+      discard await srcNode.publish(some(pubSubTopic), msg)
 
     await sleepAsync(200.millis)
 
@@ -261,7 +261,7 @@ suite "Waku v2 JSON-RPC API - Relay":
 
     ## When
     for msg in messages:
-      await srcNode.publish(none(PubsubTopic), msg)
+      discard await srcNode.publish(none(PubsubTopic), msg)
 
     await sleepAsync(200.millis)
 

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -40,9 +40,11 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58011)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
 
@@ -88,9 +90,11 @@ suite "Waku v2 Rest API - Relay":
       "pubsub-topic-x",
       ])
 
-    let restPort = Port(58012)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
     cache.pubsubSubscribe("pubsub-topic-1")
@@ -140,9 +144,11 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58013)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let pubSubTopic = "/waku/2/default-waku/proto"
     
@@ -203,9 +209,11 @@ suite "Waku v2 Rest API - Relay":
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup
-    let restPort = Port(58014)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
 
@@ -243,9 +251,11 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58011)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
 
@@ -289,9 +299,11 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58012)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let contentTopics = @[
       ContentTopic("/waku/2/default-content1/proto"),
@@ -335,9 +347,11 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58013)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let contentTopic = DefaultContentTopic
 
@@ -397,9 +411,11 @@ suite "Waku v2 Rest API - Relay":
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup
-    let restPort = Port(58014)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
     installRelayApiHandlers(restServer.router, node, cache)
@@ -439,9 +455,11 @@ suite "Waku v2 Rest API - Relay":
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup
-    let restPort = Port(58014)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.server.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
     installRelayApiHandlers(restServer.router, node, cache)

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -337,12 +337,14 @@ proc publish*(
 
   #TODO instead of discard return error when 0 peers received the message
   discard await node.wakuRelay.publish(pubsubTopic, message)
-
+  
   trace "waku.relay published",
     peerId=node.peerId,
     pubsubTopic=pubsubTopic,
     hash=pubsubTopic.computeMessageHash(message).to0xHex(),
     publishTime=getNowInNanosecondTime()
+  
+  return ok()
 
 proc startRelay*(node: WakuNode) {.async.} =
   ## Setup and start relay protocol

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -337,7 +337,7 @@ proc publish*(
 
   #TODO instead of discard return error when 0 peers received the message
   discard await node.wakuRelay.publish(pubsubTopic, message)
-  
+
   trace "waku.relay published",
     peerId=node.peerId,
     pubsubTopic=pubsubTopic,

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -327,14 +327,14 @@ proc publish*(
   
   if node.wakuRelay.isNil():
     let msg = "Invalid API call to `publish`. WakuRelay not mounted. Try `lightpush` instead."
-    error msg
+    error "publish error", msg=msg
     # TODO: Improve error handling
     return err(msg)
 
   let pubsubTopic = pubsubTopicOp.valueOr:
     getShard(message.contentTopic).valueOr:
-      let msg = "Autosharding error: ", error
-      error msg
+      let msg = "Autosharding error: " & error
+      error "publish error", msg=msg
       return err(msg)
 
   #TODO instead of discard return error when 0 peers received the message

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -322,8 +322,6 @@ proc publish*(
   ## Publish a `WakuMessage`. Pubsub topic contains; none, a named or static shard.
   ## `WakuMessage` should contain a `contentTopic` field for light node functionality.
   ## It is also used to determine the shard.
-
-  info "-------- GABRIEL ------------ called publish"
   
   if node.wakuRelay.isNil():
     let msg = "Invalid API call to `publish`. WakuRelay not mounted. Try `lightpush` instead."

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -322,7 +322,7 @@ proc publish*(
   ## Publish a `WakuMessage`. Pubsub topic contains; none, a named or static shard.
   ## `WakuMessage` should contain a `contentTopic` field for light node functionality.
   ## It is also used to determine the shard.
-  
+
   if node.wakuRelay.isNil():
     let msg = "Invalid API call to `publish`. WakuRelay not mounted. Try `lightpush` instead."
     error "publish error", msg=msg

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -193,26 +193,16 @@ proc installRelayApiHandlers*(router: var RestRouter, node: WakuNode, cache: Mes
     
     debug "get_waku_v2_relay_v1_auto_messages", contentTopic=contentTopic
 
-    info "-------------------- 1 ---------------"
-
     let contentTopic = contentTopic.valueOr:
       return RestApiResponse.badRequest($error)
 
-    info "-------------------- 2 ---------------"
-
     let messages = cache.getAutoMessages(contentTopic, clear=true).valueOr:
-      info "-------------------- 3 ---------------"
       debug "Not subscribed to topic", topic=contentTopic
       return RestApiResponse.notFound(contentTopic)
 
-    info "-------------------- 4 ---------------"
-
     let data = RelayGetMessagesResponse(messages.map(toRelayWakuMessage))
 
-    info "-------------------- 5 ---------------"
-
     return RestApiResponse.jsonResponse(data, status=Http200).valueOr:
-      info "-------------------- 6 ---------------"
       debug "An error ocurred while building the json respose", error = error
       return RestApiResponse.internalServerError($error)
 


### PR DESCRIPTION
# Description
When calling the endpoint `POST /relay/v1/auto/messages/{topic}` with an invalid content topic, the API response was 200 OK even though it had failed internally in the node.

Added error handling so a proper status code and message get returned.

![image](https://github.com/waku-org/nwaku/assets/101006718/d4f819b6-6981-4d3d-8075-6f5fe629739a)


# Changes

<!-- List of detailed changes -->

- [x] changed return type of `publish()` from `void` to `Future[Result[void, string]]` for subsequent error checking
- [x] added error handling to `POST /relay/v1/auto/messages/{topic}` endpoint
- [x] included test case
- [x] changed calls to `publish()` in the codebase to comply with the new function signature 

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #2190 
