### PR TITLE
fix(rln-relay): handle empty metadata returned by getMetadata proc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit
 ifeq ($(RLN_V2),true)
 LIBRLN_VERSION := v0.4.1
 else
-LIBRLN_VERSION := v0.3.4
+LIBRLN_VERSION := v0.3.6
 endif
 
 ifeq ($(OS),Windows_NT)

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -226,12 +226,13 @@ suite "Onchain group manager":
 
     let metadataSetRes = manager.setMetadata()
     assert metadataSetRes.isOk(), metadataSetRes.error
-    let metadata = manager.rlnInstance.getMetadata().valueOr:
+    let metadataOpt = manager.rlnInstance.getMetadata().valueOr:
       raiseAssert $error
-    require:
-      metadata.isSome()
-      metadata.get().chainId == 1337
-      metadata.get().contractAddress == manager.ethContractAddress
+    assert metadataOpt.isSome(), "metadata is not set"
+    let metadata = metadataOpt.get()
+    
+    assert metadata.chainId == 1337, "chainId is not equal to 1337"
+    assert metadata.contractAddress == manager.ethContractAddress, "contractAddress is not equal to " & manager.ethContractAddress
     
     await manager.stop()
 
@@ -458,11 +459,11 @@ suite "Onchain group manager":
 
     await fut
 
-    let metadata = manager.rlnInstance.getMetadata().valueOr:
+    let metadataOpt = manager.rlnInstance.getMetadata().valueOr:
       raiseAssert $error
+    assert metadataOpt.isSome(), "metadata is not set"
     check:
-      metadata.isSome()
-      metadata.get().validRoots == manager.validRoots.toSeq()
+      metadataOpt.get().validRoots == manager.validRoots.toSeq()
     await manager.stop()
 
   asyncTest "withdraw: should guard against uninitialized state":

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -226,12 +226,12 @@ suite "Onchain group manager":
 
     let metadataSetRes = manager.setMetadata()
     assert metadataSetRes.isOk(), metadataSetRes.error
-    let metadataRes = manager.rlnInstance.getMetadata()
-    assert metadataRes.isOk(), metadataRes.error
-    let metadata = metadataRes.get()
+    let metadata = manager.rlnInstance.getMetadata().valueOr:
+      raiseAssert $error
     require:
-      metadata.chainId == 1337
-      metadata.contractAddress == manager.ethContractAddress
+      metadata.isSome()
+      metadata.value.chainId == 1337
+      metadata.value.contractAddress == manager.ethContractAddress
     
     await manager.stop()
 
@@ -458,8 +458,10 @@ suite "Onchain group manager":
 
     await fut
 
+    let metadata = manager.rlnInstance.getMetadata().valueOr:
+      raiseAssert $error
     check:
-      manager.rlnInstance.getMetadata().get().validRoots == manager.validRoots.toSeq()
+      metadata.value.validRoots == manager.validRoots.toSeq()
     await manager.stop()
 
   asyncTest "withdraw: should guard against uninitialized state":

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -230,8 +230,8 @@ suite "Onchain group manager":
       raiseAssert $error
     require:
       metadata.isSome()
-      metadata.value.chainId == 1337
-      metadata.value.contractAddress == manager.ethContractAddress
+      metadata.get().chainId == 1337
+      metadata.get().contractAddress == manager.ethContractAddress
     
     await manager.stop()
 
@@ -461,7 +461,8 @@ suite "Onchain group manager":
     let metadata = manager.rlnInstance.getMetadata().valueOr:
       raiseAssert $error
     check:
-      metadata.value.validRoots == manager.validRoots.toSeq()
+      metadata.isSome()
+      metadata.get().validRoots == manager.validRoots.toSeq()
     await manager.stop()
 
   asyncTest "withdraw: should guard against uninitialized state":

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -260,14 +260,15 @@ suite "Waku rln relay":
                                   chainId: 1155511,
                                   contractAddress: "0x9c09146844c1326c2dbc41c451766c7138f88155")).isOk()
 
-    let metadata = rln.getMetadata().valueOr:
+    let metadataOpt = rln.getMetadata().valueOr:
       raiseAssert $error
 
+    assert metadataOpt.isSome(), "metadata is not set"
+    let metadata = metadataOpt.get()
     check:
