### PR TITLE
feat: Postgres partition implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC}"
+  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none"
 
 jobs:
   changes: # changes detection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           fi
 
           if [ ${{ runner.os }} == "Linux" ]; then
-            sudo docker run --rm -d -e POSTGRES_PASSWORD=test123 -p 5432:5432 postgres:9.6-alpine
+            sudo docker run --rm -d -e POSTGRES_PASSWORD=test123 -p 5432:5432 postgres:15.4-alpine3.18
           fi
 
           make V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 POSTGRES=1 test testwakunode2

--- a/tests/postgres-docker-compose.yml
+++ b/tests/postgres-docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:9.6-alpine
+    image: postgres:15.4-alpine3.18
     restart: always
     environment:
       POSTGRES_PASSWORD: test123

--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[sequtils,times,options],
+  std/[sequtils,options],
   testutils/unittests,
   chronos
 import
@@ -12,8 +12,6 @@ import
   ../testlib/wakucore,
   ../testlib/testasync,
   ../testlib/postgres
-
-proc now():int64 = getTime().toUnix()
 
 proc computeTestCursor(pubsubTopic: PubsubTopic,
                        message: WakuMessage):
@@ -56,7 +54,7 @@ suite "Postgres driver":
     # Actually, the diff randomly goes between 1 and 2 seconds.
     # although in theory it should spend 1s because we establish 100
     # connections and we spawn 100 tasks that spend ~1s each.
-    require diff < 20
+    assert diff < 20_000_000_000
 
   asyncTest "Insert a message":
     const contentTopic = "test-content-topic"
@@ -69,14 +67,14 @@ suite "Postgres driver":
     assert putRes.isOk(), putRes.error
 
     let storedMsg = (await driver.getAllMessages()).tryGet()
-    require:
-      storedMsg.len == 1
-      storedMsg.all do (item: auto) -> bool:
-        let (pubsubTopic, actualMsg, digest, storeTimestamp) = item
-        actualMsg.contentTopic == contentTopic and
-        pubsubTopic == DefaultPubsubTopic and
-        toHex(computedDigest.data) == toHex(digest) and
-        toHex(actualMsg.payload) == toHex(msg.payload)
+
+    assert storedMsg.len == 1
+
+    let (pubsubTopic, actualMsg, digest, storeTimestamp) = storedMsg[0]
+    assert actualMsg.contentTopic == contentTopic
+    assert pubsubTopic == DefaultPubsubTopic
+    assert toHex(computedDigest.data) == toHex(digest)
+    assert toHex(actualMsg.payload) == toHex(msg.payload)
 
   asyncTest "Insert and query message":
     const contentTopic1 = "test-content-topic-1"
@@ -96,21 +94,21 @@ suite "Postgres driver":
 
     let countMessagesRes = await driver.getMessagesCount()
 
-    require countMessagesRes.isOk() and countMessagesRes.get() == 2
+    assert countMessagesRes.isOk(), $countMessagesRes.error
+    assert countMessagesRes.get() == 2
 
     var messagesRes = await driver.getMessages(contentTopic = @[contentTopic1])
 
-    require messagesRes.isOk()
-    require messagesRes.get().len == 1
+    assert messagesRes.isOk(), $messagesRes.error
+    assert messagesRes.get().len == 1
 
     # Get both content topics, check ordering
     messagesRes = await driver.getMessages(contentTopic = @[contentTopic1,
                                                             contentTopic2])
     assert messagesRes.isOk(), messagesRes.error
 
-    require:
-      messagesRes.get().len == 2 and
-      messagesRes.get()[0][1].contentTopic == contentTopic1
+    assert messagesRes.get().len == 2
+    assert messagesRes.get()[0][1].contentTopic == contentTopic1
 
     # Descending order
     messagesRes = await driver.getMessages(contentTopic = @[contentTopic1,
@@ -118,9 +116,8 @@ suite "Postgres driver":
                                            ascendingOrder = false)
     assert messagesRes.isOk(), messagesRes.error
 
-    require:
-      messagesRes.get().len == 2 and
-      messagesRes.get()[0][1].contentTopic == contentTopic2
+    assert messagesRes.get().len == 2
+    assert messagesRes.get()[0][1].contentTopic == contentTopic2
 
     # cursor
     # Get both content topics
@@ -130,8 +127,8 @@ suite "Postgres driver":
                                  cursor = some(
                                         computeTestCursor(pubsubTopic1,
                                                           messagesRes.get()[1][1])))
