### PR TITLE
feat: archive update for store v3

### DIFF
--- a/tests/waku_archive/archive_utils.nim
+++ b/tests/waku_archive/archive_utils.nim
@@ -30,7 +30,8 @@ proc computeArchiveCursor*(
     pubsubTopic: pubsubTopic,
     senderTime: message.timestamp,
     storeTime: message.timestamp,
-    digest: waku_archive.computeDigest(message),
+    digest: computeDigest(message),
+    hash: computeMessageHash(pubsubTopic, message),
   )
 
 proc put*(
@@ -38,7 +39,7 @@ proc put*(
 ): ArchiveDriver =
   for msg in msgList:
     let
-      msgDigest = waku_archive.computeDigest(msg)
+      msgDigest = computeDigest(msg)
       msgHash = computeMessageHash(pubsubTopic, msg)
       _ = waitFor driver.put(pubsubTopic, msg, msgDigest, msgHash, msg.timestamp)
           # discard crashes

--- a/tests/waku_archive/test_driver_postgres_query.nim
+++ b/tests/waku_archive/test_driver_postgres_query.nim
@@ -8,7 +8,6 @@ import
 import
   ../../../waku/waku_archive,
   ../../../waku/waku_archive/driver as driver_module,
-  ../../../waku/waku_archive/driver/builder,
   ../../../waku/waku_archive/driver/postgres_driver,
   ../../../waku/waku_core,
   ../../../waku/waku_core/message/digest,
@@ -670,10 +669,10 @@ suite "Postgres driver - queries":
     ]
     var messages = expected
 
-    let hashes = messages.mapIt(computeMessageHash(DefaultPubsubTopic, it))
-
     shuffle(messages)
     debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
+
+    let hashes = messages.mapIt(computeMessageHash(DefaultPubsubTopic, it))
 
     for (msg, hash) in messages.zip(hashes):
       require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), hash, msg.timestamp)).isOk()

--- a/tests/waku_archive/test_driver_postgres_query.nim
+++ b/tests/waku_archive/test_driver_postgres_query.nim
@@ -33,7 +33,8 @@ proc computeTestCursor(pubsubTopic: PubsubTopic, message: WakuMessage): ArchiveC
     pubsubTopic: pubsubTopic,
     senderTime: message.timestamp,
     storeTime: message.timestamp,
-    digest: computeDigest(message)
+    digest: computeDigest(message),
+    hash: computeMessageHash(pubsubTopic, message)
   )
 
 suite "Postgres driver - queries":
@@ -651,6 +652,45 @@ suite "Postgres driver - queries":
     let filteredMessages = res.tryGet().mapIt(it[1])
     check:
       filteredMessages == expectedMessages[4..5].reversed()
+
+  asyncTest "only hashes - descending order":
+    ## Given
+    let timeOrigin = now()
+    var expected = @[
+      fakeWakuMessage(@[byte 0], ts=ts(00, timeOrigin)),
+      fakeWakuMessage(@[byte 1], ts=ts(10, timeOrigin)),
+      fakeWakuMessage(@[byte 2], ts=ts(20, timeOrigin)),
+      fakeWakuMessage(@[byte 3], ts=ts(30, timeOrigin)),
+      fakeWakuMessage(@[byte 4],  ts=ts(40, timeOrigin)),
+      fakeWakuMessage(@[byte 5],  ts=ts(50, timeOrigin)),
+      fakeWakuMessage(@[byte 6],  ts=ts(60, timeOrigin)),
+      fakeWakuMessage(@[byte 7],  ts=ts(70, timeOrigin)),
+      fakeWakuMessage(@[byte 8],  ts=ts(80, timeOrigin)),
+      fakeWakuMessage(@[byte 9],  ts=ts(90, timeOrigin)),
+    ]
+    var messages = expected
+
+    let hashes = messages.mapIt(computeMessageHash(DefaultPubsubTopic, it))
+
+    shuffle(messages)
+    debug "randomized message insertion sequence", sequence=messages.mapIt(it.payload)
+
+    for (msg, hash) in messages.zip(hashes):
+      require (await driver.put(DefaultPubsubTopic, msg, computeDigest(msg), hash, msg.timestamp)).isOk()
+
+    ## When
+    let res = await driver.getMessages(
+      hashes=hashes,
+      ascendingOrder=false
+    )
+
+    ## Then
+    assert res.isOk(), res.error
+
+    let expectedMessages = expected.reversed()
+    let filteredMessages = res.tryGet().mapIt(it[1])
+    check:
+      filteredMessages == expectedMessages
 
   asyncTest "start time only":
     ## Given

--- a/tests/waku_archive/test_driver_queue_query.nim
+++ b/tests/waku_archive/test_driver_queue_query.nim
@@ -30,7 +30,8 @@ proc computeTestCursor(pubsubTopic: PubsubTopic, message: WakuMessage): ArchiveC
     pubsubTopic: pubsubTopic,
     senderTime: message.timestamp,
     storeTime: message.timestamp,
-    digest: computeDigest(message)
+    digest: computeDigest(message),
+    hash: computeMessageHash(pubsubTopic, message),
   )
 
 

--- a/tests/waku_archive/test_driver_sqlite.nim
+++ b/tests/waku_archive/test_driver_sqlite.nim
@@ -41,9 +41,10 @@ suite "SQLite driver":
     let driver = newSqliteArchiveDriver()
 
     let msg = fakeWakuMessage(contentTopic=contentTopic)
+    let msgHash = computeMessageHash(DefaultPubsubTopic, msg)
 
     ## When
-    let putRes = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), computeMessageHash(DefaultPubsubTopic, msg), msg.timestamp)
+    let putRes = waitFor driver.put(DefaultPubsubTopic, msg, computeDigest(msg), msgHash, msg.timestamp)
 
     ## Then
     check:
@@ -53,9 +54,10 @@ suite "SQLite driver":
     check:
       storedMsg.len == 1
       storedMsg.all do (item: auto) -> bool:
-        let (pubsubTopic, msg, digest, storeTimestamp) = item
+        let (pubsubTopic, msg, _, _, hash) = item
         msg.contentTopic == contentTopic and
-        pubsubTopic == DefaultPubsubTopic
+        pubsubTopic == DefaultPubsubTopic and
+        hash == msgHash
 
     ## Cleanup
     (waitFor driver.close()).expect("driver to close")

--- a/tests/waku_archive/test_retention_policy.nim
+++ b/tests/waku_archive/test_retention_policy.nim
@@ -138,7 +138,7 @@ suite "Waku Archive - Retention policy":
     check:
       storedMsg.len == capacity
       storedMsg.all do (item: auto) -> bool:
-        let (pubsubTopic, msg, digest, storeTimestamp) = item
+        let (pubsubTopic, msg, _, _, _) = item
         msg.contentTopic == contentTopic and
         pubsubTopic == DefaultPubsubTopic
 

--- a/tests/waku_archive/test_waku_archive.nim
+++ b/tests/waku_archive/test_waku_archive.nim
@@ -59,6 +59,22 @@ suite "Waku Archive - message handling":
     check:
       (waitFor driver.getMessagesCount()).tryGet() == 2
 