-      metadata.isSome()
-      metadata.get().lastProcessedBlock == 128
-      metadata.get().chainId == 1155511
-      metadata.get().contractAddress == "0x9c09146844c1326c2dbc41c451766c7138f88155"
+      metadata.lastProcessedBlock == 128
+      metadata.chainId == 1155511
+      metadata.contractAddress == "0x9c09146844c1326c2dbc41c451766c7138f88155"
 
   test "getMetadata: empty rln metadata":
     # create an RLN instance which also includes an empty Merkle tree

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -265,17 +265,14 @@ suite "Waku rln relay":
 
     check:
       metadata.isSome()
-      metadata.value.lastProcessedBlock == 128
-      metadata.value.chainId == 1155511
-      metadata.value.contractAddress == "0x9c09146844c1326c2dbc41c451766c7138f88155"
+      metadata.get().lastProcessedBlock == 128
+      metadata.get().chainId == 1155511
+      metadata.get().contractAddress == "0x9c09146844c1326c2dbc41c451766c7138f88155"
 
   test "getMetadata: empty rln metadata":
     # create an RLN instance which also includes an empty Merkle tree
-    let rlnInstance = createRLNInstanceWrapper()
-    require:
-      rlnInstance.isOk()
-    let rln = rlnInstance.get()
-
+    let rln = createRLNInstanceWrapper().valueOr:
+      raiseAssert $error
     let metadata = rln.getMetadata().valueOr:
       raiseAssert $error
 

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -260,17 +260,27 @@ suite "Waku rln relay":
                                   chainId: 1155511,
                                   contractAddress: "0x9c09146844c1326c2dbc41c451766c7138f88155")).isOk()
 
-    let metadataRes = rln.getMetadata()
-
-    require:
-      metadataRes.isOk()
-
-    let metadata = metadataRes.get()
+    let metadata = rln.getMetadata().valueOr:
+      raiseAssert $error
 
     check:
-      metadata.lastProcessedBlock == 128
-      metadata.chainId == 1155511
-      metadata.contractAddress == "0x9c09146844c1326c2dbc41c451766c7138f88155"
+      metadata.isSome()
+      metadata.value.lastProcessedBlock == 128
+      metadata.value.chainId == 1155511
+      metadata.value.contractAddress == "0x9c09146844c1326c2dbc41c451766c7138f88155"
+
+  test "getMetadata: empty rln metadata":
+    # create an RLN instance which also includes an empty Merkle tree
+    let rlnInstance = createRLNInstanceWrapper()
+    require:
+      rlnInstance.isOk()
+    let rln = rlnInstance.get()
+
+    let metadata = rln.getMetadata().valueOr:
+      raiseAssert $error
+
+    check:
+      metadata.isNone()
 
   test "Merkle tree consistency check between deletion and insertion":
     # create an RLN instance

--- a/tools/rln_db_inspector/rln_db_inspector.nim
+++ b/tools/rln_db_inspector/rln_db_inspector.nim
@@ -30,6 +30,10 @@ proc doInspectRlnDb*(conf: WakuNodeConf) =
   let metadata = rlnInstance.getMetadata().valueOr:
     error "failure while getting RLN metadata", error
     quit(1)
+  
+  if metadata.isNone():
+    error "RLN metadata does not exist"
+    quit(1)
 
   info "RLN metadata", lastProcessedBlock = metadata.lastProcessedBlock, 
                        chainId = metadata.chainId,

--- a/tools/rln_db_inspector/rln_db_inspector.nim
+++ b/tools/rln_db_inspector/rln_db_inspector.nim
@@ -27,13 +27,14 @@ proc doInspectRlnDb*(conf: WakuNodeConf) =
     quit(1)
 
   # 3. get metadata
-  let metadata = rlnInstance.getMetadata().valueOr:
+  let metadataOpt = rlnInstance.getMetadata().valueOr:
     error "failure while getting RLN metadata", error
     quit(1)
   
-  if metadata.isNone():
+  if metadataOpt.isNone():
     error "RLN metadata does not exist"
     quit(1)
