### PR TITLE
fix: bug fix in ci/Jenkinsfile.release: make -d:postgres part of NIMFLAGS

### DIFF
--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -65,7 +65,7 @@ pipeline {
           "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
           "--label=commit='${env.GIT_COMMIT.take(8)}' " +
           "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
-          "--build-arg=NIMFLAGS='${params.NIMFLAGS}' -d:postgres " +
+          "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres' " +
           "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
           "--target=${params.DEBUG ? "debug" : "prod"} ."
         )

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -65,7 +65,7 @@ pipeline {
           "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
           "--label=commit='${env.GIT_COMMIT.take(8)}' " +
           "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
-          "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres' " +
+          "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres ' " +
           "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
           "--target=${params.DEBUG ? "debug" : "prod"} ."
         )


### PR DESCRIPTION
## Description
This PR fixes an issue that came from a change where we enforced the `-d:postgres` flag to always be used when creating a release.

Before this fix, the `-d:postgres` wasn't considered properly as a `NIMFLAG`. Instead, it was considered as a Docker parameter.

![image](https://github.com/waku-org/nwaku/assets/128452529/6bd9f35f-4adb-4c30-be73-5c44ea0a3f1c)

@apentori - apologies for the inconvenience and thanks for the hints!

## Issue
https://github.com/waku-org/nwaku/issues/2372