### PR TITLE
fix(rln-relay): make nullifier log abide by epoch ordering

### DIFF
--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -713,18 +713,15 @@ suite "Waku rln relay":
                                  rlnRelayCredIndex: some(index1),
                                  rlnEpochSizeSec: 1,
                                  rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_3"))
-    let wakuRlnRelay1Res = await WakuRlnRelay.new(rlnConf1)
-    if wakuRlnRelay1Res.isErr(): assert false, "failed to create waku rln relay: " & $wakuRlnRelay1Res.error
-    let wakuRlnRelay1 = wakuRlnRelay1Res.get()
+    let wakuRlnRelay1 = (await WakuRlnRelay.new(rlnConf1)).valueOr:
+      raiseAssert "failed to create waku rln relay: " & $error
 
     let rlnConf2 = WakuRlnConfig(rlnRelayDynamic: false,
                                  rlnRelayCredIndex: some(index2),
                                  rlnEpochSizeSec: 1,
                                  rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_4"))
-    let wakuRlnRelay2Res = await WakuRlnRelay.new(rlnConf2)
-    if wakuRlnRelay2Res.isErr():
-      assert false, "failed to create waku rln relay: " & $wakuRlnRelay2Res.error
-    let wakuRlnRelay2 = wakuRlnRelay2Res.get()
+    let wakuRlnRelay2 = (await WakuRlnRelay.new(rlnConf2)).valueOr:
+      raiseAssert "failed to create waku rln relay: " & $error
     # get the current epoch time
     let time = epochTime()
 

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -632,30 +632,25 @@ suite "Waku rln relay":
 
     # check whether hasDuplicate correctly finds records with the same nullifiers but different secret shares
     # no duplicate for proof1 should be found, since the log is empty
-    let result1 = wakurlnrelay.hasDuplicate(proof1.extractMetadata().tryGet())
-    require:
-      result1.isOk()
-      # no duplicate is found
-      result1.value == false
+    let result1 = wakurlnrelay.hasDuplicate(epoch, proof1.extractMetadata().tryGet())
+    assert result1.isOk(), $result1.error
+    assert result1.value == false, "no duplicate should be found"
     #  add it to the log
-    discard wakurlnrelay.updateLog(proof1.extractMetadata().tryGet())
+    discard wakurlnrelay.updateLog(epoch, proof1.extractMetadata().tryGet())
 
-    # # no duplicate for proof2 should be found, its nullifier differs from proof1
-    let result2 = wakurlnrelay.hasDuplicate(proof2.extractMetadata().tryGet())
-    require:
-      result2.isOk()
-      # no duplicate is found
-      result2.value == false
+    # no duplicate for proof2 should be found, its nullifier differs from proof1
+    let result2 = wakurlnrelay.hasDuplicate(epoch, proof2.extractMetadata().tryGet())
+    assert result2.isOk(), $result2.error
+    # no duplicate is found
+    assert result2.value == false, "no duplicate should be found"
     #  add it to the log
-    discard wakurlnrelay.updateLog(proof2.extractMetadata().tryGet())
+    discard wakurlnrelay.updateLog(epoch, proof2.extractMetadata().tryGet())
 
     #  proof3 has the same nullifier as proof1 but different secret shares, it should be detected as duplicate
-    let result3 = wakurlnrelay.hasDuplicate(proof3.extractMetadata().tryGet())
-    require:
-      result3.isOk()
-    check:
-      # it is a duplicate
-      result3.value == true
+    let result3 = wakurlnrelay.hasDuplicate(epoch, proof3.extractMetadata().tryGet())
+    assert result3.isOk(), $result3.error
+    # it is a duplicate
+    assert result3.value, "duplicate should be found"
 
   asyncTest "validateMessageAndUpdateLog test":
     let index = MembershipIndex(5)

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -123,7 +123,7 @@ proc hasDuplicate*(rlnPeer: WakuRLNRelay,
     return ok(false)
 
   except KeyError:
-    return err("the epoch was not found")
+    return err("the epoch was not found: " & getCurrentExceptionMsg())
 
 proc updateLog*(rlnPeer: WakuRLNRelay,
                 epoch: Epoch,
@@ -145,7 +145,7 @@ proc updateLog*(rlnPeer: WakuRLNRelay,
       return ok()
     return ok()
   except KeyError:
-    return err("the epoch was not found") # should never happen
+    return err("the epoch was not found: " & getCurrentExceptionMsg()) # should never happen
 
 proc getCurrentEpoch*(rlnPeer: WakuRLNRelay): Epoch =
   ## gets the current rln Epoch time

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -79,7 +79,7 @@ proc createMembershipList*(rln: ptr RLN, n: int): RlnRelayResult[(
 
 type WakuRLNRelay* = ref object of RootObj
   # the log of nullifiers and Shamir shares of the past messages grouped per epoch
-  nullifierLog*: OrderedTable[Epoch, seq[ProofMetadata]]
+  nullifierLog*: OrderedTable[Epoch, Table[Nullifier, ProofMetadata]]
   lastEpoch*: Epoch # the epoch of the last published rln message
   rlnEpochSizeSec*: uint64
   rlnMaxEpochGap*: uint64
@@ -103,58 +103,54 @@ proc stop*(rlnPeer: WakuRLNRelay) {.async: (raises: [Exception]).} =
   await rlnPeer.groupManager.stop()
 
 proc hasDuplicate*(rlnPeer: WakuRLNRelay,
+                   epoch: Epoch,
                    proofMetadata: ProofMetadata): RlnRelayResult[bool] =
   ## returns true if there is another message in the  `nullifierLog` of the `rlnPeer` with the same
   ## epoch and nullifier as `proofMetadata`'s epoch and nullifier
   ## otherwise, returns false
   ## Returns an error if it cannot check for duplicates
 
-  let externalNullifier = proofMetadata.externalNullifier
   # check if the epoch exists
-  if not rlnPeer.nullifierLog.hasKey(externalNullifier):
+  let nullifier = proofMetadata.nullifier
+  if not rlnPeer.nullifierLog.hasKey(epoch):
     return ok(false)
   try:
-    if rlnPeer.nullifierLog[externalNullifier].contains(proofMetadata):
+    if rlnPeer.nullifierLog[epoch].hasKey(nullifier):
       # there is an identical record, mark it as spam
-      return ok(true)
-
-    # check for a message with the same nullifier but different secret shares
-    let matched = rlnPeer.nullifierLog[externalNullifier].filterIt((
-        it.nullifier == proofMetadata.nullifier) and ((it.shareX != proofMetadata.shareX) or
-        (it.shareY != proofMetadata.shareY)))
-
-    if matched.len != 0:
-      # there is a duplicate
       return ok(true)
 
     # there is no duplicate
     return ok(false)
 
-  except KeyError as e:
+  except KeyError:
     return err("the epoch was not found")
 
 proc updateLog*(rlnPeer: WakuRLNRelay,
+                epoch: Epoch,
                 proofMetadata: ProofMetadata): RlnRelayResult[void] =
   ## saves supplied proofMetadata `proofMetadata`
   ## in the `nullifierLog` of the `rlnPeer`
   ## Returns an error if it cannot update the log
 
-  let externalNullifier = proofMetadata.externalNullifier
-  # check if the externalNullifier exists
-  if not rlnPeer.nullifierLog.hasKey(externalNullifier):
-    rlnPeer.nullifierLog[externalNullifier] = @[proofMetadata]
+  # check if the epoch exists
+  if not rlnPeer.nullifierLog.hasKey(epoch):
+    rlnPeer.nullifierLog[epoch] = initTable[Nullifier, ProofMetadata]()
+    try: 
+      rlnPeer.nullifierLog[epoch][proofMetadata.nullifier] = proofMetadata
+    except KeyError:
+      return err("the epoch was not found") # should never happen
     return ok()
 
   try:
     # check if an identical record exists
-    if rlnPeer.nullifierLog[externalNullifier].contains(proofMetadata):
+    if rlnPeer.nullifierLog[epoch].hasKey(proofMetadata.nullifier):
       # TODO: slashing logic
       return ok()
     # add proofMetadata to the log
-    rlnPeer.nullifierLog[externalNullifier].add(proofMetadata)
+    rlnPeer.nullifierLog[epoch][proofMetadata.nullifier] = proofMetadata
     return ok()
-  except KeyError as e:
-    return err("the external nullifier was not found") # should never happen
+  except KeyError:
+    return err("the epoch was not found") # should never happen
 
 proc getCurrentEpoch*(rlnPeer: WakuRLNRelay): Epoch =
   ## gets the current rln Epoch time
@@ -249,7 +245,7 @@ proc validateMessage*(rlnPeer: WakuRLNRelay,
   if proofMetadataRes.isErr():
     waku_rln_errors_total.inc(labelValues=["proof_metadata_extraction"])
     return MessageValidationResult.Invalid
-  let hasDup = rlnPeer.hasDuplicate(proofMetadataRes.get())
+  let hasDup = rlnPeer.hasDuplicate(msgEpoch, proofMetadataRes.get())
   if hasDup.isErr():
     waku_rln_errors_total.inc(labelValues=["duplicate_check"])
   elif hasDup.value == true:
@@ -282,7 +278,7 @@ proc validateMessageAndUpdateLog*(
     return MessageValidationResult.Invalid
 
   # insert the message to the log (never errors)
-  discard rlnPeer.updateLog(proofMetadataRes.get())
+  discard rlnPeer.updateLog(msgProof.epoch, proofMetadataRes.get())
 
   return result
 

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -133,21 +133,16 @@ proc updateLog*(rlnPeer: WakuRLNRelay,
   ## Returns an error if it cannot update the log
 
   # check if the epoch exists
-  if not rlnPeer.nullifierLog.hasKey(epoch):
-    rlnPeer.nullifierLog[epoch] = initTable[Nullifier, ProofMetadata]()
-    try: 
-      rlnPeer.nullifierLog[epoch][proofMetadata.nullifier] = proofMetadata
-    except KeyError:
-      return err("the epoch was not found") # should never happen
+  if not rlnPeer.nullifierLog.hasKeyOrPut(epoch, { proofMetadata.nullifier: proofMetadata }.toTable()):
     return ok()
 
   try:
     # check if an identical record exists
-    if rlnPeer.nullifierLog[epoch].hasKey(proofMetadata.nullifier):
+    if rlnPeer.nullifierLog[epoch].hasKeyOrPut(proofMetadata.nullifier, proofMetadata):
+      # the above condition could be `discarded` but it is kept for clarity, that slashing will 
+      # be implemented here
       # TODO: slashing logic
       return ok()
-    # add proofMetadata to the log
-    rlnPeer.nullifierLog[epoch][proofMetadata.nullifier] = proofMetadata
     return ok()
   except KeyError:
     return err("the epoch was not found") # should never happen


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->

~Instead of using the `epoch` as the key for the nullifierLog, `externalNullifier` was being used. This could lead to a node only accepting one valid message sent during an epoch `e`, and reject all other messages sent during epoch `e`.~
Made the NullifierLog properly map from Epoch to Nullifiers instead of ExternalNullifier to ProofMetadata.
Optimized by nesting the hashmap to locate duplicates faster instead of searching an array.

# Changes

<!-- List of detailed changes -->

- [x] nullifierLog is now `OrderedTable[Epoch, Table[Nullifier, ProofMetadata]]`
- [x] updated tests

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