+  let metadata = metadataOpt.get()
 
   info "RLN metadata", lastProcessedBlock = metadata.lastProcessedBlock, 
                        chainId = metadata.chainId,

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -669,8 +669,8 @@ method init*(g: OnchainGroupManager): Future[void] {.async.} =
   let metadataGetRes = g.rlnInstance.getMetadata()
   if metadataGetRes.isErr():
     warn "could not initialize with persisted rln metadata"
-  else:
-    let metadata = metadataGetRes.get()
+  elif metadataGetRes.get().isSome():
+    let metadata = metadataGetRes.get().value
     if metadata.chainId != uint64(g.chainId.get()):
       raise newException(ValueError, "persisted data: chain id mismatch")
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -670,7 +670,7 @@ method init*(g: OnchainGroupManager): Future[void] {.async.} =
   if metadataGetRes.isErr():
     warn "could not initialize with persisted rln metadata"
   elif metadataGetRes.get().isSome():
-    let metadata = metadataGetRes.get().value
+    let metadata = metadataGetRes.get().get()
     if metadata.chainId != uint64(g.chainId.get()):
       raise newException(ValueError, "persisted data: chain id mismatch")
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -666,11 +666,11 @@ method init*(g: OnchainGroupManager): Future[void] {.async.} =
 
     g.idCredentials = some(keystoreCred.identityCredential)
 
-  let metadataGetRes = g.rlnInstance.getMetadata()
-  if metadataGetRes.isErr():
+  let metadataGetOptRes = g.rlnInstance.getMetadata()
+  if metadataGetOptRes.isErr():
     warn "could not initialize with persisted rln metadata"
-  elif metadataGetRes.get().isSome():
-    let metadata = metadataGetRes.get().get()
+  elif metadataGetOptRes.get().isSome():
+    let metadata = metadataGetOptRes.get().get()
     if metadata.chainId != uint64(g.chainId.get()):
       raise newException(ValueError, "persisted data: chain id mismatch")
 

--- a/waku/waku_rln_relay/rln/wrappers.nim
+++ b/waku/waku_rln_relay/rln/wrappers.nim
@@ -500,7 +500,7 @@ proc setMetadata*(rlnInstance: ptr RLN, metadata: RlnMetadata): RlnRelayResult[v
     return err("could not set the metadata")
   return ok()
 
-proc getMetadata*(rlnInstance: ptr RLN): RlnRelayResult[RlnMetadata] =
+proc getMetadata*(rlnInstance: ptr RLN): RlnRelayResult[Option[RlnMetadata]] =
   ## gets the metadata of the RLN instance
   ## returns an error if the metadata could not be retrieved
   ## returns the metadata if the metadata is retrieved successfully
@@ -513,6 +513,9 @@ proc getMetadata*(rlnInstance: ptr RLN): RlnRelayResult[RlnMetadata] =
   if not getMetadataSuccessful:
     return err("could not get the metadata")
   trace "metadata length", metadataLen = metadata.len
+
+  if metadata.len == 0:
+    return ok(none(RlnMetadata))
 
   let 
     lastProcessedBlockOffset = 0
@@ -536,7 +539,7 @@ proc getMetadata*(rlnInstance: ptr RLN): RlnRelayResult[RlnMetadata] =
   let validRootsBytes = metadataBytes[validRootsOffset..metadataBytes.high]
   validRoots = MerkleNodeSeq.deserialize(validRootsBytes)
 
-  return ok(RlnMetadata(lastProcessedBlock: lastProcessedBlock,
-                        chainId: chainId,
-                        contractAddress: "0x" & contractAddress,
-                        validRoots: validRoots))
+  return ok(some(RlnMetadata(lastProcessedBlock: lastProcessedBlock,
+                             chainId: chainId,
+                             contractAddress: "0x" & contractAddress,
+                             validRoots: validRoots)))


### PR DESCRIPTION
- **fix(rln-relay): silence error on startup when metadata is not found**
- **chore: fix fetching value from option**


# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR silences the execution error that is received when trying to fetch the rln metadata from the db.
Zerokit's PR: https://github.com/vacp2p/zerokit/pull/231
If it returns a buf of len 0, then we assume the metadata is not found, and proceed execution as usual.

# Changes

<!-- List of detailed changes -->

- [x] updated rln static lib version to v0.3.6
- [x] updated zerokit submodule
- [x] added test for empty metadata returned


## How to test

1. `make -j16 test`



## Issue

closes #2471

