### PR TITLE
chore: Implemented CORS handling for nwaku REST server

### DIFF
--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -419,7 +419,7 @@ type
               "Argument may be repeated." &
               "Wildcards: * or ? allowed." &
               "Ex.: \"localhost:*\" or \"127.0.0.1:8080\"",
-        defaultValue: @[""]
+        defaultValue: newSeq[string]()
         name: "rest-allow-origin" }: seq[string]
 
       ## Metrics config

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -414,6 +414,14 @@ type
         defaultValue: false
         name: "rest-private" }: bool
 
+      restAllowOrigin* {.
+        desc: "Allow cross-origin requests from the specified origin." &
+              "Argument may be repeated." &
+              "Wildcards: * or ? allowed." &
+              "Ex.: \"localhost:*\" or \"127.0.0.1:8080\"",
+        defaultValue: @[""]
+        name: "rest-allow-origin" }: seq[string]
+
       ## Metrics config
 
       metricsServer* {.

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -85,7 +85,8 @@ import
   ./wakunode_rest/test_rest_filter,
   ./wakunode_rest/test_rest_legacy_filter,
   ./wakunode_rest/test_rest_lightpush,
-  ./wakunode_rest/test_rest_admin
+  ./wakunode_rest/test_rest_admin,
+  ./wakunode_rest/test_rest_cors
 
 import
   ./waku_rln_relay/test_waku_rln_relay,

--- a/tests/wakunode_rest/test_all.nim
+++ b/tests/wakunode_rest/test_all.nim
@@ -10,4 +10,5 @@ import
   ./test_rest_relay,
   ./test_rest_serdes,
   ./test_rest_store,
-  ./test_rest_admin
+  ./test_rest_admin,
+  ./test_rest_cors

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -30,7 +30,7 @@ suite "Waku v2 Rest API - Admin":
   var peerInfo1 {.threadvar.}: RemotePeerInfo
   var peerInfo2 {.threadvar.}: RemotePeerInfo
   var peerInfo3 {.threadvar.}: RemotePeerInfo
-  var restServer {.threadvar.}: RestServerRef
+  var restServer {.threadvar.}: WakuRestServerRef
   var client{.threadvar.}: RestClientRef
 
   asyncSetup:
@@ -46,7 +46,7 @@ suite "Waku v2 Rest API - Admin":
 
     let restPort = Port(58011)
     let restAddress = parseIpAddress("127.0.0.1")
-    restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installAdminApiHandlers(restServer.router, node1)
 

--- a/tests/wakunode_rest/test_rest_cors.nim
+++ b/tests/wakunode_rest/test_rest_cors.nim
@@ -1,0 +1,269 @@
+{.used.}
+
+import
+  stew/shims/net,
+  testutils/unittests,
+  presto,
+  presto/client as presto_client,
+  libp2p/peerinfo,
+  libp2p/multiaddress,
+  libp2p/crypto/crypto
+import
+  ../../waku/waku_node,
+  ../../waku/node/waku_node as waku_node2,
+  ../../waku/waku_api/rest/server,
+  ../../waku/waku_api/rest/client,
+  ../../waku/waku_api/rest/responses,
+  ../../waku/waku_api/rest/debug/handlers as debug_api,
+  ../../waku/waku_api/rest/debug/client as debug_api_client,
+  ../testlib/common,
+  ../testlib/wakucore,
+  ../testlib/wakunode
+
+
+type
+  TestResponseTuple = tuple[status: int, data: string, headers: HttpTable]
+
+proc testWakuNode(): WakuNode =
+  let
+    privkey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
+    bindIp = parseIpAddress("0.0.0.0")
+    extIp = parseIpAddress("127.0.0.1")
+    port = Port(58000)
+
+  newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
+
+proc fetchWithHeader(request: HttpClientRequestRef): Future[TestResponseTuple]
+    {.async: (raises: [CancelledError, HttpError]).} =
+  var response: HttpClientResponseRef
+  try:
+    response = await request.send()
+    let buffer = await response.getBodyBytes()
+    let status = response.status
+    let headers = response.headers
+    await response.closeWait()
+    response = nil
+    return (status, buffer.bytesToString(), headers)
+  except HttpError as exc:
+    if not(isNil(response)): await response.closeWait()
+    raise exc
+  except CancelledError as exc:
+    if not(isNil(response)): await response.closeWait()
+    raise exc
+
+proc issueRequest(
+        address: HttpAddress,
+        reqOrigin: Option[string] = none(string)
+      ): Future[TestResponseTuple] {.async.} =
+
+  var
+    session = HttpSessionRef.new({HttpClientFlag.Http11Pipeline})
+    data: TestResponseTuple
+
+  var originHeader : seq[HttpHeaderTuple]
+  if reqOrigin.isSome():
+    originHeader.insert(("Origin", reqOrigin.get()))
+
+  var
+    request = HttpClientRequestRef.new(session,
+                                       address,
+                                       version = HttpVersion11,
+                                       headers = originHeader)
+  try:
+    data = await request.fetchWithHeader()
+  finally:
+    await request.closeWait()
+  return data
+
+proc checkResponse(response: TestResponseTuple,
+                   expectedStatus : int,
+                   expectedOrigin : Option[string]): bool =
+  if response.status != expectedStatus:
+    echo(" -> check failed: expected status" & $expectedStatus &
+         " got " & $response.status)
+    return false
+
+  if not (expectedOrigin.isNone() or
+          (expectedOrigin.isSome() and
+           response.headers.contains("Access-Control-Allow-Origin") and
+           response.headers.getLastString("Access-Control-Allow-Origin") == expectedOrigin.get())):
+    echo(" -> check failed: expected origin " & $expectedOrigin & " got " &
+            response.headers.getLastString("Access-Control-Allow-Origin"))
+    return false
+
+  return true
+
+suite "Waku v2 REST API CORS Handling":
+  asyncTest "AllowedOrigin matches":
+    # Given
+    let node = testWakuNode()
+    await node.start()
+    await node.mountRelay()
+
+    let restPort = Port(58001)
+    let restAddress = parseIpAddress("0.0.0.0")
+    let restServer = WakuRestServerRef.init(restAddress,
+                    restPort,
+                    allowedOrigin=some("test.net:1234,https://localhost:*,http://127.0.0.1:?8,?waku*.net:*80*")
+                    ).tryGet()
+
+    installDebugApiHandlers(restServer.router, node)
+    restServer.start()
+
+    let srvAddr = restServer.localAddress()
+    let ha = getAddress(srvAddr, HttpClientScheme.NonSecure, "/debug/v1/info")
+
+    # When
+    var response = await issueRequest(ha, some("http://test.net:1234"))
+    check checkResponse(response, 200, some("http://test.net:1234"))
+
+    response = await issueRequest(ha, some("https://test.net:1234"))
+    check checkResponse(response, 200, some("https://test.net:1234"))
+
+    response = await issueRequest(ha, some("https://localhost:8080"))
+    check checkResponse(response, 200, some("https://localhost:8080"))
+
+    response = await issueRequest(ha, some("https://localhost:80"))
+    check checkResponse(response, 200, some("https://localhost:80"))
+
+    response = await issueRequest(ha, some("http://127.0.0.1:78"))
+    check checkResponse(response, 200, some("http://127.0.0.1:78"))
+
+    response = await issueRequest(ha, some("http://wakuTHE.net:8078"))
+    check checkResponse(response, 200, some("http://wakuTHE.net:8078"))
+
+    response = await issueRequest(ha, some("http://nwaku.main.net:1980"))
+    check checkResponse(response, 200, some("http://nwaku.main.net:1980"))
+
+    response = await issueRequest(ha, some("http://nwaku.main.net:80"))
+    check checkResponse(response, 200, some("http://nwaku.main.net:80"))
+
+    await restServer.stop()
+    await restServer.closeWait()
+    await node.stop()
+
+  asyncTest "AllowedOrigin reject":
+    # Given
+    let node = testWakuNode()
+    await node.start()
+    await node.mountRelay()
+
+    let restPort = Port(58001)
+    let restAddress = parseIpAddress("0.0.0.0")
+    let restServer = WakuRestServerRef.init(restAddress,
+                      restPort,
+                      allowedOrigin=some("test.net:1234,https://localhost:*,http://127.0.0.1:?8,?waku*.net:*80*")
+                      ).tryGet()
+
+    installDebugApiHandlers(restServer.router, node)
+    restServer.start()
+
+    let srvAddr = restServer.localAddress()
+    let ha = getAddress(srvAddr, HttpClientScheme.NonSecure, "/debug/v1/info")
+
+    # When
+    var response = await issueRequest(ha, some("http://test.net:12334"))
+    check checkResponse(response, 403, none(string))
+
+    response = await issueRequest(ha, some("http://test.net:12345"))
+    check checkResponse(response, 403, none(string))
+
+    response = await issueRequest(ha, some("xhttp://test.net:1234"))
+    check checkResponse(response, 403, none(string))
+
+    response = await issueRequest(ha, some("https://xtest.net:1234"))
+    check checkResponse(response, 403, none(string))
+
+    response = await issueRequest(ha, some("http://localhost:8080"))
+    check checkResponse(response, 403, none(string))
+
+    response = await issueRequest(ha, some("https://127.0.0.1:78"))
+    check checkResponse(response, 403, none(string))
+
+    response = await issueRequest(ha, some("http://127.0.0.1:89"))
+    check checkResponse(response, 403, none(string))
+
+    response = await issueRequest(ha, some("http://the.waku.net:8078"))
+    check checkResponse(response, 403, none(string))
+
+    response = await issueRequest(ha, some("http://nwaku.main.net:1900"))
+    check checkResponse(response, 403, none(string))
+
+    await restServer.stop()
+    await restServer.closeWait()
+    await node.stop()
+
+  asyncTest "AllowedOrigin allmatches":
+    # Given
+    let node = testWakuNode()
+    await node.start()
+    await node.mountRelay()
+
+    let restPort = Port(58001)
+    let restAddress = parseIpAddress("0.0.0.0")
+    let restServer = WakuRestServerRef.init(restAddress,
+                                            restPort,
+                                            allowedOrigin=some("*")
+                                            ).tryGet()
+
+    installDebugApiHandlers(restServer.router, node)
+    restServer.start()
+
+    let srvAddr = restServer.localAddress()
+    let ha = getAddress(srvAddr, HttpClientScheme.NonSecure, "/debug/v1/info")
+
+    # When
+    var response = await issueRequest(ha, some("http://test.net:1234"))
+    check checkResponse(response, 200, some("*"))
+
+    response = await issueRequest(ha, some("https://test.net:1234"))
+    check checkResponse(response, 200, some("*"))
+
+    response = await issueRequest(ha, some("https://localhost:8080"))
+    check checkResponse(response, 200, some("*"))
+
+    response = await issueRequest(ha, some("https://localhost:80"))
+    check checkResponse(response, 200, some("*"))
+
+    response = await issueRequest(ha, some("http://127.0.0.1:78"))
+    check checkResponse(response, 200, some("*"))
+
+    response = await issueRequest(ha, some("http://wakuTHE.net:8078"))
+    check checkResponse(response, 200, some("*"))
+
+    response = await issueRequest(ha, some("http://nwaku.main.net:1980"))
+    check checkResponse(response, 200, some("*"))
+
+    response = await issueRequest(ha, some("http://nwaku.main.net:80"))
+    check checkResponse(response, 200, some("*"))
+
+    await restServer.stop()
+    await restServer.closeWait()
+    await node.stop()
+
+  asyncTest "No origin goes through":
+    # Given
+    let node = testWakuNode()
+    await node.start()
+    await node.mountRelay()
+
+    let restPort = Port(58001)
+    let restAddress = parseIpAddress("0.0.0.0")
+    let restServer = WakuRestServerRef.init(restAddress,
+                      restPort,
+                      allowedOrigin=some("test.net:1234,https://localhost:*,http://127.0.0.1:?8,?waku*.net:*80*")
+                      ).tryGet()
+
+    installDebugApiHandlers(restServer.router, node)
+    restServer.start()
+
+    let srvAddr = restServer.localAddress()
+    let ha = getAddress(srvAddr, HttpClientScheme.NonSecure, "/debug/v1/info")
+
+    # When
+    var response = await issueRequest(ha, none(string))
+    check checkResponse(response, 200, none(string))
+
+    await restServer.stop()
+    await restServer.closeWait()
+    await node.stop()

--- a/tests/wakunode_rest/test_rest_cors.nim
+++ b/tests/wakunode_rest/test_rest_cors.nim
@@ -46,10 +46,10 @@ proc fetchWithHeader(request: HttpClientRequestRef): Future[TestResponseTuple]
     return (status, buffer.bytesToString(), headers)
   except HttpError as exc:
     if not(isNil(response)): await response.closeWait()
-    raise exc
+    assert false
   except CancelledError as exc:
     if not(isNil(response)): await response.closeWait()
-    raise exc
+    assert false
 
 proc issueRequest(
         address: HttpAddress,

--- a/tests/wakunode_rest/test_rest_debug.nim
+++ b/tests/wakunode_rest/test_rest_debug.nim
@@ -40,7 +40,7 @@ suite "Waku v2 REST API - Debug":
 
     let restPort = Port(58001)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installDebugApiHandlers(restServer.router, node)
     restServer.start()
@@ -67,7 +67,7 @@ suite "Waku v2 REST API - Debug":
 
     let restPort = Port(58002)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installDebugApiHandlers(restServer.router, node)
     restServer.start()

--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -39,8 +39,8 @@ proc testWakuNode(): WakuNode =
 type RestFilterTest = object
   serviceNode: WakuNode
   subscriberNode: WakuNode
-  restServer: RestServerRef
-  restServerForService: RestServerRef
+  restServer: WakuRestServerRef
+  restServerForService: WakuRestServerRef
   messageCache: MessageCache
   client: RestClientRef
   clientTwdServiceNode: RestClientRef
@@ -61,10 +61,10 @@ proc init(T: type RestFilterTest): Future[T] {.async.} =
 
   let restPort = Port(58011)
   let restAddress = parseIpAddress("127.0.0.1")
-  testSetup.restServer = RestServerRef.init(restAddress, restPort).tryGet()
+  testSetup.restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
   let restPort2 = Port(58012)
-  testSetup.restServerForService = RestServerRef.init(restAddress, restPort2).tryGet()
+  testSetup.restServerForService = WakuRestServerRef.init(restAddress, restPort2).tryGet()
 
   # through this one we will see if messages are pushed according to our content topic sub
   testSetup.messageCache = MessageCache.init()

--- a/tests/wakunode_rest/test_rest_health.nim
+++ b/tests/wakunode_rest/test_rest_health.nim
@@ -44,7 +44,7 @@ suite "Waku v2 REST API - health":
 
     let restPort = Port(58001)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installHealthApiHandler(restServer.router, node)
     restServer.start()

--- a/tests/wakunode_rest/test_rest_legacy_filter.nim
+++ b/tests/wakunode_rest/test_rest_legacy_filter.nim
@@ -38,7 +38,7 @@ proc testWakuNode(): WakuNode =
 type RestFilterTest = object
   filterNode: WakuNode
   clientNode: WakuNode
-  restServer: RestServerRef
+  restServer: WakuRestServerRef
   messageCache: MessageCache
   client: RestClientRef
 
@@ -58,7 +58,7 @@ proc setupRestFilter(): Future[RestFilterTest] {.async.} =
 
   let restPort = Port(58011)
   let restAddress = parseIpAddress("0.0.0.0")
-  result.restServer = RestServerRef.init(restAddress, restPort).tryGet()
+  result.restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
   result.messageCache = MessageCache.init()
   installLegacyFilterRestApiHandlers(result.restServer.router

--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -39,7 +39,7 @@ type RestLightPushTest = object
   serviceNode: WakuNode
   pushNode: WakuNode
   consumerNode: WakuNode
-  restServer: RestServerRef
+  restServer: WakuRestServerRef
   client: RestClientRef
 
 
@@ -71,7 +71,7 @@ proc init(T: type RestLightPushTest): Future[T] {.async.} =
 
   let restPort = Port(58011)
   let restAddress = parseIpAddress("127.0.0.1")
-  testSetup.restServer = RestServerRef.init(restAddress, restPort).tryGet()
+  testSetup.restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
   installLightPushRequestHandler(testSetup.restServer.router, testSetup.pushNode)
 

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -43,9 +43,9 @@ suite "Waku v2 Rest API - Relay":
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
 
@@ -93,9 +93,9 @@ suite "Waku v2 Rest API - Relay":
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
     cache.pubsubSubscribe("pubsub-topic-1")
@@ -147,12 +147,12 @@ suite "Waku v2 Rest API - Relay":
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let pubSubTopic = "/waku/2/default-waku/proto"
-    
+
     var messages = @[
       fakeWakuMessage(contentTopic = "content-topic-x", payload = toBytes("TEST-1"),
         meta = toBytes("test-meta") )
@@ -168,7 +168,7 @@ suite "Waku v2 Rest API - Relay":
           meta = toBytes("test-meta"))
 
       messages.add(msg)
-    
+
     let cache = MessageCache.init()
 
     cache.pubsubSubscribe(pubSubTopic)
@@ -215,9 +215,9 @@ suite "Waku v2 Rest API - Relay":
     # RPC server setup
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
 
@@ -257,9 +257,9 @@ suite "Waku v2 Rest API - Relay":
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
 
@@ -305,9 +305,9 @@ suite "Waku v2 Rest API - Relay":
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let contentTopics = @[
       ContentTopic("/waku/2/default-content1/proto"),
@@ -353,9 +353,9 @@ suite "Waku v2 Rest API - Relay":
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let contentTopic = DefaultContentTopic
 
@@ -369,9 +369,9 @@ suite "Waku v2 Rest API - Relay":
 
       while msg == messages[i]:
         msg = fakeWakuMessage(contentTopic = DefaultContentTopic, payload = toBytes("TEST-1"))
-      
+
       messages.add(msg)
-    
+
     let cache = MessageCache.init()
 
     cache.contentSubscribe(contentTopic)
@@ -417,9 +417,9 @@ suite "Waku v2 Rest API - Relay":
     # RPC server setup
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
     installRelayApiHandlers(restServer.router, node, cache)
@@ -461,9 +461,9 @@ suite "Waku v2 Rest API - Relay":
     # RPC server setup
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
     installRelayApiHandlers(restServer.router, node, cache)
@@ -500,9 +500,9 @@ suite "Waku v2 Rest API - Relay":
     # RPC server setup
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
 
@@ -521,7 +521,7 @@ suite "Waku v2 Rest API - Relay":
       contentTopic: some(DefaultContentTopic),
       timestamp: some(int64(2022))
     ))
-    
+
     # Then
     check:
       response.status == 400
@@ -544,9 +544,9 @@ suite "Waku v2 Rest API - Relay":
     # RPC server setup
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     let cache = MessageCache.init()
 
@@ -565,7 +565,7 @@ suite "Waku v2 Rest API - Relay":
       contentTopic: some(DefaultContentTopic),
       timestamp: some(int64(2022))
     ))
