### PR TITLE
feat: Incentivization: add codec for eligibility proofs

### DIFF
--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -42,7 +42,8 @@ import
   ./waku_filter_v2/test_all,
   ./waku_peer_exchange/test_all,
   ./waku_lightpush/test_all,
-  ./waku_relay/test_all
+  ./waku_relay/test_all,
+  ./incentivization/test_all
 
 import
   # Waku v2 tests

--- a/tests/incentivization/test_all.nim
+++ b/tests/incentivization/test_all.nim
@@ -1,0 +1,2 @@
+import
+  ./test_rpc_codec

--- a/tests/incentivization/test_rpc_codec.nim
+++ b/tests/incentivization/test_rpc_codec.nim
@@ -1,0 +1,39 @@
+import
+  std/options,
+  std/strscans,
+  testutils/unittests,
+  chronicles,
+  chronos,
+  libp2p/crypto/crypto
+
+import
+  ../../../waku/incentivization/rpc,
+  ../../../waku/incentivization/rpc_codec
+
+proc createRequestWithProof(): DummyRequest = 
+  var ep: EligibilityProof
+  ep.proofType = EligibilityProofType.TX_ID
+  ep.proof = "0xffffffff"
+  result.requestId = "request1"
+  result.eligibilityProof = some(ep)
+
+proc createResponse(): DummyResponse = 
+  var es: EligibilityStatus
+  es.statusCode = 200
+  es.statusDesc = "OK"
+  result.requestId = "request1"
+  result.eligibilityStatus = some(es)
+
+suite "Waku Incentivization Eligibility Codec":
+
+    asyncTest "encode eligibility request with proof":
+      let req = createRequestWithProof()
+      let decoded = DummyRequest.decode(encode(req).buffer).get()
+      check:
+          req == decoded
+        
+    asyncTest "encode eligibility response":
+      let resp = createResponse()
+      let decoded = DummyResponse.decode(encode(resp).buffer).get()
+      check:
+        resp == decoded

--- a/tests/incentivization/test_rpc_codec.nim
+++ b/tests/incentivization/test_rpc_codec.nim
@@ -10,30 +10,23 @@ import
   ../../../waku/incentivization/rpc,
   ../../../waku/incentivization/rpc_codec
 
-proc createRequestWithProof(): DummyRequest = 
-  var ep: EligibilityProof
-  ep.proofType = EligibilityProofType.TX_ID
-  ep.proof = "0xffffffff"
-  result.requestId = "request1"
-  result.eligibilityProof = some(ep)
-
-proc createResponse(): DummyResponse = 
-  var es: EligibilityStatus
-  es.statusCode = 200
-  es.statusDesc = "OK"
-  result.requestId = "request1"
-  result.eligibilityStatus = some(es)
 
 suite "Waku Incentivization Eligibility Codec":
 
-    asyncTest "encode eligibility request with proof":
-      let req = createRequestWithProof()
-      let decoded = DummyRequest.decode(encode(req).buffer).get()
+    asyncTest "encode eligibility proof":
+      var byteSequence: seq[byte] = @[1, 2, 3]
+      let epRpc = EligibilityProof(proof: some(byteSequence))
+      let encoded = encode(epRpc)
+      let decoded = EligibilityProof.decode(encoded.buffer).get()
       check:
-          req == decoded
-        
-    asyncTest "encode eligibility response":
-      let resp = createResponse()
-      let decoded = DummyResponse.decode(encode(resp).buffer).get()
+          epRpc == decoded
+    
+    asyncTest "encode eligibility status":
+      let esRpc = EligibilityStatus(
+        statusCode: some(uint32(200)),
+        statusDesc: some("OK")
+      )
+      let encoded = encode(esRpc)
+      let decoded = EligibilityStatus.decode(encoded.buffer).get()
       check:
-        resp == decoded
+        esRpc == decoded

