### PR TITLE
chore: bindings return multiaddress array

### DIFF
--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -297,6 +297,8 @@ int main(int argc, char** argv) {
     waku_set_event_callback(ctx, event_handler, userData);
     waku_start(ctx, event_handler, userData);
 
+    waku_listen_addresses(ctx, event_handler, userData);
+
     printf("Establishing connection with: %s\n", cfgNode.peers);
 
     WAKU_CALL( waku_connect(ctx,

--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -91,7 +91,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 
 static struct argp argp = { options, parse_opt, args_doc, doc, 0, 0, 0 };
 
-void event_handler(int callerRet, const char* msg, size_t len) {
+void event_handler(int callerRet, const char* msg, size_t len, void* userData) {
     if (callerRet == RET_ERR) {
         printf("Error: %s\n", msg);
         exit(1);
@@ -102,7 +102,7 @@ void event_handler(int callerRet, const char* msg, size_t len) {
 }
 
 char* contentTopic = NULL;
-void handle_content_topic(int callerRet, const char* msg, size_t len) {
+void handle_content_topic(int callerRet, const char* msg, size_t len, void* userData) {
     if (contentTopic != NULL) {
         free(contentTopic);
     }
@@ -112,7 +112,7 @@ void handle_content_topic(int callerRet, const char* msg, size_t len) {
 }
 
 char* publishResponse = NULL;
-void handle_publish_ok(int callerRet, const char* msg, size_t len) {
+void handle_publish_ok(int callerRet, const char* msg, size_t len, void* userData) {
     printf("Publish Ok: %s %lu\n", msg, len);
 
     if (publishResponse != NULL) {
@@ -159,11 +159,11 @@ void show_help_and_exit() {
     exit(1);
 }
 
-void print_default_pubsub_topic(int callerRet, const char* msg, size_t len) {
+void print_default_pubsub_topic(int callerRet, const char* msg, size_t len, void* userData) {
     printf("Default pubsub topic: %s\n", msg);
 }
 
-void print_waku_version(int callerRet, const char* msg, size_t len) {
+void print_waku_version(int callerRet, const char* msg, size_t len, void* userData) {
     printf("Git Version: %s\n", msg);
 }
 

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -83,6 +83,10 @@ int waku_connect(void* ctx,
                  WakuCallBack callback,
                  void* userData);
 
+int waku_listen_addresses(void* ctx,
+                          WakuCallBack callback,
+                          void* userData);
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -19,6 +19,7 @@ import
   ./waku_thread/inter_thread_communication/requests/peer_manager_request,
   ./waku_thread/inter_thread_communication/requests/protocols/relay_request,
   ./waku_thread/inter_thread_communication/requests/protocols/store_request,
+  ./waku_thread/inter_thread_communication/requests/debug_node_request,
   ./waku_thread/inter_thread_communication/waku_thread_request,
   ./alloc,
   ./callback
@@ -355,6 +356,27 @@ proc waku_store_query(ctx: ptr Context,
   #   return RET_ERR
 
   return RET_OK
+
+proc waku_listen_addresses(ctx: ptr Context,
+                           callback: WakuCallBack,
+                           userData: pointer): cint
+                           {.dynlib, exportc.} =
+
+  ctx[].userData = userData
+
+  let connRes = waku_thread.sendRequestToWakuThread(
+                                   ctx,
+                                   RequestType.DEBUG,
+                                   DebugNodeRequest.createShared(
+                                            DebugNodeMsgType.RETRIEVE_LISTENING_ADDRESSES))
+  if connRes.isErr():
+    let msg = $connRes.error
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return RET_ERR
+  else:
+    let msg = $connRes.value
+    callback(RET_OK, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return RET_OK
 
 ### End of exported procs
 ################################################################################

--- a/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
@@ -1,0 +1,44 @@
+
+import
+  std/[options,sequtils,strutils,json]
+import
+  chronicles,
+  chronos,
+  stew/results,
+  stew/shims/net
+import
+  ../../../../waku/node/waku_node,
+  ../../../alloc
+
+type
+  DebugNodeMsgType* = enum
+    RETRIEVE_LISTENING_ADDRESSES
+
+type
+  DebugNodeRequest* = object
+    operation: DebugNodeMsgType
+
+proc createShared*(T: type DebugNodeRequest,
+                   op: DebugNodeMsgType): ptr type T =
+
+  var ret = createShared(T)
+  ret[].operation = op
+  return ret
+
+proc destroyShared(self: ptr DebugNodeRequest) =
+  deallocShared(self)
+
+proc getMultiaddresses(node: WakuNode): seq[string] =
+  return node.info().listenAddresses
+
+proc process*(self: ptr DebugNodeRequest,
+              node: WakuNode): Future[Result[string, string]] {.async.} =
+
+  defer: destroyShared(self)
+
+  case self.operation:
+    of RETRIEVE_LISTENING_ADDRESSES:
+      return ok($( %* node.getMultiaddresses()))
+
+  return err("unsupported operation in DebugNodeRequest")
+

--- a/library/waku_thread/inter_thread_communication/waku_thread_request.nim
+++ b/library/waku_thread/inter_thread_communication/waku_thread_request.nim
@@ -13,7 +13,8 @@ import
   ./requests/node_lifecycle_request,
   ./requests/peer_manager_request,
   ./requests/protocols/relay_request,
-  ./requests/protocols/store_request
+  ./requests/protocols/store_request,
+  ./requests/debug_node_request
 
 type
   RequestType* {.pure.} = enum
@@ -21,6 +22,7 @@ type
     PEER_MANAGER,
     RELAY,
     STORE,
+    DEBUG,
 
 type
   InterThreadRequest* = object
@@ -54,6 +56,8 @@ proc process*(T: type InterThreadRequest,
         cast[ptr RelayRequest](request[].reqContent).process(node)
       of STORE:
         cast[ptr StoreRequest](request[].reqContent).process(node)
+      of DEBUG:
+        cast[ptr DebugNodeRequest](request[].reqContent).process(node[])
 
   return await retFut
 


### PR DESCRIPTION
## Description
Adding new function that helps to extract the multiaddresses the node is listening to. The information is returned as a string with that contains a JSON-array. e.g.: `["/ip4/100.79.7.227/tcp/60001/p2p/16Uiu2HAm2eqzqp6xn32fzgGi8K4BuF88W4Xy6yxsmDcW8h1gj6ie"]`

kudos to @richard-ramos! It's been a great pair programming session :)

## Changes
- examples/cbindings/waku_example.c: adapt signatures to accept the recently added `void* userData` (outside of the scope of this PR.)
- examples/cbindings/waku_example.c: invoke `waku_listen_addresses(ctx, event_handler, userData);`
- library/waku_thread/inter_thread_communication/requests/debug_node_request.nim: new file added.
- library/libwaku.nim, libwaku.h:  waku_listen_addresses implementation

## How to test it
1. make cwaku_example -j11
2. `./build/cwaku_example --host=0.0.0.0 --peers=/dns4/node-01.do-ams3.wakuv2.test.statusim.net/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ --port=60001 --key=364d111d729a6eb6d2e6113e163f017b5ef03a6f94c9b5b7bb1bb36fa5cb07a9`