-    
+
     # Then
     check:
       response.status == 400

--- a/tests/wakunode_rest/test_rest_store.nim
+++ b/tests/wakunode_rest/test_rest_store.nim
@@ -83,7 +83,7 @@ procSuite "Waku v2 Rest API - Store":
 
     let restPort = Port(58011)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -153,7 +153,7 @@ procSuite "Waku v2 Rest API - Store":
 
     let restPort = Port(58012)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -251,7 +251,7 @@ procSuite "Waku v2 Rest API - Store":
 
     let restPort = Port(58013)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -325,7 +325,7 @@ procSuite "Waku v2 Rest API - Store":
 
     let restPort = Port(58014)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -416,7 +416,7 @@ procSuite "Waku v2 Rest API - Store":
 
     let restPort = Port(58015)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -473,7 +473,7 @@ procSuite "Waku v2 Rest API - Store":
 
     let restPort = Port(58016)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -482,7 +482,7 @@ procSuite "Waku v2 Rest API - Store":
     let driver: ArchiveDriver = QueueDriver.new()
     let mountArchiveRes = node.mountArchive(driver)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
-    
+
     await node.mountStore()
     node.mountStoreClient()
 

--- a/tests/wakunode_rest/test_rest_store.nim
+++ b/tests/wakunode_rest/test_rest_store.nim
@@ -547,7 +547,7 @@ procSuite "Waku v2 Rest API - Store":
 
     let restPort = Port(58014)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -609,9 +609,9 @@ procSuite "Waku v2 Rest API - Store":
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
-    let restServer = RestServerRef.init(restAddress, restPort).tryGet()
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
-    restPort = restServer.server.address.port # update with bound port for client use
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()

