### PR TITLE
chore(ci): use git describe for image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ LABEL maintainer="jakub@status.im"
 LABEL source="https://github.com/waku-org/nwaku"
 LABEL description="Wakunode: Waku client"
 LABEL commit="unknown"
+LABEL version="unknown"
 
 # DevP2P, LibP2P, and JSON RPC ports
 EXPOSE 30303 60000 8545

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,8 @@ docker-image:
 		--build-arg="NIMFLAGS=$(DOCKER_IMAGE_NIMFLAGS)" \
 		--build-arg="NIM_COMMIT=$(DOCKER_NIM_COMMIT)" \
 		--build-arg="LOG_LEVEL=$(LOG_LEVEL)" \
-		--label="commit=$(GIT_VERSION)" \
+		--label="commit=$(shell git rev-parse HEAD)" \
+		--label="version=$(GIT_VERSION)" \
 		--target $(TARGET) \
 		--tag $(DOCKER_IMAGE_NAME) .
 

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.6'
+library 'status-jenkins-lib@v1.8.9'
 
 pipeline {
   agent { label 'linux' }
@@ -66,7 +66,9 @@ pipeline {
       steps { script {
         image = docker.build(
           "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
-          "--label=commit='${env.GIT_COMMIT.take(8)}' " +
+          "--label=build='${env.BUILD_URL}' " +
+          "--label=commit='${git.commit()}' " +
+          "--label=version='${git.describe()}' " +
           "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
           "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres ' " +
           "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +


### PR DESCRIPTION
This way we get both the full commit and the version, whether it's a proper release or not.
```
 > d inspect docker.io/wakuorg/nwaku:wakunode2-v0.25.0-rc.0-33-ga49930 | grep -A4 commit
                "build": "https://ci.infra.status.im/job/nim-waku/job/docker-manual/119/",
                "commit": "a4993005944741a4418ded35c8a0a37d8271bba6",
                "description": "Wakunode: Waku client",
                "maintainer": "jakub@status.im",
                "source": "https://github.com/waku-org/nwaku",
                "version": "v0.25.0-rc.0-33-ga49930"
```