### PR TITLE
chore: Bump `nim-dnsdisc`

### DIFF
--- a/tests/test_waku_dnsdisc.nim
+++ b/tests/test_waku_dnsdisc.nim
@@ -9,7 +9,7 @@ import
   chronos,
   libp2p/crypto/crypto,
   eth/keys,
-  discovery/dnsdisc/builder
+  dnsdisc/builder
 import
   ../../waku/node/peer_manager,
   ../../waku/waku_node,

--- a/tests/waku_rln_relay/test_rln_group_manager_static.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_static.nim
@@ -19,7 +19,7 @@ import
   chronos,
   libp2p/crypto/crypto,
   eth/keys,
-  discovery/dnsdisc/builder
+  dnsdisc/builder
 
 import
   std/tempfiles

--- a/waku/waku_dnsdisc.nim
+++ b/waku/waku_dnsdisc.nim
@@ -20,7 +20,8 @@ import
   libp2p/crypto/secp,
   libp2p/multiaddress,
   libp2p/peerid,
-  discovery/dnsdisc/client
+  dnsdisc/client
+
 import
   ./waku_core
 


### PR DESCRIPTION
# Description
Updating version of  `nim-dnsdisc` after merging [this PR](https://github.com/status-im/nim-dnsdisc/pull/18)

# Changes

<!-- List of detailed changes -->

- Bump `nim-dnsdiscc
- Update import path of dnsdisc