### PR TITLE
feat: `eventCallback` per wakunode and `userData` 

### DIFF
--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -294,7 +294,7 @@ int main(int argc, char** argv) {
     printf("Bind addr: %s:%u\n", cfgNode.host, cfgNode.port);
     printf("Waku Relay enabled: %s\n", cfgNode.relay == 1 ? "YES": "NO");
 
-    waku_set_event_callback(event_handler, userData);
+    waku_set_event_callback(ctx, event_handler, userData);
     waku_start(ctx, event_handler, userData);
 
     printf("Establishing connection with: %s\n", cfgNode.peers);

--- a/library/callback.nim
+++ b/library/callback.nim
@@ -2,4 +2,5 @@
 type
   WakuCallBack* = proc(callerRet: cint,
                        msg: ptr cchar,
-                       len: csize_t) {.cdecl, gcsafe, raises: [].}
+                       len: csize_t,
+                       userData: pointer) {.cdecl, gcsafe, raises: [].}

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -39,7 +39,8 @@ int waku_version(void* ctx,
                  WakuCallBack callback,
                  void* userData);
 
-void waku_set_event_callback(WakuCallBack callback,
+void waku_set_event_callback(void* ctx,
+                             WakuCallBack callback,
                              void* userData);
 
 int waku_content_topic(void* ctx,

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-typedef void (*WakuCallBack) (int callerRet, const char* msg, size_t len);
+typedef void (*WakuCallBack) (int callerRet, const char* msg, size_t len, void* userData);
 
 // Creates a new instance of the waku node.
 // Sets up the waku node from the given configuration.

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -6,6 +6,8 @@
 #ifndef __libwaku__
 #define __libwaku__
 
+#include <stddef.h>
+
 // The possible returned values for the functions that return int
 #define RET_OK                0
 #define RET_ERR               1

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -46,11 +46,11 @@ proc relayEventCallback(ctx: ptr Context): WakuRelayHandler =
     if not isNil(ctx[].eventCallback):
       try:
         let event = $JsonMessageEvent.new(pubsubTopic, msg)
-        cast[WakuCallBack](ctx[].eventCallback)(RET_OK, unsafeAddr event[0], cast[csize_t](len(event)))
+        cast[WakuCallBack](ctx[].eventCallback)(RET_OK, unsafeAddr event[0], cast[csize_t](len(event)), nil)
       except Exception,CatchableError:
         let msg = "Exception when calling 'eventCallBack': " &
                   getCurrentExceptionMsg()
-        cast[WakuCallBack](ctx[].eventCallback)(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+        cast[WakuCallBack](ctx[].eventCallback)(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), nil)
     else:
       error "eventCallback is nil"
 
@@ -73,7 +73,7 @@ proc waku_new(configJson: cstring,
   ## Create the Waku thread that will keep waiting for req from the main thread.
   var ctx = waku_thread.createWakuThread().valueOr:
     let msg = "Error in createWakuThread: " & $error
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return nil
 
   ctx.userData = userData
@@ -86,7 +86,7 @@ proc waku_new(configJson: cstring,
                                               configJson))
   if sendReqRes.isErr():
     let msg = $sendReqRes.error
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return nil
 
   return ctx
@@ -101,7 +101,7 @@ proc waku_version(ctx: ptr Context,
     return RET_MISSING_CALLBACK
 
   callback(RET_OK, cast[ptr cchar](WakuNodeVersionString),
-           cast[csize_t](len(WakuNodeVersionString)))
+           cast[csize_t](len(WakuNodeVersionString)), userData)
 
   return RET_OK
 
@@ -128,7 +128,7 @@ proc waku_content_topic(ctx: ptr Context,
   let encodingStr = encoding.alloc()
 
   let contentTopic = fmt"/{$appStr}/{appVersion}/{$ctnStr}/{$encodingStr}"
-  callback(RET_OK, unsafeAddr contentTopic[0], cast[csize_t](len(contentTopic)))
+  callback(RET_OK, unsafeAddr contentTopic[0], cast[csize_t](len(contentTopic)), userData)
 
   deallocShared(appStr)
   deallocShared(ctnStr)
@@ -150,7 +150,7 @@ proc waku_pubsub_topic(ctx: ptr Context,
   let topicNameStr = topicName.alloc()
 
   let outPubsubTopic = fmt"/waku/2/{$topicNameStr}"
-  callback(RET_OK, unsafeAddr outPubsubTopic[0], cast[csize_t](len(outPubsubTopic)))
+  callback(RET_OK, unsafeAddr outPubsubTopic[0], cast[csize_t](len(outPubsubTopic)), userData)
 
   deallocShared(topicNameStr)
 
@@ -166,7 +166,7 @@ proc waku_default_pubsub_topic(ctx: ptr Context,
   if isNil(callback):
     return RET_MISSING_CALLBACK
 
-  callback(RET_OK, cast[ptr cchar](DefaultPubsubTopic), cast[csize_t](len(DefaultPubsubTopic)))
+  callback(RET_OK, cast[ptr cchar](DefaultPubsubTopic), cast[csize_t](len(DefaultPubsubTopic)), userData)
 
   return RET_OK
 
@@ -192,7 +192,7 @@ proc waku_relay_publish(ctx: ptr Context,
   except JsonParsingError:
     deallocShared(jwm)
     let msg = fmt"Error parsing json message: {getCurrentExceptionMsg()}"
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
   deallocShared(jwm)
@@ -213,7 +213,7 @@ proc waku_relay_publish(ctx: ptr Context,
     )
   except KeyError:
     let msg = fmt"Problem building the WakuMessage: {getCurrentExceptionMsg()}"
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
   let pst = pubSubTopic.alloc()
@@ -234,7 +234,7 @@ proc waku_relay_publish(ctx: ptr Context,
 
   if sendReqRes.isErr():
     let msg = $sendReqRes.error
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
   return RET_OK
@@ -283,7 +283,7 @@ proc waku_relay_subscribe(
 
   if sendReqRes.isErr():
     let msg = $sendReqRes.error
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
   return RET_OK
@@ -309,7 +309,7 @@ proc waku_relay_unsubscribe(
 
   if sendReqRes.isErr():
     let msg = $sendReqRes.error
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
   return RET_OK
@@ -332,7 +332,7 @@ proc waku_connect(ctx: ptr Context,
                                             chronos.milliseconds(timeoutMs)))
   if connRes.isErr():
     let msg = $connRes.error
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)))
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
   return RET_OK

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -26,6 +26,7 @@ type
     respChannel: ChannelSPSCSingle[ptr InterThreadResponse]
     respSignal: ThreadSignalPtr
     userData*: pointer
+    eventCallback*: pointer
 
 # To control when the thread is running
 var running: Atomic[bool]


### PR DESCRIPTION
# Description
1. Instead of using a global variable for the event callback, each wakunode instance will have their own event callback
2. Uses some of the code changes from https://github.com/waku-org/nwaku/pull/2089 to pass the `userData` to the callbacks
