### PR TITLE
fix: time on 32 bits architecture

### DIFF
--- a/tests/testlib/wakucore.nim
+++ b/tests/testlib/wakucore.nim
@@ -20,7 +20,7 @@ proc now*(): Timestamp =
   getNanosecondTime(getTime().toUnixFloat())
 
 proc ts*(offset=0, origin=now()): Timestamp =
-  origin + getNanosecondTime(offset)
+  origin + getNanosecondTime(int64(offset))
 
 
 # Switch

--- a/tests/waku_core/test_time.nim
+++ b/tests/waku_core/test_time.nim
@@ -21,14 +21,10 @@ suite "Waku Core - Time":
 
     ## When
     let
-      timeInSecondsInt = secondsPart.int
       timeInSecondsInt64 = secondsPart.int64
-      timeInSecondsFloat = float(secondsFloat)
       timeInSecondsFloat64 = float64(secondsFloat)
 
     ## Then
     check:
-      getNanosecondTime(timeInSecondsInt) == lowResTimestamp
       getNanosecondTime(timeInSecondsInt64) == lowResTimestamp
-      getNanosecondTime(timeInSecondsFloat) == highResTimestamp
       getNanosecondTime(timeInSecondsFloat64) == highResTimestamp

--- a/waku/waku_core/time.nim
+++ b/waku/waku_core/time.nim
@@ -9,8 +9,8 @@ import
 
 type Timestamp* = int64 # A nanosecond precision timestamp
 
-proc getNanosecondTime*[T: SomeNumber](timeInSeconds: T): Timestamp =
-  var ns = Timestamp(timeInSeconds * 1_000_000_000.T)
+proc getNanosecondTime*(timeInSeconds: int64 | float64): Timestamp =
+  let ns = Timestamp(timeInSeconds * 1_000_000_000)
   return ns
 
 proc nowInUnixFloat(): float =


### PR DESCRIPTION
Copy of https://github.com/waku-org/nwaku/pull/2476 for merging purpose.

> Description
> The function [getNanosecondTime](https://github.com/waku-org/nwaku/blob/master/waku/waku_core/time.nim#L12) does not > work on 32 bit architecture, so this is a suggestion of a fix.
> 
> Changes
> Use int64.
> 
> To reproduce the problem
> Pass --cpu:i386 -t:-m32 -l:-m32 to the nim compiler
> 
> Issue
> closes # https://github.com/waku-org/nwaku/issues/2475