### PR TITLE
fix: Lightpush fixes

### DIFF
--- a/tests/waku_lightpush/test_client.nim
+++ b/tests/waku_lightpush/test_client.nim
@@ -214,7 +214,7 @@ suite "Waku Lightpush Client":
       # And the message is received with the correct topic and payload
       check (pubsubTopic, message9) == handlerFuture.read()
 
-    xasyncTest "Valid Paylod Sizes":
+    asyncTest "Valid Payload Sizes":
       # Given some valid payloads
       let
         message1 =

--- a/waku/waku_lightpush/client.nim
+++ b/waku/waku_lightpush/client.nim
@@ -45,7 +45,12 @@ proc sendPushRequest(wl: WakuLightPushClient, req: PushRequest, peer: PeerId|Rem
   let rpc = PushRPC(requestId: generateRequestId(wl.rng), request: some(req))
   await connection.writeLP(rpc.encode().buffer)
 
-  var buffer = await connection.readLp(MaxRpcSize.int)
+  var buffer: seq[byte]
+  try:
+    buffer = await connection.readLp(MaxRpcSize.int)
+  except LPStreamRemoteClosedError:
+    return err("Exception reading: " & getCurrentExceptionMsg())
+
   let decodeRespRes = PushRPC.decode(buffer)
   if decodeRespRes.isErr():
     error "failed to decode response"


### PR DESCRIPTION
This PR:

- Enhances the test protection against `core dump` issue when an exception is raised within the test body.
- Enables the "Valid Payload Sizes" test.
- Performs better exception management in `waku_lightpush/client.nim`

See the commit list for better details :)

The test of interest can be run with:
`nim c -r -d:chronicles_log_level=DEBUG -d:release -d:postgres  -d:rln --passL:librln_v0.3.4.a --passL:-lm -d:nimDebugDlOpen ./tests/waku_lightpush/test_client.nim test "Valid Payload Sizes"`

Notice that this test will still fail because it is trying to push a message too large. I suggest using the msg size constants so that the test is always aligned with those values: https://github.com/waku-org/nwaku/blob/2f8e8bcb529ebe7ad1528de213b39d887cf08596/waku/waku_core/message/default_values.nim#L8