+  test "it should archive a message with no sender timestamp":
+    ## Setup
+    let driver = newSqliteArchiveDriver()
+    let archive = newWakuArchive(driver)
+
+    ## Given
+    let invalidSenderTime = 0
+    let message = fakeWakuMessage(ts=invalidSenderTime)
+
+    ## When
+    waitFor archive.handleMessage(DefaultPubSubTopic, message)
+
+    ## Then
+    check:
+      (waitFor driver.getMessagesCount()).tryGet() == 1
+
   test "it should not archive a message with a sender time variance greater than max time variance (future)":
     ## Setup
     let driver = newSqliteArchiveDriver()

--- a/tests/waku_archive/test_waku_archive.nim
+++ b/tests/waku_archive/test_waku_archive.nim
@@ -59,22 +59,6 @@ suite "Waku Archive - message handling":
     check:
       (waitFor driver.getMessagesCount()).tryGet() == 2
 
-  test "it should archive a message with no sender timestamp":
-    ## Setup
-    let driver = newSqliteArchiveDriver()
-    let archive = newWakuArchive(driver)
-
-    ## Given
-    let invalidSenderTime = 0
-    let message = fakeWakuMessage(ts=invalidSenderTime)
-
-    ## When
-    waitFor archive.handleMessage(DefaultPubSubTopic, message)
-
-    ## Then
-    check:
-      (waitFor driver.getMessagesCount()).tryGet() == 1
-
   test "it should not archive a message with a sender time variance greater than max time variance (future)":
     ## Setup
     let driver = newSqliteArchiveDriver()

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -784,7 +784,8 @@ proc mountArchive*(node: WakuNode,
     return err("error in mountArchive: " & wakuArchiveRes.error)
 
   node.wakuArchive = wakuArchiveRes.get()
-  asyncSpawn node.wakuArchive.start()
+  node.wakuArchive.start()
+
   return ok()
 
 ## Waku store
@@ -1194,7 +1195,7 @@ proc stop*(node: WakuNode) {.async.} =
       error "exception stopping the node", error=getCurrentExceptionMsg()
 
   if not node.wakuArchive.isNil():
-    await node.wakuArchive.stop()
+    await node.wakuArchive.stopWait()
 
   node.started = false
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -777,13 +777,12 @@ proc mountArchive*(node: WakuNode,
                    driver: ArchiveDriver,
                    retentionPolicy = none(RetentionPolicy)):
                    Result[void, string] =
+  node.wakuArchive = WakuArchive.new(
+    driver = driver,
+    retentionPolicy = retentionPolicy,
+    ).valueOr:
+    return err("error in mountArchive: " & error)
 
-  let wakuArchiveRes = WakuArchive.new(driver,
-                                       retentionPolicy)
-  if wakuArchiveRes.isErr():
-    return err("error in mountArchive: " & wakuArchiveRes.error)
-
-  node.wakuArchive = wakuArchiveRes.get()
   node.wakuArchive.start()
 
   return ok()

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -4,22 +4,15 @@ else:
   {.push raises: [].}
 
 import
-  std/[tables, times, sequtils, options, algorithm, strutils],
+  std/[times, options, sequtils, strutils, algorithm],
   stew/[results, byteutils],
   chronicles,
   chronos,
-  regex,
   metrics
 import
-  ../common/[
-    databases/dburl,
-    databases/db_sqlite,
-    paging
-  ],
+  ../common/paging,
   ./driver,
   ./retention_policy,
-  ./retention_policy/retention_policy_capacity,
-  ./retention_policy/retention_policy_time,
   ../waku_core,
   ../waku_core/message/digest,
   ./common,
@@ -29,28 +22,46 @@ logScope:
   topics = "waku archive"
 
 const
-  DefaultPageSize*: uint = 20
-  MaxPageSize*: uint = 100
+  #TODO if waku message are 150KiB max are those numbers still appropriate???
+  DefaultPageSize*: uint = 20 # 2.93 MiB
+  MaxPageSize*: uint = 100 # 14.65 MiB
 
-## Message validation
+# Retention policy
+const WakuArchiveDefaultRetentionPolicyInterval* = chronos.minutes(30)
 
-type
-  MessageValidator* = ref object of RootObj
+# Metrics reporting
+const WakuArchiveDefaultMetricsReportInterval* = chronos.minutes(1)
 
-  ValidationResult* = Result[void, string]
+# Message validation
+# 20 seconds maximum allowable sender timestamp "drift"
+const MaxMessageTimestampVariance* = getNanoSecondTime(20) 
 
-method validate*(validator: MessageValidator, msg: WakuMessage): ValidationResult {.base.} = discard
+## Archive
 
-# Default message validator
+type WakuArchive* = ref object
+  driver: ArchiveDriver
 
-const MaxMessageTimestampVariance* = getNanoSecondTime(20) # 20 seconds maximum allowable sender timestamp "drift"
+  retentionPolicy: Option[RetentionPolicy]
 
-type DefaultMessageValidator* = ref object of MessageValidator
+  retentionPolicyHandle: Future[void]
+  metricsHandle: Future[void]
 
-method validate*(validator: DefaultMessageValidator, msg: WakuMessage): ValidationResult =
-  if msg.timestamp == 0:
-    return ok()
+proc new*(T: type WakuArchive,
+          driver: ArchiveDriver,
+          retentionPolicy = none(RetentionPolicy)):
+          Result[T, string] =
+  if driver.isNil():
+    return err("archive driver is Nil")
 
+  let archive =
+    WakuArchive(
+      driver: driver,
+      retentionPolicy: retentionPolicy,
+    )
+
+  return ok(archive)
+
+proc validate*(self: WakuArchive, msg: WakuMessage): Result[void, string] =
   let
     now = getNanosecondTime(getTime().toUnixFloat())
     lowerBound = now - MaxMessageTimestampVariance
@@ -64,186 +75,148 @@ method validate*(validator: DefaultMessageValidator, msg: WakuMessage): Validati
 
   ok()
 
-## Archive
-
-type
-  WakuArchive* = ref object
-    driver*: ArchiveDriver  # TODO: Make this field private. Remove asterisk
-    validator: MessageValidator
-    retentionPolicy: RetentionPolicy
-    retPolicyFut: Future[Result[void, string]]  ## retention policy cancelable future
-    retMetricsRepFut: Future[Result[void, string]]  ## metrics reporting cancelable future
-
-proc new*(T: type WakuArchive,
-          driver: ArchiveDriver,
-          retentionPolicy = none(RetentionPolicy)):
-          Result[T, string] =
-
-  let retPolicy = if retentionPolicy.isSome():
-                    retentionPolicy.get()
-                  else:
-                    nil
-
-  let wakuArch = WakuArchive(driver: driver,
-                             validator: DefaultMessageValidator(),
-                             retentionPolicy: retPolicy)
-  return ok(wakuArch)
-
-proc handleMessage*(w: WakuArchive,
+proc handleMessage*(self: WakuArchive,
                     pubsubTopic: PubsubTopic,
                     msg: WakuMessage) {.async.} =
   if msg.ephemeral:
     # Ephemeral message, do not store
     return
 
-  if not w.validator.isNil():
-    let validationRes = w.validator.validate(msg)
-    if validationRes.isErr():
-      waku_archive_errors.inc(labelValues = [validationRes.error])
-      return
+  self.validate(msg).isOkOr:
+    waku_archive_errors.inc(labelValues = [error])
+    return
 
+  let
+    msgDigest = computeDigest(msg)
+    msgHash = computeMessageHash(pubsubTopic, msg)
+
+  trace "handling message",
+    pubsubTopic=pubsubTopic,
+    contentTopic=msg.contentTopic,
+    timestamp=msg.timestamp,
+    digest=toHex(msgDigest.data),
+    messageHash=toHex(msgHash)
+  
   let insertStartTime = getTime().toUnixFloat()
 
-  block:
-    let
-      msgDigest = computeDigest(msg)
-      msgHash = computeMessageHash(pubsubTopic, msg)
-      msgDigestHex = toHex(msgDigest.data)
-      msgHashHex = toHex(msgHash)
-      msgReceivedTime = if msg.timestamp > 0: msg.timestamp
-                        else: getNanosecondTime(getTime().toUnixFloat())
-
-    trace "handling message", pubsubTopic=pubsubTopic, contentTopic=msg.contentTopic, timestamp=msg.timestamp, digest=msgDigestHex, messageHash=msgHashHex
-
-    let putRes = await w.driver.put(pubsubTopic, msg, msgDigest, msgHash, msgReceivedTime)
-    if putRes.isErr():
-      if "duplicate key value violates unique constraint" in putRes.error:
-        trace "failed to insert message", err=putRes.error
-      else:
-        debug "failed to insert message", err=putRes.error
-      waku_archive_errors.inc(labelValues = [insertFailure])
-
+  (await self.driver.put(pubsubTopic, msg, msgDigest, msgHash, msg.timestamp)).isOkOr:
+    waku_archive_errors.inc(labelValues = [insertFailure])
+    # Prevent spamming the logs when multiple nodes are connected to the same database.
+    # In that case, the message cannot be inserted but is an expected "insert error"
+    # and therefore we reduce its visibility by having the log in trace level.
+    if "duplicate key value violates unique constraint" in error:
+      trace "failed to insert message", err=error
+    else:
+      debug "failed to insert message", err=error
+    
   let insertDuration = getTime().toUnixFloat() - insertStartTime
   waku_archive_insert_duration_seconds.observe(insertDuration)
 
-proc findMessages*(w: WakuArchive, query: ArchiveQuery): Future[ArchiveResult] {.async, gcsafe.} =
+proc findMessages*(self: WakuArchive, query: ArchiveQuery): Future[ArchiveResult] {.async, gcsafe.} =
   ## Search the archive to return a single page of messages matching the query criteria
-  let
-    qContentTopics = query.contentTopics
-    qPubSubTopic = query.pubsubTopic
-    qCursor = query.cursor
-    qStartTime = query.startTime
-    qEndTime = query.endTime
-    qMaxPageSize = if query.pageSize <= 0: DefaultPageSize
-                   else: min(query.pageSize, MaxPageSize)
-    isAscendingOrder = query.direction.into()
+  
+  let maxPageSize =
+    if query.pageSize <= 0:
+      DefaultPageSize
+    else:
+      min(query.pageSize, MaxPageSize)
+    
+  let isAscendingOrder = query.direction.into()
 
-  if qContentTopics.len > 10:
+  if query.contentTopics.len > 10:
     return err(ArchiveError.invalidQuery("too many content topics"))
 
   let queryStartTime = getTime().toUnixFloat()
 
-  let queryRes = await w.driver.getMessages(
-      contentTopic = qContentTopics,
-      pubsubTopic = qPubSubTopic,
-      cursor = qCursor,
-      startTime = qStartTime,
-      endTime = qEndTime,
-      maxPageSize = qMaxPageSize + 1,
-      ascendingOrder = isAscendingOrder
-    )
+  let rows = (await self.driver.getMessages(
+    contentTopic = query.contentTopics,
+    pubsubTopic = query.pubsubTopic,
+    cursor = query.cursor,
+    startTime = query.startTime,
+    endTime = query.endTime,
+    hashes = query.hashes,
+    maxPageSize = maxPageSize + 1,
+    ascendingOrder = isAscendingOrder
+  )).valueOr:
+    return err(ArchiveError(kind: ArchiveErrorKind.DRIVER_ERROR, cause: error))
 
   let queryDuration = getTime().toUnixFloat() - queryStartTime
   waku_archive_query_duration_seconds.observe(queryDuration)
 
-  # Build response
-  if queryRes.isErr():
-    return err(ArchiveError(kind: ArchiveErrorKind.DRIVER_ERROR, cause: queryRes.error))
-
-  let rows = queryRes.get()
+  var hashes = newSeq[WakuMessageHash]()
   var messages = newSeq[WakuMessage]()
   var cursor = none(ArchiveCursor)
+  
   if rows.len == 0:
-    return ok(ArchiveResponse(messages: messages, cursor: cursor))
+    return ok(ArchiveResponse(hashes: hashes, messages: messages, cursor: cursor))
 
   ## Messages
-  let pageSize = min(rows.len, int(qMaxPageSize))
+  let pageSize = min(rows.len, int(maxPageSize))
+  
+  #TODO once store v2 is removed, unzip instead of 2x map
   messages = rows[0..<pageSize].mapIt(it[1])
+  hashes = rows[0..<pageSize].mapIt(it[4])
 
   ## Cursor
-  if rows.len > int(qMaxPageSize):
+  if rows.len > int(maxPageSize):
     ## Build last message cursor
     ## The cursor is built from the last message INCLUDED in the response
     ## (i.e. the second last message in the rows list)
-    let (pubsubTopic, message, digest, storeTimestamp) = rows[^2]
+    
+    #TODO Once Store v2 is removed keep only message and hash
+    let (pubsubTopic, message, digest, storeTimestamp, hash) = rows[^2]
 
-    # TODO: Improve coherence of MessageDigest type
-    let messageDigest = block:
-        var data: array[32, byte]
-        for i in 0..<min(digest.len, 32):
-          data[i] = digest[i]
-
-        MessageDigest(data: data)
-
+    #TODO Once Store v2 is removed, the cursor becomes the hash of the last message
     cursor = some(ArchiveCursor(
-      pubsubTopic: pubsubTopic,
-      senderTime: message.timestamp,
+      digest: MessageDigest.fromBytes(digest),
       storeTime: storeTimestamp,
-      digest: messageDigest
+      sendertime: message.timestamp,
+      pubsubTopic: pubsubTopic,
+      hash: hash,
     ))
 
   # All messages MUST be returned in chronological order
   if not isAscendingOrder:
     reverse(messages)
+    reverse(hashes)
 
-  return ok(ArchiveResponse(messages: messages, cursor: cursor))
+  return ok(ArchiveResponse(hashes: hashes, messages: messages, cursor: cursor))
 
-# Retention policy
-const WakuArchiveDefaultRetentionPolicyInterval* = chronos.minutes(30)
+proc periodicRetentionPolicy(self: WakuArchive) {.async.} =
+  debug "executing message retention policy"
 
-proc loopApplyRetentionPolicy*(w: WakuArchive):
-                               Future[Result[void, string]] {.async.} =
-
-  if w.retentionPolicy.isNil():
-    return err("retentionPolicy is Nil in executeMessageRetentionPolicy")
-
-  if w.driver.isNil():
-    return err("driver is Nil in executeMessageRetentionPolicy")
+  let policy = self.retentionPolicy.get()
 
   while true:
-    debug "executing message retention policy"
-    let retPolicyRes = await w.retentionPolicy.execute(w.driver)
-    if retPolicyRes.isErr():
-        waku_archive_errors.inc(labelValues = [retPolicyFailure])
-        error "failed execution of retention policy", error=retPolicyRes.error
-
     await sleepAsync(WakuArchiveDefaultRetentionPolicyInterval)
 
-  return ok()
+    (await policy.execute(self.driver)).isOkOr:
+      waku_archive_errors.inc(labelValues = [retPolicyFailure])
+      error "failed execution of retention policy", error=error
 
-# Metrics reporting
-const WakuArchiveDefaultMetricsReportInterval* = chronos.minutes(1)
-
-proc loopReportStoredMessagesMetric*(w: WakuArchive):
-                                     Future[Result[void, string]] {.async.} =
-  if w.driver.isNil():
-    return err("driver is Nil in loopReportStoredMessagesMetric")
-
+proc periodicMetricReport(self: WakuArchive) {.async.} =
   while true:
-    let resCount = await w.driver.getMessagesCount()
-    if resCount.isErr():
-      return err("loopReportStoredMessagesMetric failed to get messages count: " & resCount.error)
-
-    waku_archive_messages.set(resCount.value, labelValues = ["stored"])
     await sleepAsync(WakuArchiveDefaultMetricsReportInterval)
 
-  return ok()
+    let count = (await self.driver.getMessagesCount()).valueOr:
+      error "loopReportStoredMessagesMetric failed to get messages count", error=error
+      continue
 
-proc start*(self: WakuArchive) {.async.} =
-  ## TODO: better control the Result in case of error. Now it is ignored
-  self.retPolicyFut = self.loopApplyRetentionPolicy()
-  self.retMetricsRepFut = self.loopReportStoredMessagesMetric()
+    waku_archive_messages.set(count, labelValues = ["stored"])
 
-proc stop*(self: WakuArchive) {.async.} =
-  self.retPolicyFut.cancel()
-  self.retMetricsRepFut.cancel()
+proc start*(self: WakuArchive) =
+  if self.retentionPolicy.isSome():
+    self.retentionPolicyHandle = periodicRetentionPolicy(self)
+
+  self.metricsHandle = periodicMetricReport(self)
+
+proc stopWait*(self: WakuArchive) {.async.} =
+  var futures: seq[Future[void]]
+
+  if self.retentionPolicy.isSome() and not self.retentionPolicyHandle.isNil():
+    futures.add(self.retentionPolicyHandle.cancelAndWait())
+
+  if not self.metricsHandle.isNil:
+    futures.add(self.metricsHandle.cancelAndWait())
+
+  await noCancel(allFutures(futures))

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -5,7 +5,7 @@ else:
 
 import
   std/[times, options, sequtils, strutils, algorithm],
-  stew/results,
+  stew/[results, byteutils],
   chronicles,
   chronos,
   metrics

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -198,7 +198,7 @@ proc periodicMetricReport(self: WakuArchive) {.async.} =
   while true:
     let countRes = (await self.driver.getMessagesCount())
     if countRes.isErr():
-      error "loopReportStoredMessagesMetric failed to get messages count", error=error
+      error "loopReportStoredMessagesMetric failed to get messages count", error=countRes.error
     else:
       let count = countRes.get()
       waku_archive_messages.set(count, labelValues = ["stored"])

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -206,9 +206,9 @@ proc periodicMetricReport(self: WakuArchive) {.async.} =
 
 proc start*(self: WakuArchive) =
   if self.retentionPolicy.isSome():
-    self.retentionPolicyHandle = periodicRetentionPolicy(self)
+    self.retentionPolicyHandle = self.periodicRetentionPolicy()
 
-  self.metricsHandle = periodicMetricReport(self)
+  self.metricsHandle = self.periodicMetricReport()
 
 proc stopWait*(self: WakuArchive) {.async.} =
   var futures: seq[Future[void]]

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -9,7 +9,6 @@ import
   chronos
 import
   ../waku_core,
-  ../common/error_handling,
   ./common
 
 const DefaultPageSize*: uint = 25
@@ -18,7 +17,8 @@ type
   ArchiveDriverResult*[T] = Result[T, string]
   ArchiveDriver* = ref object of RootObj
 
-type ArchiveRow* = (PubsubTopic, WakuMessage, seq[byte], Timestamp)
+#TODO Once Store v2 is removed keep only messages and hashes
+type ArchiveRow* = (PubsubTopic, WakuMessage, seq[byte], Timestamp, WakuMessageHash)
 
 # ArchiveDriver interface
 
@@ -34,11 +34,12 @@ method getAllMessages*(driver: ArchiveDriver):
                        Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async.} = discard
 
 method getMessages*(driver: ArchiveDriver,
-                    contentTopic: seq[ContentTopic] = @[],
+                    contentTopic = newSeq[ContentTopic](0),
                     pubsubTopic = none(PubsubTopic),
                     cursor = none(ArchiveCursor),
                     startTime = none(Timestamp),
                     endTime = none(Timestamp),
+                    hashes = newSeq[WakuMessageHash](0),
                     maxPageSize = DefaultPageSize,
                     ascendingOrder = true):
                     Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async.} = discard

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -4,8 +4,8 @@ else:
   {.push raises: [].}
 
 import
