### PR TITLE
chore: add coverage target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,12 +206,16 @@ networkmonitor: | build deps librln
 ###################
 ## Documentation ##
 ###################
-.PHONY: docs
+.PHONY: docs coverage
 
 # TODO: Remove unused target
 docs: | build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim doc --run --index:on --project --out:.gh-pages waku/waku.nim waku.nims
+
+coverage:
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) ./scripts/run_cov.sh -y
 
 
 #####################

--- a/scripts/run_cov.sh
+++ b/scripts/run_cov.sh
@@ -22,7 +22,7 @@ SCRIPT_PATH=$(dirname "$(realpath -s "$0")")
 REPO_ROOT=$(dirname $SCRIPT_PATH)
 generated_not_to_break_here="$REPO_ROOT/generated_not_to_break_here"
 
-if [ -f $generated_not_to_break_here ]
+if [ "$1" != "-y" ] && [ -f "$generated_not_to_break_here" ]
 then
     echo "The file '$generated_not_to_break_here' already exists. Do you want to continue? (y/n)"
     read -r response


### PR DESCRIPTION
## Description
Add coverage target to make coverage reporting more straightforward. 

## Changes
- Makefile with coverage target in Docs section.
- Add -y option to run_cov.sh silently when an old report exists.
