### PR TITLE
docs: Update link to DNS discovery tutorial

### DIFF
--- a/waku/README.md
+++ b/waku/README.md
@@ -173,7 +173,7 @@ This is necessary to verify domain certificates when connecting to this node ove
 
 ## Using DNS discovery to connect to existing nodes
 
-A node can discover other nodes to connect to using [DNS-based discovery](../../docs/tutorial/dns-disc.md).
+A node can discover other nodes to connect to using [DNS-based discovery](../docs/tutorial/dns-disc.md).
 The following command line options are available:
 
 ```
@@ -197,7 +197,7 @@ Current URLs for the published fleet lists:
 - production fleet: `enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im`
 - test fleet: `enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im`
 
-See the [separate tutorial](../../..//docs/tutorial/dns-disc.md) for a complete guide to DNS discovery.
+See the [separate tutorial](../docs/tutorial/dns-disc.md) for a complete guide to DNS discovery.
 
 ## Enabling Websocket
 

--- a/waku/README.md
+++ b/waku/README.md
@@ -197,7 +197,7 @@ Current URLs for the published fleet lists:
 - production fleet: `enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im`
 - test fleet: `enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im`
 
-See the [separate tutorial](../../docs/tutorial/dns-disc.md) for a complete guide to DNS discovery.
+See the [separate tutorial](../../..//docs/tutorial/dns-disc.md) for a complete guide to DNS discovery.
 
 ## Enabling Websocket
 


### PR DESCRIPTION
# Description
The link to the DNS discovery tutorial is currently broken. This commit should fix it

# Changes
Removed one of the ".." from the link path.

## How to test
Click the links