### PR TITLE
fix: adding rln validator as default

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -984,10 +984,11 @@ proc mountRlnRelay*(node: WakuNode,
   let rlnRelay = rlnRelayRes.get()
   let validator = generateRlnValidator(rlnRelay, spamHandler)
 
-  # register rln validator for all subscribed relay pubsub topics
-  for pubsubTopic in node.wakuRelay.subscribedTopics:
-    debug "Registering RLN validator for topic", pubsubTopic=pubsubTopic
-    node.wakuRelay.addValidator(pubsubTopic, validator)
+  
+  # register rln validator as default validator
+  debug "Registering RLN validator"
+  node.wakuRelay.addDefaultValidator(validator)
+  
   node.wakuRlnRelay = rlnRelay
 
 ## Waku peer-exchange

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -984,7 +984,6 @@ proc mountRlnRelay*(node: WakuNode,
   let rlnRelay = rlnRelayRes.get()
   let validator = generateRlnValidator(rlnRelay, spamHandler)
 
-  
   # register rln validator as default validator
   debug "Registering RLN validator"
   node.wakuRelay.addDefaultValidator(validator)


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
It was noticed that RLN validator wasn't configured for dynamically subscribed pubsub topics.
Therefore, we decided to implement the same approach to validators as in go-waku: we're adding now support for default validators, which will be run for all pubsub topics. We're adding RLN validator to the default validators whenever RLN is enabled.

# Changes

<!-- List of detailed changes -->

- [x] added default validators, which run for all pubsub topics
- [x] included RLN validator to the default validators when RLN is mounted

## How to test

Simulated the scenario in which we send an invalid message on a dynamically added pubsub topics with and without this fix.

With this fix:
<img width="1506" alt="Screenshot 2024-01-26 at 17 42 07" src="https://github.com/waku-org/nwaku/assets/101006718/ccb47ffb-b843-417c-b46e-39fc44843072">

Without it:
<img width="1512" alt="Screenshot 2024-01-26 at 17 42 46" src="https://github.com/waku-org/nwaku/assets/101006718/ccd674ca-998a-4585-ab4a-021953e148ba">

Thanks @AlejandroCabeza for it!
Not adding the test in this PR as it is added in Alex's PR of the RLN test suite

Also, thanks @chaitanyaprem for helping from go-waku side to maintain consistency between both :)



## Issue

closes #2365 