--- a/tests/incentivization/test_rpc_codec.nim
+++ b/tests/incentivization/test_rpc_codec.nim
@@ -23,7 +23,7 @@ suite "Waku Incentivization Eligibility Codec":
     
     asyncTest "encode eligibility status":
       let esRpc = EligibilityStatus(
-        statusCode: some(uint32(200)),
+        statusCode: uint32(200),
         statusDesc: some("OK")
       )
       let encoded = encode(esRpc)

--- a/tests/incentivization/test_rpc_codec.nim
+++ b/tests/incentivization/test_rpc_codec.nim
@@ -14,8 +14,8 @@ import
 suite "Waku Incentivization Eligibility Codec":
 
     asyncTest "encode eligibility proof":
-      var byteSequence: seq[byte] = @[1, 2, 3]
-      let epRpc = EligibilityProof(proof: some(byteSequence))
+      var byteSequence: seq[byte] = @[1, 2, 3, 4, 5, 6, 7, 8]
+      let epRpc = EligibilityProof(proofOfPayment: some(byteSequence))
       let encoded = encode(epRpc)
       let decoded = EligibilityProof.decode(encoded.buffer).get()
       check:

--- a/waku/incentivization/rpc.nim
+++ b/waku/incentivization/rpc.nim
@@ -10,7 +10,7 @@ import
 type
 
   EligibilityProof* = object
-    proof*: Option[seq[byte]]
+    proofOfPayment*: Option[seq[byte]]
 
   EligibilityStatus* = object
     statusCode*: Option[uint32]

--- a/waku/incentivization/rpc.nim
+++ b/waku/incentivization/rpc.nim
@@ -1,0 +1,27 @@
+import
+  json_serialization,
+  std/options
+import
+  ../waku_core
+
+type
+  EligibilityProofType* {.pure.} = enum
+    # Indicates the type of eligibility proof
+    NONE = uint32(0)
+    TX_ID = uint32(1)
+
+  EligibilityProof* = object
+    proofType*: EligibilityProofType
+    proof*: string # or bytes?
+
+  DummyRequest* = object
+    requestId*: string
+    eligibilityProof*: Option[EligibilityProof]
+
+  EligibilityStatus* = object
+    statusCode*: uint32
+    statusDesc*: string # should descripiton be optional?
+
+  DummyResponse* = object
+    requestId*: string
+    eligibilityStatus*: Option[EligibilityStatus]

--- a/waku/incentivization/rpc.nim
+++ b/waku/incentivization/rpc.nim
@@ -4,24 +4,14 @@ import
 import
   ../waku_core
 
+# Exactly following the RFC:
+# https://github.com/vacp2p/rfc/tree/master/content/docs/rfcs/73
+
 type
-  EligibilityProofType* {.pure.} = enum
-    # Indicates the type of eligibility proof
-    NONE = uint32(0)
-    TX_ID = uint32(1)
 
   EligibilityProof* = object
-    proofType*: EligibilityProofType
-    proof*: string # or bytes?
-
-  DummyRequest* = object
-    requestId*: string
-    eligibilityProof*: Option[EligibilityProof]
+    proof*: Option[seq[byte]]
 
   EligibilityStatus* = object
-    statusCode*: uint32
-    statusDesc*: string # should descripiton be optional?
-
-  DummyResponse* = object
-    requestId*: string
-    eligibilityStatus*: Option[EligibilityStatus]
+    statusCode*: Option[uint32]
+    statusDesc*: Option[string]

--- a/waku/incentivization/rpc.nim
+++ b/waku/incentivization/rpc.nim
@@ -4,7 +4,7 @@ import
 import
   ../waku_core
 
-# Exactly following the RFC:
+# Implementing the RFC:
 # https://github.com/vacp2p/rfc/tree/master/content/docs/rfcs/73
 
 type
@@ -13,5 +13,5 @@ type
     proofOfPayment*: Option[seq[byte]]
 
   EligibilityStatus* = object
-    statusCode*: Option[uint32]
+    statusCode*: uint32
     statusDesc*: Option[string]

