### PR TITLE
chore: add stdef.h to libwaku.h

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -6,6 +6,8 @@
 #ifndef __libwaku__
 #define __libwaku__
 
+#include <stddef.h>
+
 // The possible returned values for the functions that return int
 #define RET_OK                0
 #define RET_ERR               1


### PR DESCRIPTION
# Description
While generating the bindings for rust, I ran into the error `unknown type name 'size_t'`. This PR adds a header to `libwaku.h` to fix that problem. 

Curiously enough, in the c-bindings example we don't have such error because we include `stdio.h` which includes `stddef.h`
