### PR TITLE
chore: remove rln epoch hardcoding

### DIFF
--- a/apps/benchmarks/benchmarks.nim
+++ b/apps/benchmarks/benchmarks.nim
@@ -30,7 +30,7 @@ proc main(): Future[string] {.async, gcsafe.} =
   var proofVerTimes: seq[times.Duration] = @[]
   for i in 0 .. 50:
     var time = getTime()
-    let proof = manager.generateProof(data, getCurrentEpoch()).get()
+    let proof = manager.generateProof(data, default(Epoch)).get()
     proofGenTimes.add(getTime() - time)
 
     time = getTime()

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -523,6 +523,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
           rlnRelayCredPath: conf.rlnRelayCredPath,
           rlnRelayCredPassword: conf.rlnRelayCredPassword,
           rlnRelayUserMessageLimit: conf.rlnRelayUserMessageLimit,
+          rlnEpochSizeSec: conf.rlnEpochSizeSec
         )
       else:
         let rlnConf = WakuRlnConfig(
@@ -532,6 +533,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
           rlnRelayEthClientAddress: string(conf.rlnRelayethClientAddress),
           rlnRelayCredPath: conf.rlnRelayCredPath,
           rlnRelayCredPassword: conf.rlnRelayCredPassword,
+          rlnEpochSizeSec: conf.rlnEpochSizeSec
         )
 
       waitFor node.mountRlnRelay(rlnConf,

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -272,6 +272,11 @@ type
       defaultValue: 1,
       name: "rln-relay-user-message-limit" .}: uint64
 
+    rlnEpochSizeSec* {.
+      desc: "Epoch size in second used to rate limit RLN memberships. Default is 1 second.",
+      defaultValue: 1
+      name: "rln-relay-epoch-sec" .}: uint64
+
 # NOTE: Keys are different in nim-libp2p
 proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
   try:

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -273,7 +273,7 @@ type
       name: "rln-relay-user-message-limit" .}: uint64
 
     rlnEpochSizeSec* {.
-      desc: "Epoch size in second used to rate limit RLN memberships. Default is 1 second.",
+      desc: "Epoch size in seconds used to rate limit RLN memberships. Default is 1 second.",
       defaultValue: 1
       name: "rln-relay-epoch-sec" .}: uint64
 

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -494,6 +494,8 @@ when isMainModule:
     conf.pubsubTopics = twnClusterConf.pubsubTopics
     conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
     conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
+    conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
+    conf.rlnRelayUserMessageLimit: twnClusterConf.rlnRelayUserMessageLimit
 
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)
@@ -546,6 +548,7 @@ when isMainModule:
       rlnRelayCredPath: "",
       rlnRelayCredPassword: "",
       rlnRelayTreePath: conf.rlnRelayTreePath,
+      rlnEpochSizeSec: conf.rlnEpochSizeSec
     )
 
     try:

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -495,7 +495,7 @@ when isMainModule:
     conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
     conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
     conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
-    conf.rlnRelayUserMessageLimit: twnClusterConf.rlnRelayUserMessageLimit
+    conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
 
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -75,6 +75,16 @@ type
       defaultValue: "",
       name: "rln-relay-eth-contract-address" }: string
 
+    rlnEpochSizeSec* {.
+      desc: "Epoch size in second used to rate limit RLN memberships. Default is 1 second.",
+      defaultValue: 1
+      name: "rln-relay-epoch-sec" .}: uint64
+
+    rlnRelayUserMessageLimit* {.
+      desc: "Set a user message limit for the rln membership registration. Must be a positive integer. Default is 1.",
+      defaultValue: 1,
+      name: "rln-relay-user-message-limit" .}: uint64
+
     ## Prometheus metrics config
     metricsServer* {.
       desc: "Enable the metrics server: true|false"

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -76,7 +76,7 @@ type
       name: "rln-relay-eth-contract-address" }: string
 
     rlnEpochSizeSec* {.
-      desc: "Epoch size in second used to rate limit RLN memberships. Default is 1 second.",
+      desc: "Epoch size in seconds used to rate limit RLN memberships. Default is 1 second.",
       defaultValue: 1
       name: "rln-relay-epoch-sec" .}: uint64
 