-  std/[nre,options,sequtils,strutils,strformat,times],
-  stew/[results,byteutils],
+  std/[nre, options, sequtils, strutils, strformat, times],
+  stew/[results, byteutils, arrayops],
   db_postgres,
   postgres,
   chronos,
@@ -36,7 +36,7 @@ const InsertRowStmtDefinition =
 
 const SelectNoCursorAscStmtName = "SelectWithoutCursorAsc"
 const SelectNoCursorAscStmtDef =
- """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id FROM messages
+ """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id, messageHash FROM messages
     WHERE contentTopic IN ($1) AND
           pubsubTopic = $2 AND
           storedAt >= $3 AND
@@ -45,7 +45,7 @@ const SelectNoCursorAscStmtDef =
 
 const SelectNoCursorDescStmtName = "SelectWithoutCursorDesc"
 const SelectNoCursorDescStmtDef =
- """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id FROM messages
+ """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id, messageHash FROM messages
     WHERE contentTopic IN ($1) AND
           pubsubTopic = $2 AND
           storedAt >= $3 AND
@@ -54,7 +54,7 @@ const SelectNoCursorDescStmtDef =
 
 const SelectWithCursorDescStmtName = "SelectWithCursorDesc"
 const SelectWithCursorDescStmtDef =
- """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id FROM messages
+ """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id, messageHash FROM messages
     WHERE contentTopic IN ($1) AND
           pubsubTopic = $2 AND
           (storedAt, id) < ($3,$4) AND
