### PR TITLE
fix: introduce new field for shards in metadata protocol

### DIFF
--- a/waku/waku_metadata/rpc.nim
+++ b/waku/waku_metadata/rpc.nim
@@ -23,9 +23,7 @@ proc encode*(rpc: WakuMetadataRequest): ProtoBuffer =
   var pb = initProtoBuffer()
 
   pb.write3(1, rpc.clusterId)
-
-  for shard in rpc.shards:
-    pb.write3(2, shard)
+  pb.writePacked(2, rpc.shards)
   pb.finish3()
 
   pb
@@ -41,7 +39,7 @@ proc decode*(T: type WakuMetadataRequest, buffer: seq[byte]): ProtoResult[T] =
     rpc.clusterId = some(clusterId.uint32)
 
   var shards: seq[uint64]
-  if ?pb.getRepeatedField(2, shards):
+  if ?pb.getPackedRepeatedField(2, shards):
     for shard in shards:
       rpc.shards.add(shard.uint32)
 
@@ -51,9 +49,7 @@ proc encode*(rpc: WakuMetadataResponse): ProtoBuffer =
   var pb = initProtoBuffer()
 
   pb.write3(1, rpc.clusterId)
-
-  for shard in rpc.shards:
-    pb.write3(2, shard)
+  pb.writePacked(2, rpc.shards)
   pb.finish3()
 
   pb
@@ -69,7 +65,7 @@ proc decode*(T: type WakuMetadataResponse, buffer: seq[byte]): ProtoResult[T] =
     rpc.clusterId = some(clusterId.uint32)
 
   var shards: seq[uint64]
-  if ?pb.getRepeatedField(2, shards):
+  if ?pb.getPackedRepeatedField(2, shards):
     for shard in shards:
       rpc.shards.add(shard.uint32)
 

--- a/waku/waku_metadata/rpc.nim
+++ b/waku/waku_metadata/rpc.nim
@@ -23,7 +23,9 @@ proc encode*(rpc: WakuMetadataRequest): ProtoBuffer =
   var pb = initProtoBuffer()
 
   pb.write3(1, rpc.clusterId)
-  pb.writePacked(2, rpc.shards)
+  for shard in rpc.shards:
+    pb.write3(2, shard) # deprecated
+  pb.writePacked(3, rpc.shards)
   pb.finish3()
 
   pb
@@ -39,7 +41,13 @@ proc decode*(T: type WakuMetadataRequest, buffer: seq[byte]): ProtoResult[T] =
     rpc.clusterId = some(clusterId.uint32)
 
   var shards: seq[uint64]
-  if ?pb.getPackedRepeatedField(2, shards):
+  if ?pb.getPackedRepeatedField(3, shards):
+    for shard in shards:
+      rpc.shards.add(shard.uint32)
+  elif ?pb.getPackedRepeatedField(2, shards):
+    for shard in shards:
+      rpc.shards.add(shard.uint32)
+  elif ?pb.getRepeatedField(2, shards):
     for shard in shards:
       rpc.shards.add(shard.uint32)
 
@@ -49,7 +57,9 @@ proc encode*(rpc: WakuMetadataResponse): ProtoBuffer =
   var pb = initProtoBuffer()
 
   pb.write3(1, rpc.clusterId)
-  pb.writePacked(2, rpc.shards)
+  for shard in rpc.shards:
+    pb.write3(2, shard) # deprecated
+  pb.writePacked(3, rpc.shards)
   pb.finish3()
 
   pb
@@ -65,8 +75,16 @@ proc decode*(T: type WakuMetadataResponse, buffer: seq[byte]): ProtoResult[T] =
     rpc.clusterId = some(clusterId.uint32)
 
   var shards: seq[uint64]
-  if ?pb.getPackedRepeatedField(2, shards):
+
+  if ?pb.getPackedRepeatedField(3, shards):
     for shard in shards:
       rpc.shards.add(shard.uint32)
+  elif ?pb.getPackedRepeatedField(2, shards):
+    for shard in shards:
+      rpc.shards.add(shard.uint32)
+  elif ?pb.getRepeatedField(2, shards):
+    for shard in shards:
+      rpc.shards.add(shard.uint32)
+
 
   ok(rpc)


### PR DESCRIPTION
# Description
This is the solution #3 described in https://github.com/waku-org/nwaku/pull/2509


Add a new field for the shards and deprecate field 2, and for at least 2 releases support both fields i.e.:
```proto
message WakuMetadataRequest {
  optional uint32 cluster_id = 1;
  repeated uint32 shards = 2  [deprecated = true];
  repeated uint32 shards = 3;
}
```

We would use getPackedRepeatedField on field 3, and if it's not populated, use getPackedRepeatedField on field2, and if it's empty, use getRepeatedField. This would solve the problem of nwaku not understanding go-waku's packed field. 

For writing, we'd still use write3 for field 2 and writePacked for field3.

Currently go-waku does not care about the format of the field for reading data since it seems to try decoding both packed and unpacked data. go-waku should also implement the same solution, but for the time being this would allow users of different nwaku and go-waku versions to connect with each other and not introduce breaking changes