### PR TITLE
chore: automatically generating certs if not provided (Waku Canary)

### DIFF
--- a/apps/wakucanary/certsgenerator.nim
+++ b/apps/wakucanary/certsgenerator.nim
@@ -1,4 +1,17 @@
-import osproc, os
+import 
+  osproc, 
+  os, 
+  httpclient, 
+  strutils
+
+proc getPublicIP(): string =
+  let client = newHttpClient()
+  try:
+    let response = client.get("http://api.ipify.org")
+    return response.body
+  except Exception as e:
+    echo "Could not fetch public IP: " & e.msg
+    return "127.0.0.1"
 
 # Function to generate a self-signed certificate
 proc generateSelfSignedCertificate*(certPath: string, keyPath: string) : int =
@@ -8,10 +21,16 @@ proc generateSelfSignedCertificate*(certPath: string, keyPath: string) : int =
     echo "OpenSSL is not installed or not in the PATH."
     return 1
 
+  let publicIP = getPublicIP()
+  
+  if publicIP != "127.0.0.1":
+    echo "Your public IP address is: ", publicIP 
+  
   # Command to generate private key and cert
   let 
     cmd = "openssl req -x509 -newkey rsa:4096 -keyout " & keyPath & " -out " & certPath &
-            " -sha256 -days 3650 -nodes -subj '/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname'"
+            " -sha256 -days 3650 -nodes -subj '/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=" & 
+            publicIP & "'"
     res = execCmd(cmd)
 
   if res == 0:

--- a/apps/wakucanary/certsgenerator.nim
+++ b/apps/wakucanary/certsgenerator.nim
@@ -1,0 +1,23 @@
+import osproc, os
+
+# Function to generate a self-signed certificate
+proc generateSelfSignedCertificate*(certPath: string, keyPath: string) : int =
+  
+  # Ensure the OpenSSL is installed
+  if findExe("openssl") == "":
+    echo "OpenSSL is not installed or not in the PATH."
+    return 1
+
+  # Command to generate private key and cert
+  let 
+    cmd = "openssl req -x509 -newkey rsa:4096 -keyout " & keyPath & " -out " & certPath &
+            " -sha256 -days 3650 -nodes -subj '/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname'"
+    res = execCmd(cmd)
+
+  if res == 0:
+    echo "Successfully generated self-signed certificate and key."
+  else:
+    echo "Failed to generate certificate and key."
+  
+  return res
+  

--- a/apps/wakucanary/wakucanary.nim
+++ b/apps/wakucanary/wakucanary.nim
@@ -26,7 +26,7 @@ const ProtocolsTable = {
 }.toTable
 
 const WebSocketPortOffset = 1000
-const CertsDirectory = "./apps/wakucanary/certs"
+const CertsDirectory = "./certs"
 
 # cli flags
 type

--- a/apps/wakucanary/wakucanary.nim
+++ b/apps/wakucanary/wakucanary.nim
@@ -3,13 +3,15 @@ import
   confutils,
   chronos,
   stew/shims/net,
-  chronicles/topics_registry
+  chronicles/topics_registry,
+  os
 import
   libp2p/protocols/ping,
   libp2p/crypto/[crypto, secp],
   libp2p/nameresolving/dnsresolver,
   libp2p/multicodec
 import
+  ./certsgenerator,
   ../../waku/waku_enr,
   ../../waku/node/peer_manager,
   ../../waku/waku_core,
@@ -24,6 +26,7 @@ const ProtocolsTable = {
 }.toTable
 
 const WebSocketPortOffset = 1000
+const CertsDirectory = "./apps/wakucanary/certs"
 
 # cli flags
 type
@@ -154,6 +157,14 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
     nodeTcpPort = Port(conf.nodePort)
     isWs = peer.addrs[0].contains(multiCodec("ws")).get()
     isWss = peer.addrs[0].contains(multiCodec("wss")).get()
+    keyPath = if conf.websocketSecureKeyPath.len > 0:
+                conf.websocketSecureKeyPath
+              else:
+                CertsDirectory & "/key.pem"
+    certPath = if conf.websocketSecureCertPath.len > 0:
+                conf.websocketSecureCertPath
+              else:
+                CertsDirectory & "/cert.pem"
 
   var builder = WakuNodeBuilder.init()
   builder.withNodeKey(nodeKey)
@@ -177,14 +188,18 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
 
   if isWss and (conf.websocketSecureKeyPath.len == 0 or
       conf.websocketSecureCertPath.len == 0):
-    error "WebSocket Secure requires key and certificate, see --help"
-    return 1
+    info "WebSocket Secure requires key and certificate. Generating them"
+    if not dirExists(CertsDirectory):
+      createDir(CertsDirectory)
+    if generateSelfSignedCertificate(certPath, keyPath) != 0:
+      error "Error generating key and certificate"
+      return 1
 
   builder.withRecord(record)
   builder.withNetworkConfiguration(netConfig.tryGet())
   builder.withSwitchConfiguration(
-    secureKey = some(conf.websocketSecureKeyPath),
-    secureCert = some(conf.websocketSecureCertPath),
+    secureKey = some(keyPath),
+    secureCert = some(certPath),
     nameResolver = resolver,
   )
 


### PR DESCRIPTION
# Description
Automatically generating a self signed certificate in Waku Canary if not provided and WSS is used.

Notice that the keys and certificate are generated only if `OpenSSL` is installed. It comes preinstalled in Ubuntu, other common Linux distributions and MacOS.
If `openssl` command is not available and certificates are not provided, an error message is shown.

# Changes

<!-- List of detailed changes -->

- [x] generating key and certificate if needed and not provided

## How to test

1. Build Waku Canary: `make wakucanary`
3. Run it on a WSS address without setting certificates: `./build/wakucanary --address=/dns4/node-01.gc-us-central1-a.status.test.statusim.net/tcp/443/wss/p2p/16Uiu2HAmGDX3iAFox93PupVYaHa88kULGqMpJ7AEHGwj3jbMtt76 --protocol=relay`




## Issue

closes #2349 
