### PR TITLE
chore: Refactor of FilterV2 subscription management with Time-to-live maintenance

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -468,6 +468,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
     let peerInfo = parsePeerInfo(conf.filternode)
     if peerInfo.isOk():
       await node.mountFilter()
+      await node.mountLegacyFilter()
       await node.mountFilterClient()
       node.peerManager.addServicePeer(peerInfo.value, WakuLegacyFilterCodec)
 
@@ -507,7 +508,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
           echo "A spam message is found and discarded"
         chat.prompt = false
         showChatPrompt(chat)
-    
+
       echo "rln-relay preparation is in progress..."
 
       let rlnConf = WakuRlnConfig(

--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -288,6 +288,7 @@ when isMainModule:
 
   if conf.filter:
     waitFor mountFilter(bridge.nodev2)
+    waitFor mountLegacyFilter(bridge.nodev2)
 
   if conf.staticnodes.len > 0:
     waitFor connectToNodes(bridge.nodev2, conf.staticnodes)

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -319,9 +319,8 @@ type
         defaultValue: 1000
         name: "filter-max-peers-to-serve" }: uint32
 
-
       filterMaxCriteria* {.
-        desc: "Maximum number of criteria per peers at a time. Only for v2 filter protocol.",
+        desc: "Maximum number of pubsub- and content topic combination per peers at a time. Only for v2 filter protocol.",
         defaultValue: 1000
         name: "filter-max-criteria" }: uint32
 

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -95,6 +95,7 @@ type
         defaultValue: false,
         name: "execute" .}: bool
 
+
     of noCommand:
       ##  Application-level configuration
       protectedTopics* {.
@@ -221,7 +222,7 @@ type
         desc: "Rln relay identity commitment key as a Hex string",
         defaultValue: ""
         name: "rln-relay-id-commitment-key" }: string
-      
+
       rlnRelayTreePath* {.
         desc: "Path to the RLN merkle tree sled db (https://github.com/spacejam/sled)",
         defaultValue: ""
@@ -304,9 +305,25 @@ type
         name: "filternode" }: string
 
       filterTimeout* {.
-        desc: "Timeout for filter node in seconds.",
+        desc: "Filter clients will be wiped out if not able to receive push messages within this timeout. In seconds.",
         defaultValue: 14400 # 4 hours
         name: "filter-timeout" }: int64
+
+      filterSubscriptionTimeout* {.
+        desc: "Timeout for filter subscription without ping or refresh it, in seconds. Only for v2 filter protocol.",
+        defaultValue: 300 # 5 minutes
+        name: "filter-subscription-timeout" }: int64
+
+      filterMaxPeersToServe* {.
+        desc: "Maximum number of peers to serve at a time. Only for v2 filter protocol.",
+        defaultValue: 1000
+        name: "filter-max-peers-to-serve" }: uint32
+
+
+      filterMaxCriteria* {.
+        desc: "Maximum number of criteria per peers at a time. Only for v2 filter protocol.",
+        defaultValue: 1000
+        name: "filter-max-criteria" }: uint32
 
       ## Lightpush config
 

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -53,6 +53,7 @@ procSuite "Peer Manager":
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
     await allFutures(nodes.mapIt(it.mountFilter()))
+    await allFutures(nodes.mapIt(it.mountLegacyFilter()))
 
     # Dial node2 from node1
     let conn = await nodes[0].peerManager.dialPeer(nodes[1].peerInfo.toRemotePeerInfo(), WakuLegacyFilterCodec)
@@ -528,6 +529,7 @@ procSuite "Peer Manager":
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
     await allFutures(nodes.mapIt(it.mountFilter()))
+    await allFutures(nodes.mapIt(it.mountLegacyFilter()))
 
     let pInfos = nodes.mapIt(it.switch.peerInfo.toRemotePeerInfo())
 
@@ -579,6 +581,7 @@ procSuite "Peer Manager":
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
     await allFutures(nodes.mapIt(it.mountFilter()))
+    await allFutures(nodes.mapIt(it.mountLegacyFilter()))
 
     let pInfos = nodes.mapIt(it.switch.peerInfo.toRemotePeerInfo())
 

--- a/tests/test_wakunode_filter_legacy.nim
+++ b/tests/test_wakunode_filter_legacy.nim
@@ -29,6 +29,7 @@ suite "WakuNode - Filter":
     waitFor allFutures(server.start(), client.start())
 
     waitFor server.mountFilter()
+    waitFor server.mountLegacyFilter()
     waitFor client.mountFilterClient()
 
     ## Given

--- a/tests/waku_filter_v2/test_waku_client.nim
+++ b/tests/waku_filter_v2/test_waku_client.nim
@@ -170,7 +170,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When sending a message to the subscribed content topic
         let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -232,7 +232,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicsSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicsSeq)
 
         # When sending a message to the one of the subscribed content topics
         let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -316,7 +316,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When subscribing to a different pubsub topic
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -328,7 +328,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq & otherContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq & otherContentTopicSeq)
 
         # When sending a message to one of the subscribed content topics
         let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -372,7 +372,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), otherContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), otherContentTopicSeq)
 
         # When sending a message to the previously subscribed content topic
         pushHandlerFuture = newPushHandlerFuture() # Clear previous future
@@ -430,7 +430,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When subscribing to a different content topic
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -442,7 +442,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq & otherContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq & otherContentTopicSeq)
 
         # When sending a message to one of the subscribed content topics
         let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -480,7 +480,7 @@ suite "Waku Filter - End to End":
         let unsubscribeResponse = await wakuFilterClient.unsubscribeAll(serverRemotePeerInfo)
 
         # Then the unsubscription is successful
-        # assert unsubscribeResponse.isOk(), $unsubscribeResponse.error
+        assert unsubscribeResponse.isOk(), $unsubscribeResponse.error
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 0
 
@@ -513,7 +513,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicsSeq1)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicsSeq1)
 
         # When subscribing to a different pubsub topic
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -525,7 +525,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicsSeq1 & contentTopicsSeq2)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicsSeq1 & contentTopicsSeq2)
 
         # When sending a message to (pubsubTopic, contentTopic)
         let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -588,7 +588,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), @[contentTopic, otherContentTopic2])
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), @[contentTopic, otherContentTopic2])
 
         # When sending a message to (pubsubTopic, contentTopic)
         pushHandlerFuture = newPushHandlerFuture() # Clear previous future
