### PR TITLE
fix(rln-relay): regex pattern match for extended domains

### DIFF
--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -322,8 +322,8 @@ proc parseCmdArg*(T: type EthRpcUrl, s: string): T =
   ## https://url:port/path?query
   ## disallowed patterns:
   ## any valid/invalid ws or wss url
-  var httpPattern = re2"^(https?:\/\/)(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))"
-  var wsPattern =   re2"^(wss?:\/\/)(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))"
+  var httpPattern = re2"^(http|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])"
+  var wsPattern =   re2"^(ws|wss):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])"
   if regex.match(s, wsPattern):
     raise newException(ValueError, "Websocket RPC URL is not supported, Please use an HTTP URL")
   if not regex.match(s, httpPattern):

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -133,8 +133,8 @@ proc parseCmdArg*(T: type EthRpcUrl, s: string): T =
   ## https://url:port/path?query
   ## disallowed patterns:
   ## any valid/invalid ws or wss url
-  var httpPattern = re2"^(https?:\/\/)(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))"
-  var wsPattern =   re2"^(wss?:\/\/)(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))"
+  var httpPattern = re2"^(http|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])"
+  var wsPattern =   re2"^(ws|wss):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])"
   if regex.match(s, wsPattern):
     echo "here"
     raise newException(ValueError, "Websocket RPC URL is not supported, Please use an HTTP URL")

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -619,8 +619,8 @@ proc parseCmdArg*(T: type EthRpcUrl, s: string): T =
   ## https://url:port/path?query
   ## disallowed patterns:
   ## any valid/invalid ws or wss url
-  var httpPattern = re2"^(https?:\/\/)(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))"
-  var wsPattern =   re2"^(wss?:\/\/)(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))"
+  var httpPattern = re2"^(http|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])"
+  var wsPattern =   re2"^(ws|wss):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])"
   if regex.match(s, wsPattern):
     raise newException(ValueError, "Websocket RPC URL is not supported, Please use an HTTP URL")
   if not regex.match(s, httpPattern):


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->

Fixed the regex pattern since the fleet url's are parsed as invalid.

# Changes

<!-- List of detailed changes -->

- [x] regex patterns

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->