### PR TITLE
chore: ci/Jenkinsfile.release: enforce -d:postgres flag is always used

### DIFF
--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -44,7 +44,6 @@ pipeline {
         '-d:disableMarchNative',
         '-d:chronicles_colors:none',
         '-d:insecure',
-        '-d:postgres',
       ].join(' ')
     )
     choice(
@@ -66,7 +65,7 @@ pipeline {
           "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
           "--label=commit='${env.GIT_COMMIT.take(8)}' " +
           "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
-          "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
+          "--build-arg=NIMFLAGS='${params.NIMFLAGS}' -d:postgres " +
           "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
           "--target=${params.DEBUG ? "debug" : "prod"} ."
         )


### PR DESCRIPTION
## Description
Simple PR to enforce the `-d:postgres` flag is always being set when creating a release image.
Jenkins is not 100% reliable in terms of its parameters and therefore, we need to enforce the usage of this compulsory compilation flag in releases.

With that, we want to prevent errors like the following:
```
2024-01-26 16:05:49 ERR 2024-01-26 14:05:49.204+00:00 4/7 Mounting protocols failed              topics="wakunode main" tid=1 file=wakunode2.nim:89 error="failed to setup archive driver: Postgres has been configured but not been compiled. Check compiler definitions."
```



## Issue
closes https://github.com/waku-org/nwaku/issues/2372