### PR TITLE
feat(networkmonitor): add support for rln

### DIFF
--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -28,6 +28,7 @@ import
   ../../waku/waku_discv5,
   ../../waku/waku_dnsdisc,
   ../../waku/waku_rln_relay,
+  ../wakunode2/networks_config,
   ./networkmonitor_metrics,
   ./networkmonitor_config,
   ./networkmonitor_utils
@@ -376,6 +377,10 @@ proc initAndStartApp(conf: NetworkMonitorConf): Result[(WakuNode, WakuDiscoveryV
       udpPort = some(nodeUdpPort),
   )
   builder.withWakuCapabilities(flags)
+  let addShardedTopics = builder.withShardedTopics(conf.pubsubTopics)
+  if addShardedTopics.isErr():
+    error "failed to add sharded topics to ENR", error=addShardedTopics.error
+    return err($addShardedTopics.error)
 
   let recordRes = builder.build()
   let record =
@@ -387,6 +392,9 @@ proc initAndStartApp(conf: NetworkMonitorConf): Result[(WakuNode, WakuDiscoveryV
 
   nodeBuilder.withNodeKey(key)
   nodeBuilder.withRecord(record)
+  nodeBuilder.withPeerManagerConfig(
+    maxRelayPeers = none(int),
+    shardAware = true)
   let res = nodeBuilder.withNetworkConfigurationDetails(bindIp, nodeTcpPort)
   if res.isErr():
     return err("node building error" & $res.error)
@@ -476,8 +484,16 @@ when isMainModule:
     error "could not load cli variables", err=confRes.error
     quit(1)
 
-  let conf = confRes.get()
+  var conf = confRes.get()
   info "cli flags", conf=conf
+
+  if conf.clusterId == 1:
+    let twnClusterConf = ClusterConf.TheWakuNetworkConf()
+
+    conf.bootstrapNodes = twnClusterConf.discv5BootstrapNodes
+    conf.pubsubTopics = twnClusterConf.pubsubTopics
+    conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
+    conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
 
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)
@@ -538,7 +554,7 @@ when isMainModule:
       error "failed to setup RLN", err=getCurrentExceptionMsg()
       quit 1
 
-  node.mountMetadata(1).isOkOr:
+  node.mountMetadata(conf.clusterId).isOkOr:
     error "failed to mount waku metadata protocol: ", err=error
     quit 1
 

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -524,7 +524,7 @@ when isMainModule:
 
     let rlnConf = WakuRlnConfig(
       rlnRelayDynamic: conf.rlnRelayDynamic,
-      rlnRelayCredIndex: conf.rlnRelayCredIndex,
+      rlnRelayCredIndex: some(uint(0)),
       rlnRelayEthContractAddress: conf.rlnRelayEthContractAddress,
       rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress,
       rlnRelayCredPath: "",

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -42,6 +42,11 @@ type
       name: "refresh-interval",
       abbr: "r" }: int
 
+    clusterId* {.
+      desc: "Cluster id that the node is running in. Node in a different cluster id is disconnected."
+      defaultValue: 1
+      name: "cluster-id" }: uint32
+
     rlnRelay* {.
         desc: "Enable spam protection through rln-relay: true|false",
         defaultValue: true

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -32,11 +32,45 @@ type
       defaultValue: ""
       name: "dns-discovery-url" }: string
 
+    pubsubTopics* {.
+      desc: "Default pubsub topic to subscribe to. Argument may be repeated."
+      name: "pubsub-topic" .}: seq[string]
+
     refreshInterval* {.
       desc: "How often new peers are discovered and connected to (in seconds)",
       defaultValue: 5,
       name: "refresh-interval",
       abbr: "r" }: int
+
+    rlnRelay* {.
+        desc: "Enable spam protection through rln-relay: true|false",
+        defaultValue: true
+        name: "rln-relay" }: bool
+
+    rlnRelayCredIndex* {.
+      desc: "the index of the onchain commitment to use",
+      defaultValue: some(uint(0)),
+      name: "rln-relay-membership-index" }: Option[uint]
+
+    rlnRelayDynamic* {.
+      desc: "Enable  waku-rln-relay with on-chain dynamic group management: true|false",
+      defaultValue: true
+      name: "rln-relay-dynamic" }: bool
+
+    rlnRelayTreePath* {.
+      desc: "Path to the RLN merkle tree sled db (https://github.com/spacejam/sled)",
+      defaultValue: ""
+      name: "rln-relay-tree-path" }: string
+
+    rlnRelayEthClientAddress* {.
+      desc: "WebSocket address of an Ethereum testnet client e.g., http://localhost:8540/",
+      defaultValue: "http://localhost:8540/",
+      name: "rln-relay-eth-client-address" }: string
+
+    rlnRelayEthContractAddress* {.
+      desc: "Address of membership contract on an Ethereum testnet",
+      defaultValue: "",
+      name: "rln-relay-eth-contract-address" }: string
 
     ## Prometheus metrics config
     metricsServer* {.

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -47,11 +47,6 @@ type
         defaultValue: true
         name: "rln-relay" }: bool
 
-    rlnRelayCredIndex* {.
-      desc: "the index of the onchain commitment to use",
-      defaultValue: some(uint(0)),
-      name: "rln-relay-membership-index" }: Option[uint]
-
     rlnRelayDynamic* {.
       desc: "Enable  waku-rln-relay with on-chain dynamic group management: true|false",
       defaultValue: true


### PR DESCRIPTION
# Description
This PR adds support of RLN into NetworkMonitor - so that we can tun it for The Waku Network

# Changes

- [ ] add RLN related config options
- [ ] mount RLN relay
- [ ] mount Metadata protocol


## How to test

1. `make networkmonitor`
1. ```
    /build/networkmonitor --rln-relay-eth-client-address=$ETH_CLIENT_ADDRESS --bootstrap-node="enr:-QESuEC1p_s3xJzAC_XlOuuNrhVUETmfhbm1wxRGis0f7DlqGSw2FM-p2Ugl_r25UHQJ3f1rIRrpzxJXSMaJe4yk1XFSAYJpZIJ2NIJpcISygI2rim11bHRpYWRkcnO4XAArNiZub2RlLTAxLmRvLWFtczMud2FrdS50ZXN0LnN0YXR1c2ltLm5ldAZ2XwAtNiZub2RlLTAxLmRvLWFtczMud2FrdS50ZXN0LnN0YXR1c2ltLm5ldAYfQN4DgnJzkwABCAAAAAEAAgADAAQABQAGAAeJc2VjcDI1NmsxoQJATXRSRSUyTw_QLB6H_U3oziVQgNRgrXpK7wp2AMyNxYN0Y3CCdl-DdWRwgiMohXdha3UyDw" --pubsub-topic=/waku/2/rs/1/0  --pubsub-topic=/waku/2/rs/1/1   --pubsub-topic=/waku/2/rs/1/2  --pubsub-topic=/waku/2/rs/1/3  --pubsub-topic=/waku/2/rs/1/4  --pubsub-topic=/waku/2/rs/1/5  --pubsub-topic=/waku/2/rs/1/6  --pubsub-topic=/waku/2/rs/1/7 --rln-relay-eth-contract-address=0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4 --rln-relay-tree-path="./rln_tree" 
    ```
1. ```curl http://localhost:8008/metrics```





## Issue

closes #2400