--- a/waku/waku_api/rest/origin_handler.nim
+++ b/waku/waku_api/rest/origin_handler.nim
@@ -1,0 +1,124 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/[options, strutils, re],
+  stew/results,
+  stew/shims/net,
+  chronicles,
+  chronos,
+  chronos/apps/http/httpserver
+
+type
+  OriginHandlerMiddlewareRef* = ref object of HttpServerMiddlewareRef
+    allowedOriginMatcher*: Option[Regex]
+    everyOriginAllowed*: bool
+
+
+proc isEveryOriginAllowed(maybeAllowedOrigin: Option[string]): bool =
+  return maybeAllowedOrigin.isSome and maybeAllowedOrigin.get() == "*"
+
+proc compileOriginMatcher(maybeAllowedOrigin: Option[string]): Option[Regex] =
+  if maybeAllowedOrigin.isNone:
+    return none(Regex)
+
+  let allowedOrigin = maybeAllowedOrigin.get()
+
+  if (len(allowedOrigin) == 0):
+    return none(Regex)
+
+  try:
+    var matchOrigin : string
+
+    if allowedOrigin == "*":
+      matchOrigin = r".*"
+      return some(re(matchOrigin, {reIgnoreCase, reExtended}))
+
+    let allowedOrigins = allowedOrigin.split(",")
+
+    var matchExpressions : seq[string] = @[]
+
+    var prefix : string
+    for allowedOrigin in allowedOrigins:
+      if allowedOrigin.startsWith("http://"):
+        prefix = r"http:\/\/"
+        matchOrigin = allowedOrigin.substr(7)
+      elif allowedOrigin.startsWith("https://"):
+        prefix = r"https:\/\/"
+        matchOrigin = allowedOrigin.substr(8)
+      else:
+        prefix = r"https?:\/\/"
+        matchOrigin = allowedOrigin
+
+      matchOrigin = matchOrigin.replace(".", r"\.")
+      matchOrigin = matchOrigin.replace("*", ".*")
+      matchOrigin = matchOrigin.replace("?", ".?")
+
+      matchExpressions.add("^" & prefix & matchOrigin & "$")
+
+    let finalExpression = matchExpressions.join("|")
+
+    return some(re(finalExpression, {reIgnoreCase, reExtended}))
+  except RegexError:
+    var msg = getCurrentExceptionMsg()
+    error "Failed to compile regex", source=allowedOrigin, err=msg
+    return none(Regex)
+
+proc originsMatch(originHandler: OriginHandlerMiddlewareRef,
+                  requestOrigin: string): bool =
+
+  if originHandler.allowedOriginMatcher.isNone():
+    return false
+
+  return requestOrigin.match(originHandler.allowedOriginMatcher.get())
+
+proc originMiddlewareProc(
+                          middleware: HttpServerMiddlewareRef,
+                          reqfence: RequestFence,
+                          nextHandler: HttpProcessCallback2
+                          ): Future[HttpResponseRef] {.async: (raises: [CancelledError]).} =
+  if reqfence.isErr():
+    # Ignore request errors
+    return await nextHandler(reqfence)
+
+  let self = OriginHandlerMiddlewareRef(middleware)
+  let request = reqfence.get()
+  var reqHeaders = request.headers
+  var response = request.getResponse()
+
+  if self.allowedOriginMatcher.isSome:
+    let origin = reqHeaders.getList("Origin")
+    try:
+      if origin.len == 1:
+        if self.everyOriginAllowed:
+          response.addHeader("Access-Control-Allow-Origin", "*")
+        elif self.originsMatch(origin[0]):
+          # The Vary: Origin header to must be set to prevent
+          # potential cache poisoning attacks:
+          # https://textslashplain.com/2018/08/02/cors-and-vary/
+          response.addHeader("Vary", "Origin")
+          response.addHeader("Access-Control-Allow-Origin", origin[0])
+        else:
+          return await request.respond(Http403, "Origin not allowed")
+      elif origin.len == 0:
+        discard
+      elif origin.len > 1:
+        return await request.respond(Http400, "Only a single Origin header must be specified")
+    except HttpWriteError as exc:
+      # We use default error handler if we unable to send response.
+      return defaultResponse(exc)
+
+  # Calling next handler.
+  return await nextHandler(reqfence)
+
+proc new*(t: typedesc[OriginHandlerMiddlewareRef],
+          allowedOrigin: Option[string] = none(string)
+         ): HttpServerMiddlewareRef =
+
+  let middleware =
+    OriginHandlerMiddlewareRef(allowedOriginMatcher: compileOriginMatcher(allowedOrigin),
+                               everyOriginAllowed: isEveryOriginAllowed(allowedOrigin),
+                               handler: originMiddlewareProc)
+  return HttpServerMiddlewareRef(middleware)

