### PR TITLE
feat: add yamux support

### DIFF
--- a/waku/node/waku_switch.nim
+++ b/waku/node/waku_switch.nim
@@ -91,6 +91,7 @@ proc newWakuSwitch*(
       .withMaxOut(maxOut)
       .withMaxConnsPerPeer(maxConnsPerPeer)
       .withMplex(inTimeout, outTimeout)
+      .withYamux()
       .withNoise()
       .withTcpTransport(transportFlags)
       .withNameResolver(nameResolver)


### PR DESCRIPTION
# Description
Added support to yamux. Since the order of multiplexers matter, it's added after mplex so it continues being the default multiplexer (instead of completely removing mplex, as suggested in the og issue). This is required since go-libp2p is removing support for mplex.

Closes #2331