--- a/waku/incentivization/rpc_codec.nim
+++ b/waku/incentivization/rpc_codec.nim
@@ -10,9 +10,9 @@ import
 
 proc encode*(epRpc: EligibilityProof): ProtoBuffer = 
   var pb = initProtoBuffer()
-  if epRpc.proof.isSome:
-    let proof = epRpc.proof.get()
-    pb.write3(1, proof)
+  if epRpc.proofOfPayment.isSome():
+    let proofOfPayment = epRpc.proofOfPayment.get()
+    pb.write3(1, proofOfPayment)
   else:
     # there is no proof
     discard
@@ -21,11 +21,11 @@ proc encode*(epRpc: EligibilityProof): ProtoBuffer =
 proc decode*(T: type EligibilityProof, buffer: seq[byte]): ProtobufResult[T] = 
   let pb = initProtoBuffer(buffer)
   var epRpc = EligibilityProof()
-  var proof = newSeq[byte]()
-  if not ?pb.getField(1, proof):
-    epRpc.proof = none(seq[byte])
+  var proofOfPayment = newSeq[byte]()
+  if not ?pb.getField(1, proofOfPayment):
+    epRpc.proofOfPayment = none(seq[byte])
   else:
-    epRpc.proof = some(proof)
+    epRpc.proofOfPayment = some(proofOfPayment)
   ok(epRpc)
 
 
@@ -33,9 +33,9 @@ proc decode*(T: type EligibilityProof, buffer: seq[byte]): ProtobufResult[T] =
 
 proc encode*(esRpc: EligibilityStatus): ProtoBuffer = 
   var pb = initProtoBuffer()
-  if esRpc.statusCode.isSome:
+  if esRpc.statusCode.isSome():
     pb.write3(1, esRpc.statusCode.get())
-  if esRpc.statusDesc.isSome:
+  if esRpc.statusDesc.isSome():
     pb.write3(2, esRpc.statusDesc.get())
   pb
 
@@ -43,10 +43,6 @@ proc decode*(T: type EligibilityStatus, buffer: seq[byte]): ProtobufResult[T] =
   let pb = initProtoBuffer(buffer)
   var esRpc = EligibilityStatus()
   # status code
-  # TODO: write this more concisely: ternary operator, default values?
-  # something like this, if hasField by field number existed:
-  #esRpc.statusCode = pb.hasField(1) ? some(pb.getField(1)) : none(uint32)
-  # the same applies to the EligibilityProof's decode
   var code = uint32(0)
   if not ?pb.getField(1, code):
     esRpc.statusCode = none(uint32)