--- a/waku/waku_api/rest/origin_handler.nim
+++ b/waku/waku_api/rest/origin_handler.nim
@@ -88,7 +88,7 @@ proc originMiddlewareProc(
   var reqHeaders = request.headers
   var response = request.getResponse()
 
-  if self.allowedOriginMatcher.isSome:
+  if self.allowedOriginMatcher.isSome():
     let origin = reqHeaders.getList("Origin")
     try:
       if origin.len == 1:

--- a/waku/waku_api/rest/origin_handler.nim
+++ b/waku/waku_api/rest/origin_handler.nim
@@ -21,7 +21,7 @@ proc isEveryOriginAllowed(maybeAllowedOrigin: Option[string]): bool =
   return maybeAllowedOrigin.isSome() and maybeAllowedOrigin.get() == "*"
 
 proc compileOriginMatcher(maybeAllowedOrigin: Option[string]): Option[Regex] =
-  if maybeAllowedOrigin.isNone:
+  if maybeAllowedOrigin.isNone():
     return none(Regex)
 
   let allowedOrigin = maybeAllowedOrigin.get()

--- a/waku/waku_api/rest/origin_handler.nim
+++ b/waku/waku_api/rest/origin_handler.nim
@@ -18,7 +18,7 @@ type
 
 
 proc isEveryOriginAllowed(maybeAllowedOrigin: Option[string]): bool =
-  return maybeAllowedOrigin.isSome and maybeAllowedOrigin.get() == "*"
+  return maybeAllowedOrigin.isSome() and maybeAllowedOrigin.get() == "*"
 
 proc compileOriginMatcher(maybeAllowedOrigin: Option[string]): Option[Regex] =
   if maybeAllowedOrigin.isNone:

--- a/waku/waku_api/rest/origin_handler.nim
+++ b/waku/waku_api/rest/origin_handler.nim
@@ -80,7 +80,8 @@ proc originMiddlewareProc(
                           nextHandler: HttpProcessCallback2
                           ): Future[HttpResponseRef] {.async: (raises: [CancelledError]).} =
   if reqfence.isErr():
-    # Ignore request errors
+    # Ignore request errors that detected before our middleware.
+    # Let final handler deal with it.
     return await nextHandler(reqfence)
 
   let self = OriginHandlerMiddlewareRef(middleware)

--- a/waku/waku_api/rest/origin_handler.nim
+++ b/waku/waku_api/rest/origin_handler.nim
@@ -13,8 +13,8 @@ import
 
 type
   OriginHandlerMiddlewareRef* = ref object of HttpServerMiddlewareRef
-    allowedOriginMatcher*: Option[Regex]
-    everyOriginAllowed*: bool
+    allowedOriginMatcher: Option[Regex]
+    everyOriginAllowed: bool
 
 
 proc isEveryOriginAllowed(maybeAllowedOrigin: Option[string]): bool =

--- a/waku/waku_api/rest/server.nim
+++ b/waku/waku_api/rest/server.nim
@@ -83,6 +83,8 @@ proc new*(t: typedesc[WakuRestServerRef],
   let middlewares = [originHandlerMiddleware,
                      restMiddleware]
 
+  ## This must be empty and needed only to confirm original initialization requirements of
+  ## the RestHttpServer now combining old and new middleware approach.
   proc defaultProcessCallback(rf: RequestFence): Future[HttpResponseRef] {.
         async: (raises: [CancelledError]).} =
     discard

--- a/waku/waku_api/rest/server.nim
+++ b/waku/waku_api/rest/server.nim
@@ -23,8 +23,6 @@ type
   WakuRestServer* = object of RootObj
     router*: RestRouter
     httpServer*: HttpServerRef
-    # restMiddleware*: HttpServerMiddlewareRef
-    # originHandlerMiddleware*: OriginHandlerMiddlewareRef
 
   WakuRestServerRef* = ref WakuRestServer
 


### PR DESCRIPTION
# Description
Long running CORS issue come to the end. 
After serveral ping pong on solution about where and how CORS headers / aka allowed origin / shall be solved for nim-waku rest services we have full flexibility on configuring this behavior of rest responses.

Main goal is to enable calling rest api from inside a browser window against a local wakunode. Without this solution browsers are rejecting to properly propage the response from the service to the script layer.
This act of course as a protection layer, but also prevented js-waku to correctly use nwaku REST services.

Change to the CLI argument!

New option introduced for rest:
--rest-allow-origin=<string>

    - option can be repeated multiple times
    - value can contain ? or * as wildcard characters for greater flexibility (e.g. easier to describe port ranges)
    - default is none
    
# Changes

- [X] chronos and presto llibrary introduced a new concpet of middlerware that stands for a chain of request processors that can be extended by httpserver user. Presto library adapted to this new concpet thus RestServer implemented also as a middleware (while also kept original functioning order) 
- [X] Upgraged nim-presto library to latest on their master (chronos was already up to date by now)
- [X] On nim-waku side RestServer initialization, configuration and some interanals are reworked while kept backward compat 
- [X] CORS header management is implemented on nwaku side as a new separate middlerware. It is using wakunode's own configuration and logic to check and respond to origin header contained requests.
- [X] Adapted necessary code parts to the new naming of rest server class.
- [X] Adapted tests
- [X] New cors tests added

## How to test

Test example:
1. run a node either locally or via docker with using configuration option: -rest-allow-origin=waku.org.githoub.io
2. go to https://waku-org.github.io/waku-rest-api/#get-/debug/v1/info in your browser
3. you can use TRY button for the api's to get answer from your node.


## Issue
https://github.com/waku-org/nwaku/issues/2223