-    require messagesRes.isOk()
-    require messagesRes.get().len == 1
+    assert messagesRes.isOk()
+    assert messagesRes.get().len == 1
 
     # Get both content topics but one pubsub topic
     messagesRes = await driver.getMessages(contentTopic = @[contentTopic1,
@@ -139,16 +136,15 @@ suite "Postgres driver":
                                            pubsubTopic = some(pubsubTopic1))
     assert messagesRes.isOk(), messagesRes.error
 
-    require:
-      messagesRes.get().len == 1 and
-      messagesRes.get()[0][1].contentTopic == contentTopic1
+    assert messagesRes.get().len == 1
+    assert messagesRes.get()[0][1].contentTopic == contentTopic1
 
     # Limit
     messagesRes = await driver.getMessages(contentTopic = @[contentTopic1,
                                                             contentTopic2],
                                            maxPageSize = 1)
     assert messagesRes.isOk(), messagesRes.error
-    require messagesRes.get().len == 1
+    assert messagesRes.get().len == 1
 
   asyncTest "Insert true duplicated messages":
     # Validates that two completely equal messages can not be stored.
@@ -164,5 +160,5 @@ suite "Postgres driver":
 
     putRes = await driver.put(DefaultPubsubTopic,
                               msg2, computeDigest(msg2), computeMessageHash(DefaultPubsubTopic, msg2), msg2.timestamp)
-    require not putRes.isOk()
+    assert not putRes.isOk()
 

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -73,7 +73,8 @@ method deleteOldestMessagesNotWithinLimit*(driver: ArchiveDriver,
                                            Future[ArchiveDriverResult[void]] {.base, async.} = discard
 
 method decreaseDatabaseSize*(driver: ArchiveDriver,
-                             targetSizeInBytes: int64):
+                             targetSizeInBytes: int64,
+                             forceRemoval: bool = false):
                              Future[ArchiveDriverResult[void]] {.base, async.} = discard
 
 method close*(driver: ArchiveDriver):

--- a/waku/waku_archive/driver/builder.nim
+++ b/waku/waku_archive/driver/builder.nim
@@ -108,7 +108,8 @@ proc new*(T: type ArchiveDriver,
           return err("ArchiveDriver build failed in migration: " & $migrateRes.error)
 
       ## This should be started once we make sure the 'messages' table exists
-      asyncSpawn driver.loopPartitionFactory(onFatalErrorAction)
+      ## Hence, this should be run after the migration is completed.
+      asyncSpawn driver.startPartitionFactory(onFatalErrorAction)
 
       info "waiting for a partition to be created"
       for i in 0..<100:
@@ -117,7 +118,7 @@ proc new*(T: type ArchiveDriver,
         await sleepAsync(chronos.milliseconds(100))
 
       if not driver.containsAnyPartition():
-        return err("a partition could not be created")
+        onFatalErrorAction("a partition could not be created")
 
       return ok(driver)
 

--- a/waku/waku_archive/driver/builder.nim
+++ b/waku/waku_archive/driver/builder.nim
@@ -110,6 +110,15 @@ proc new*(T: type ArchiveDriver,
       ## This should be started once we make sure the 'messages' table exists
       asyncSpawn driver.loopPartitionFactory(onFatalErrorAction)
 
+      info "waiting for a partition to be created"
+      for i in 0..<100:
+        if driver.containsAnyPartition():
+          break
+        await sleepAsync(chronos.milliseconds(100))
+
+      if not driver.containsAnyPartition():
+        return err("a partition could not be created")
+
       return ok(driver)
 
     else:

--- a/waku/waku_archive/driver/builder.nim
+++ b/waku/waku_archive/driver/builder.nim
@@ -107,6 +107,9 @@ proc new*(T: type ArchiveDriver,
         if migrateRes.isErr():
           return err("ArchiveDriver build failed in migration: " & $migrateRes.error)
 
+      ## This should be started once we make sure the 'messages' table exists
+      asyncSpawn driver.loopPartitionFactory(onFatalErrorAction)
+
       return ok(driver)
 
     else:

--- a/waku/waku_archive/driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver.nim
@@ -5,8 +5,11 @@ else:
 
 import
   ./postgres_driver/postgres_driver,
-  ./postgres_driver/partitions_manager
+  ./postgres_driver/partitions_manager,
+  ./postgres_driver/postgres_healthcheck
 
 export
   postgres_driver,
-  partitions_manager
+  partitions_manager,
+  postgres_healthcheck
+

--- a/waku/waku_archive/driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver.nim
@@ -3,6 +3,10 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import ./postgres_driver/postgres_driver
+import
+  ./postgres_driver/postgres_driver,
+  ./postgres_driver/partitions_manager
 
-export postgres_driver
+export
+  postgres_driver,
+  partitions_manager

--- a/waku/waku_archive/driver/postgres_driver/migrations.nim
+++ b/waku/waku_archive/driver/postgres_driver/migrations.nim
@@ -13,7 +13,7 @@ import
 logScope:
   topics = "waku archive migration"
 
-const SchemaVersion* = 1 # increase this when there is an update in the database schema
+const SchemaVersion* = 2 # increase this when there is an update in the database schema
 
 proc breakIntoStatements*(script: string): seq[string] =
   ## Given a full migration script, that can potentially contain a list

--- a/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
+++ b/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
@@ -81,17 +81,18 @@ proc removeOldestPartitionName*(self: PartitionManager) =
 proc isEmpty*(self: PartitionManager): bool =
   return self.partitions.len == 0
 
-proc getLastMoment*(partition: Partition): Moment =
+proc getLastMoment*(partition: Partition): int64 =
   ## Considering the time range covered by the partition, this
-  ## returns the `end` 'Moment' of such range.
+  ## returns the `end` time (number of seconds since epoch) of such range.
   let lastTimeInSec = partition.timeRange.`end`
-  return Moment.init(lastTimeInSec, Second)
+  return lastTimeInSec
 
-proc containsMoment*(partition: Partition, moment: Moment): bool =
+proc containsMoment*(partition: Partition, time: int64): bool =
   ## Returns true if the given moment is contained within the partition window,
   ## 'false' otherwise.
-  if partition.timeRange.beginning <= moment.epochSeconds() and
-     moment.epochSeconds() < partition.timeRange.`end`:
+  ## time - number of seconds since epoch
+  if partition.timeRange.beginning <= time and
+     time < partition.timeRange.`end`:
     return true
 
   return false

--- a/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
+++ b/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
@@ -1,0 +1,108 @@
+
+## This module is aimed to handle the creation and truncation of partition tables
+## in order to limit the space occupied in disk by the database.
+##
+## The created partitions are referenced by the 'storedAt' field.
+##
+
+import
+  std/[times, deques],
+  strutils
+import
+  chronos,
+  chronicles
+import
+  ../../../waku_core/time,
+  ../../driver
+
+logScope:
+  topics = "waku archive partitions_manager"
+
+## The Timestamp range is measured in seconds
+type TimeRange* = tuple[beginning: Timestamp, `end`: Timestamp]
+
+type
+  Partition = object
+    name: string
+    timeRange: TimeRange
+
+  PartitionManager* = ref object
+    partitions: Deque[Partition] # FIFO of partition table names. The first is the oldest partition
+
+proc new*(T: type PartitionManager): T =
+  return PartitionManager()
+
+# proc getTimeRangeFromPartitionName*(partitionName: string): ArchiveDriverResult[TimeRange] =
+#   ## Given a partition name, this proc extracts a tuple containing the timestamp range
+
+#   if not partitionName.contains("messages_"):
+#     return err("partition name should contain 'messages_'")
+
+#   let onlyDatesString = partitionName.replace("messages_", "")
+
+#   let timesAsString = onlyDatesString.split("_")
+#   if timesAsString.len != 2:
+#     return err("expected two timestamps in partition name, but found: " & partitionName)
+
+#   var ret: TimeRange
+#   try:
+#     ret.beginning = Timestamp(parseInt(timesAsString[0]))
+#   except ValueError:
+#     return err("invalid beginning timestamp: " & getCurrentExceptionMsg())
+
+#   try:
+#     ret.`end` = Timestamp(parseInt(timesAsString[1]))
+#   except ValueError:
+#     return err("invalid end timestamp: " & getCurrentExceptionMsg())
+
+#   return ok(ret)
+
+proc isCurrentPartitionTheLastOne*(self: PartitionManager): Result[bool, string] =
+  ## Returns 'true' is the current partition is the last created one, i.e the newest,
+  ## 'false' otherwise
+  if self.partitions.len == 0:
+    return err("There are no partitions")
+
+  let mostRecentRange = self.partitions.peekLast.timeRange
+  let timeOfInterest = now().toTime().toUnix()
+
+  return ok(mostRecentRange.beginning <= timeOfInterest and
+            timeOfInterest < mostRecentRange.`end`)
+
+proc getPartitionNameFromDateTime*(self: PartitionManager,
+                                   dateTimeOfInterest: DateTime):
+                                   Result[string, string] =
+  ## Returns the partition name that might store a message containing the passed timestamp.
+  ## In order words, it simply returns the partition name which contains the given timestamp.
+
+  if self.partitions.len == 0:
+    return err("There are no partitions")
+
+  let timeOfInterest = dateTimeOfInterest.toTime()
+  for partition in self.partitions:
+    let timeRange = partition.timeRange
+
+    let beginning = times.fromUnix(timeRange.beginning)
+    let `end` = times.fromUnix(timeRange.`end`)
+
+    if beginning <= timeOfInterest and timeOfInterest < `end`:
+      return ok(partition.name)
+
+  return err("Could'nt find a partition table for given time: " & $timeOfInterest.toUnix())
+
+proc getOldestPartitionName*(self: PartitionManager): string =
+  let oldestPartition = self.partitions.peekFirst
+  return oldestPartition.name
+
+proc addPartition*(self: PartitionManager,
+                   partitionName: string,
+                   beginning: Timestamp,
+                   `end`: Timestamp) =
+  ## The Timestamp is stored in seconds, unix epoch
+  self.partitions.addLast(Partition(
+                                name: partitionName,
+                                timeRange: (beginning, `end`)))
+
+proc removeOldestPartitionName*(self: PartitionManager) =
+  discard self.partitions.popFirst()
+

--- a/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
+++ b/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
@@ -6,20 +6,16 @@
 ##
 
 import
-  std/[times, deques],
-  strutils
+  std/deques
 import
   chronos,
   chronicles
-import
-  ../../../waku_core/time,
-  ../../driver
 
 logScope:
   topics = "waku archive partitions_manager"
 
-## The Timestamp range is measured in seconds
-type TimeRange* = tuple[beginning: Timestamp, `end`: Timestamp]
+## The time range has seconds resolution
+type TimeRange* = tuple[beginning: int64, `end`: int64]
 
 type
   Partition = object
@@ -32,77 +28,77 @@ type
 proc new*(T: type PartitionManager): T =
   return PartitionManager()
 
-# proc getTimeRangeFromPartitionName*(partitionName: string): ArchiveDriverResult[TimeRange] =
-#   ## Given a partition name, this proc extracts a tuple containing the timestamp range
-
-#   if not partitionName.contains("messages_"):
-#     return err("partition name should contain 'messages_'")
-
-#   let onlyDatesString = partitionName.replace("messages_", "")
-
-#   let timesAsString = onlyDatesString.split("_")
-#   if timesAsString.len != 2:
-#     return err("expected two timestamps in partition name, but found: " & partitionName)
-
-#   var ret: TimeRange
-#   try:
-#     ret.beginning = Timestamp(parseInt(timesAsString[0]))
-#   except ValueError:
-#     return err("invalid beginning timestamp: " & getCurrentExceptionMsg())
-
-#   try:
-#     ret.`end` = Timestamp(parseInt(timesAsString[1]))
-#   except ValueError:
-#     return err("invalid end timestamp: " & getCurrentExceptionMsg())
-
-#   return ok(ret)
-
-proc isCurrentPartitionTheLastOne*(self: PartitionManager): Result[bool, string] =
-  ## Returns 'true' is the current partition is the last created one, i.e the newest,
-  ## 'false' otherwise
-  if self.partitions.len == 0:
-    return err("There are no partitions")
-
-  let mostRecentRange = self.partitions.peekLast.timeRange
-  let timeOfInterest = now().toTime().toUnix()
-
-  return ok(mostRecentRange.beginning <= timeOfInterest and
-            timeOfInterest < mostRecentRange.`end`)
-
-proc getPartitionNameFromDateTime*(self: PartitionManager,
-                                   dateTimeOfInterest: DateTime):
-                                   Result[string, string] =
+proc getPartitionFromDateTime*(self: PartitionManager,
+                               targetMoment: Moment):
+                               Result[Partition, string] =
   ## Returns the partition name that might store a message containing the passed timestamp.
   ## In order words, it simply returns the partition name which contains the given timestamp.
 
   if self.partitions.len == 0:
     return err("There are no partitions")
 
-  let timeOfInterest = dateTimeOfInterest.toTime()
+  let targetMomentSec = targetMoment.epochSeconds()
   for partition in self.partitions:
     let timeRange = partition.timeRange
 
-    let beginning = times.fromUnix(timeRange.beginning)
-    let `end` = times.fromUnix(timeRange.`end`)
+    let beginning = timeRange.beginning
+    let `end` = timeRange.`end`
 
-    if beginning <= timeOfInterest and timeOfInterest < `end`:
-      return ok(partition.name)
+    if beginning <= targetMomentSec and targetMomentSec < `end`:
+      return ok(partition)
 
-  return err("Could'nt find a partition table for given time: " & $timeOfInterest.toUnix())
+  return err("Could'nt find a partition table for given time: " & $targetMomentSec)
 
-proc getOldestPartitionName*(self: PartitionManager): string =
+proc getNewestPartition*(self: PartitionManager): Result[Partition, string] =
+  if self.partitions.len == 0:
+    return err("there are no partitions allocated")
+
+  let newestPartition = self.partitions.peekLast
+  return ok(newestPartition)
+
+proc getOldestPartition*(self: PartitionManager): Result[Partition, string] =
+  if self.partitions.len == 0:
+    return err("there are no partitions allocated")
+
   let oldestPartition = self.partitions.peekFirst
-  return oldestPartition.name
+  return ok(oldestPartition)
 
-proc addPartition*(self: PartitionManager,
-                   partitionName: string,
-                   beginning: Timestamp,
-                   `end`: Timestamp) =
-  ## The Timestamp is stored in seconds, unix epoch
+proc addPartitionInfo*(self: PartitionManager,
+                       partitionName: string,
+                       beginning: int64,
+                       `end`: int64) =
+  ## The given partition range has seconds resolution.
+  ## We just store information of the new added partition merely to keep track of it.
   self.partitions.addLast(Partition(
                                 name: partitionName,
                                 timeRange: (beginning, `end`)))
 
 proc removeOldestPartitionName*(self: PartitionManager) =
+  ## Simply removed the partition from the tracked/known partitions queue.
+  ## Just remove it and ignore it.
   discard self.partitions.popFirst()
+
+proc isEmpty*(self: PartitionManager): bool =
+  return self.partitions.len == 0
+
+proc getLastMoment*(partition: Partition): Moment =
+  ## Considering the time range covered by the partition, this
+  ## returns the `end` 'Moment' of such range.
+  let lastTimeInSec = partition.timeRange.`end`
+  return Moment.init(lastTimeInSec, Second)
+
+proc containsMoment*(partition: Partition, moment: Moment): bool =
+  ## Returns true if the given moment is contained within the partition window,
+  ## 'false' otherwise.
+  if partition.timeRange.beginning <= moment.epochSeconds() and
+     moment.epochSeconds() < partition.timeRange.`end`:
+    return true
+
+  return false
+
+proc getName*(partition: Partition): string =
+  return partition.name
+
+func `==`*(a, b: Partition): bool {.inline.} =
+  return a.name == b.name
 

--- a/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
+++ b/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
@@ -47,7 +47,7 @@ proc getPartitionFromDateTime*(self: PartitionManager,
     if beginning <= targetMoment and targetMoment < `end`:
       return ok(partition)
 
-  return err("Could'nt find a partition table for given time: " & $targetMoment)
+  return err("Couldn't find a partition table for given time: " & $targetMoment)
 
 proc getNewestPartition*(self: PartitionManager): Result[Partition, string] =
   if self.partitions.len == 0:

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -566,7 +566,7 @@ proc addPartition(self: PostgresDriver,
   (await self.performWriteQuery(createPartitionQuery)).isOkOr:
     return err(fmt"error adding partition [{partitionName}]: " & $error)
 
-  debug "New partition added", query = createPartitionQuery
+  debug "new partition added", query = createPartitionQuery
 
   self.partitionMngr.addPartitionInfo(partitionName, beginning, `end`)
   return ok()
@@ -607,6 +607,8 @@ proc loopPartitionFactory*(self: PostgresDriver,
                            onFatalError: OnFatalErrorHandler) {.async.} =
   ## Loop proc that continuously checks whether we need to create a new partition.
   ## Notice that the deletion of partitions is handled by the retention policy modules.
+
+  debug "starting loopPartitionFactory"
 
   if PartitionsRangeInterval < DefaultDatabasePartitionCheckTimeInterval:
     onFatalError("partition factory partition range interval should be bigger than check interval")
@@ -702,7 +704,7 @@ method decreaseDatabaseSize*(driver: PostgresDriver,
   ## database size in bytes
   var totalSizeOfDB: int64 = int64(dbSize)
 
-  debug "Reduce database size", targetSize = $targetSizeInBytes, currentSize = $totalSizeOfDB
+  debug "reduce database size", targetSize = $targetSizeInBytes, currentSize = $totalSizeOfDB
 
   if totalSizeOfDB <= targetSizeInBytes:
     return ok()

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -725,6 +725,9 @@ proc removeOldestPartition(self: PostgresDriver,
 
   return ok()
 
+proc containsAnyPartition*(self: PostgresDriver): bool =
+  return not self.partitionMngr.isEmpty()
+
 method decreaseDatabaseSize*(driver: PostgresDriver,
                              targetSizeInBytes: int64,
                              forceRemoval: bool = false):

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -706,10 +706,10 @@ method decreaseDatabaseSize*(driver: PostgresDriver,
   ## database size in bytes
   var totalSizeOfDB: int64 = int64(dbSize)
 
-  debug "reduce database size", targetSize = $targetSizeInBytes, currentSize = $totalSizeOfDB
-
   if totalSizeOfDB <= targetSizeInBytes:
     return ok()
+
+  debug "start reducing database size", targetSize = $targetSizeInBytes, currentSize = $totalSizeOfDB
 
   while totalSizeOfDB > targetSizeInBytes and driver.containsAnyPartition():
     (await driver.removeOldestPartition(forceRemoval)).isOkOr:

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -25,8 +25,6 @@ type PostgresDriver* = ref object of ArchiveDriver
   readConnPool: PgAsyncPool
 
   ## Partition container
-proc dropTableQuery(): string =
-  "DROP TABLE messages"
   partitionMngr: PartitionManager
   futLoopPartitionFactory: Future[void]
 
@@ -103,6 +101,7 @@ proc new*(T: type PostgresDriver,
   return ok(driver)
 
 proc reset*(s: PostgresDriver): Future[ArchiveDriverResult[void]] {.async.} =
+  ## Clear the database partitions
   let targetSize = 0
   let forceRemoval = true
   let ret = await s.decreaseDatabaseSize(targetSize, forceRemoval)
@@ -731,7 +730,7 @@ method decreaseDatabaseSize*(driver: PostgresDriver,
 
     totalSizeOfDB = newCurrentSize
 
-    debug "Reducing database size", targetSize = $targetSizeInBytes, newCurrentSize = $totalSizeOfDB
+    debug "reducing database size", targetSize = $targetSizeInBytes, newCurrentSize = $totalSizeOfDB
 
   return ok()
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -511,11 +511,10 @@ method deleteOldestMessagesNotWithinLimit*(
 
   return ok()
 
-method decreaseDatabaseSize*(driver: ArchiveDriver,
+method decreaseDatabaseSize*(driver: PostgresDriver,
                              targetSizeInBytes: int64):
                              Future[ArchiveDriverResult[void]] {.async.} =
   ## TODO: refactor this implementation and use partition management instead
-
   ## To remove 20% of the outdated data from database
   const DeleteLimit = 0.80
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -560,7 +560,7 @@ proc addPartition(self: PostgresDriver,
 
   let partitionName = "messages_" & fromInSec & "_" & untilInSec
 
-  let createPartitionQuery = "CREATE TABLE " & partitionName & " PARTITION OF " &
+  let createPartitionQuery = "CREATE TABLE IF NOT EXISTS " & partitionName & " PARTITION OF " &
         "messages FOR VALUES FROM ('" & fromInNanoSec & "') TO ('" & untilInNanoSec & "');"
 
   (await self.performWriteQuery(createPartitionQuery)).isOkOr:

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -511,6 +511,41 @@ method deleteOldestMessagesNotWithinLimit*(
 
   return ok()
 
+method decreaseDatabaseSize*(driver: ArchiveDriver,
+                             targetSizeInBytes: int64):
+                             Future[ArchiveDriverResult[void]] {.async.} =
+  ## TODO: refactor this implementation and use partition management instead
+
+  ## To remove 20% of the outdated data from database
+  const DeleteLimit = 0.80
+
+  ## when db size overshoots the database limit, shread 20% of outdated messages
+  ## get size of database
+  let dbSize = (await driver.getDatabaseSize()).valueOr:
+    return err("failed to get database size: " & $error)
+
+  ## database size in bytes
+  let totalSizeOfDB: int64 = int64(dbSize)
+
+  if totalSizeOfDB < targetSizeInBytes:
+    return ok()
+
+  ## to shread/delete messsges, get the total row/message count
+  let numMessages = (await driver.getMessagesCount()).valueOr:
+    return err("failed to get messages count: " & error)
+
+  ## NOTE: Using SQLite vacuuming is done manually, we delete a percentage of rows
+  ## if vacumming is done automatically then we aim to check DB size periodially for efficient
+  ## retention policy implementation.
+
+  ## 80% of the total messages are to be kept, delete others
+  let pageDeleteWindow = int(float(numMessages) * DeleteLimit)
+
+  (await driver.deleteOldestMessagesNotWithinLimit(limit=pageDeleteWindow)).isOkOr:
+    return err("deleting oldest messages failed: " & error)
+
+  return ok()
+
 method close*(s: PostgresDriver):
               Future[ArchiveDriverResult[void]] {.async.} =
   ## Close the database connection

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -683,12 +683,6 @@ proc removeOldestPartition(self: PostgresDriver,
   (await self.performWriteQuery(detachPartitionQuery)).isOkOr:
     return err(fmt"error in {detachPartitionQuery}: " & $error)
 
-  ## Clear all data from the partition and retrieve back space to the operating system
-  let truncateQuery = "TRUNCATE TABLE " & oldestPartition.getName()
-  debug "removeOldestPartition truncate", query = truncateQuery
-  (await self.performWriteQuery(truncateQuery)).isOkOr:
-    return err(fmt"error in {truncateQuery}: " & $error)
-
   ## Drop the partition
   let dropPartitionQuery = "DROP TABLE " & oldestPartition.getName()
   debug "removeOldestPartition drop partition", query = dropPartitionQuery

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -326,16 +326,6 @@ method decreaseDatabaseSize*(driver: QueueDriver,
                              Future[ArchiveDriverResult[void]] {.async.} =
   return err("interface method not implemented")
 
-method decreaseDatabaseSize*(driver: ArchiveDriver,
-                             targetSizeInBytes: int64):
-                             Future[ArchiveDriverResult[void]] {.async.} =
-  return err("interface method not implemented")
-
-method decreaseDatabaseSize*(driver: QueueDriver,
-                             targetSizeInBytes: int64):
-                             Future[ArchiveDriverResult[void]] {.async.} =
-  return err("interface method not implemented")
-
 method close*(driver: QueueDriver):
               Future[ArchiveDriverResult[void]] {.async.} =
   return ok()

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -322,7 +322,8 @@ method deleteOldestMessagesNotWithinLimit*(driver: QueueDriver,
   return err("interface method not implemented")
 
 method decreaseDatabaseSize*(driver: QueueDriver,
-                             targetSizeInBytes: int64):
+                             targetSizeInBytes: int64,
+                             forceRemoval: bool = false):
                              Future[ArchiveDriverResult[void]] {.async.} =
   return err("interface method not implemented")
 

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -331,7 +331,7 @@ method decreaseDatabaseSize*(driver: ArchiveDriver,
                              Future[ArchiveDriverResult[void]] {.async.} =
   return err("interface method not implemented")
 
-method decreaseDatabaseSize*(driver: ArchiveDriver,
+method decreaseDatabaseSize*(driver: QueueDriver,
                              targetSizeInBytes: int64):
                              Future[ArchiveDriverResult[void]] {.async.} =
   return err("interface method not implemented")

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -326,6 +326,11 @@ method decreaseDatabaseSize*(driver: QueueDriver,
                              Future[ArchiveDriverResult[void]] {.async.} =
   return err("interface method not implemented")
 
+method decreaseDatabaseSize*(driver: ArchiveDriver,
+                             targetSizeInBytes: int64):
+                             Future[ArchiveDriverResult[void]] {.async.} =
+  return err("interface method not implemented")
+
 method close*(driver: QueueDriver):
               Future[ArchiveDriverResult[void]] {.async.} =
   return ok()

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -331,6 +331,11 @@ method decreaseDatabaseSize*(driver: ArchiveDriver,
                              Future[ArchiveDriverResult[void]] {.async.} =
   return err("interface method not implemented")
 
+method decreaseDatabaseSize*(driver: ArchiveDriver,
+                             targetSizeInBytes: int64):
+                             Future[ArchiveDriverResult[void]] {.async.} =
+  return err("interface method not implemented")
+
 method close*(driver: QueueDriver):
               Future[ArchiveDriverResult[void]] {.async.} =
   return ok()

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -147,7 +147,8 @@ method deleteOldestMessagesNotWithinLimit*(s: SqliteDriver,
   return s.db.deleteOldestMessagesNotWithinLimit(limit)
 
 method decreaseDatabaseSize*(driver: SqliteDriver,
-                             targetSizeInBytes: int64):
+                             targetSizeInBytes: int64,
+                             forceRemoval: bool = false):
                              Future[ArchiveDriverResult[void]] {.async.} =
 
   ## To remove 20% of the outdated data from database


### PR DESCRIPTION
## Description
First of all, special thanks to @NagyZoltanPeter for suggesting such a great partition proposal :partying_face: !

In this PR we start managing the partition creation and deletion.
This is interesting from the database size maintenance pov.

There will always be a current partition.
The `loopPartitionFactory` proc responsible for making sure that there will always be a future partition available.

The `loopPartitionFactory` will check every `DefaultDatabasePartitionCheckTimeInterval` (10 minutes hard-coded) whether a new partition should be created or not.

The `PartitionsRangeInterval` is also hard-coded (1 hour.) This value establishes the time window to store messaged based in their `storedAt` (epoch time in nanoseconds.)

Notice that the partitions are *only* removed when `size` retention policy is being applied.

![image](https://github.com/waku-org/nwaku/assets/128452529/4ca59eca-eb2f-4ae8-b471-4356d3646e06)


## Changes

- [x] Avoid using `require` on postgres tests. I've noticed that it doesn't handle the failure cases very well.
- [x] Bump the Postgres schema version to 2 (`waku/waku_archive/driver/postgres_driver/migrations.nim`.)
- [x] New `waku/waku_archive/driver/postgres_driver/partitions_manager.nim` that just keeps track the partitions. The partitions are being created from within the `postgres_driver.nim` (`loopPartitionFactory`.) and removed from the size retention policy.
- [x] Cleanup in `postgres_driver.nim`. Removes `createMessageTable`, `init`, and `deleteMessageTable` procs.
- [x] Notice that the `forceRemoval: bool = false` param in `decreaseDatabaseSize` is for testing purposes, to allow forcing all the partitions. 

