### PR TITLE
chore: libwaku - simpler ctx mgmt. Param now receiving void* instead of void**

### DIFF
--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -288,24 +288,24 @@ int main(int argc, char** argv) {
 
     ctx = waku_new(jsonConfig, event_handler, userData);
 
-    WAKU_CALL( waku_default_pubsub_topic(&ctx, print_default_pubsub_topic, userData) );
-    WAKU_CALL( waku_version(&ctx, print_waku_version, userData) );
+    WAKU_CALL( waku_default_pubsub_topic(ctx, print_default_pubsub_topic, userData) );
+    WAKU_CALL( waku_version(ctx, print_waku_version, userData) );
 
     printf("Bind addr: %s:%u\n", cfgNode.host, cfgNode.port);
     printf("Waku Relay enabled: %s\n", cfgNode.relay == 1 ? "YES": "NO");
 
     waku_set_event_callback(event_handler, userData);
-    waku_start(&ctx, event_handler, userData);
+    waku_start(ctx, event_handler, userData);
 
     printf("Establishing connection with: %s\n", cfgNode.peers);
 
-    WAKU_CALL( waku_connect(&ctx,
+    WAKU_CALL( waku_connect(ctx,
                             cfgNode.peers,
                             10000 /* timeoutMs */,
                             event_handler,
                             userData) );
 
-    WAKU_CALL( waku_relay_subscribe(&ctx,
+    WAKU_CALL( waku_relay_subscribe(ctx,
                                     "/waku/2/default-waku/proto",
                                     event_handler,
                                     userData) );

--- a/examples/nodejs/waku_addon.c
+++ b/examples/nodejs/waku_addon.c
@@ -234,7 +234,7 @@ static napi_value WakuVersion(napi_env env, napi_callback_info info) {
 
   NAPI_CALL(napi_create_reference(env, cb, 1, &ref_version_callback));
 
-  WAKU_CALL( waku_version(&ctx, handle_waku_version, userData) );
+  WAKU_CALL( waku_version(ctx, handle_waku_version, userData) );
 
   return NULL;
 }
@@ -290,7 +290,7 @@ static napi_value WakuSetEventCallback(napi_env env, napi_callback_info info) {
 }
 
 static napi_value WakuStart(napi_env env, napi_callback_info info) {
-  waku_start(&ctx, event_handler, userData);
+  waku_start(ctx, event_handler, userData);
   return NULL;
 }
 
@@ -347,7 +347,7 @@ static napi_value WakuConnect(napi_env env, napi_callback_info info) {
   my_env = env;
   NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
 
-  WAKU_CALL(waku_connect(&ctx, peers, timeoutMs, handle_error, userData));
+  WAKU_CALL(waku_connect(ctx, peers, timeoutMs, handle_error, userData));
 
   // Free allocated memory
   free(peers);
@@ -418,7 +418,7 @@ static napi_value WakuRelayPublish(napi_env env, napi_callback_info info) {
   char *msgPayload = b64_encode((unsigned char*) msg, strlen(msg));
 
   // TODO: move all the 'waku_content_topic' logic inside the libwaku
-  WAKU_CALL( waku_content_topic(&ctx,
+  WAKU_CALL( waku_content_topic(ctx,
                                 "appName",
                                 1,
                                 content_topic_name,
@@ -457,7 +457,7 @@ static napi_value WakuRelayPublish(napi_env env, napi_callback_info info) {
   NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
 
   // Perform the actual 'publish'
-  WAKU_CALL( waku_relay_publish(&ctx,
+  WAKU_CALL( waku_relay_publish(ctx,
                                 pubsub_topic,
                                 jsonWakuMsg,
                                 timeoutMs,
@@ -496,7 +496,7 @@ static napi_value WakuDefaultPubsubTopic(napi_env env, napi_callback_info info) 
 
   NAPI_CALL(napi_create_reference(env, cb, 1, &ref_def_pubsub_topic_callback));
 
-  WAKU_CALL( waku_default_pubsub_topic(&ctx, handle_default_pubsub_topic, userData) );
+  WAKU_CALL( waku_default_pubsub_topic(ctx, handle_default_pubsub_topic, userData) );
 
   return NULL;
 }
@@ -543,7 +543,7 @@ static napi_value WakuRelaySubscribe(napi_env env, napi_callback_info info) {
   NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
 
   // Calling the actual 'subscribe' waku function
-  WAKU_CALL( waku_relay_subscribe(&ctx, pubsub_topic, handle_error, userData) );
+  WAKU_CALL( waku_relay_subscribe(ctx, pubsub_topic, handle_error, userData) );
 
   free(pubsub_topic);
 

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -94,11 +94,11 @@ proc waku_new(configJson: cstring,
 
   return ctx
 
-proc waku_version(ctx: ptr ptr Context,
+proc waku_version(ctx: ptr Context,
                   callback: WakuCallBack,
                   userData: pointer): cint {.dynlib, exportc.} =
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   if isNil(callback):
     return RET_MISSING_CALLBACK
@@ -111,7 +111,7 @@ proc waku_version(ctx: ptr ptr Context,
 proc waku_set_event_callback(callback: WakuCallBack) {.dynlib, exportc.} =
   extEventCallback = callback
 
-proc waku_content_topic(ctx: ptr ptr Context,
+proc waku_content_topic(ctx: ptr Context,
                         appName: cstring,
                         appVersion: cuint,
                         contentTopicName: cstring,
@@ -120,7 +120,7 @@ proc waku_content_topic(ctx: ptr ptr Context,
                         userData: pointer): cint {.dynlib, exportc.} =
   # https://rfc.vac.dev/spec/36/#extern-char-waku_content_topicchar-applicationname-unsigned-int-applicationversion-char-contenttopicname-char-encoding
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   if isNil(callback):
     return RET_MISSING_CALLBACK
@@ -138,13 +138,13 @@ proc waku_content_topic(ctx: ptr ptr Context,
 
   return RET_OK
 
-proc waku_pubsub_topic(ctx: ptr ptr Context,
+proc waku_pubsub_topic(ctx: ptr Context,
                        topicName: cstring,
                        callback: WakuCallBack,
                        userData: pointer): cint {.dynlib, exportc, cdecl.} =
   # https://rfc.vac.dev/spec/36/#extern-char-waku_pubsub_topicchar-name-char-encoding
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   if isNil(callback):
     return RET_MISSING_CALLBACK
@@ -158,12 +158,12 @@ proc waku_pubsub_topic(ctx: ptr ptr Context,
 
   return RET_OK
 
-proc waku_default_pubsub_topic(ctx: ptr ptr Context,
+proc waku_default_pubsub_topic(ctx: ptr Context,
                                callback: WakuCallBack,
                                userData: pointer): cint {.dynlib, exportc.} =
   # https://rfc.vac.dev/spec/36/#extern-char-waku_default_pubsub_topic
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   if isNil(callback):
     return RET_MISSING_CALLBACK
@@ -172,7 +172,7 @@ proc waku_default_pubsub_topic(ctx: ptr ptr Context,
 
   return RET_OK
 
-proc waku_relay_publish(ctx: ptr ptr Context,
+proc waku_relay_publish(ctx: ptr Context,
                         pubSubTopic: cstring,
                         jsonWakuMessage: cstring,
                         timeoutMs: cuint,
@@ -182,7 +182,7 @@ proc waku_relay_publish(ctx: ptr ptr Context,
                         {.dynlib, exportc, cdecl.} =
   # https://rfc.vac.dev/spec/36/#extern-char-waku_relay_publishchar-messagejson-char-pubsubtopic-int-timeoutms
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   if isNil(callback):
     return RET_MISSING_CALLBACK
@@ -226,7 +226,7 @@ proc waku_relay_publish(ctx: ptr ptr Context,
                             $pst
 
   let sendReqRes = waku_thread.sendRequestToWakuThread(
-                          ctx[],
+                          ctx,
                           RequestType.RELAY,
                           RelayRequest.createShared(RelayMsgType.PUBLISH,
                                           PubsubTopic($pst),
@@ -241,42 +241,42 @@ proc waku_relay_publish(ctx: ptr ptr Context,
 
   return RET_OK
 
-proc waku_start(ctx: ptr ptr Context,
+proc waku_start(ctx: ptr Context,
                 callback: WakuCallBack,
                 userData: pointer): cint {.dynlib, exportc.} =
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
   ## TODO: handle the error
   discard waku_thread.sendRequestToWakuThread(
-                                      ctx[],
+                                      ctx,
                                       RequestType.LIFECYCLE,
                                       NodeLifecycleRequest.createShared(
                                               NodeLifecycleMsgType.START_NODE))
 
-proc waku_stop(ctx: ptr ptr Context,
+proc waku_stop(ctx: ptr Context,
                callback: WakuCallBack,
                userData: pointer): cint {.dynlib, exportc.} =
-  ctx[][].userData = userData
+  ctx[].userData = userData
   ## TODO: handle the error
   discard waku_thread.sendRequestToWakuThread(
-                                      ctx[],
+                                      ctx,
                                       RequestType.LIFECYCLE,
                                       NodeLifecycleRequest.createShared(
                                               NodeLifecycleMsgType.STOP_NODE))
 
 proc waku_relay_subscribe(
-                ctx: ptr ptr Context,
+                ctx: ptr Context,
                 pubSubTopic: cstring,
                 callback: WakuCallBack,
                 userData: pointer): cint
                 {.dynlib, exportc.} =
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   let pst = pubSubTopic.alloc()
 
   let sendReqRes = waku_thread.sendRequestToWakuThread(
-                              ctx[],
+                              ctx,
                               RequestType.RELAY,
                               RelayRequest.createShared(RelayMsgType.SUBSCRIBE,
                                     PubsubTopic($pst),
@@ -291,18 +291,18 @@ proc waku_relay_subscribe(
   return RET_OK
 
 proc waku_relay_unsubscribe(
-                ctx: ptr ptr Context,
+                ctx: ptr Context,
                 pubSubTopic: cstring,
                 callback: WakuCallBack,
                 userData: pointer): cint
                 {.dynlib, exportc.} =
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   let pst = pubSubTopic.alloc()
 
   let sendReqRes = waku_thread.sendRequestToWakuThread(
-                              ctx[],
+                              ctx,
                               RequestType.RELAY,
                               RelayRequest.createShared(RelayMsgType.SUBSCRIBE,
                                     PubsubTopic($pst),
@@ -316,17 +316,17 @@ proc waku_relay_unsubscribe(
 
   return RET_OK
 
-proc waku_connect(ctx: ptr ptr Context,
+proc waku_connect(ctx: ptr Context,
                   peerMultiAddr: cstring,
                   timeoutMs: cuint,
                   callback: WakuCallBack,
                   userData: pointer): cint
                   {.dynlib, exportc.} =
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   let connRes = waku_thread.sendRequestToWakuThread(
-                                   ctx[],
+                                   ctx,
                                    RequestType.PEER_MANAGER,
                                    PeerManagementRequest.createShared(
                                             PeerManagementMsgType.CONNECT_TO,
@@ -339,7 +339,7 @@ proc waku_connect(ctx: ptr ptr Context,
 
   return RET_OK
 
-proc waku_store_query(ctx: ptr ptr Context,
+proc waku_store_query(ctx: ptr Context,
                       queryJson: cstring,
                       peerId: cstring,
                       timeoutMs: cint,
@@ -347,7 +347,7 @@ proc waku_store_query(ctx: ptr ptr Context,
                       userData: pointer): cint
                       {.dynlib, exportc.} =
 
-  ctx[][].userData = userData
+  ctx[].userData = userData
 
   ## TODO: implement the logic that make the "self" node to act as a Store client
 


### PR DESCRIPTION
## Description
This change is needed so that interoperability with other languages becomes simpler. Particularly, this simplification is needed from the Python point of view, where it is tricky to pass a void** as a parameter to an FFI function.


