### PR TITLE
chore: REST store - get msgs from self node when store is mounted and no peerAddr is passed

### DIFF
--- a/waku/waku_api/rest/store/client.nim
+++ b/waku/waku_api/rest/store/client.nim
@@ -70,3 +70,26 @@ proc getStoreMessagesV1*(
               {.rest,
                 endpoint: "/store/v1/messages",
                 meth: HttpMethod.MethodGet.}
+
+proc getStoreMessagesV1*(
+                         # URL-encoded reference to the store-node
+                         peerAddr: Option[string],
+                         pubsubTopic: string = "",
+                         # URL-encoded comma-separated list of content topics
+                         contentTopics: string = "",
+                         startTime: string = "",
+                         endTime: string = "",
+
+                         # Optional cursor fields
+                         senderTime: string = "",
+                         storeTime: string = "",
+                         digest: string = "", # base64-encoded digest
+
+                         pageSize: string = "",
+                         ascending: string = ""
+                         ):
+      RestResponse[StoreResponseRest]
+
+              {.rest,
+                endpoint: "/store/v1/messages",
+                meth: HttpMethod.MethodGet.}

--- a/waku/waku_store/protocol.nim
+++ b/waku/waku_store/protocol.nim
@@ -40,7 +40,7 @@ type
   WakuStore* = ref object of LPProtocol
     peerManager: PeerManager
     rng: ref rand.HmacDrbgContext
-    queryHandler: HistoryQueryHandler
+    queryHandler*: HistoryQueryHandler
 
 ## Protocol
 

--- a/waku/waku_store/self_req_handler.nim
+++ b/waku/waku_store/self_req_handler.nim
@@ -1,0 +1,38 @@
+
+##
+## This file is aimed to attend the requests that come directly
+## from the 'self' node. It is expected to attend the store requests that
+## come from REST-store endpoint when those requests don't indicate
+## any store-peer address.
+##
+## Notice that the REST-store requests normally assume that the REST
+## server is acting as a store-client. In this module, we allow that
+## such REST-store node can act as store-server as well by retrieving
+## its own stored messages. The typical use case for that is when
+## using `nwaku-compose`, which spawn a Waku node connected to a local
+## database, and the user is interested in retrieving the messages
+## stored by that local store node.
+##
+
+import
+  stew/results,
+  chronos,
+  chronicles
+import
+  ./protocol,
+  ./common
+
+proc handleSelfStoreRequest*(self: WakuStore, histQuery: HistoryQuery):
+                             Future[WakuStoreResult[HistoryResponse]] {.async.} =
+  ## Handles the store requests made by the node to itself.
+  ## Normally used in REST-store requests
+
+  try:
+    let resp: HistoryResponse = (await self.queryHandler(histQuery)).valueOr:
+      return err("error in handleSelfStoreRequest: " & $error)
+
+    return WakuStoreResult[HistoryResponse].ok(resp)
+
+  except Exception:
+    return err("exception in handleSelfStoreRequest: " & getCurrentExceptionMsg())
+


### PR DESCRIPTION
## Description

A node that handles REST-Store requests it normally acted as a Store-client and therefore it retrieved the messages from another Store-node.
With these changes, we allow a node that has Store mounted, to retrieve its own messages. In other words, the node can act as a Store-server of its own messages.

# Changes

* test_rest_store.nim: add new test to validate that the self-node can retrieve its own messages to the REST client.

* rest/store/client.nim: add new proc to allow making a GET store request without peerAddr.

* rest/store/handle.nim: add logic to handle requests that doesn't provide peerAddr but the self/local node has Store mounted. In this case the self/local node will retrieve its local stored messages.

* waku_store/self_req_handler.nim: logic to handle "store" requests allowing the REST-store node to act as a Store-server node itself. The 'self_req_handler.nim' helps to bypass the store protocol and directly retrieve the messages from the local/self node. I added this logic in a separate file from 'protocol.nim' because it doesn't participate in any libp2p comunication.

* waku_store/protocol.nim: make 'queryHandler' attribute public so that it can be used from the 'self_req_handler.nim' module.


## How to test

Run the new unittest that is being added:
```
nim c -r -d:chronicles_log_level=DEBUG -d:release -d:postgres  -d:rln --passL:librln_v0.3.4.a --passL:-lm -d:nimDebugDlOpen ./tests/wakunode_rest/test_rest_store.nim test "retrieve historical messages from a self-store-node"
```

## Issue

closes https://github.com/waku-org/nwaku/issues/2196