--- a/waku/incentivization/rpc_codec.nim
+++ b/waku/incentivization/rpc_codec.nim
@@ -1,0 +1,81 @@
+import
+  std/options
+import
+  ../common/protobuf,
+  ../waku_core,
+  ./rpc
+
+
+proc encode*(rpc: DummyRequest): ProtoBuffer = 
+  var pb = initProtoBuffer()
+
+  pb.write3(1, rpc.requestId)
+
+  if rpc.eligibilityProof.isSome:
+    let ep = rpc.eligibilityProof.get()
+    pb.write3(2, uint32(ord(ep.proofType)))
+    pb.write3(3, ep.proof)
+  else:
+    pb.write3(2, uint32(ord(EligibilityProofType.NONE)))
+
+  pb
+
+proc decode*(T: type DummyRequest, buffer: seq[byte]): ProtobufResult[T] = 
+  let pb = initProtoBuffer(buffer)
+  var rpc = DummyRequest()
+
+  if not ?pb.getField(1, rpc.requestId):
+    return err(ProtobufError.missingRequiredField("request_id"))
+
+  var eligibilityProofType: uint32
+  var eligibilityProof: EligibilityProof
+  if not ?pb.getField(2, eligibilityProofType):
+    eligibilityProof.proofType = EligibilityProofType.NONE
+  elif eligibilityProofType == uint32(EligibilityProofType.NONE):
+    eligibilityProof.proofType = EligibilityProofType.NONE
+  else:
+    eligibilityProof.proofType = EligibilityProofType(eligibilityProofType)
+
+  var proof: string
+  if not ?pb.getField(3, proof):
+    return err(ProtobufError.missingRequiredField("proof"))
+  else:
+    eligibilityProof.proof = proof
+    rpc.eligibilityProof = some(eligibilityProof)
+
+  ok(rpc)
+
+
+proc encode*(rpc: DummyResponse): ProtoBuffer = 
+  var pb = initProtoBuffer()
+
+  pb.write3(1, rpc.requestId)
+
+  if rpc.eligibilityStatus.isSome:
+    let es = rpc.eligibilityStatus.get()
+    pb.write3(2, es.statusCode)
+    pb.write3(3, es.statusDesc)
+
+  pb
+
+
+proc decode*(T: type DummyResponse, buffer: seq[byte]): ProtobufResult[T] = 
+  let pb = initProtoBuffer(buffer)
+  var rpc = DummyResponse()
+
+  if not ?pb.getField(1, rpc.requestId):
+    return err(ProtobufError.missingRequiredField("request_id"))
+
+  var code: uint32
+  var desc: string
+  var eligibilityStatus: EligibilityStatus
+  if ?pb.getField(2, code):
+    eligibilityStatus.statusCode = code
+    if ?pb.getField(3, desc):
+      eligibilityStatus.statusDesc = desc
+    else:
+      # assuming description is not optional
+      return err(ProtobufError.missingRequiredField("status_desc"))
+    rpc.eligibilityStatus = some(eligibilityStatus)
+
+  ok(rpc)

--- a/waku/incentivization/rpc_codec.nim
+++ b/waku/incentivization/rpc_codec.nim
@@ -33,8 +33,7 @@ proc decode*(T: type EligibilityProof, buffer: seq[byte]): ProtobufResult[T] =
 
 proc encode*(esRpc: EligibilityStatus): ProtoBuffer = 
   var pb = initProtoBuffer()
-  if esRpc.statusCode.isSome():
-    pb.write3(1, esRpc.statusCode.get())
+  pb.write3(1, esRpc.statusCode)
   if esRpc.statusDesc.isSome():
     pb.write3(2, esRpc.statusDesc.get())
   pb
@@ -45,9 +44,10 @@ proc decode*(T: type EligibilityStatus, buffer: seq[byte]): ProtobufResult[T] =
   # status code
   var code = uint32(0)
   if not ?pb.getField(1, code):
-    esRpc.statusCode = none(uint32)
+    # status code is mandatory
+    return err(ProtobufError.missingRequiredField("status_code"))
   else:
-    esRpc.statusCode = some(code)
+    esRpc.statusCode = code
   # status description
   var description = ""
   if not ?pb.getField(2, description):


### PR DESCRIPTION
# Description

Encoding and decoding data structures that store proofs of eligibility is the first step towards a PoC implementation of incentivization for Store (and, in the future, other protocols), as outlined in #1961 and RFC [73/WAKU2-INCENTIVIZATION](https://github.com/vacp2p/rfc/tree/master/content/docs/rfcs/73).

# Changes

The PR implements the following:

- [x] new data types: `EligibilityProof` (which, for now, is thought to be a transaction id) and `EligibilityStatus`;
- [ ] ~~data types `DummyRequest` (with `EligibilityProof`) and `DummyResponse` (with `EligibilityStatus`) for testing purposes (to be replaced by the request and response structures of the corresponding protocol, e.g. Store);~~ (left for future work)
- [x] `encode` and `decode` procedures that convert Nim data types into protocol buffers and back, respectively;
- [x] tests to ensure that encoding and decoding work correctly: `decode(encode(X)) == X`.


## How to test

```
./env.sh bash
nim c -r ./tests/incentivization/test_rpc_codec.nim
```


<!--
## Issue

closes #
-->