@@ -763,7 +763,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When subscribing to the second service node
         let subscriptionResponse2 = await wakuFilterClient.subscribe(
@@ -775,13 +775,13 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter2.subscriptions.subscribedPeerCount() == 1
           wakuFilter2.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter2.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter2.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # And the first service node is still subscribed
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When sending a message to the subscribed content topic on the first service node
         let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -815,7 +815,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When refreshing the subscription
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -827,7 +827,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When sending a message to the refreshed subscription
         let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -938,7 +938,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When unsubscribing from the subscription
         let unsubscribeResponse = await wakuFilterClient.unsubscribe(
@@ -959,7 +959,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When refreshing the subscription
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -971,7 +971,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), contentTopicSeq)
 
         # When unsubscribing from the subscription
         let unsubscribeResponse = await wakuFilterClient.unsubscribe(
@@ -993,7 +993,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # When unsubscribing from one of the content topics
         let unsubscribeResponse1 = await wakuFilterClient.unsubscribe(
@@ -1005,7 +1005,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
 
         # When unsubscribing from the other content topic
         let unsubscribeResponse = await wakuFilterClient.unsubscribe(
@@ -1027,7 +1027,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # When unsubscribing from all content topics
         let unsubscribeResponse = await wakuFilterClient.unsubscribe(
@@ -1049,7 +1049,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # And a successful complete refresh of the subscription
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -1060,7 +1060,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # When unsubscribing from one of the content topics
         let unsubscribeResponse1 = await wakuFilterClient.unsubscribe(
@@ -1072,7 +1072,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
 
         # When unsubscribing from the other content topic
         let unsubscribeResponse2 = await wakuFilterClient.unsubscribe(
@@ -1094,7 +1094,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # And a successful complete refresh of the subscription
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -1105,7 +1105,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # When unsubscribing from all content topics
         let unsubscribeResponse = await wakuFilterClient.unsubscribe(
@@ -1127,7 +1127,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # Unsubscribing from one content topic
         let unsubscribeResponse1 = await wakuFilterClient.unsubscribe(
@@ -1137,7 +1137,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
 
         # And a successful refresh of the partial subscription
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -1147,7 +1147,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # When unsubscribing from one of the content topics
         let unsubscribeResponse2 = await wakuFilterClient.unsubscribe(
@@ -1159,7 +1159,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
 
         # When unsubscribing from the other content topic
         let unsubscribeResponse3 = await wakuFilterClient.unsubscribe(
@@ -1181,7 +1181,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # Unsubscribing from one content topic
         let unsubscribeResponse1 = await wakuFilterClient.unsubscribe(
@@ -1191,7 +1191,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), @["other-content-topic"])
 
         # And a successful refresh of the partial subscription
         let subscribeResponse2 = await wakuFilterClient.subscribe(
@@ -1201,7 +1201,7 @@ suite "Waku Filter - End to End":
         check:
           wakuFilter.subscriptions.subscribedPeerCount() == 1
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
-          cmpSeqNoOrder(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
+          unorderedCompare(wakuFilter.getSubscribedContentTopics(clientPeerId), multipleContentTopicSeq)
 
         # When unsubscribing from all content topics
         let unsubscribeResponse2 = await wakuFilterClient.unsubscribe(

--- a/tests/waku_filter_v2/test_waku_client.nim
+++ b/tests/waku_filter_v2/test_waku_client.nim
@@ -2180,7 +2180,7 @@ suite "Waku Filter - End to End":
       pushHandlerFuture = newPushHandlerFuture()
       messagePushHandler = proc(
         pubsubTopic: PubsubTopic, message: WakuMessage
-      ): Future[void] {.async, closure, gcsafe.} =
+      ): Future[void] {.async, closure.} =
         msgSeq.add((pubsubTopic, message))
         pushHandlerFuture.complete((pubsubTopic, message))
 
@@ -2237,7 +2237,7 @@ suite "Waku Filter - End to End":
         pushedMsgPubsubTopic1 == pubsubTopic
         pushedMsg1 == msg1
 
-      sleep(2500)
+      await sleepAsync(2500)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       let msg2 = fakeWakuMessage(contentTopic=contentTopic)
@@ -2267,14 +2267,14 @@ suite "Waku Filter - End to End":
         pushedMsgPubsubTopic1 == pubsubTopic
         pushedMsg1 == msg1
 
-      sleep(1000)
+      await sleepAsync(1000)
 
       let pingResponse = await wakuFilterClient.ping(serverRemotePeerInfo)
 
-      check pingResponse.isOk()
+      assert pingResponse.isOk(), $pingResponse.error
 
       # wait more in sum of the timeout
-      sleep(1200)
+      await sleepAsync(1200)
 
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
 
@@ -2309,7 +2309,7 @@ suite "Waku Filter - End to End":
         pushedMsgPubsubTopic1 == pubsubTopic
         pushedMsg1 == msg1
 
-      sleep(1000)
+      await sleepAsync(1000)
 
       let contentTopic2nd = "content-topic-2nd"
       contentTopicSeq = @[contentTopic2nd]
@@ -2320,7 +2320,7 @@ suite "Waku Filter - End to End":
       assert subscribeResponse2nd.isOk(), $subscribeResponse2nd.error
 
       # wait more in sum of the timeout
-      sleep(1200)
+      await sleepAsync(1200)
 
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
       check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
@@ -2357,7 +2357,7 @@ suite "Waku Filter - End to End":
         pushedMsgPubsubTopic1 == pubsubTopic
         pushedMsg1 == msg1
 
-      sleep(1000)
+      await sleepAsync(1000)
 
       contentTopicSeq = @[contentTopic2nd]
       let unsubscribeResponse = await wakuFilterClient.subscribe(
@@ -2367,7 +2367,7 @@ suite "Waku Filter - End to End":
       assert unsubscribeResponse.isOk(), $unsubscribeResponse.error
 
       # wait more in sum of the timeout
-      sleep(1200)
+      await sleepAsync(1200)
 
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
       check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
@@ -2395,7 +2395,7 @@ suite "Waku Filter - End to End":
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
       check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
-      sleep(1000)
+      await sleepAsync(1000)
 
       let
         subscribeResponse2nd = await wakuFilterClient2nd.subscribe(
@@ -2426,7 +2426,7 @@ suite "Waku Filter - End to End":
           pushedMsgPubsubTopic1 == pubsubTopic
           pushedMsg1 == msg1
 
-      sleep(1200)
+      await sleepAsync(1200)
 
       check not wakuFilter.subscriptions.isSubscribed(clientPeerId)
 
@@ -2443,7 +2443,7 @@ suite "Waku Filter - End to End":
         pushedMsgPubsubTopic2 == pubsubTopic
         pushedMsg2 == msg2
 
-      sleep(1000)
+      await sleepAsync(1000)
 
       check not wakuFilter.subscriptions.isSubscribed(clientPeerId2nd)
 
@@ -2487,7 +2487,7 @@ suite "Waku Filter - End to End":
           pushedMsgPubsubTopic1 == pubsubTopic
           pushedMsg1 == msg1
 
-      sleep(2200)
+      await sleepAsync(2200)
 
       wakuFilter.maintainSubscriptions()
 

--- a/tests/waku_filter_v2/test_waku_client.nim
+++ b/tests/waku_filter_v2/test_waku_client.nim
@@ -89,7 +89,6 @@ suite "Waku Filter - End to End":
           )
         assert subscribeResponse.isOk(), $subscribeResponse.error
         check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-        check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
         # When
         let subscribedPingResponse = await wakuFilterClient.ping(serverRemotePeerInfo)
@@ -2225,7 +2224,6 @@ suite "Waku Filter - End to End":
         )
       assert subscribeResponse.isOk(), $subscribeResponse.error
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -2255,7 +2253,6 @@ suite "Waku Filter - End to End":
         )
       assert subscribeResponse.isOk(), $subscribeResponse.error
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -2297,7 +2294,6 @@ suite "Waku Filter - End to End":
         )
       assert subscribeResponse.isOk(), $subscribeResponse.error
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       let msg1 = fakeWakuMessage(contentTopic=contentTopic)
@@ -2323,7 +2319,6 @@ suite "Waku Filter - End to End":
       await sleepAsync(1200)
 
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       let msg2 = fakeWakuMessage(contentTopic=contentTopic2nd)
@@ -2345,7 +2340,6 @@ suite "Waku Filter - End to End":
         )
       assert subscribeResponse.isOk(), $subscribeResponse.error
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       let msg1 = fakeWakuMessage(contentTopic=contentTopic2nd)
@@ -2370,7 +2364,6 @@ suite "Waku Filter - End to End":
       await sleepAsync(1200)
 
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       let msg2 = fakeWakuMessage(contentTopic=contentTopic)
@@ -2393,7 +2386,6 @@ suite "Waku Filter - End to End":
         )
       assert subscribeResponse.isOk(), $subscribeResponse.error
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
       await sleepAsync(1000)
 
@@ -2404,7 +2396,6 @@ suite "Waku Filter - End to End":
 
       assert subscribeResponse2nd.isOk(), $subscribeResponse2nd.error
       check wakuFilter.subscriptions.isSubscribed(clientPeerId2nd)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId2nd)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       pushHandlerFuture2nd = newPushHandlerFuture() # Clear previous future
@@ -2457,7 +2448,6 @@ suite "Waku Filter - End to End":
         )
       assert subscribeResponse.isOk(), $subscribeResponse.error
       check wakuFilter.subscriptions.isSubscribed(clientPeerId)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
 
       let
         subscribeResponse2nd = await wakuFilterClient2nd.subscribe(
@@ -2466,7 +2456,6 @@ suite "Waku Filter - End to End":
 
       assert subscribeResponse2nd.isOk(), $subscribeResponse2nd.error
       check wakuFilter.subscriptions.isSubscribed(clientPeerId2nd)
-      check wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId2nd)
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       pushHandlerFuture2nd = newPushHandlerFuture() # Clear previous future
@@ -2493,8 +2482,6 @@ suite "Waku Filter - End to End":
 
       check not wakuFilter.subscriptions.isSubscribed(clientPeerId)
       check not wakuFilter.subscriptions.isSubscribed(clientPeerId2nd)
-      check not wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId)
-      check not wakuFilter.subscriptions.peersSubscribed.hasKey(clientPeerId2nd)
 
 
 

--- a/tests/waku_filter_v2/test_waku_filter_protocol.nim
+++ b/tests/waku_filter_v2/test_waku_filter_protocol.nim
@@ -13,7 +13,8 @@ import
   ../../../waku/waku_filter_v2/subscriptions,
   ../../../waku/waku_core,
   ../testlib/common,
-  ../testlib/wakucore
+  ../testlib/wakucore,
+  ./waku_filter_utils
 
 proc newTestWakuFilter(switch: Switch): WakuFilter =
   let
@@ -109,7 +110,7 @@ suite "Waku Filter - handling subscribe requests":
     check:
       wakuFilter.subscriptions.subscribedPeerCount() == 1
       wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 2
-      wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest.contentTopics
+      unorderedCompare(wakuFilter.getSubscribedContentTopics(peerId), filterSubscribeRequest.contentTopics)
       response.requestId == filterSubscribeRequest.requestId
       response.statusCode == 200
       response.statusDesc.get() == "OK"
@@ -159,7 +160,7 @@ suite "Waku Filter - handling subscribe requests":
     check:
       wakuFilter.subscriptions.subscribedPeerCount() == 1
       wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 1
-      wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest1.contentTopics
+      unorderedCompare(wakuFilter.getSubscribedContentTopics(peerId), filterSubscribeRequest1.contentTopics)
       response1.requestId == filterSubscribeRequest1.requestId
       response1.statusCode == 200
       response1.statusDesc.get() == "OK"
@@ -171,9 +172,9 @@ suite "Waku Filter - handling subscribe requests":
     check:
       wakuFilter.subscriptions.subscribedPeerCount() == 1
       wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 2
-      wakuFilter.getSubscribedContentTopics(peerId) ==
-        filterSubscribeRequest1.contentTopics &
-        filterSubscribeRequest2.contentTopics
+      unorderedCompare(wakuFilter.getSubscribedContentTopics(peerId),
+                    filterSubscribeRequest1.contentTopics &
+                      filterSubscribeRequest2.contentTopics)
       response2.requestId == filterSubscribeRequest2.requestId
       response2.statusCode == 200
       response2.statusDesc.get() == "OK"
@@ -185,7 +186,7 @@ suite "Waku Filter - handling subscribe requests":
     check:
       wakuFilter.subscriptions.subscribedPeerCount() == 1
       wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 1
-      wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest2.contentTopics
+      unorderedCompare(wakuFilter.getSubscribedContentTopics(peerId), filterSubscribeRequest2.contentTopics)
       response3.requestId == filterUnsubscribeRequest1.requestId
       response3.statusCode == 200
       response3.statusDesc.get() == "OK"

--- a/tests/waku_filter_v2/test_waku_filter_protocol.nim
+++ b/tests/waku_filter_v2/test_waku_filter_protocol.nim
@@ -38,9 +38,11 @@ proc createRequest(filterSubscribeType: FilterSubscribeType, pubsubTopic = none(
   )
 
 proc getSubscribedContentTopics(wakuFilter: WakuFilter, peerId: PeerId): seq[ContentTopic] =
-  var contentTopics: seq[ContentTopic]
-  for filterCriterion in wakuFilter.subscriptions[peerId]:
-    contentTopics.add(filterCriterion[1])
+  var contentTopics: seq[ContentTopic] = @[]
+  let peersCreitera = wakuFilter.subscriptions.getPeerSubscriptions(peerId)
+
+  for filterCriterion in peersCreitera:
+    contentTopics.add(filterCriterion.contentTopic)
 
   return contentTopics
 
@@ -68,8 +70,8 @@ suite "Waku Filter - handling subscribe requests":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 1
-      wakuFilter.subscriptions[peerId].len == 1
+      wakuFilter.subscriptions.subscribedPeerCount() == 1
+      wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 1
       response.requestId == filterSubscribeRequest.requestId
       response.statusCode == 200
       response.statusDesc.get() == "OK"
@@ -79,7 +81,7 @@ suite "Waku Filter - handling subscribe requests":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 0 # peerId is removed from subscriptions
+      wakuFilter.subscriptions.subscribedPeerCount() == 0 # peerId is removed from subscriptions
       response2.requestId == filterUnsubscribeRequest.requestId
       response2.statusCode == 200
       response2.statusDesc.get() == "OK"
@@ -105,8 +107,8 @@ suite "Waku Filter - handling subscribe requests":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 1
-      wakuFilter.subscriptions[peerId].len == 2
+      wakuFilter.subscriptions.subscribedPeerCount() == 1
+      wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 2
       wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest.contentTopics
       response.requestId == filterSubscribeRequest.requestId
       response.statusCode == 200
@@ -117,7 +119,7 @@ suite "Waku Filter - handling subscribe requests":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 0 # peerId is removed from subscriptions
+      wakuFilter.subscriptions.subscribedPeerCount() == 0 # peerId is removed from subscriptions
       response2.requestId == filterUnsubscribeAllRequest.requestId
       response2.statusCode == 200
       response2.statusDesc.get() == "OK"
@@ -155,8 +157,8 @@ suite "Waku Filter - handling subscribe requests":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 1
-      wakuFilter.subscriptions[peerId].len == 1
+      wakuFilter.subscriptions.subscribedPeerCount() == 1
+      wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 1
       wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest1.contentTopics
       response1.requestId == filterSubscribeRequest1.requestId
       response1.statusCode == 200
@@ -167,8 +169,8 @@ suite "Waku Filter - handling subscribe requests":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 1
-      wakuFilter.subscriptions[peerId].len == 2
+      wakuFilter.subscriptions.subscribedPeerCount() == 1
+      wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 2
       wakuFilter.getSubscribedContentTopics(peerId) ==
         filterSubscribeRequest1.contentTopics &
         filterSubscribeRequest2.contentTopics
@@ -181,8 +183,8 @@ suite "Waku Filter - handling subscribe requests":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 1
-      wakuFilter.subscriptions[peerId].len == 1
+      wakuFilter.subscriptions.subscribedPeerCount() == 1
+      wakuFilter.subscriptions.peersSubscribed[peerId].criteriaCount == 1
       wakuFilter.getSubscribedContentTopics(peerId) == filterSubscribeRequest2.contentTopics
       response3.requestId == filterUnsubscribeRequest1.requestId
       response3.statusCode == 200
@@ -193,7 +195,7 @@ suite "Waku Filter - handling subscribe requests":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 0 # peerId is removed from subscriptions
+      wakuFilter.subscriptions.subscribedPeerCount() == 0 # peerId is removed from subscriptions
       response4.requestId == filterUnsubscribeRequest2.requestId
       response4.statusCode == 200
       response4.statusDesc.get() == "OK"
@@ -255,9 +257,9 @@ suite "Waku Filter - handling subscribe requests":
 
     # When
     let
-      filterCriteria = toSeq(1 .. MaxCriteriaPerSubscription + 1).mapIt((DefaultPubsubTopic, ContentTopic("/waku/2/content-$#/proto" % [$it])))
+      filterCriteria = toSeq(1 .. MaxFilterCriteriaPerPeer).mapIt((DefaultPubsubTopic, ContentTopic("/waku/2/content-$#/proto" % [$it])))
 
-    wakuFilter.subscriptions[peerId] = filterCriteria.toHashSet()
+    discard wakuFilter.subscriptions.addSubscription(peerId, filterCriteria.toHashSet())
 
     let
       reqTooManyFilterCriteria = createRequest(
@@ -276,9 +278,11 @@ suite "Waku Filter - handling subscribe requests":
     ## Max subscriptions exceeded
 
     # When
-    wakuFilter.subscriptions.clear()
-    for _ in 1 .. MaxTotalSubscriptions:
-      wakuFilter.subscriptions[PeerId.random().get()] = @[(DefaultPubsubTopic, DefaultContentTopic)].toHashSet()
+    wakuFilter.subscriptions.removePeer(peerId)
+    wakuFilter.subscriptions.cleanUp()
+
+    for _ in 1 .. MaxFilterPeers:
+      discard wakuFilter.subscriptions.addSubscription(PeerId.random().get(), @[(DefaultPubsubTopic, DefaultContentTopic)].toHashSet())
 
     let
       reqTooManySubscriptions = createRequest(
@@ -443,10 +447,10 @@ suite "Waku Filter - subscription maintenance":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 3
-      wakuFilter.subscriptions.hasKey(peerId1)
-      wakuFilter.subscriptions.hasKey(peerId2)
-      wakuFilter.subscriptions.hasKey(peerId3)
+      wakuFilter.subscriptions.subscribedPeerCount() == 3
+      wakuFilter.subscriptions.isSubscribed(peerId1)
+      wakuFilter.subscriptions.isSubscribed(peerId2)
+      wakuFilter.subscriptions.isSubscribed(peerId3)
 
     # When
     # Maintenance loop should leave all peers in peer store intact
@@ -454,10 +458,10 @@ suite "Waku Filter - subscription maintenance":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 3
-      wakuFilter.subscriptions.hasKey(peerId1)
-      wakuFilter.subscriptions.hasKey(peerId2)
-      wakuFilter.subscriptions.hasKey(peerId3)
+      wakuFilter.subscriptions.subscribedPeerCount() == 3
+      wakuFilter.subscriptions.isSubscribed(peerId1)
+      wakuFilter.subscriptions.isSubscribed(peerId2)
+      wakuFilter.subscriptions.isSubscribed(peerId3)
 
     # When
     # Remove peerId1 and peerId3 from peer store
@@ -467,8 +471,8 @@ suite "Waku Filter - subscription maintenance":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 1
-      wakuFilter.subscriptions.hasKey(peerId2)
+      wakuFilter.subscriptions.subscribedPeerCount() == 1
+      wakuFilter.subscriptions.isSubscribed(peerId2)
 
     # When
     # Remove peerId2 from peer store
@@ -477,4 +481,4 @@ suite "Waku Filter - subscription maintenance":
 
     # Then
     check:
-      wakuFilter.subscriptions.len == 0
+      wakuFilter.subscriptions.subscribedPeerCount() == 0

--- a/tests/waku_filter_v2/waku_filter_utils.nim
+++ b/tests/waku_filter_v2/waku_filter_utils.nim
@@ -24,10 +24,14 @@ import
   ]
 
 
-proc newTestWakuFilter*(switch: Switch): Future[WakuFilter] {.async.} =
+proc newTestWakuFilter*(switch: Switch,
+                        subscriptionTimeout: Duration = DefaultSubscriptionTimeToLiveSec,
+                        maxFilterPeers: uint32 = MaxFilterPeers,
+                        maxFilterCriteriaPerPeer: uint32 = MaxFilterCriteriaPerPeer):
+                    Future[WakuFilter] {.async.} =
   let
     peerManager = PeerManager.new(switch)
-    proto = WakuFilter.new(peerManager)
+    proto = WakuFilter.new(peerManager, subscriptionTimeout, maxFilterPeers, maxFilterCriteriaPerPeer)
 
   await proto.start()
   switch.mount(proto)

--- a/tests/waku_filter_v2/waku_filter_utils.nim
+++ b/tests/waku_filter_v2/waku_filter_utils.nim
@@ -2,7 +2,9 @@ import
   std/[
     options,
     tables,
-    sets
+    sets,
+    sequtils,
+    algorithm
   ],
   chronos,
   chronicles,
@@ -51,12 +53,13 @@ proc getSubscribedContentTopics*(wakuFilter: WakuFilter, peerId: PeerId): seq[Co
 
   return contentTopics
 
-proc cmpSeqNoOrder*[T](seq1, seq2: seq[T]): bool {.noSideEffect.} =
-  if seq1.len() != seq2.len():
-    return false
+proc unorderedCompare*[T](a, b: seq[T]): bool =
+  if a == b:
+    return true
 
-  for item in seq1:
-    if item notin seq2:
-      return false
+  var aSorted = a
+  var bSorted = b
+  aSorted.sort()
+  bSorted.sort()
 
-  return true
+  return aSorted == bSorted

--- a/tests/waku_filter_v2/waku_filter_utils.nim
+++ b/tests/waku_filter_v2/waku_filter_utils.nim
@@ -50,9 +50,9 @@ proc newTestWakuFilterClient*(switch: Switch): Future[WakuFilterClient] {.async.
 
 proc getSubscribedContentTopics*(wakuFilter: WakuFilter, peerId: PeerId): seq[ContentTopic] =
   var contentTopics: seq[ContentTopic] = @[]
-  let peersCreitera = wakuFilter.subscriptions.getPeerSubscriptions(peerId)
+  let peersCriteria = wakuFilter.subscriptions.getPeerSubscriptions(peerId)
 
-  for filterCriterion in peersCreitera:
+  for filterCriterion in peersCriteria:
     contentTopics.add(filterCriterion.contentTopic)
 
   return contentTopics

--- a/tests/waku_store/test_wakunode_store.nim
+++ b/tests/waku_store/test_wakunode_store.nim
@@ -205,7 +205,7 @@ procSuite "WakuNode - Store":
 
     waitFor allFutures(client.start(), server.start(), filterSource.start())
 
-    waitFor filterSource.mountFilter()
+    waitFor filterSource.mountLegacyFilter()
     let driver = newSqliteArchiveDriver()
 
     let mountArchiveRes = server.mountArchive(driver)

--- a/tests/waku_store/test_wakunode_store.nim
+++ b/tests/waku_store/test_wakunode_store.nim
@@ -205,6 +205,7 @@ procSuite "WakuNode - Store":
 
     waitFor allFutures(client.start(), server.start(), filterSource.start())
 
+    waitFor filterSource.mountFilter()
     waitFor filterSource.mountLegacyFilter()
     let driver = newSqliteArchiveDriver()
 

--- a/tests/wakunode_jsonrpc/test_jsonrpc_admin.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_admin.nim
@@ -154,6 +154,7 @@ procSuite "Waku v2 JSON-RPC API - Admin":
     await client.connect("127.0.0.1", rpcPort, false)
 
     await node.mountFilter()
+    await node.mountLegacyFilter()
     await node.mountFilterClient()
     let driver: ArchiveDriver = QueueDriver.new()
     let mountArchiveRes = node.mountArchive(driver)

--- a/tests/wakunode_jsonrpc/test_jsonrpc_filter.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_filter.nim
@@ -31,6 +31,7 @@ procSuite "Waku v2 JSON-RPC API - Filter":
 
     await allFutures(node1.start(), node2.start())
 
+    await node1.mountFilter()
     await node1.mountLegacyFilter()
     await node2.mountFilterClient()
 

--- a/tests/wakunode_jsonrpc/test_jsonrpc_filter.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_filter.nim
@@ -31,7 +31,7 @@ procSuite "Waku v2 JSON-RPC API - Filter":
 
     await allFutures(node1.start(), node2.start())
 
-    await node1.mountFilter()
+    await node1.mountLegacyFilter()
     await node2.mountFilterClient()
 
     node2.peerManager.addServicePeer(node1.peerInfo.toRemotePeerInfo(), WakuLegacyFilterCodec)

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -107,10 +107,11 @@ suite "Waku v2 Rest API - Admin":
       pubsubTopicNode2 = DefaultPubsubTopic
       pubsubTopicNode3 = PubsubTopic("/waku/2/custom-waku/proto")
 
+      ## TODO: Note that such checks may depend heavily on the order of the returned data!
       expectedFilterData2 = fmt"(peerId: ""{$peerInfo2}"", filterCriteria:" &
-        fmt" @[(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[0]}""), " &
-        fmt"(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[1]}""), " &
-        fmt"(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[2]}"")]"
+        fmt" @[(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[1]}""), " &
+        fmt"(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[2]}""), " &
+        fmt"(pubsubTopic: ""{pubsubTopicNode2}"", contentTopic: ""{contentFiltersNode2[0]}"")]"
 
       expectedFilterData3 = fmt"(peerId: ""{$peerInfo3}"", filterCriteria:" &
         fmt" @[(pubsubTopic: ""{pubsubTopicNode3}"", contentTopic: ""{contentFiltersNode3[0]}""), " &
@@ -128,6 +129,10 @@ suite "Waku v2 Rest API - Admin":
     assert subscribeResponse3.isOk(), $subscribeResponse3.error
 
     let getRes = await client.getFilterSubscriptions()
+
+    echo "getRes.data: ",$getRes.data
+    echo "expectedFilterData2: ",$expectedFilterData2
+    echo "expectedFilterData3: ",$expectedFilterData3
 
     check:
       getRes.status == 200

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -130,10 +130,6 @@ suite "Waku v2 Rest API - Admin":
 
     let getRes = await client.getFilterSubscriptions()
 
-    echo "getRes.data: ",$getRes.data
-    echo "expectedFilterData2: ",$expectedFilterData2
-    echo "expectedFilterData3: ",$expectedFilterData3
-
     check:
       getRes.status == 200
       $getRes.contentType == $MIMETYPE_JSON

--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -11,7 +11,6 @@ import
   ../../waku/waku_core,
   ../../waku/waku_node,
   ../../waku/node/peer_manager,
-  ../../waku/waku_filter,
   ../../waku/waku_api/rest/server,
   ../../waku/waku_api/rest/client,
   ../../waku/waku_api/rest/responses,

--- a/tests/wakunode_rest/test_rest_legacy_filter.nim
+++ b/tests/wakunode_rest/test_rest_legacy_filter.nim
@@ -50,6 +50,7 @@ proc setupRestFilter(): Future[RestFilterTest] {.async.} =
   await allFutures(result.filterNode.start(), result.clientNode.start())
 
   await result.filterNode.mountFilter()
+  await result.filterNode.mountLegacyFilter()
   await result.clientNode.mountFilterClient()
 
   result.clientNode.peerManager.addServicePeer(result.filterNode.peerInfo.toRemotePeerInfo()
@@ -174,7 +175,7 @@ suite "Waku v2 Rest API - Filter":
 
       while msg == messages[i]:
         msg = fakeWakuMessage(contentTopic = "content-topic-x", payload = toBytes("TEST-1"))
-      
+
       messages.add(msg)
 
     restFilterTest.messageCache.contentSubscribe(contentTopic)

--- a/waku/utils/tableutils.nim
+++ b/waku/utils/tableutils.nim
@@ -1,0 +1,31 @@
+import std/tables,
+       stew/objects,
+       stew/templateutils
+
+template keepItIf*[A, B](tableParam: var Table[A, B], itPredicate: untyped) =
+  bind evalTemplateParamOnce
+  evalTemplateParamOnce(tableParam, t):
+    var itemsToDelete: seq[A]
+    var key {.inject.} : A
+    var val {.inject.} : B
+
+    for key, val in t:
+      if not itPredicate:
+        itemsToDelete.add(key)
+
+    for item in itemsToDelete:
+      t.del(item)
+
+template keepItIf*[A, B](tableParam: var TableRef[A, B], itPredicate: untyped) =
+  bind evalTemplateParamOnce
+  evalTemplateParamOnce(tableParam, t):
+    var itemsToDelete: seq[A]
+    let key {.inject.} : A
+    let val {.inject.} : B
+
+    for key, val in t:
+      if not itPredicate:
+        itemsToDelete.add(key)
+
+    for item in itemsToDelete:
+      t.del(item)

--- a/waku/utils/tableutils.nim
+++ b/waku/utils/tableutils.nim
@@ -23,9 +23,9 @@ template keepItIf*[A, B](tableParam: var TableRef[A, B], itPredicate: untyped) =
     let key {.inject.} : A
     let val {.inject.} : B
 
-    for key, val in t:
+    for key, val in t[]:
       if not itPredicate:
         itemsToDelete.add(key)
 
     for item in itemsToDelete:
-      t.del(item)
+      t[].del(item)

--- a/waku/utils/tableutils.nim
+++ b/waku/utils/tableutils.nim
@@ -9,7 +9,9 @@ template keepItIf*[A, B](tableParam: var Table[A, B], itPredicate: untyped) =
     var key {.inject.} : A
     var val {.inject.} : B
 
-    for key, val in t:
+    for k, v in t.mpairs():
+      key = k
+      val = v
       if not itPredicate:
         itemsToDelete.add(key)
 
@@ -23,7 +25,9 @@ template keepItIf*[A, B](tableParam: var TableRef[A, B], itPredicate: untyped) =
     let key {.inject.} : A
     let val {.inject.} : B
 
-    for key, val in t[]:
+    for k, v in t[].mpairs():
+      key = k
+      val = v
       if not itPredicate:
         itemsToDelete.add(key)
 

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -121,9 +121,10 @@ proc installAdminV1GetFilterSubsHandler(router: var RestRouter, node: WakuNode) 
       subscriptions: seq[FilterSubscription] = @[]
       filterCriteria: seq[FilterTopic]
 
-    for (peerId, criteria) in node.wakuFilter.subscriptions.pairs():
-      filterCriteria = criteria.toSeq().mapIt(FilterTopic(pubsubTopic: it[0],
-        contentTopic: it[1]))
+    for peerId in node.wakuFilter.subscriptions.peersSubscribed.keys:
+      filterCriteria = node.wakuFilter.subscriptions.getPeerSubscriptions(peerId)
+                                                    .mapIt(FilterTopic(pubsubTopic: it[0],
+                                                                       contentTopic: it[1]))
 
       subscriptions.add(FilterSubscription(peerId: $peerId, filterCriteria: filterCriteria))
 

--- a/waku/waku_filter/protocol.nim
+++ b/waku/waku_filter/protocol.nim
@@ -22,7 +22,7 @@ logScope:
 const
   WakuLegacyFilterCodec* = "/vac/waku/filter/2.0.0-beta1"
 
-  WakuFilterTimeout: Duration = 2.hours
+  WakuLegacyFilterTimeout*: Duration = 2.hours
 
 
 type WakuFilterResult*[T] = Result[T, string]
@@ -113,7 +113,7 @@ proc initProtocolHandler(wf: WakuFilterLegacy) =
 proc new*(T: type WakuFilterLegacy,
            peerManager: PeerManager,
            rng: ref rand.HmacDrbgContext,
-           timeout: Duration = WakuFilterTimeout): T =
+           timeout: Duration = WakuLegacyFilterTimeout): T =
   let wf = WakuFilterLegacy(rng: rng,
                       peerManager: peerManager,
                       timeout: timeout)
@@ -123,7 +123,7 @@ proc new*(T: type WakuFilterLegacy,
 proc init*(T: type WakuFilterLegacy,
            peerManager: PeerManager,
            rng: ref rand.HmacDrbgContext,
-           timeout: Duration = WakuFilterTimeout): T {.
+           timeout: Duration = WakuLegacyFilterTimeout): T {.
   deprecated: "WakuFilterLegacy.new()' instead".} =
   WakuFilterLegacy.new(peerManager, rng, timeout)
 

--- a/waku/waku_filter_v2.nim
+++ b/waku/waku_filter_v2.nim
@@ -1,7 +1,9 @@
 import
   ./waku_filter_v2/common,
-  ./waku_filter_v2/protocol
+  ./waku_filter_v2/protocol,
+  ./waku_filter_v2/subscriptions
 
 export
   common,
-  protocol
+  protocol,
+  subscriptions

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -50,10 +50,10 @@ proc subscribe(wf: WakuFilter,
                contentTopics: seq[ContentTopic]): FilterSubscribeResult =
 
   # TODO: check if this condition is valid???
-  if pubsubTopic.isNone() or contentTopics.len() == 0:
+  if pubsubTopic.isNone() or contentTopics.len == 0:
     return err(FilterSubscribeError.badRequest("pubsubTopic and contentTopics must be specified"))
 
-  if contentTopics.len() > MaxContentTopicsPerRequest:
+  if contentTopics.len > MaxContentTopicsPerRequest:
     return err(FilterSubscribeError.badRequest("exceeds maximum content topics: " &
                 $MaxContentTopicsPerRequest))
 
@@ -70,10 +70,10 @@ proc unsubscribe(wf: WakuFilter,
                  peerId: PeerID,
                  pubsubTopic: Option[PubsubTopic],
                  contentTopics: seq[ContentTopic]): FilterSubscribeResult =
-  if pubsubTopic.isNone() or contentTopics.len() == 0:
+  if pubsubTopic.isNone() or contentTopics.len == 0:
     return err(FilterSubscribeError.badRequest("pubsubTopic and contentTopics must be specified"))
 
-  if contentTopics.len() > MaxContentTopicsPerRequest:
+  if contentTopics.len > MaxContentTopicsPerRequest:
     return err(FilterSubscribeError.badRequest("exceeds maximum content topics: " & $MaxContentTopicsPerRequest))
 
   let filterCriteria = toHashSet(contentTopics.mapIt((pubsubTopic.get(), it)))
@@ -81,7 +81,6 @@ proc unsubscribe(wf: WakuFilter,
   debug "unsubscribing peer from filter criteria", peerId=peerId, filterCriteria=filterCriteria
 
   wf.subscriptions.removeSubscription(peerId, filterCriteria).isOkOr:
-    # debug error, peerId=peerId, pubsubTopic=pubsubTopic.get(), contentTopics=contentTopics
     return err(FilterSubscribeError.notFound())
 
   ok()
@@ -177,13 +176,13 @@ proc maintainSubscriptions*(wf: WakuFilter) =
       debug "peer has been removed from peer store, removing subscription", peerId=peerId
       peersToRemove.add(peerId)
 
-  if peersToRemove.len() > 0:
+  if peersToRemove.len > 0:
     wf.subscriptions.removePeers(peersToRemove)
 
   wf.subscriptions.cleanUp()
 
   ## Periodic report of number of subscriptions
-  waku_filter_subscriptions.set(wf.subscriptions.peersSubscribed.len().float64)
+  waku_filter_subscriptions.set(wf.subscriptions.peersSubscribed.len.float64)
 
 const MessagePushTimeout = 20.seconds
 proc handleMessage*(wf: WakuFilter, pubsubTopic: PubsubTopic, message: WakuMessage) {.async.} =
@@ -194,7 +193,7 @@ proc handleMessage*(wf: WakuFilter, pubsubTopic: PubsubTopic, message: WakuMessa
   block:
     ## Find subscribers and push message to them
     let subscribedPeers = wf.subscriptions.findSubscribedPeers(pubsubTopic, message.contentTopic)
-    if subscribedPeers.len() == 0:
+    if subscribedPeers.len == 0:
       trace "no subscribed peers found", pubsubTopic=pubsubTopic, contentTopic=message.contentTopic
       return
 

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -282,4 +282,5 @@ method stop*(wf: WakuFilter) {.async.} =
   debug "stopping filter protocol"
   if not wf.maintenanceTask.isNil():
     wf.maintenanceTask.clearTimer()
+
   await procCall LPProtocol(wf).stop()

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -25,7 +25,7 @@ logScope:
   topics = "waku filter"
 
 const
-  MaxContentTopicsPerRequest* = 30
+  MaxContentTopicsPerRequest* = 100
 
 type
   WakuFilter* = ref object of LPProtocol
@@ -36,41 +36,40 @@ type
 proc pingSubscriber(wf: WakuFilter, peerId: PeerID): FilterSubscribeResult =
   trace "pinging subscriber", peerId=peerId
 
-  if peerId notin wf.subscriptions:
+  if not wf.subscriptions.isSubscribed(peerId):
     debug "pinging peer has no subscriptions", peerId=peerId
     return err(FilterSubscribeError.notFound())
 
+  wf.subscriptions.refreshSubscription(peerId)
+
   ok()
 
-proc subscribe(wf: WakuFilter, peerId: PeerID, pubsubTopic: Option[PubsubTopic], contentTopics: seq[ContentTopic]): FilterSubscribeResult =
+proc subscribe(wf: WakuFilter,
+               peerId: PeerID,
+               pubsubTopic: Option[PubsubTopic],
+               contentTopics: seq[ContentTopic]): FilterSubscribeResult =
+
+  # TODO: check if this condition is valid???
   if pubsubTopic.isNone() or contentTopics.len() == 0:
     return err(FilterSubscribeError.badRequest("pubsubTopic and contentTopics must be specified"))
 
   if contentTopics.len() > MaxContentTopicsPerRequest:
-    return err(FilterSubscribeError.badRequest("exceeds maximum content topics: " & $MaxContentTopicsPerRequest))
+    return err(FilterSubscribeError.badRequest("exceeds maximum content topics: " &
+                $MaxContentTopicsPerRequest))
 
   let filterCriteria = toHashSet(contentTopics.mapIt((pubsubTopic.get(), it)))
 
   trace "subscribing peer to filter criteria", peerId=peerId, filterCriteria=filterCriteria
 
-  if peerId in wf.subscriptions:
-    # We already have a subscription for this peer. Try to add the new filter criteria.
-    var peerSubscription = wf.subscriptions.mgetOrPut(peerId, initHashSet[FilterCriterion]())
-    if peerSubscription.len() + filterCriteria.len() > MaxCriteriaPerSubscription:
-      return err(FilterSubscribeError.serviceUnavailable("peer has reached maximum number of filter criteria"))
-
-    peerSubscription.incl(filterCriteria)
-    wf.subscriptions[peerId] = peerSubscription
-  else:
-    # We don't have a subscription for this peer yet. Try to add it.
-    if wf.subscriptions.len() >= MaxTotalSubscriptions:
-      return err(FilterSubscribeError.serviceUnavailable("node has reached maximum number of subscriptions"))
-    debug "creating new subscription", peerId=peerId
-    wf.subscriptions[peerId] = filterCriteria
+  wf.subscriptions.addSubscription(peerId, filterCriteria).isOkOr:
+    return err(FilterSubscribeError.serviceUnavailable(error))
 
   ok()
 
-proc unsubscribe(wf: WakuFilter, peerId: PeerID, pubsubTopic: Option[PubsubTopic], contentTopics: seq[ContentTopic]): FilterSubscribeResult =
+proc unsubscribe(wf: WakuFilter,
+                 peerId: PeerID,
+                 pubsubTopic: Option[PubsubTopic],
+                 contentTopics: seq[ContentTopic]): FilterSubscribeResult =
   if pubsubTopic.isNone() or contentTopics.len() == 0:
     return err(FilterSubscribeError.badRequest("pubsubTopic and contentTopics must be specified"))
 
@@ -79,39 +78,28 @@ proc unsubscribe(wf: WakuFilter, peerId: PeerID, pubsubTopic: Option[PubsubTopic
 
   let filterCriteria = toHashSet(contentTopics.mapIt((pubsubTopic.get(), it)))
 
-  trace "unsubscribing peer from filter criteria", peerId=peerId, filterCriteria=filterCriteria
+  debug "unsubscribing peer from filter criteria", peerId=peerId, filterCriteria=filterCriteria
 
-  if peerId notin wf.subscriptions:
-    debug "unsubscribing peer has no subscriptions", peerId=peerId
+  wf.subscriptions.removeSubscription(peerId, filterCriteria).isOkOr:
+    # debug error, peerId=peerId, pubsubTopic=pubsubTopic.get(), contentTopics=contentTopics
     return err(FilterSubscribeError.notFound())
-
-  var peerSubscription = wf.subscriptions.mgetOrPut(peerId, initHashSet[FilterCriterion]())
-
-  if not peerSubscription.containsAny(filterCriteria):
-    debug "unsubscribing peer is not subscribed to any of the content topics in this pubsub topic", peerId=peerId, pubsubTopic=pubsubTopic.get(), contentTopics=contentTopics
-    return err(FilterSubscribeError.notFound())
-
-  peerSubscription.excl(filterCriteria)
-
-  if peerSubscription.len() == 0:
-    debug "peer has no more subscriptions, removing subscription", peerId=peerId
-    wf.subscriptions.del(peerId)
-  else:
-    wf.subscriptions[peerId] = peerSubscription
 
   ok()
 
 proc unsubscribeAll(wf: WakuFilter, peerId: PeerID): FilterSubscribeResult =
-  if peerId notin wf.subscriptions:
+  if not wf.subscriptions.isSubscribed(peerId):
     debug "unsubscribing peer has no subscriptions", peerId=peerId
     return err(FilterSubscribeError.notFound())
 
   debug "removing peer subscription", peerId=peerId
-  wf.subscriptions.del(peerId)
+  wf.subscriptions.removePeer(peerId)
+  wf.subscriptions.cleanUp()
 
   ok()
 
-proc handleSubscribeRequest*(wf: WakuFilter, peerId: PeerId, request: FilterSubscribeRequest): FilterSubscribeResponse =
+proc handleSubscribeRequest*(wf: WakuFilter,
+                             peerId: PeerId,
+                             request: FilterSubscribeRequest): FilterSubscribeResponse =
   info "received filter subscribe request", peerId=peerId, request=request
   waku_filter_requests.inc(labelValues = [$request.filterSubscribeType])
 
@@ -134,7 +122,8 @@ proc handleSubscribeRequest*(wf: WakuFilter, peerId: PeerId, request: FilterSubs
   let
     requestDuration = Moment.now() - requestStartTime
     requestDurationSec = requestDuration.milliseconds.float / 1000  # Duration in seconds with millisecond precision floating point
-  waku_filter_request_duration_seconds.observe(requestDurationSec, labelValues = [$request.filterSubscribeType])
+  waku_filter_request_duration_seconds.observe(
+          requestDurationSec, labelValues = [$request.filterSubscribeType])
 
   if subscribeResult.isErr():
     return FilterSubscribeResponse(
@@ -153,6 +142,7 @@ proc pushToPeer(wf: WakuFilter, peer: PeerId, buffer: seq[byte]) {.async.} =
     trace "no addresses for peer", peer=peer
     return
 
+  ## TODO: Check if dial is necessary always???
   let conn = await wf.peerManager.dialPeer(peer, WakuFilterPushCodec)
   if conn.isNone():
     ## We do not remove this peer, but allow the underlying peer manager
@@ -163,7 +153,10 @@ proc pushToPeer(wf: WakuFilter, peer: PeerId, buffer: seq[byte]) {.async.} =
   await conn.get().writeLp(buffer)
 
 proc pushToPeers(wf: WakuFilter, peers: seq[PeerId], messagePush: MessagePush) {.async.} =
-  debug "pushing message to subscribed peers", pubsubTopic=messagePush.pubsubTopic, contentTopic=messagePush.wakuMessage.contentTopic, peers=peers, hash=messagePush.pubsubTopic.computeMessageHash(messagePush.wakuMessage).to0xHex()
+  debug "pushing message to subscribed peers", pubsubTopic=messagePush.pubsubTopic,
+          contentTopic=messagePush.wakuMessage.contentTopic,
+          peers=peers,
+          hash=messagePush.pubsubTopic.computeMessageHash(messagePush.wakuMessage).to0xHex()
 
   let bufferToPublish = messagePush.encode().buffer
 
@@ -179,9 +172,7 @@ proc maintainSubscriptions*(wf: WakuFilter) =
 
   ## Remove subscriptions for peers that have been removed from peer store
   var peersToRemove: seq[PeerId]
-  for peerId, peerSubscription in wf.subscriptions.pairs():
-    ## TODO: currently we only maintain by syncing with peer store. We could
-    ## consider other metrics, such as subscription age, activity, etc.
+  for peerId in wf.subscriptions.peersSubscribed.keys:
     if not wf.peerManager.peerStore.hasPeer(peerId, WakuFilterPushCodec):
       debug "peer has been removed from peer store, removing subscription", peerId=peerId
       peersToRemove.add(peerId)
@@ -189,8 +180,10 @@ proc maintainSubscriptions*(wf: WakuFilter) =
   if peersToRemove.len() > 0:
     wf.subscriptions.removePeers(peersToRemove)
 
+  wf.subscriptions.cleanUp()
+
   ## Periodic report of number of subscriptions
-  waku_filter_subscriptions.set(wf.subscriptions.len().float64)
+  waku_filter_subscriptions.set(wf.subscriptions.peersSubscribed.len().float64)
 
 const MessagePushTimeout = 20.seconds
 proc handleMessage*(wf: WakuFilter, pubsubTopic: PubsubTopic, message: WakuMessage) {.async.} =
@@ -210,11 +203,15 @@ proc handleMessage*(wf: WakuFilter, pubsubTopic: PubsubTopic, message: WakuMessa
           wakuMessage: message)
 
     if not await wf.pushToPeers(subscribedPeers, messagePush).withTimeout(MessagePushTimeout):
-      debug "timed out pushing message to peers", pubsubTopic=pubsubTopic, contentTopic=message.contentTopic, hash=pubsubTopic.computeMessageHash(message).to0xHex()
+      debug "timed out pushing message to peers", pubsubTopic=pubsubTopic,
+                                                  contentTopic=message.contentTopic,
+                                                  hash=pubsubTopic.computeMessageHash(message).to0xHex()
       waku_filter_errors.inc(labelValues = [pushTimeoutFailure])
     else:
-      debug "pushed message succesfully to all subscribers", pubsubTopic=pubsubTopic, contentTopic=message.contentTopic, hash=pubsubTopic.computeMessageHash(message).to0xHex()
-
+      debug "pushed message succesfully to all subscribers",
+              pubsubTopic=pubsubTopic,
+              contentTopic=message.contentTopic,
+              hash=pubsubTopic.computeMessageHash(message).to0xHex()
 
   let
     handleMessageDuration = Moment.now() - handleMessageStartTime
@@ -247,13 +244,21 @@ proc initProtocolHandler(wf: WakuFilter) =
   wf.codec = WakuFilterSubscribeCodec
 
 proc new*(T: type WakuFilter,
-          peerManager: PeerManager): T =
+          peerManager: PeerManager,
+          subscriptionTimeout: Duration = DefaultSubscriptionTimeToLiveSec,
+          maxFilterPeers: uint32 = MaxFilterPeers,
+          maxFilterCriteriaPerPeer: uint32 = MaxFilterCriteriaPerPeer): T =
 
   let wf = WakuFilter(
+    subscriptions: FilterSubscriptions.init(subscriptionTimeout,
+                                            maxFilterPeers,
+                                            maxFilterCriteriaPerPeer
+                                           ),
     peerManager: peerManager
   )
+
   wf.initProtocolHandler()
-  wf
+  return wf
 
 const MaintainSubscriptionsInterval* = 1.minutes
 

--- a/waku/waku_filter_v2/subscriptions.nim
+++ b/waku/waku_filter_v2/subscriptions.nim
@@ -95,8 +95,7 @@ proc removePeer*(s: var FilterSubscriptions, peerId: PeerID) =
 
 proc removePeers*(s: var FilterSubscriptions, peerIds: seq[PeerID]) =
   ## Remove all subscriptions for a given list of peers
-  for peerId in peerIds:
-    s.removePeer(peerId)
+  s.peersSubscribed.keepItIf(key notin peerIds)
 
 proc cleanUp*(fs: var FilterSubscriptions) =
   ## Remove all subscriptions for peers that have not been seen for a while

--- a/waku/waku_filter_v2/subscriptions.nim
+++ b/waku/waku_filter_v2/subscriptions.nim
@@ -37,10 +37,10 @@ type
 
   FilterSubscriptions* = object
     peersSubscribed*    : Table[PeerID, PeerData]
-    subscriptions*      : Table[FilterCriterion, SubscribedPeers]
-    subscriptionTimeout*: Duration
-    maxPeers*           : uint
-    maxCriteriaPerPeer* : uint
+    subscriptions       : Table[FilterCriterion, SubscribedPeers]
+    subscriptionTimeout : Duration
+    maxPeers            : uint
+    maxCriteriaPerPeer  : uint
 
 proc init*(T: type FilterSubscriptions,
           subscriptionTimeout: Duration = DefaultSubscriptionTimeToLiveSec,
@@ -62,7 +62,7 @@ proc isSubscribed*(s: var FilterSubscriptions, peerId: PeerID): bool =
   return false
 
 proc subscribedPeerCount*(s: FilterSubscriptions): uint =
-  return cast[uint](s.peersSubscribed.len())
+  return cast[uint](s.peersSubscribed.len)
 
 proc getPeerSubscriptions*(s: var FilterSubscriptions, peerId: PeerID): seq[FilterCriterion] =
   ## Get all pubsub-content topics a peer is subscribed to
@@ -107,7 +107,7 @@ proc cleanUp*(fs: var FilterSubscriptions) =
   for filterCriterion, subscribedPeers in fs.subscriptions.mpairs:
     subscribedPeers.keepItIf(fs.isSubscribed(it)==true)
 
-  fs.subscriptions.keepItIf(val.len() > 0)
+  fs.subscriptions.keepItIf(val.len > 0)
 
 proc refreshSubscription*(s: var FilterSubscriptions, peerId: PeerID) =
   s.peersSubscribed.withValue(peerId, data):
@@ -118,7 +118,7 @@ proc addSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCriteria
   var peerData: ptr PeerData
 
   s.peersSubscribed.withValue(peerId, data):
-    if data.criteriaCount + cast[uint](filterCriteria.len()) > s.maxCriteriaPerPeer:
+    if data.criteriaCount + cast[uint](filterCriteria.len) > s.maxCriteriaPerPeer:
       return err("peer has reached maximum number of filter criteria")
 
     data.lastSeen = Moment.now()
@@ -126,7 +126,7 @@ proc addSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCriteria
 
   do:
     ## not yet subscribed
-    if cast[uint](s.peersSubscribed.len()) >= s.maxPeers:
+    if cast[uint](s.peersSubscribed.len) >= s.maxPeers:
       return err("node has reached maximum number of subscriptions")
 
     let newPeerData: PeerData = (lastSeen: Moment.now(), criteriaCount: 0)
@@ -140,7 +140,10 @@ proc addSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCriteria
 
   return ok()
 
-proc removeSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCriteria: FilterCriteria): Result[void, string] =
+proc removeSubscription*(s: var FilterSubscriptions,
+                        peerId: PeerID,
+                        filterCriteria: FilterCriteria):
+                  Result[void, string] =
   ## Remove a subscription for a given peer
 
   s.peersSubscribed.withValue(peerId, peerData):
@@ -150,7 +153,7 @@ proc removeSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCrite
         if peers[].missingOrexcl(peerId) == false:
           peerData.criteriaCount -= 1
 
-          if peers[].len() == 0:
+          if peers[].len == 0:
             s.subscriptions.del(filterCriterion)
           if peerData.criteriaCount == 0:
             s.peersSubscribed.del(peerId)

--- a/waku/waku_filter_v2/subscriptions.nim
+++ b/waku/waku_filter_v2/subscriptions.nim
@@ -119,7 +119,7 @@ proc addSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCriteria
 
   s.peersSubscribed.withValue(peerId, data):
     if data.criteriaCount + cast[uint](filterCriteria.len()) > s.maxCriteriaPerPeer:
-      return err("Max number of criteria for peer (" & $s.maxCriteriaPerPeer & ") reached")
+      return err("peer has reached maximum number of filter criteria")
 
     data.lastSeen = Moment.now()
     peerData = data
@@ -127,7 +127,7 @@ proc addSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCriteria
   do:
     ## not yet subscribed
     if cast[uint](s.peersSubscribed.len()) >= s.maxPeers:
-      return err("Max number of peers (" & $s.maxPeers & ") reached")
+      return err("node has reached maximum number of subscriptions")
 
     let newPeerData: PeerData = (lastSeen: Moment.now(), criteriaCount: 0)
     peerData = addr(s.peersSubscribed.mgetOrPut(peerId, newPeerData))

--- a/waku/waku_filter_v2/subscriptions.nim
+++ b/waku/waku_filter_v2/subscriptions.nim
@@ -6,48 +6,161 @@ else:
 import
   std/[sets,tables],
   chronicles,
-  libp2p/peerid
+  chronos,
+  libp2p/peerid,
+  stew/shims/sets
 import
-  ../waku_core
+  ../waku_core,
+  ../utils/tableutils
 
 logScope:
   topics = "waku filter subscriptions"
 
 const
-  MaxTotalSubscriptions* = 1000 # TODO make configurable
-  MaxCriteriaPerSubscription* = 1000
+  MaxFilterPeers* = 1000
+  MaxFilterCriteriaPerPeer* = 1000
+  DefaultSubscriptionTimeToLiveSec* = 5.minutes
 
 type
-  FilterCriterion* = (PubsubTopic, ContentTopic) # a single filter criterion is fully defined by a pubsub topic and content topic
+  # a single filter criterion is fully defined by a pubsub topic and content topic
+  FilterCriterion* = tuple
+    pubsubTopic: PubsubTopic
+    contentTopic: ContentTopic
+
   FilterCriteria* = HashSet[FilterCriterion] # a sequence of filter criteria
-  FilterSubscriptions* = Table[PeerID, FilterCriteria] # a mapping of peer ids to a sequence of filter criteria
 
-proc findSubscribedPeers*(subscriptions: FilterSubscriptions, pubsubTopic: PubsubTopic, contentTopic: ContentTopic): seq[PeerID] =
-  ## Find all peers subscribed to a given topic and content topic
-  let filterCriterion = (pubsubTopic, contentTopic)
+  SubscribedPeers* = HashSet[PeerID] # a sequence of peer ids
 
-  var subscribedPeers: seq[PeerID]
+  PeerData* = tuple
+    lastSeen: Moment
+    criteriaCount: uint
 
-  # TODO: for large maps, this can be optimized using a reverse index
-  for (peerId, criteria) in subscriptions.pairs():
-    if filterCriterion in criteria:
-      subscribedPeers.add(peerId)
+  FilterSubscriptions* = object
+    peersSubscribed*    : Table[PeerID, PeerData]
+    subscriptions*      : Table[FilterCriterion, SubscribedPeers]
+    subscriptionTimeout*: Duration
+    maxPeers*           : uint
+    maxCriteriaPerPeer* : uint
 
-  subscribedPeers
+proc init*(T: type FilterSubscriptions,
+          subscriptionTimeout: Duration = DefaultSubscriptionTimeToLiveSec,
+          maxFilterPeers: uint32 = MaxFilterPeers,
+          maxFilterCriteriaPerPeer: uint32 = MaxFilterCriteriaPerPeer): FilterSubscriptions =
+  ## Create a new filter subscription object
+  return FilterSubscriptions(
+              peersSubscribed: initTable[PeerID, PeerData](),
+              subscriptions: initTable[FilterCriterion, SubscribedPeers](),
+              subscriptionTimeout: subscriptionTimeout,
+              maxPeers: maxFilterPeers,
+              maxCriteriaPerPeer: maxFilterCriteriaPerPeer
+            )
 
-proc removePeer*(subscriptions: var FilterSubscriptions, peerId: PeerID) =
+proc isSubscribed*(s: var FilterSubscriptions, peerId: PeerID): bool =
+  s.peersSubscribed.withValue(peerId, data):
+    return Moment.now() - data.lastSeen <= s.subscriptionTimeout
+
+  return false
+
+proc subscribedPeerCount*(s: FilterSubscriptions): uint =
+  return cast[uint](s.peersSubscribed.len())
+
+proc getPeerSubscriptions*(s: var FilterSubscriptions, peerId: PeerID): seq[FilterCriterion] =
+  ## Get all pubsub-content topics a peer is subscribed to
+  var subscribedContentTopics: seq[FilterCriterion] = @[]
+  s.peersSubscribed.withValue(peerId, data):
+    if data.criteriaCount == 0:
+      return subscribedContentTopics
+
+    for filterCriterion, subscribedPeers in s.subscriptions.mpairs:
+      if peerId in subscribedPeers:
+        subscribedContentTopics.add(filterCriterion)
+
+  return subscribedContentTopics
+
+proc findSubscribedPeers*(s: var FilterSubscriptions, pubsubTopic: PubsubTopic, contentTopic: ContentTopic): seq[PeerID] =
+  let filterCriterion : FilterCriterion = (pubsubTopic, contentTopic)
+
+  var foundPeers : seq[PeerID] = @[]
+  # only peers subscribed to criteria and with legit subscription is counted
+  s.subscriptions.withValue(filterCriterion, peers):
+    for peer in peers[]:
+      if s.isSubscribed(peer):
+        foundPeers.add(peer)
+
+  return foundPeers
+
+proc removePeer*(s: var FilterSubscriptions, peerId: PeerID) =
   ## Remove all subscriptions for a given peer
-  subscriptions.del(peerId)
+  s.peersSubscribed.del(peerId)
 
-proc removePeers*(subscriptions: var FilterSubscriptions, peerIds: seq[PeerID]) =
+proc removePeers*(s: var FilterSubscriptions, peerIds: seq[PeerID]) =
   ## Remove all subscriptions for a given list of peers
   for peerId in peerIds:
-    subscriptions.removePeer(peerId)
+    s.removePeer(peerId)
 
-proc containsAny*(criteria: FilterCriteria, otherCriteria: FilterCriteria): bool =
-  ## Check if a given pubsub topic is contained in a set of filter criteria
-  ## TODO: Better way to achieve this?
-  for criterion in otherCriteria:
-    if criterion in criteria:
-      return true
-  false
+proc cleanUp*(fs: var FilterSubscriptions) =
+  ## Remove all subscriptions for peers that have not been seen for a while
+  let now = Moment.now()
+  fs.peersSubscribed.keepItIf(now - val.lastSeen <= fs.subscriptionTimeout)
+
+  var filtersToRemove: seq[FilterCriterion] = @[]
+  for filterCriterion, subscribedPeers in fs.subscriptions.mpairs:
+    subscribedPeers.keepItIf(fs.isSubscribed(it)==true)
+
+  fs.subscriptions.keepItIf(val.len() > 0)
+
+proc refreshSubscription*(s: var FilterSubscriptions, peerId: PeerID) =
+  s.peersSubscribed.withValue(peerId, data):
+    data.lastSeen = Moment.now()
+
+proc addSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCriteria: FilterCriteria): Result[void, string] =
+  ## Add a subscription for a given peer
+  var peerData: ptr PeerData
+
+  s.peersSubscribed.withValue(peerId, data):
+    if data.criteriaCount + cast[uint](filterCriteria.len()) > s.maxCriteriaPerPeer:
+      return err("Max number of criteria for peer (" & $s.maxCriteriaPerPeer & ") reached")
+
+    data.lastSeen = Moment.now()
+    peerData = data
+
+  do:
+    ## not yet subscribed
+    if cast[uint](s.peersSubscribed.len()) >= s.maxPeers:
+      return err("Max number of peers (" & $s.maxPeers & ") reached")
+
+    let newPeerData: PeerData = (lastSeen: Moment.now(), criteriaCount: 0)
+    peerData = addr(s.peersSubscribed.mgetOrPut(peerId, newPeerData))
+
+  for filterCriterion in filterCriteria:
+    var peersOfSub = addr(s.subscriptions.mgetOrPut(filterCriterion, SubscribedPeers()))
+    if peerId notin peersOfSub[]:
+      peersOfSub[].incl(peerId)
+      peerData.criteriaCount += 1
+
+  return ok()
+
+proc removeSubscription*(s: var FilterSubscriptions, peerId: PeerID, filterCriteria: FilterCriteria): Result[void, string] =
+  ## Remove a subscription for a given peer
+
+  s.peersSubscribed.withValue(peerId, peerData):
+    peerData.lastSeen = Moment.now()
+    for filterCriterion in filterCriteria:
+      s.subscriptions.withValue(filterCriterion, peers):
+        if peers[].missingOrexcl(peerId) == false:
+          peerData.criteriaCount -= 1
+
+          if peers[].len() == 0:
+            s.subscriptions.del(filterCriterion)
+          if peerData.criteriaCount == 0:
+            s.peersSubscribed.del(peerId)
+      do:
+        ## Maybe let just run through and log it as a warning
+        return err("Peer was not subscribed to criterion")
+
+    return ok()
+
+  do:
+    return err("Peer has no subscriptions")
+
+


### PR DESCRIPTION
# Description
As during Status dogfooding it turned out we need to handle situation with stale filter subscriptions to ensure  service quality.

NOTE: This become a relative large refactor on management filter subscription. Sorry for that to issue such a big PR.
The structure changes involved a lot changes in filter v2 test.
But because of the I would like to ask you to start reviewing it, if there is something not ok should come early as possible.
THX!!!

NOTE2: Still a work in progress, as realized need to add some more test cases.

# Changes

- [X] New CLI configuration options are added for filter v2: subscription timeout, max peers served and max criterion per peer. 
- [X] From now, a filter client needs to periodically refresh it's subscriptions with PING (within the timeout period) in order to receive message push
- [X] Filter v2 subscriptions are fully reworked. New structure is introduced for better speed. Now subscription management is now encapsulated into its own module.
- [X] test_waku_client adapted to changes.
 - [X] Mount of legacy and filter v2 are now separated to ease future removal of legacy filter.
 
## Issue
https://github.com/waku-org/nwaku/issues/2293

covers also: https://github.com/waku-org/nwaku/issues/2338
