### PR TITLE
fix(postgres): import under feature flag

### DIFF
--- a/waku/waku_archive/driver/builder.nim
+++ b/waku/waku_archive/driver/builder.nim
@@ -15,7 +15,6 @@ import
   ../../common/error_handling,
   ./sqlite_driver,
   ./sqlite_driver/migrations as archive_driver_sqlite_migrations,
-  ./postgres_driver/migrations as archive_postgres_driver_migrations,
   ./queue_driver
 
 export
@@ -23,7 +22,9 @@ export
   queue_driver
 
 when defined(postgres):
-  import ./postgres_driver ## This import adds dependency with an external libpq library
+  import ## These imports add dependency with an external libpq library
+    ./postgres_driver/migrations as archive_postgres_driver_migrations,  
+    ./postgres_driver 
   export postgres_driver
 
 proc new*(T: type ArchiveDriver,


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
Previously, the postgres migration was imported outside of the feature flag and hence caused a dependency on the libpq library

# Changes

<!-- List of detailed changes -->

- [x] moved import to under the feature flag

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
