### PR TITLE
docs: Add check spell allowed words

### DIFF
--- a/docs/benchmarks/cspell.json
+++ b/docs/benchmarks/cspell.json
@@ -1,0 +1,20 @@
+{ "words":
+    [
+        "pubsubtopic",
+        "jmeter",
+        "analyzed",
+        "queryc",
+        "wakudev",
+        "statusim",
+        "queryc",
+        "wakudev",
+        "statusim",
+        "chronos",
+        "libpqis",
+        "Conn",
+        "messageindex",
+        "storedat",
+        "pubsubtopic",
+        "wakudev"
+    ]
+}

--- a/docs/benchmarks/postgres-adoption.md
+++ b/docs/benchmarks/postgres-adoption.md
@@ -109,7 +109,7 @@ Notice that the two `nwaku` nodes run the very same version, which is compiled l
 
 #### Comparing archive SQLite & Postgres performance in [nwaku-b6dd6899](https://github.com/waku-org/nwaku/tree/b6dd6899030ee628813dfd60ad1ad024345e7b41)
 
-The next results were obtained by running the docker-compose-manual-binaries.yml from [test-waku-queryc078075](https://github.com/waku-org/test-waku-query/tree/c07807597faa781ae6c8c32eefdf48ecac03a7ba) in the sandbox machine (metal-01.he-eu-hel1.wakudev.misc.statusim.net.)
+The next results were obtained by running the docker-compose-manual-binaries.yml from [test-waku-query-c078075](https://github.com/waku-org/test-waku-query/tree/c07807597faa781ae6c8c32eefdf48ecac03a7ba) in the sandbox machine (metal-01.he-eu-hel1.wakudev.misc.statusim.net.)
 
 **Scenario 1**
 
@@ -155,7 +155,7 @@ In this case, the performance is similar regarding the timings. The store rate i
 
 This nwaku commit is after a few **Postgres** optimizations were applied.
 
-The next results were obtained by running the docker-compose-manual-binaries.yml from [test-waku-queryc078075](https://github.com/waku-org/test-waku-query/tree/c07807597faa781ae6c8c32eefdf48ecac03a7ba) in the sandbox machine (metal-01.he-eu-hel1.wakudev.misc.statusim.net.)
+The next results were obtained by running the docker-compose-manual-binaries.yml from [test-waku-query-c078075](https://github.com/waku-org/test-waku-query/tree/c07807597faa781ae6c8c32eefdf48ecac03a7ba) in the sandbox machine (metal-01.he-eu-hel1.wakudev.misc.statusim.net.)
 
 **Scenario 1**
 


### PR DESCRIPTION
## Description
Simple PR that prevents `cspell` from giving error for the following words:

"pubsubtopic",
"jmeter",
"analyzed",
"queryc",
"wakudev",
"statusim",
"queryc",
"wakudev",
"statusim",
"chronos",
"libpqis",
"Conn",
"messageindex",
"storedat",
"pubsubtopic",
"wakudev

## Issue

This PR tackles the following comment:
https://github.com/waku-org/docs.waku.org/pull/157#issuecomment-1909149371