--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -477,6 +477,7 @@ proc setupProtocols(node: WakuNode,
         rlnRelayCredPassword: conf.rlnRelayCredPassword,
         rlnRelayTreePath: conf.rlnRelayTreePath,
         rlnRelayUserMessageLimit: conf.rlnRelayUserMessageLimit,
+        rlnEpochSizeSec: conf.rlnEpochSizeSec,
         onFatalErrorAction: onFatalErrorAction,
       )
     else:
@@ -488,6 +489,7 @@ proc setupProtocols(node: WakuNode,
         rlnRelayCredPath: conf.rlnRelayCredPath,
         rlnRelayCredPassword: conf.rlnRelayCredPassword,
         rlnRelayTreePath: conf.rlnRelayTreePath,
+        rlnEpochSizeSec: conf.rlnEpochSizeSec,
         onFatalErrorAction: onFatalErrorAction,
       )
 

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -90,7 +90,7 @@ type
       name: "rln-relay-user-message-limit" .}: uint64
 
     rlnEpochSizeSec* {.
-      desc: "Epoch size in second used to rate limit RLN memberships. Default is 1 second.",
+      desc: "Epoch size in seconds used to rate limit RLN memberships. Default is 1 second.",
       defaultValue: 1
       name: "rln-relay-epoch-sec" .}: uint64
 

--- a/apps/wakunode2/external_config.nim
+++ b/apps/wakunode2/external_config.nim
@@ -34,7 +34,7 @@ type ProtectedTopic* = object
   topic*: string
   key*: secp256k1.SkPublicKey
 
-type ShardIdx = distinct uint16 
+type ShardIdx = distinct uint16
 
 type EthRpcUrl = distinct string
 
@@ -83,11 +83,16 @@ type
       desc: "Private key for broadcasting transactions",
       defaultValue: "",
       name: "rln-relay-eth-private-key" }: string
-  
+
     rlnRelayUserMessageLimit* {.
       desc: "Set a user message limit for the rln membership registration. Must be a positive integer. Default is 1.",
       defaultValue: 1,
       name: "rln-relay-user-message-limit" .}: uint64
