### PR TITLE
fix: repeated fields are packed in proto3

### DIFF
--- a/waku/waku_metadata/rpc.nim
+++ b/waku/waku_metadata/rpc.nim
@@ -23,9 +23,7 @@ proc encode*(rpc: WakuMetadataRequest): ProtoBuffer =
   var pb = initProtoBuffer()
 
   pb.write3(1, rpc.clusterId)
-
-  for shard in rpc.shards:
-    pb.write3(2, shard)
+  pb.writePacked(2, rpc.shards)
   pb.finish3()
 
   pb
@@ -41,7 +39,7 @@ proc decode*(T: type WakuMetadataRequest, buffer: seq[byte]): ProtoResult[T] =
     rpc.clusterId = some(clusterId.uint32)
 
   var shards: seq[uint64]
-  if ?pb.getRepeatedField(2, shards):
+  if ?pb.getPackedRepeatedField(2, shards):
     for shard in shards:
       rpc.shards.add(shard.uint32)
 
@@ -51,9 +49,7 @@ proc encode*(rpc: WakuMetadataResponse): ProtoBuffer =
   var pb = initProtoBuffer()
 
   pb.write3(1, rpc.clusterId)
-
-  for shard in rpc.shards:
-    pb.write3(2, shard)
+  pb.writePacked(2, rpc.shards)
   pb.finish3()
 
   pb
@@ -69,7 +65,7 @@ proc decode*(T: type WakuMetadataResponse, buffer: seq[byte]): ProtoResult[T] =
     rpc.clusterId = some(clusterId.uint32)
 
   var shards: seq[uint64]
-  if ?pb.getRepeatedField(2, shards):
+  if ?pb.getPackedRepeatedField(2, shards):
     for shard in shards:
       rpc.shards.add(shard.uint32)
 


### PR DESCRIPTION
# Description
As described here https://github.com/status-im/nim-libp2p/issues/1035 proto3 repeated fields are packed by default, so with this PR we use `writePacked` and `getPackedRepeatedField` instead of `write3` and `getRepeatedField`.
However, this would mean that once a release is done, nodes using the previous version would not be compatible with the newer release, which can be problematic.

@jm-clius, @alrevuelta, what would be the recommended approach here?


Some possibilities that come to mind are the following:


1. In go-waku use the attribute `[packed=false]` so it behaves like nwaku, and then just close this PR. This would be the 'easy' solution, and would require some coordination so when infra deploys a release containing this version, all contributors also update their desktop version to something that uses this protobuffer:

```proto
message WakuMetadataRequest {
  optional uint32 cluster_id = 1;
  repeated uint32 shards = 2 [packed=false];
}
```

---

2. Merge this PR in nwaku and then, on new release, all users need to upgrade their nwaku version or they'll be disconnected. 

Neither the first nor the second option seem ideal because the impact they have and also because they modify an existing field in a protobuffer, and this seems to not be the recommended approach?

---

3. Add a new field for the shards and deprecate this field, and for at least 2 releases support both fields i.e.:
```
message WakuMetadataRequest {
  optional uint32 cluster_id = 1;
  repeated uint32 shards = 2  [deprecated = true];
  repeated uint32 shards = 3;
}
```
Then in nwaku code we'd use `getPackedRepeatedField` on field 3, and if it's not populated, use `getPackedRepeatedField` on field2, and if it's empty, use `getRepeatedField`. This would solve the problem of nwaku not understanding go-waku's  packed field. For writing, we'd still use `write3` for field 2 and `writePacked` for field3. 
Currently go-waku does not care about the format of the field for reading data since it seems to try decoding both packed and unpacked data.  I think this is the cleanest option

