### PR TITLE
chore: factory cleanup

### DIFF
--- a/apps/wakunode2/app.nim
+++ b/apps/wakunode2/app.nim
@@ -85,6 +85,38 @@ func node*(app: App): WakuNode =
 func version*(app: App): string =
   app.version
 
+## Retrieve dynamic bootstrap nodes (DNS discovery)
+
+proc retrieveDynamicBootstrapNodes*(dnsDiscovery: bool,
+                                    dnsDiscoveryUrl: string,
+                                    dnsDiscoveryNameServers: seq[IpAddress]):
+                                    Result[seq[RemotePeerInfo], string] =
+
+  if dnsDiscovery and dnsDiscoveryUrl != "":
+    # DNS discovery
+    debug "Discovering nodes using Waku DNS discovery", url=dnsDiscoveryUrl
+
+    var nameServers: seq[TransportAddress]
+    for ip in dnsDiscoveryNameServers:
+      nameServers.add(initTAddress(ip, Port(53))) # Assume all servers use port 53
+
+    let dnsResolver = DnsResolver.new(nameServers)
+
+    proc resolver(domain: string): Future[string] {.async, gcsafe.} =
+      trace "resolving", domain=domain
+      let resolved = await dnsResolver.resolveTxt(domain)
+      return resolved[0] # Use only first answer
+
+    var wakuDnsDiscovery = WakuDnsDiscovery.init(dnsDiscoveryUrl, resolver)
+    if wakuDnsDiscovery.isOk():
+      return wakuDnsDiscovery.get().findPeers()
+        .mapErr(proc (e: cstring): string = $e)
+    else:
+      warn "Failed to init Waku DNS discovery"
+
+  debug "No method for retrieving dynamic bootstrap nodes specified."
+  ok(newSeq[RemotePeerInfo]()) # Return an empty seq by default
+
 ## Initialisation
 
 proc init*(T: type App, conf: WakuNodeConf): Result[App, string] =


### PR DESCRIPTION
# Description
Cleaning `node_factory.nim`. Only exporting `setupNode()` and `startNode()`.
# Changes

<!-- List of detailed changes -->

- [x] moving `retrieveDynamicBootstrapNodes()` to `app.nim`
- [x] not exporting utility procs in `node_factory.nim`

<!--
## How to test

1.
1.
1.

-->


## Issue

extends #2441 