+
+    rlnEpochSizeSec* {.
+      desc: "Epoch size in second used to rate limit RLN memberships. Default is 1 second.",
+      defaultValue: 1
+      name: "rln-relay-epoch-sec" .}: uint64
 
     maxMessageSize* {.
       desc: "Maximum message size. Accepted units: KiB, KB, and B. e.g. 1024KiB; 1500 B; etc."

--- a/apps/wakunode2/networks_config.nim
+++ b/apps/wakunode2/networks_config.nim
@@ -10,13 +10,15 @@ type ClusterConf* = object
   rlnRelayEthContractAddress*: string
   rlnRelayDynamic*: bool
   rlnRelayBandwidthThreshold*: int
+  rlnEpochSizeSec*: uint64
+  rlnRelayUserMessageLimit*: uint64
   pubsubTopics*: seq[string]
   discv5Discovery*: bool
   discv5BootstrapNodes*: seq[string]
 
-# cluster-id=1
+# cluster-id=1
 # Cluster configuration corresponding to The Waku Network. Note that it
-# overrides existing cli configuration
+# overrides existing cli configuration
 proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
   return ClusterConf(
     maxMessageSize: "150KiB",
@@ -25,6 +27,9 @@ proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
     rlnRelayEthContractAddress: "0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4",
     rlnRelayDynamic: true,
     rlnRelayBandwidthThreshold: 0,
+    rlnEpochSizeSec: 1,
+    # parameter to be defined with rln_v2
+    rlnRelayUserMessageLimit: 1,
     pubsubTopics:
       @[
         "/waku/2/rs/1/0", "/waku/2/rs/1/1", "/waku/2/rs/1/2", "/waku/2/rs/1/3",

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -33,8 +33,10 @@ proc logConfig(conf: WakuNodeConf) =
 
   info "Configuration. Network",
     cluster = conf.clusterId,
-    pubsubTopics = conf.pubsubTopics,
     maxPeers = conf.maxRelayPeers
+
+  for shard in conf.pubsubTopics:
+    info "Configuration. Shards", shard=shard
 
   for i in conf.discv5BootstrapNodes:
     info "Configuration. Bootstrap nodes", node = i
@@ -43,7 +45,10 @@ proc logConfig(conf: WakuNodeConf) =
     info "Configuration. Validation",
       mechanism = "onchain rln",
       contract = conf.rlnRelayEthContractAddress,
-      maxMessageSize = conf.maxMessageSize
+      maxMessageSize = conf.maxMessageSize,
+      rlnEpochSizeSec = conf.rlnEpochSizeSec,
+      rlnRelayUserMessageLimit = conf.rlnRelayUserMessageLimit,
+      rlnRelayEthClientAddress = string(conf.rlnRelayEthClientAddress)
 
 {.pop.}
   # @TODO confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -100,6 +100,8 @@ when isMainModule:
       conf.discv5Discovery = twnClusterConf.discv5Discovery
       conf.discv5BootstrapNodes =
         conf.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
+      conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
+      conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
 
     var wakunode2 = App.init(rng, conf)
 

--- a/tests/node/test_wakunode_relay_rln.nim
+++ b/tests/node/test_wakunode_relay_rln.nim
@@ -30,6 +30,7 @@ proc setupRln(node: WakuNode, identifier: uint) {.async.} =
       rlnRelayDynamic: false,
       rlnRelayCredIndex: some(identifier),
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_" & $identifier),
+      rlnEpochSizeSec: 1
     )
   )
 
@@ -76,7 +77,7 @@ proc sendRlnMessageWithInvalidProof(
       client.wakuRlnRelay.groupManager.generateProof(
         concat(payload, extraBytes),
           # we add extra bytes to invalidate proof verification against original payload
-        getCurrentEpoch()
+        client.wakuRlnRelay.getCurrentEpoch()
       )
     rateLimitProof = rateLimitProofRes.get().encode().buffer
     message =
@@ -249,17 +250,17 @@ suite "Waku RlnRelay - End to End":
           WakuMessage(payload: @payload150kibPlus, contentTopic: contentTopic)
 
       doAssert(
-        client.wakuRlnRelay.appendRLNProof(message1b, epoch + EpochUnitSeconds * 0).isOk()
+        client.wakuRlnRelay.appendRLNProof(message1b, epoch + client.wakuRlnRelay.rlnEpochSizeSec * 0).isOk()
       )
       doAssert(
-        client.wakuRlnRelay.appendRLNProof(message1kib, epoch + EpochUnitSeconds * 1).isOk()
+        client.wakuRlnRelay.appendRLNProof(message1kib, epoch + client.wakuRlnRelay.rlnEpochSizeSec * 1).isOk()
       )
       doAssert(
-        client.wakuRlnRelay.appendRLNProof(message150kib, epoch + EpochUnitSeconds * 2).isOk()
+        client.wakuRlnRelay.appendRLNProof(message150kib, epoch + client.wakuRlnRelay.rlnEpochSizeSec * 2).isOk()
       )
       doAssert(
         client.wakuRlnRelay.appendRLNProof(
-          message151kibPlus, epoch + EpochUnitSeconds * 3
+          message151kibPlus, epoch + client.wakuRlnRelay.rlnEpochSizeSec * 3
         ).isOk()
       )
 
@@ -324,7 +325,7 @@ suite "Waku RlnRelay - End to End":
 
       doAssert(
         client.wakuRlnRelay.appendRLNProof(
-          message151kibPlus, epoch + EpochUnitSeconds * 3
+          message151kibPlus, epoch + client.wakuRlnRelay.rlnEpochSizeSec * 3
         )
       )
 

--- a/tests/waku_rln_relay/rln_v2/test_rln_relay_v2_serde.nim
+++ b/tests/waku_rln_relay/rln_v2/test_rln_relay_v2_serde.nim
@@ -73,7 +73,7 @@ suite "RLN Relay v2: serde":
                                 userMessageLimit = rateCommitment.userMessageLimit,
                                 messageId = 0,
                                 index = 0,
-                                epoch = calcEpoch(epochTime()))
+                                epoch = rln.calcEpoch(epochTime()))
     
     assert proofRes.isOk, $proofRes.error
 

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -590,7 +590,7 @@ suite "Waku rln relay":
   test "updateLog and hasDuplicate tests":
     let
       wakurlnrelay = WakuRLNRelay()
