### PR TITLE
chore(rln-relay): remove websocket from OnchainGroupManager

### DIFF
--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -252,8 +252,8 @@ type
       name: "rln-relay-id-commitment-key" }: string
 
     rlnRelayEthClientAddress* {.
-      desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",
-      defaultValue: "ws://localhost:8540/"
+      desc: "WebSocket address of an Ethereum testnet client e.g., http://localhost:8540/",
+      defaultValue: "http://localhost:8540/"
       name: "rln-relay-eth-client-address" }: string
 
     rlnRelayEthContractAddress* {.

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -61,8 +61,8 @@ type
       name: "rln-relay-cred-path" }: string
 
     rlnRelayEthClientAddress* {.
-      desc: "WebSocket address of an Ethereum testnet client e.g., ws://localhost:8540/",
-      defaultValue: "ws://localhost:8540/",
+      desc: "WebSocket address of an Ethereum testnet client e.g., http://localhost:8540/",
+      defaultValue: "http://localhost:8540/",
       name: "rln-relay-eth-client-address" }: string
 
     rlnRelayEthContractAddress* {.

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -232,9 +232,9 @@ suite "Onchain group manager":
 
     try:
       await manager.startGroupSync()
-    except ValueError:
+    except CatchableError:
       assert true
-    except Exception, CatchableError:
+    except Exception:
       assert false, "exception raised when calling startGroupSync: " & getCurrentExceptionMsg()
 
     await manager.stop()
@@ -330,9 +330,9 @@ suite "Onchain group manager":
 
     try:
       await manager.register(dummyCommitment)
-    except ValueError:
+    except CatchableError:
       assert true
-    except Exception, CatchableError:
+    except Exception:
       assert false, "exception raised: " & getCurrentExceptionMsg()
 
     await manager.stop()
@@ -399,9 +399,9 @@ suite "Onchain group manager":
 
     try:
       await manager.withdraw(idSecretHash)
-    except ValueError:
+    except CatchableError:
       assert true
-    except Exception, CatchableError:
+    except Exception:
       assert false, "exception raised: " & getCurrentExceptionMsg()
 
     await manager.stop()
@@ -627,7 +627,7 @@ suite "Onchain group manager":
     await manager.stop()
 
   asyncTest "isReady should return false if ethRpc is none":
-    var manager = await setup()
+    let manager = await setup()
     await manager.init()
 
     manager.ethRpc = none(Web3)
@@ -644,7 +644,7 @@ suite "Onchain group manager":
     await manager.stop()
 
   asyncTest "isReady should return false if lastSeenBlockHead > lastProcessed":
-    var manager = await setup()
+    let manager = await setup()
     await manager.init()
 
     var isReady = true
@@ -659,14 +659,13 @@ suite "Onchain group manager":
     await manager.stop()
 
   asyncTest "isReady should return true if ethRpc is ready":
-    var manager = await setup()
+    let manager = await setup()
     await manager.init()
     # node can only be ready after group sync is done
     try:
       await manager.startGroupSync()
     except Exception, CatchableError:
       assert false, "exception raised when calling startGroupSync: " & getCurrentExceptionMsg()
-    
     var isReady = false
     try:
       isReady = await manager.isReady()

--- a/waku/waku_rln_relay/constants.nim
+++ b/waku/waku_rln_relay/constants.nim
@@ -18,7 +18,7 @@ const
   MembershipFee* = 1000000000000000.u256
   #  the current implementation of the rln lib supports a circuit for Merkle tree with depth 20
   MerkleTreeDepth* = 20
-  EthClient* = "ws://127.0.0.1:8540"
+  EthClient* = "http://127.0.0.1:8540"
 
 const
   # the size of poseidon hash output in bits

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -80,7 +80,7 @@ type
 const DefaultKeyStorePath* = "rlnKeystore.json"
 const DefaultKeyStorePassword* = "password"
 
-const DefaultBlockPollRate* = 1.seconds
+const DefaultBlockPollRate* = 6.seconds
 
 template initializedGuard(g: OnchainGroupManager): untyped =
   if not g.initialized:

--- a/waku/waku_rln_relay/group_manager/on_chain/retry_wrapper.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/retry_wrapper.nim
@@ -21,12 +21,15 @@ template retryWrapper*(res: auto,
                        body: untyped): auto =
   var retryCount = retryStrategy.retryCount
   var shouldRetry = retryStrategy.shouldRetry
+  var exceptionMessage = ""
+
   while shouldRetry and retryCount > 0:
     try:
       res = body
       shouldRetry = false
     except:
       retryCount -= 1
+      exceptionMessage = getCurrentExceptionMsg()
       await sleepAsync(retryStrategy.retryDelay)
   if shouldRetry:
-    raise newException(CatchableError, errStr & ": " & $getCurrentExceptionMsg())
+    raise newException(CatchableError, errStr & ": " & exceptionMessage)


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Removes dependence on eth_subscribe since websocket connections can be flaky.

# Changes

<!-- List of detailed changes -->

- [x] Removes eth_subscribe call and replaces it with block polling every `1` second. default can be changed


## How to test

1. Pass in a http rpc provider instead of ws while running nwaku / `make -j16 test`
2. Generate an rln keystore using
  ```
  ./build/wakunode2 generateRlnKeystore \
    --rln-relay-cred-path:./rlnKeystore.json \
    --rln-relay-eth-client-address:https:<> \
    --rln-relay-cred-password:sup3rsecure \
    --rln-relay-eth-contract-address:0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4 \
    --rln-relay-eth-private-key:<> \
    --execute
  ```
  insert your https rpc provider as well as private key in the required positions


## Issue
addresses part of #2345

