### PR TITLE
chore(rln-relay-v2): added tests for onchain rln-relay-v2

### DIFF
--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -436,6 +436,7 @@ suite "Onchain group manager":
       
       when defined(rln_v2):
         require:
+          registrations.len == 1
           registrations[0].rateCommitment == RateCommitment(idCommitment: idCommitment, userMessageLimit: UserMessageLimit(1))
       else:
         require:

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -251,8 +251,15 @@ procSuite "WakuNode - RLN relay":
       contentTopicBytes = contentTopic.toBytes
       input = concat(payload, contentTopicBytes)
       extraBytes: seq[byte] = @[byte(1),2,3]
-      rateLimitProofRes = node1.wakuRlnRelay.groupManager.generateProof(concat(input, extraBytes),   # we add extra bytes to invalidate proof verification against original payload
-                                                                        epoch)
+
+    when defined(rln_v2):
+      let nonceManager = node1.wakuRlnRelay.nonceManager
+      let rateLimitProofRes = node1.wakuRlnRelay.groupManager.generateProof(input, 
+                                                                            epoch,
+                                                                            MessageId(0))
+    else:
+      let rateLimitProofRes = node1.wakuRlnRelay.groupManager.generateProof(concat(input, extraBytes),   # we add extra bytes to invalidate proof verification against original payload
+                                                                            epoch)
     require:
       rateLimitProofRes.isOk()
     let rateLimitProof = rateLimitProofRes.get().encode().buffer

--- a/waku/waku_rln_relay/nonce_manager.nim
+++ b/waku/waku_rln_relay/nonce_manager.nim
@@ -52,7 +52,7 @@ proc init*(T: type NonceManager, nonceLimit: Nonce, epoch = EpochUnitSeconds): T
   )
 
 
-proc get*(n: NonceManager): NonceManagerResult[Nonce] =
+proc getNonce*(n: NonceManager): NonceManagerResult[Nonce] =
   let now = getTime().toUnixFloat()
   var retNonce = n.nextNonce
 

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -89,7 +89,7 @@ type WakuRLNRelay* = ref object of RootObj
   groupManager*: GroupManager
   onFatalErrorAction*: OnFatalErrorHandler
   when defined(rln_v2):
-    nonceManager: NonceManager
+    nonceManager*: NonceManager
 
 proc stop*(rlnPeer: WakuRLNRelay) {.async: (raises: [Exception]).} =
   ## stops the rln-relay protocol
@@ -303,7 +303,7 @@ proc appendRLNProof*(rlnPeer: WakuRLNRelay,
   let epoch = calcEpoch(senderEpochTime)
 
   when defined(rln_v2):
-    let nonce = rlnPeer.nonceManager.get().valueOr:
+    let nonce = rlnPeer.nonceManager.getNonce().valueOr:
       return err("could not get new message id to generate an rln proof: " & $error)
     let proof = rlnPeer.groupManager.generateProof(input, epoch, nonce).valueOr:
       return err("could not generate rln-v2 proof: " & $error)


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR includes changes to the `test_rln_group_manager_onchain` with fixes to some of the serde done at the event parsing side.

> [!NOTE]
> The rln-v2 test suite is not feature complete yet, i.e it has to be integrated in other test suites like `test_wakunode_rln_relay.nim` and `test_waku_rln_relay.nim`, those will be addressed in follow up PRs


# Changes

<!-- List of detailed changes -->

- [x] User is able to register and generate valid proofs with the onchain group manager
- [x] Changes to all the test vectors to account for rate commitments instead of id commitments.


## How to test

1. `source env.sh`
2. `nim c --out:build/onchain_rln_test -r -d:chronicles_log_level=DEBUG -d:rln_v2:true -d:os=Darwin --verbosity:0 --hints:off -d:chronicles_log_level=TRACE -d:git_version="v0.24.0-rc.0-35-g50308e" -d:release --passL:librln_v0.4.1.a --passL:-lm  tests/waku_rln_relay/test_rln_group_manager_onchain.nim`


## Issue

closes #2481