-      epoch = getCurrentEpoch()
+      epoch = wakurlnrelay.getCurrentEpoch()
 
     #  create some dummy nullifiers and secret shares
     var nullifier1: Nullifier
@@ -662,6 +662,7 @@ suite "Waku rln relay":
 
     let rlnConf = WakuRlnConfig(rlnRelayDynamic: false,
                                 rlnRelayCredIndex: some(index),
+                                rlnEpochSizeSec: 1,
                                 rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_2"))
     let wakuRlnRelayRes = await WakuRlnRelay.new(rlnConf)
     require:
@@ -683,7 +684,7 @@ suite "Waku rln relay":
     let
       proofAdded1 = wakuRlnRelay.appendRLNProof(wm1, time)
       proofAdded2 = wakuRlnRelay.appendRLNProof(wm2, time)
-      proofAdded3 = wakuRlnRelay.appendRLNProof(wm3, time+EpochUnitSeconds)
+      proofAdded3 = wakuRlnRelay.appendRLNProof(wm3, time+float64(wakuRlnRelay.rlnEpochSizeSec))
 
     # ensure proofs are added
     require:

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -41,6 +41,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(1.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode"),
     ))
 
@@ -51,6 +52,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(2.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_2"),
     ))
 
@@ -61,6 +63,7 @@ procSuite "WakuNode - RLN relay":
 
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(3.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_3"),
     ))
 
@@ -122,6 +125,7 @@ procSuite "WakuNode - RLN relay":
     for index, node in nodes:
       await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
         rlnRelayCredIndex: some(index.uint + 1),
+        rlnEpochSizeSec: 1,
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_" & $(index+1))))
 
     # start them
@@ -200,6 +204,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(1.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_4"),
     ))
 
@@ -210,6 +215,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(2.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_5"),
     ))
 
@@ -220,6 +226,7 @@ procSuite "WakuNode - RLN relay":
 
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(3.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_6"),
     ))
 
@@ -244,7 +251,7 @@ procSuite "WakuNode - RLN relay":
     let payload = "Hello".toBytes()
 
     # prepare the epoch
-    let epoch = getCurrentEpoch()
+    let epoch = node1.wakuRlnRelay.getCurrentEpoch()
 
     # prepare the proof
     let
@@ -299,6 +306,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(1.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_7"),
     ))
 
@@ -310,6 +318,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(2.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_8"),
     ))
 
@@ -321,6 +330,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node3.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(3.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_9"),
     ))
 
@@ -341,7 +351,7 @@ procSuite "WakuNode - RLN relay":
       proofAdded2 = node3.wakuRlnRelay.appendRLNProof(wm2, time)
       #  wm3 points to the next epoch
       wm3 = WakuMessage(payload: "message 3".toBytes(), contentTopic: contentTopic)
-      proofAdded3 = node3.wakuRlnRelay.appendRLNProof(wm3, time+EpochUnitSeconds)
+      proofAdded3 = node3.wakuRlnRelay.appendRLNProof(wm3, time+float64(node3.wakuRlnRelay.rlnEpochSizeSec))
       wm4 = WakuMessage(payload: "message 4".toBytes(), contentTopic: contentTopic)
 
     #  check proofs are added correctly
@@ -419,6 +429,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node1.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(1.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_10"),
     ))
 
@@ -430,6 +441,7 @@ procSuite "WakuNode - RLN relay":
     # mount rlnrelay in off-chain mode
     await node2.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(2.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode_11"),
     ))
 
@@ -448,7 +460,7 @@ procSuite "WakuNode - RLN relay":
       proofAdded2 = node1.wakuRlnRelay.appendRLNProof(wm2, time)
       #  wm3 points to the next epoch
       wm3 = WakuMessage(payload: "message 3".toBytes(), contentTopic: contentTopic)
-      proofAdded3 = node1.wakuRlnRelay.appendRLNProof(wm3, time + EpochUnitSeconds * 2)
+      proofAdded3 = node1.wakuRlnRelay.appendRLNProof(wm3, time + float64(node1.wakuRlnRelay.rlnEpochSizeSec * 2))
 
     #  check proofs are added correctly
     check:

--- a/tests/wakunode_jsonrpc/test_jsonrpc_relay.nim
+++ b/tests/wakunode_jsonrpc/test_jsonrpc_relay.nim
@@ -94,10 +94,12 @@ suite "Waku v2 JSON-RPC API - Relay":
 
     await srcNode.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
         rlnRelayCredIndex: some(1.uint),
