### PR TITLE
feat(c-bindings): add function to dealloc nodes

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -35,6 +35,11 @@ int waku_stop(void* ctx,
               WakuCallBack callback,
               void* userData);
 
+// Destroys an instance of a waku node created with waku_new
+int waku_destroy(void* ctx,
+                 WakuCallBack callback,
+                 void* userData);
+
 int waku_version(void* ctx,
                  WakuCallBack callback,
                  void* userData);

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -100,6 +100,21 @@ proc waku_new(configJson: cstring,
 
   return ctx
 
+proc waku_destroy(ctx: ptr Context,
+               callback: WakuCallBack,
+               userData: pointer): cint {.dynlib, exportc.} =
+
+  if isNil(callback):
+    return RET_MISSING_CALLBACK
+
+  let stopNodeRes = waku_thread.stopWakuNodeThread(ctx)
+  if stopNodeRes.isErr():
+    let msg = $stopNodeRes.error
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return RET_ERR
+
+  return RET_OK
+
 proc waku_version(ctx: ptr Context,
                   callback: WakuCallBack,
                   userData: pointer): cint {.dynlib, exportc.} =

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -107,9 +107,8 @@ proc waku_destroy(ctx: ptr Context,
   if isNil(callback):
     return RET_MISSING_CALLBACK
 
-  let stopNodeRes = waku_thread.stopWakuNodeThread(ctx)
-  if stopNodeRes.isErr():
-    let msg = $stopNodeRes.error
+  waku_thread.stopWakuThread(ctx).isOkOr:
+    let msg = $error
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -95,12 +95,16 @@ proc createWakuThread*(): Result[ptr Context, string] =
 
   return ok(ctx)
 
-proc stopWakuNodeThread*(ctx: ptr Context) =
+proc stopWakuNodeThread*(ctx: ptr Context): Result[void, string] =
   running.store(false)
+  let fireRes = ctx.reqSignal.fireSync()
+  if fireRes.isErr():
+    return err(fireRes.error)
   joinThread(ctx.thread)
   discard ctx.reqSignal.close()
   discard ctx.respSignal.close()
   freeShared(ctx)
+  ok()
 
 proc sendRequestToWakuThread*(ctx: ptr Context,
                               reqType: RequestType,

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -58,7 +58,7 @@ proc run(ctx: ptr Context) {.thread.} =
     var request: ptr InterThreadRequest
     waitFor ctx.reqSignal.wait()
     let recvOk = ctx.reqChannel.tryRecv(request)
-    if recvOk == true:
+    if running.load and recvOk == true:
       let resultResponse =
         waitFor InterThreadRequest.process(request, addr node)
 


### PR DESCRIPTION
# Description
While working with the rust bindings I noticed that when I closed the example program, it segfaulted, and this happened due to the waku thread still being alive. This PR adds a `waku_destroy` function that stops the thread, as well as firing a signal so the code does not stay stuck at https://github.com/waku-org/nwaku/blob/9ef2eccb8aa19e80a9381dcb2ece29718ebce30f/library/waku_thread/waku_thread.nim#L59
