### PR TITLE
fix: check max message size in validator according to configured value

### DIFF
--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -523,7 +523,7 @@ suite "Waku v2 Rest API - Relay":
     check:
       response.status == 400
       $response.contentType == $MIMETYPE_TEXT
-      response.data == fmt"Failed to publish: Message size exceeded maximum of {DefaultMaxWakuMessageSizeStr}"
+      response.data == fmt"Failed to publish: Message size exceeded maximum of {MaxWakuMessageSize} bytes"
 
     await restServer.stop()
     await restServer.closeWait()
@@ -567,7 +567,7 @@ suite "Waku v2 Rest API - Relay":
     check:
       response.status == 400
       $response.contentType == $MIMETYPE_TEXT
-      response.data == fmt"Failed to publish: Message size exceeded maximum of {DefaultMaxWakuMessageSizeStr}"
+      response.data == fmt"Failed to publish: Message size exceeded maximum of {MaxWakuMessageSize} bytes"
 
     await restServer.stop()
     await restServer.closeWait()

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -8,6 +8,7 @@ else:
   {.push raises: [].}
 
 import
+  std/strformat,
   stew/results,
   sequtils,
   chronos,
@@ -215,21 +216,15 @@ proc generateOrderedValidator*(w: WakuRelay): auto {.gcsafe.} =
     return ValidationResult.Accept
   return wrappedValidator
 
-proc isValidSize(message: WakuMessage, maxMessageSize = MaxWakuMessageSize): Result[void, string] =
-  let messageSizeBytes = uint64(message.encode().buffer.len)
-
-  if(messageSizeBytes > maxMessageSize):
-      let message = "Message size exceeded maximum of " & $maxMessageSize & " bytes"
-      debug "Invalid Waku Message", error=message
-      return err(message)
-    
-  return ok()
-
 proc validateMessage*(w: WakuRelay, pubsubTopic: string, msg: WakuMessage):
   Future[Result[void, string]] {.async.} =
 
-    msg.isValidSize(uint64(w.maxMessageSize)).isOkOr:
-      return err(error)
+    let messageSizeBytes = msg.encode().buffer.len
+
+    if messageSizeBytes > w.maxMessageSize:
+      let message = fmt"Message size exceeded maximum of {w.maxMessageSize} bytes"
+      debug "Invalid Waku Message", error=message
+      return err(message)
 
     for (validator, message) in w.wakuValidators:
         let validatorRes = await validator(pubsubTopic, msg)


### PR DESCRIPTION
# Description
Maximum message size is a configurable parameter. Therefore, we're updating the validator that we run in our REST handlers to check against the configured value.

Notice that for clusterId=1, the configuration is overriden to the Waku Network's max message size during app startup.
https://github.com/waku-org/nwaku/blob/50308eda0d678ab1a63136d6ed931ba9fc5a700e/apps/wakunode2/wakunode2.nim#L78
# Changes

<!-- List of detailed changes -->

- [x] running size validator against the configured max message size value
- [x] updated tests

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #2406 
