### PR TITLE
fix: return message id on `waku_relay_publish`

### DIFF
--- a/library/alloc.nim
+++ b/library/alloc.nim
@@ -19,8 +19,9 @@ proc alloc*(str: string): cstring =
   return ret
 
 proc allocSharedSeq*[T](s: seq[T]): SharedSeq[T] =
-  let data = cast[ptr T](allocShared(s.len))
-  copyMem(data, unsafeAddr s, s.len)
+  let data = allocShared(sizeof(T) * s.len)
+  if s.len != 0:
+    copyMem(data, unsafeAddr s[0], s.len)
   return (cast[ptr UncheckedArray[T]](data), s.len)
 
 proc deallocSharedSeq*[T](s: var SharedSeq[T]) =

--- a/library/events/json_message_event.nim
+++ b/library/events/json_message_event.nim
@@ -61,7 +61,7 @@ proc `%`*(value: WakuMessageHash): JsonNode =
 
 type JsonMessageEvent* = ref object of JsonEvent
     pubsubTopic*: string
-    messageId*: string
+    messageHash*: WakuMessageHash
     wakuMessage*: JsonMessage
 
 proc new*(T: type JsonMessageEvent,
@@ -83,12 +83,11 @@ proc new*(T: type JsonMessageEvent,
     copyMem(addr proof[0], unsafeAddr msg.proof[0], len(msg.proof))
 
   let msgHash = computeMessageHash(pubSubTopic, msg)
-  let msgHashHex = to0xHex(msgHash)
 
   return JsonMessageEvent(
     eventType: "message",
     pubSubTopic: pubSubTopic,
-    messageId: msgHashHex,
+    messageHash: msgHash,
     wakuMessage: JsonMessage(
         payload: base64.encode(payload),
         contentTopic: msg.contentTopic,

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -235,6 +235,8 @@ proc waku_relay_publish(ctx: ptr Context,
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
+  let msgHash = $sendReqRes.value
+  callback(RET_OK, unsafeAddr msgHash[0], cast[csize_t](len(msgHash)), userData)
   return RET_OK
 
 proc waku_start(ctx: ptr Context,


### PR DESCRIPTION
# Description
As defined in the [bindings](https://rfc.vac.dev/spec/36/#extern-unsinged-int-waku_relay_publishchar-messagejson-char-pubsubtopic-int-timeoutms-char-jsonresp), `waku_relay_publish` returns a message id on success