@@ -64,7 +64,7 @@ const SelectWithCursorDescStmtDef =
 
 const SelectWithCursorAscStmtName = "SelectWithCursorAsc"
 const SelectWithCursorAscStmtDef =
- """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id FROM messages
+ """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id, messageHash FROM messages
     WHERE contentTopic IN ($1) AND
           pubsubTopic = $2 AND
           (storedAt, id) > ($3,$4) AND
@@ -107,8 +107,10 @@ proc reset*(s: PostgresDriver): Future[ArchiveDriverResult[void]] {.async.} =
   let ret = await s.decreaseDatabaseSize(targetSize, forceRemoval)
   return ret
 
-proc rowCallbackImpl(pqResult: ptr PGresult,
-                     outRows: var seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp)]) =
+proc rowCallbackImpl(
+  pqResult: ptr PGresult,
+  outRows: var seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp, WakuMessageHash)],
+  ) =
   ## Proc aimed to contain the logic of the callback passed to the `psasyncpool`.
   ## That callback is used in "SELECT" queries.
   ##
@@ -116,7 +118,7 @@ proc rowCallbackImpl(pqResult: ptr PGresult,
   ## outRows - seq of Store-rows. This is populated from the info contained in pqResult
 
   let numFields = pqResult.pqnfields()
-  if numFields != 7:
+  if numFields != 8:
     error "Wrong number of fields"
     return
 
@@ -130,6 +132,7 @@ proc rowCallbackImpl(pqResult: ptr PGresult,
     var storedAt: int64
     var digest: string
     var payload: string
+    var hashHex: string
 
     try:
       storedAt = parseInt( $(pqgetvalue(pqResult, iRow, 0)) )
@@ -139,6 +142,7 @@ proc rowCallbackImpl(pqResult: ptr PGresult,
       version = parseUInt( $(pqgetvalue(pqResult, iRow, 4)) )
       timestamp = parseInt( $(pqgetvalue(pqResult, iRow, 5)) )
       digest = parseHexStr( $(pqgetvalue(pqResult, iRow, 6)) )
+      hashHex = parseHexStr( $(pqgetvalue(pqResult, iRow, 7)) )
     except ValueError:
       error "could not parse correctly", error = getCurrentExceptionMsg()
 
@@ -147,10 +151,16 @@ proc rowCallbackImpl(pqResult: ptr PGresult,
     wakuMessage.contentTopic = contentTopic
     wakuMessage.payload = @(payload.toOpenArrayByte(0, payload.high))
 
+    var msgHash: WakuMessageHash
+    let byteCount = copyFrom(msgHash, hashHex.toOpenArrayByte(0, 31))
+    assert byteCount == 32
+
     outRows.add((pubSubTopic,
                  wakuMessage,
                  @(digest.toOpenArrayByte(0, digest.high)),
-                 storedAt))
+                 storedAt,
+                 msgHash,
+                 ))
 
 method put*(s: PostgresDriver,
             pubsubTopic: PubsubTopic,
@@ -195,13 +205,13 @@ method getAllMessages*(s: PostgresDriver):
                        Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   ## Retrieve all messages from the store.
 
-  var rows: seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp)]
+  var rows: seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp, WakuMessageHash)]
   proc rowCallback(pqResult: ptr PGresult) =
     rowCallbackImpl(pqResult, rows)
 
   (await s.readConnPool.pgQuery("""SELECT storedAt, contentTopic,
                                        payload, pubsubTopic, version, timestamp,
-                                       id FROM messages ORDER BY storedAt ASC""",
+                                       id, messageHash FROM messages ORDER BY storedAt ASC""",
                                        newSeq[string](0),
                                        rowCallback
                               )).isOkOr:
@@ -242,12 +252,13 @@ proc getMessagesArbitraryQuery(s: PostgresDriver,
                     cursor = none(ArchiveCursor),
                     startTime = none(Timestamp),
                     endTime = none(Timestamp),
+                    hexHashes: seq[string] = @[],
                     maxPageSize = DefaultPageSize,
                     ascendingOrder = true):
                     Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   ## This proc allows to handle atypical queries. We don't use prepared statements for those.
 
-  var query = """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id FROM messages"""
+  var query = """SELECT storedAt, contentTopic, payload, pubsubTopic, version, timestamp, id, messageHash FROM messages"""
   var statements: seq[string]
   var args: seq[string]
 
@@ -255,6 +266,12 @@ proc getMessagesArbitraryQuery(s: PostgresDriver,
     let cstmt = "contentTopic IN (" & "?".repeat(contentTopic.len).join(",") & ")"
     statements.add(cstmt)
     for t in contentTopic:
+      args.add(t)
+
+  if hexHashes.len > 0:
+    let cstmt = "messageHash IN (" & "?".repeat(hexHashes.len).join(",") & ")"
+    statements.add(cstmt)
+    for t in hexHashes:
       args.add(t)
 
   if pubsubTopic.isSome():
@@ -289,10 +306,10 @@ proc getMessagesArbitraryQuery(s: PostgresDriver,
   query &= " LIMIT ?"
   args.add($maxPageSize)
 
-  var rows: seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp)]
+  var rows: seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp, WakuMessageHash)]
   proc rowCallback(pqResult: ptr PGresult) =
     rowCallbackImpl(pqResult, rows)
-
+  
   (await s.readConnPool.pgQuery(query, args, rowCallback)).isOkOr:
     return err("failed to run query: " & $error)
 
@@ -313,7 +330,7 @@ proc getMessagesPreparedStmt(s: PostgresDriver,
   ##
   ## contentTopic - string with list of conten topics. e.g: "'ctopic1','ctopic2','ctopic3'"
 
-  var rows: seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp)]
+  var rows: seq[(PubsubTopic, WakuMessage, seq[byte], Timestamp, WakuMessageHash)]
   proc rowCallback(pqResult: ptr PGresult) =
     rowCallbackImpl(pqResult, rows)
 
@@ -327,7 +344,7 @@ proc getMessagesPreparedStmt(s: PostgresDriver,
 
     let digest = toHex(cursor.get().digest.data)
     let storeTime = $cursor.get().storeTime
-
+    
     (await s.readConnPool.runStmt(
                                   stmtName,
                                   stmtDef,
@@ -354,6 +371,7 @@ proc getMessagesPreparedStmt(s: PostgresDriver,
   else:
     var stmtName = if ascOrder: SelectNoCursorAscStmtName else: SelectNoCursorDescStmtName
     var stmtDef = if ascOrder: SelectNoCursorAscStmtDef else: SelectNoCursorDescStmtDef
+    
     (await s.readConnPool.runStmt(stmtName,
                                   stmtDef,
                                  @[contentTopic,
@@ -379,10 +397,12 @@ method getMessages*(s: PostgresDriver,
                     cursor = none(ArchiveCursor),
                     startTime = none(Timestamp),
                     endTime = none(Timestamp),
+                    hashes: seq[WakuMessageHash] = @[],
                     maxPageSize = DefaultPageSize,
                     ascendingOrder = true):
                     Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
-
+  let hexHashes = hashes.mapIt(toHex(it))
+  
   if contentTopicSeq.len == 1 and
     pubsubTopic.isSome() and
     startTime.isSome() and
@@ -399,12 +419,13 @@ method getMessages*(s: PostgresDriver,
   else:
     ## We will run atypical query. In this case we don't use prepared statemets
     return await s.getMessagesArbitraryQuery(contentTopicSeq,
-                                             pubsubTopic,
-                                             cursor,
-                                             startTime,
-                                             endTime,
-                                             maxPageSize,
-                                             ascendingOrder)
+                                              pubsubTopic,
+                                              cursor,
+                                              startTime,
+                                              endTime,
+                                              hexHashes,
+                                              maxPageSize,
+                                              ascendingOrder)
 
 proc getStr(s: PostgresDriver,
             query: string):

--- a/waku/waku_archive/driver/queue_driver/index.nim
+++ b/waku/waku_archive/driver/queue_driver/index.nim
@@ -25,7 +25,7 @@ proc compute*(T: type Index, msg: WakuMessage, receivedTime: Timestamp, pubsubTo
     senderTime = msg.timestamp
     hash = computeMessageHash(pubsubTopic, msg)
 
-  Index(
+  return Index(
     pubsubTopic: pubsubTopic,
     senderTime: senderTime,
     receiverTime: receivedTime,
@@ -34,7 +34,7 @@ proc compute*(T: type Index, msg: WakuMessage, receivedTime: Timestamp, pubsubTo
   )
 
 proc tohistoryCursor*(index: Index): ArchiveCursor =
-  ArchiveCursor(
+  return ArchiveCursor(
     pubsubTopic: index.pubsubTopic,
     senderTime: index.senderTime,
     storeTime: index.receiverTime,
@@ -43,7 +43,7 @@ proc tohistoryCursor*(index: Index): ArchiveCursor =
   )
 
 proc toIndex*(index: ArchiveCursor): Index =
-  Index(
+  return Index(
     pubsubTopic: index.pubsubTopic,
     senderTime: index.senderTime,
     receiverTime: index.storeTime,
@@ -53,9 +53,10 @@ proc toIndex*(index: ArchiveCursor): Index =
 
 proc `==`*(x, y: Index): bool =
   ## receiverTime plays no role in index equality
-  (x.senderTime == y.senderTime) and
-  (x.digest == y.digest) and
-  (x.pubsubTopic == y.pubsubTopic)
+  return 
+    (x.senderTime == y.senderTime) and
+    (x.digest == y.digest) and
+    (x.pubsubTopic == y.pubsubTopic)
 
 proc cmp*(x, y: Index): int =
   ## compares x and y

--- a/waku/waku_archive/driver/queue_driver/index.nim
+++ b/waku/waku_archive/driver/queue_driver/index.nim
@@ -10,34 +10,36 @@ import
   ../../../waku_core,
   ../../common
 
-
 type Index* = object
   ## This type contains the  description of an Index used in the pagination of WakuMessages
   pubsubTopic*: string
   senderTime*: Timestamp # the time at which the message is generated
   receiverTime*: Timestamp
   digest*: MessageDigest # calculated over payload and content topic
+  hash*: WakuMessageHash
 
 proc compute*(T: type Index, msg: WakuMessage, receivedTime: Timestamp, pubsubTopic: PubsubTopic): T =
   ## Takes a WakuMessage with received timestamp and returns its Index.
   let
     digest = computeDigest(msg)
     senderTime = msg.timestamp
+    hash = computeMessageHash(pubsubTopic, msg)
 
   Index(
     pubsubTopic: pubsubTopic,
     senderTime: senderTime,
     receiverTime: receivedTime,
-    digest: digest
+    digest: digest,
+    hash: hash,
   )
-
 
 proc tohistoryCursor*(index: Index): ArchiveCursor =
   ArchiveCursor(
     pubsubTopic: index.pubsubTopic,
     senderTime: index.senderTime,
     storeTime: index.receiverTime,
-    digest: index.digest
+    digest: index.digest,
+    hash: index.hash,
   )
 
 proc toIndex*(index: ArchiveCursor): Index =
@@ -45,9 +47,9 @@ proc toIndex*(index: ArchiveCursor): Index =
     pubsubTopic: index.pubsubTopic,
     senderTime: index.senderTime,
     receiverTime: index.storeTime,
-    digest: index.digest
+    digest: index.digest,
+    hash: index.hash,
   )
-
 
 proc `==`*(x, y: Index): bool =
   ## receiverTime plays no role in index equality

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -21,16 +21,22 @@ logScope:
 const QueueDriverDefaultMaxCapacity* = 25_000
 
 type
-  IndexedWakuMessage = object
-    # TODO: may need to rename this object as it holds both the index and the pubsub topic of a waku message
-    ## This type is used to encapsulate a WakuMessage and its Index
-    msg*: WakuMessage
-    index*: Index
-    pubsubTopic*: string
+  QueryFilterMatcher = proc(index: Index, msg: WakuMessage): bool {.gcsafe, closure.}
 
-  QueryFilterMatcher = proc(indexedWakuMsg: IndexedWakuMessage): bool {.gcsafe, closure.}
+  QueueDriver* = ref object of ArchiveDriver
+    ## Bounded repository for indexed messages
+    ##
+    ## The store queue will keep messages up to its
+    ## configured capacity. As soon as this capacity
+    ## is reached and a new message is added, the oldest
+    ## item will be removed to make space for the new one.
+    ## This implies both a `delete` and `add` operation
+    ## for new items.
+    
+    # TODO: a circular/ring buffer may be a more efficient implementation
+    items: SortedSet[Index, WakuMessage] # sorted set of stored messages
+    capacity: int # Maximum amount of messages to keep
 
-type
   QueueDriverErrorKind {.pure.} = enum
     INVALID_CURSOR
 
@@ -41,26 +47,11 @@ proc `$`(error: QueueDriverErrorKind): string =
   of INVALID_CURSOR:
     "invalid_cursor"
 
-type QueueDriver* = ref object of ArchiveDriver
-    ## Bounded repository for indexed messages
-    ##
-    ## The store queue will keep messages up to its
-    ## configured capacity. As soon as this capacity
-    ## is reached and a new message is added, the oldest
-    ## item will be removed to make space for the new one.
-    ## This implies both a `delete` and `add` operation
-    ## for new items.
-    ##
-    ## TODO: a circular/ring buffer may be a more efficient implementation
-    ## TODO: we don't need to store the Index twice (as key and in the value)
-    items: SortedSet[Index, IndexedWakuMessage] # sorted set of stored messages
-    capacity: int # Maximum amount of messages to keep
-
 ### Helpers
 
-proc walkToCursor(w: SortedSetWalkRef[Index, IndexedWakuMessage],
+proc walkToCursor(w: SortedSetWalkRef[Index, WakuMessage],
                   startCursor: Index,
-                  forward: bool): SortedSetResult[Index, IndexedWakuMessage] =
+                  forward: bool): SortedSetResult[Index, WakuMessage] =
   ## Walk to util we find the cursor
   ## TODO: Improve performance here with a binary/tree search
 
@@ -81,7 +72,7 @@ proc walkToCursor(w: SortedSetWalkRef[Index, IndexedWakuMessage],
 #### API
 
 proc new*(T: type QueueDriver, capacity: int = QueueDriverDefaultMaxCapacity): T =
-  var items = SortedSet[Index, IndexedWakuMessage].init()
+  var items = SortedSet[Index, WakuMessage].init()
   return QueueDriver(items: items, capacity: capacity)
 
 proc contains*(driver: QueueDriver, index: Index): bool =
@@ -102,10 +93,10 @@ proc getPage(driver: QueueDriver,
   ## Each entry must match the `pred`
   var outSeq: seq[ArchiveRow]
 
-  var w = SortedSetWalkRef[Index,IndexedWakuMessage].init(driver.items)
+  var w = SortedSetWalkRef[Index, WakuMessage].init(driver.items)
   defer: w.destroy()
 
-  var currentEntry: SortedSetResult[Index, IndexedWakuMessage]
+  var currentEntry: SortedSetResult[Index, WakuMessage]
 
   # Find starting entry
   if cursor.isSome():
@@ -131,14 +122,14 @@ proc getPage(driver: QueueDriver,
   while currentEntry.isOk() and numberOfItems < pageSize:
     trace "Continuing page query", currentEntry=currentEntry, numberOfItems=numberOfItems
 
-    if predicate.isNil() or predicate(currentEntry.value.data):
-      let
-        key = currentEntry.value.key
-        data = currentEntry.value.data
+    let
+      key = currentEntry.value.key
+      data = currentEntry.value.data
 
+    if predicate.isNil() or predicate(key, data):
       numberOfItems += 1
 
-      outSeq.add((key.pubsubTopic, data.msg, @(key.digest.data), key.receiverTime))
+      outSeq.add((key.pubsubTopic, data, @(key.digest.data), key.receiverTime, key.hash))
 
     currentEntry = if forward: w.next()
                    else: w.prev()
@@ -150,10 +141,10 @@ proc getPage(driver: QueueDriver,
 
 ## --- SortedSet accessors ---
 
-iterator fwdIterator*(driver: QueueDriver): (Index, IndexedWakuMessage) =
+iterator fwdIterator*(driver: QueueDriver): (Index, WakuMessage) =
   ## Forward iterator over the entire store queue
   var
-    w = SortedSetWalkRef[Index,IndexedWakuMessage].init(driver.items)
+    w = SortedSetWalkRef[Index, WakuMessage].init(driver.items)
     res = w.first()
 
   while res.isOk():
@@ -162,10 +153,10 @@ iterator fwdIterator*(driver: QueueDriver): (Index, IndexedWakuMessage) =
 
   w.destroy()
 
-iterator bwdIterator*(driver: QueueDriver): (Index, IndexedWakuMessage) =
+iterator bwdIterator*(driver: QueueDriver): (Index, WakuMessage) =
   ## Backwards iterator over the entire store queue
   var
-    w = SortedSetWalkRef[Index,IndexedWakuMessage].init(driver.items)
+    w = SortedSetWalkRef[Index, WakuMessage].init(driver.items)
     res = w.last()
 
   while res.isOk():
@@ -174,45 +165,45 @@ iterator bwdIterator*(driver: QueueDriver): (Index, IndexedWakuMessage) =
 
   w.destroy()
 
-proc first*(driver: QueueDriver): ArchiveDriverResult[IndexedWakuMessage] =
+proc first*(driver: QueueDriver): ArchiveDriverResult[Index] =
   var
-    w = SortedSetWalkRef[Index,IndexedWakuMessage].init(driver.items)
+    w = SortedSetWalkRef[Index, WakuMessage].init(driver.items)
     res = w.first()
   w.destroy()
 
   if res.isErr():
     return err("Not found")
 
-  return ok(res.value.data)
+  return ok(res.value.key)
 
-proc last*(driver: QueueDriver): ArchiveDriverResult[IndexedWakuMessage] =
+proc last*(driver: QueueDriver): ArchiveDriverResult[Index] =
   var
-    w = SortedSetWalkRef[Index,IndexedWakuMessage].init(driver.items)
+    w = SortedSetWalkRef[Index, WakuMessage].init(driver.items)
     res = w.last()
   w.destroy()
 
   if res.isErr():
     return err("Not found")
 
-  return ok(res.value.data)
+  return ok(res.value.key)
 
 ## --- Queue API ---
 
-proc add*(driver: QueueDriver, msg: IndexedWakuMessage): ArchiveDriverResult[void] =
+proc add*(driver: QueueDriver, index: Index, msg: WakuMessage): ArchiveDriverResult[void] =
   ## Add a message to the queue
   ##
   ## If we're at capacity, we will be removing, the oldest (first) item
-  if driver.contains(msg.index):
-    trace "could not add item to store queue. Index already exists", index=msg.index
+  if driver.contains(index):
+    trace "could not add item to store queue. Index already exists", index=index
     return err("duplicate")
 
   # TODO: the below delete block can be removed if we convert to circular buffer
   if driver.items.len >= driver.capacity:
     var
-      w = SortedSetWalkRef[Index, IndexedWakuMessage].init(driver.items)
+      w = SortedSetWalkRef[Index, WakuMessage].init(driver.items)
       firstItem = w.first
 
-    if cmp(msg.index, firstItem.value.key) < 0:
+    if cmp(index, firstItem.value.key) < 0:
       # When at capacity, we won't add if message index is smaller (older) than our oldest item
       w.destroy # Clean up walker
       return err("too_old")
@@ -220,7 +211,7 @@ proc add*(driver: QueueDriver, msg: IndexedWakuMessage): ArchiveDriverResult[voi
     discard driver.items.delete(firstItem.value.key)
     w.destroy # better to destroy walker after a delete operation
 
-  driver.items.insert(msg.index).value.data = msg
+  driver.items.insert(index).value.data = msg
 
   return ok()
 
@@ -231,9 +222,15 @@ method put*(driver: QueueDriver,
             messageHash: WakuMessageHash,
             receivedTime: Timestamp):
             Future[ArchiveDriverResult[void]] {.async.} =
-  let index = Index(pubsubTopic: pubsubTopic, senderTime: message.timestamp, receiverTime: receivedTime, digest: digest)
-  let message = IndexedWakuMessage(msg: message, index: index, pubsubTopic: pubsubTopic)
-  return driver.add(message)
+  let index = Index(
+    pubsubTopic: pubsubTopic,
+    senderTime: message.timestamp,
+    receiverTime: receivedTime,
+    digest: digest,
+    hash: messageHash,
+    )
+  
+  return driver.add(index, message)
 
 method getAllMessages*(driver: QueueDriver):
                        Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
@@ -244,28 +241,33 @@ method existsTable*(driver: QueueDriver, tableName: string):
                     Future[ArchiveDriverResult[bool]] {.async.} =
   return err("interface method not implemented")
 
-method getMessages*(driver: QueueDriver,
-                    contentTopic: seq[ContentTopic] = @[],
-                    pubsubTopic = none(PubsubTopic),
-                    cursor = none(ArchiveCursor),
-                    startTime = none(Timestamp),
-                    endTime = none(Timestamp),
-                    maxPageSize = DefaultPageSize,
-                    ascendingOrder = true):
-                    Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.}=
+method getMessages*(
+  driver: QueueDriver,
+  contentTopic: seq[ContentTopic] = @[],
+  pubsubTopic = none(PubsubTopic),
+  cursor = none(ArchiveCursor),
+  startTime = none(Timestamp),
+  endTime = none(Timestamp),
+  hashes: seq[WakuMessageHash] = @[],
+  maxPageSize = DefaultPageSize,
+  ascendingOrder = true,
+  ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   let cursor = cursor.map(toIndex)
 
-  let matchesQuery: QueryFilterMatcher = func(row: IndexedWakuMessage): bool =
-    if pubsubTopic.isSome() and row.pubsubTopic != pubsubTopic.get():
+  let matchesQuery: QueryFilterMatcher = func(index: Index, msg: WakuMessage): bool =
+    if pubsubTopic.isSome() and index.pubsubTopic != pubsubTopic.get():
       return false
 
-    if contentTopic.len > 0 and row.msg.contentTopic notin contentTopic:
+    if contentTopic.len > 0 and msg.contentTopic notin contentTopic:
       return false
 
-    if startTime.isSome() and row.msg.timestamp < startTime.get():
+    if startTime.isSome() and msg.timestamp < startTime.get():
       return false
 
-    if endTime.isSome() and row.msg.timestamp > endTime.get():
+    if endTime.isSome() and msg.timestamp > endTime.get():
+      return false
+
+    if hashes.len > 0 and index.hash notin hashes:
       return false
 
     return true
@@ -293,7 +295,7 @@ method getPagesSize*(driver: QueueDriver):
                          Future[ArchiveDriverResult[int64]] {.async} =
   return ok(int64(driver.len()))
 
-method getDatabasesSize*(driver: QueueDriver):
+method getDatabaseSize*(driver: QueueDriver):
                          Future[ArchiveDriverResult[int64]] {.async} =
   return ok(int64(driver.len()))
 
@@ -303,11 +305,11 @@ method performVacuum*(driver: QueueDriver):
 
 method getOldestMessageTimestamp*(driver: QueueDriver):
                                   Future[ArchiveDriverResult[Timestamp]] {.async.} =
-  return driver.first().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)
+  return driver.first().map(proc(index: Index): Timestamp = index.receiverTime)
 
 method getNewestMessageTimestamp*(driver: QueueDriver):
                                   Future[ArchiveDriverResult[Timestamp]] {.async.} =
-  return driver.last().map(proc(msg: IndexedWakuMessage): Timestamp = msg.index.receiverTime)
+  return driver.last().map(proc(index: Index): Timestamp = index.receiverTime)
 
 method deleteMessagesOlderThanTimestamp*(driver: QueueDriver,
                                          ts: Timestamp):

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -77,10 +77,10 @@ proc new*(T: type QueueDriver, capacity: int = QueueDriverDefaultMaxCapacity): T
 
 proc contains*(driver: QueueDriver, index: Index): bool =
   ## Return `true` if the store queue already contains the `index`, `false` otherwise.
-  driver.items.eq(index).isOk()
+  return driver.items.eq(index).isOk()
 
 proc len*(driver: QueueDriver): int {.noSideEffect.} =
-  driver.items.len
+  return driver.items.len
 
 proc getPage(driver: QueueDriver,
              pageSize: uint = 0,

--- a/waku/waku_archive/driver/sqlite_driver/migrations.nim
+++ b/waku/waku_archive/driver/sqlite_driver/migrations.nim
@@ -49,7 +49,7 @@ proc isSchemaVersion7*(db: SqliteDatabase): DatabaseResult[bool] =
 
   else:
     info "Not considered schema version 7"
-    ok(false)
+    return ok(false)
 
 proc migrate*(db: SqliteDatabase, targetVersion = SchemaVersion): DatabaseResult[void] =
   ## Compares the `user_version` of the sqlite database with the provided `targetVersion`, then
@@ -75,4 +75,4 @@ proc migrate*(db: SqliteDatabase, targetVersion = SchemaVersion): DatabaseResult
     return err("failed to execute migration scripts: " & migrationRes.error)
 
   debug "finished message store's sqlite database migration"
-  ok()
+  return ok()

--- a/waku/waku_archive/driver/sqlite_driver/queries.nim
+++ b/waku/waku_archive/driver/sqlite_driver/queries.nim
@@ -62,11 +62,7 @@ proc queryRowWakuMessageHashCallback(s: ptr sqlite3_stmt, hashCol: cint): WakuMe
   let
     hashPointer = cast[ptr UncheckedArray[byte]](sqlite3_column_blob(s, hashCol))
     hashLength = sqlite3_column_bytes(s, hashCol)
-
-  var hash: WakuMessageHash
-
-  let copiedBytes = copyFrom(hash, toOpenArray(hashPointer, 0, hashLength-1))
-  assert copiedBytes == 32
+    hash = fromBytes(toOpenArray(hashPointer, 0, hashLength-1))
 
   hash
 

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -85,11 +85,12 @@ method getAllMessages*(s: SqliteDriver):
   return s.db.selectAllMessages()
 
 method getMessages*(s: SqliteDriver,
-                    contentTopic: seq[ContentTopic] = @[],
+                    contentTopic = newSeq[ContentTopic](0),
                     pubsubTopic = none(PubsubTopic),
                     cursor = none(ArchiveCursor),
                     startTime = none(Timestamp),
                     endTime = none(Timestamp),
+                    hashes = newSeq[WakuMessageHash](0),
                     maxPageSize = DefaultPageSize,
                     ascendingOrder = true):
                     Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
@@ -102,6 +103,7 @@ method getMessages*(s: SqliteDriver,
     cursor,
     startTime,
     endTime,
+    hashes,
     limit=maxPageSize,
     ascending=ascendingOrder
   )

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -41,7 +41,7 @@ proc init(db: SqliteDatabase): ArchiveDriverResult[void] =
   if resMsgIndex.isErr():
     return err("failed to create i_msg index: " & resMsgIndex.error())
 
-  ok()
+  return ok()
 
 type SqliteDriver* = ref object of ArchiveDriver
     db: SqliteDatabase
@@ -56,7 +56,7 @@ proc new*(T: type SqliteDriver, db: SqliteDatabase): ArchiveDriverResult[T] =
 
   # General initialization
   let insertStmt = db.prepareInsertMessageStmt()
-  ok(SqliteDriver(db: db, insertStmt: insertStmt))
+  return ok(SqliteDriver(db: db, insertStmt: insertStmt))
 
 method put*(s: SqliteDriver,
             pubsubTopic: PubsubTopic,

--- a/waku/waku_core/message/digest.nim
+++ b/waku/waku_core/message/digest.nim
@@ -6,8 +6,7 @@ else:
 
 import
   std/sequtils,
-  stew/byteutils,
-  stew/endians2,
+  stew/[byteutils, endians2, arrayops],
   nimcrypto/sha2
 import
   ../topics,
@@ -19,6 +18,11 @@ import
 
 type WakuMessageHash* = array[32, byte]
 
+converter fromBytes*(array: openArray[byte]): WakuMessageHash =
+  var hash: WakuMessageHash
+  let copiedBytes = copyFrom(hash, array)
+  assert copiedBytes == 32, "Waku message hash is 32 bytes"
+  hash
 
 converter toBytesArray*(digest: MDigest[256]): WakuMessageHash =
   digest.data

--- a/waku/waku_core/message/message.nim
+++ b/waku/waku_core/message/message.nim
@@ -11,8 +11,7 @@ else:
 
 import
   ../topics,
-  ../time,
-  ./default_values
+  ../time
 
 const
   MaxMetaAttrLength* = 64 # 64 bytes


### PR DESCRIPTION
# Description
I tried a bunch of things that didn't work. In the end I simply added hashed to requests and responses. This approach will require a good clean-up after store v2 is removed.

I simplified how message are validated since we never exposed the validation even if the intent seamed to be to make it configurable. Do we want fully configurable validation? What kind of messages do we reject exactly?

There are also couple of comments that require reviewers input.

# Changes
- [x] refactored `WakuArchive`
- [x] archive cursor new use timestamp and msg hash
- [x] simplified msg validation
- [x] compatibility with Store v2
- [x] update drivers
- [x] update tests

Tracking #2425