### PR TITLE
chore: log messageHash for lightpush request received

### DIFF
--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -6,6 +6,7 @@ else:
 import
   std/options,
   stew/results,
+  stew/byteutils,
   chronicles,
   chronos,
   metrics,
@@ -57,7 +58,7 @@ proc handleRequest*(wl: WakuLightPush, peerId: PeerId, buffer: seq[byte]): Futur
       pubSubTopic = request.get().pubSubTopic
       message = request.get().message
     waku_lightpush_messages.inc(labelValues = ["PushRequest"])
-    debug "push request", peerId=peerId, requestId=requestId, pubsubTopic=pubsubTopic
+    debug "push request", peerId=peerId, requestId=requestId, pubsubTopic=pubsubTopic, hash=pubsubTopic.computeMessageHash(message).to0xHex()
     
     let handleRes = await wl.pushHandler(peerId, pubsubTopic, message)
     isSuccess = handleRes.isOk()


### PR DESCRIPTION
# Description
While debugging message loss issues with status, had noticed that messageHash is not logged for lightpush which helps in debugging to know if message is received by the fleet nodes.

# Changes

- [x] Added messageHash to be logged while handling lightpush request.


Note: Tested by using a go-waku lightpush client to ensure messageHash is logged properly