### PR TITLE
fix: Better error logs in sharding mismatch and avoid checking clusterId if clusterId == 0

### DIFF
--- a/apps/wakunode2/internal_config.nim
+++ b/apps/wakunode2/internal_config.nim
@@ -57,6 +57,8 @@ proc enrConfiguration*(conf: WakuNodeConf, netConfig: NetConfig, key: crypto.Pri
       return err($recordRes.error)
     else: recordRes.get()
 
+  debug "enrConfiguration result", record = $record
+
   return ok(record)
 
 proc validateExtMultiAddrs*(vals: seq[string]):

--- a/apps/wakunode2/internal_config.nim
+++ b/apps/wakunode2/internal_config.nim
@@ -57,7 +57,7 @@ proc enrConfiguration*(conf: WakuNodeConf, netConfig: NetConfig, key: crypto.Pri
       return err($recordRes.error)
     else: recordRes.get()
 
-  debug "enrConfiguration result", record = $record
+  trace "enrConfiguration result", record = $record
 
   return ok(record)
 

--- a/waku/common/enr/typed_record.nim
+++ b/waku/common/enr/typed_record.nim
@@ -51,7 +51,9 @@ func toTyped*(record: Record): EnrResult[TypedRecord] =
   if idOpt.isNone():
     return err("missing id scheme field")
 
-  discard ? toRecordId(idOpt.get())
+  let toRecIdRes = toRecordId(idOpt.get())
+  if toRecIdRes.isErr():
+    return err("toRecIdRes is not ok")
 
   ok(tr)
 

--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -257,6 +257,11 @@ proc containsShard*(r: Record, topic: PubsubTopic|string): bool =
 
 proc isClusterMismatched*(record: Record, clusterId: uint32): bool =
   ## Check the ENR sharding info for matching cluster id
+
+  if clusterId == 0:
+    trace "isClusterMismatched skipping validation because clusterId == 0 "
+    return false
+
   let typedRecord = record.toTyped().valueOr:
     error "isClusterMismatched typedRecord is not ok: ", error = error
     return true


### PR DESCRIPTION
## Description
1. Enhance error management inside `isClusterMismatched`
2. Avoid validation inside `isClusterMismatched` if the node is using `clusterId == 0`. This aims to allow the node to start successfully and avoid the appearance of "cluster id mismatch configured shards" and the `quit(QuitFailure)`. In other words, the node couldn't start due to this proc even though the `clusterId` param was not being set.