+        rlnEpochSizeSec: 1,
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     await dstNode.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
         rlnRelayCredIndex: some(2.uint),
+        rlnEpochSizeSec: 1,
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_2")))
 
     await srcNode.connectToNodes(@[dstNode.peerInfo.toRemotePeerInfo()])

--- a/tests/wakunode_rest/test_rest_health.nim
+++ b/tests/wakunode_rest/test_rest_health.nim
@@ -62,6 +62,7 @@ suite "Waku v2 REST API - health":
     # now kick in rln (currently the only check for health)
     await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
       rlnRelayCredIndex: some(1.uint),
+      rlnEpochSizeSec: 1,
       rlnRelayTreePath: genTempPath("rln_tree", "wakunode"),
     ))
 

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -210,6 +210,7 @@ suite "Waku v2 Rest API - Relay":
     await node.mountRelay()
     await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
         rlnRelayCredIndex: some(1.uint),
+        rlnEpochSizeSec: 1,
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup
@@ -412,6 +413,7 @@ suite "Waku v2 Rest API - Relay":
     await node.mountRelay()
     await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
         rlnRelayCredIndex: some(1.uint),
+        rlnEpochSizeSec: 1,
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup
@@ -456,6 +458,7 @@ suite "Waku v2 Rest API - Relay":
     await node.mountRelay()
     await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
         rlnRelayCredIndex: some(1.uint),
+        rlnEpochSizeSec: 1,
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup
@@ -495,6 +498,7 @@ suite "Waku v2 Rest API - Relay":
     await node.mountRelay()
     await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
         rlnRelayCredIndex: some(1.uint),
+        rlnEpochSizeSec: 1,
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup
@@ -539,6 +543,7 @@ suite "Waku v2 Rest API - Relay":
     await node.mountRelay()
     await node.mountRlnRelay(WakuRlnConfig(rlnRelayDynamic: false,
         rlnRelayCredIndex: some(1.uint),
+        rlnEpochSizeSec: 1,
         rlnRelayTreePath: genTempPath("rln_tree", "wakunode_1")))
 
     # RPC server setup

--- a/waku/waku_rln_relay/constants.nim
+++ b/waku/waku_rln_relay/constants.nim
@@ -59,11 +59,7 @@ const
   # the root is created locally, using createMembershipList proc from waku_rln_relay_utils module, and the result is hardcoded in here
   StaticGroupMerkleRoot* = "1e534adab58f7d300aaeecae57a25e0a0b18c368a09f720280da92b288950901"
 
-const EpochUnitSeconds* = float64(1) # the rln-relay epoch length in seconds
 const MaxClockGapSeconds* = 20.0 # the maximum clock difference between peers in seconds
-
-# maximum allowed gap between the epochs of messages' RateLimitProofs
-const MaxEpochGap* = uint64(MaxClockGapSeconds/EpochUnitSeconds)
 
 # RLN Keystore defaults
 const

--- a/waku/waku_rln_relay/nonce_manager.nim
+++ b/waku/waku_rln_relay/nonce_manager.nim
@@ -43,9 +43,9 @@ proc `$`*(ne: NonceManagerError): string =
   of NonceLimitReached:
     return "NonceLimitReached: " & ne.error
 
-proc init*(T: type NonceManager, nonceLimit: Nonce, epoch = EpochUnitSeconds): T =
+proc init*(T: type NonceManager, nonceLimit: Nonce): T =
   return NonceManager(
-    epoch: epoch,
+    epoch: 0,
     nextNonce: 0,
     lastNonceTime: 0,
     nonceLimit: nonceLimit


### PR DESCRIPTION
* Remove hardcoded `EpochUnitSeconds` and allows configuring it via `rln-relay-epoch-sec`. 
* It also sets TheWakuNetwork default epoch value in [here](https://github.com/waku-org/nwaku/blob/caad9f88100923b6aed2da5b13b8d7a2e30db290/apps/wakunode2/networks_config.nim#L30) as per [spec](https://rfc.vac.dev/spec/64/#rln-parameters)
* This allows anyone to deploy another network with their own RLN configuration.