### PR TITLE
feat(rest): add `ephemeral` field support.

### DIFF
--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -155,17 +155,17 @@ suite "Waku v2 Rest API - Relay":
 
     var messages = @[
       fakeWakuMessage(contentTopic = "content-topic-x", payload = toBytes("TEST-1"),
-        meta = toBytes("test-meta") )
+        meta = toBytes("test-meta"), ephemeral = true)
     ]
 
     # Prevent duplicate messages
     for i in 0..<2:
       var msg = fakeWakuMessage(contentTopic = "content-topic-x", payload = toBytes("TEST-1"),
-        meta = toBytes("test-meta"))
+        meta = toBytes("test-meta"), ephemeral = true)
 
       while msg == messages[i]:
         msg = fakeWakuMessage(contentTopic = "content-topic-x", payload = toBytes("TEST-1"),
-          meta = toBytes("test-meta"))
+          meta = toBytes("test-meta"), ephemeral = true)
 
       messages.add(msg)
 
@@ -192,7 +192,8 @@ suite "Waku v2 Rest API - Relay":
         msg.contentTopic.get() == "content-topic-x" and
         msg.version.get() == 2 and
         msg.timestamp.get() != Timestamp(0) and
-        msg.meta.get() == base64.encode("test-meta")
+        msg.meta.get() == base64.encode("test-meta") and
+        msg.ephemeral.get() == true
 
     check:
       cache.isPubsubSubscribed(pubSubTopic)

--- a/tests/wakunode_rest/test_rest_relay_serdes.nim
+++ b/tests/wakunode_rest/test_rest_relay_serdes.nim
@@ -42,7 +42,8 @@ suite "Waku v2 Rest API - Relay - serialization":
         payload: payload,
         contentTopic: none(ContentTopic),
         version: none(Natural),
-        timestamp: none(int64)
+        timestamp: none(int64),
+        ephemeral: none(bool)
       )
 
       # When

--- a/waku/waku_api/rest/filter/types.nim
+++ b/waku/waku_api/rest/filter/types.nim
@@ -23,6 +23,7 @@ type FilterWakuMessage* = object
       version*: Option[Natural]
       timestamp*: Option[int64]
       meta*: Option[Base64String]
+      ephemeral*: Option[bool]
 
 type FilterGetMessagesResponse* = seq[FilterWakuMessage]
 
@@ -60,7 +61,8 @@ proc toFilterWakuMessage*(msg: WakuMessage): FilterWakuMessage =
     contentTopic: some(msg.contentTopic),
     version: some(Natural(msg.version)),
     timestamp: some(msg.timestamp),
-    meta: if msg.meta.len > 0: some(base64.encode(msg.meta)) else: none(Base64String)
+    meta: if msg.meta.len > 0: some(base64.encode(msg.meta)) else: none(Base64String),
+    ephemeral: some(msg.ephemeral)
   )
 
 proc toWakuMessage*(msg: FilterWakuMessage, version = 0): Result[WakuMessage, string] =
@@ -70,9 +72,10 @@ proc toWakuMessage*(msg: FilterWakuMessage, version = 0): Result[WakuMessage, st
     version = uint32(msg.version.get(version))
     timestamp = msg.timestamp.get(0)
     meta = ?msg.meta.get(Base64String("")).decode()
+    ephemeral = msg.ephemeral.get(false)
 
-  ok(WakuMessage(payload: payload, contentTopic: contentTopic, version: version, 
-    timestamp: timestamp, meta: meta))
+  ok(WakuMessage(payload: payload, contentTopic: contentTopic, version: version,
+    timestamp: timestamp, meta: meta, ephemeral: ephemeral))
 
 #### Serialization and deserialization
 
@@ -88,6 +91,8 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: FilterWakuMessage)
     writer.writeField("timestamp", value.timestamp.get())
   if value.meta.isSome():
     writer.writeField("meta", value.meta.get())
+  if value.ephemeral.isSome():
+    writer.writeField("ephemeral", value.ephemeral.get())
   writer.endRecord()
 
 proc writeValue*(writer: var JsonWriter, value: FilterLegacySubscribeRequest)
@@ -143,6 +148,7 @@ proc readValue*(reader: var JsonReader[RestJson], value: var FilterWakuMessage)
     version = none(Natural)
     timestamp = none(int64)
     meta = none(Base64String)
+    ephemeral = none(bool)
 
   var keys = initHashSet[string]()
   for fieldName in readObjectFields(reader):
@@ -163,6 +169,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var FilterWakuMessage)
       timestamp = some(reader.readValue(int64))
     of "meta":
       meta = some(reader.readValue(Base64String))
+    of "ephemeral":
+      ephemeral = some(reader.readValue(bool))
     else:
       unrecognizedFieldWarning()
 
@@ -174,7 +182,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var FilterWakuMessage)
     contentTopic: contentTopic,
     version: version,
     timestamp: timestamp,
-    meta: meta
+    meta: meta,
+    ephemeral: ephemeral,
   )
 
 proc readValue*(reader: var JsonReader[RestJson], value: var FilterLegacySubscribeRequest)

--- a/waku/waku_api/rest/relay/types.nim
+++ b/waku/waku_api/rest/relay/types.nim
@@ -23,6 +23,7 @@ type RelayWakuMessage* = object
       version*: Option[Natural]
       timestamp*: Option[int64]
       meta*: Option[Base64String]
+      ephemeral*: Option[bool]
 
 type
   RelayGetMessagesResponse* = seq[RelayWakuMessage]
@@ -36,7 +37,8 @@ proc toRelayWakuMessage*(msg: WakuMessage): RelayWakuMessage =
     contentTopic: some(msg.contentTopic),
     version: some(Natural(msg.version)),
     timestamp: some(msg.timestamp),
-    meta: if msg.meta.len > 0: some(base64.encode(msg.meta)) else: none(Base64String)
+    meta: if msg.meta.len > 0: some(base64.encode(msg.meta)) else: none(Base64String),
+    ephemeral: some(msg.ephemeral)
   )
 
 proc toWakuMessage*(msg: RelayWakuMessage, version = 0): Result[WakuMessage, string] =
@@ -45,6 +47,7 @@ proc toWakuMessage*(msg: RelayWakuMessage, version = 0): Result[WakuMessage, str
     contentTopic = msg.contentTopic.get(DefaultContentTopic)
     version = uint32(msg.version.get(version))
     meta = ?msg.meta.get(Base64String("")).decode()
+    ephemeral = msg.ephemeral.get(false)
 
   var timestamp = msg.timestamp.get(0)
 
@@ -52,7 +55,7 @@ proc toWakuMessage*(msg: RelayWakuMessage, version = 0): Result[WakuMessage, str
     timestamp = getNanosecondTime(getTime().toUnixFloat())
 
   return ok(WakuMessage(payload: payload, contentTopic: contentTopic, version: version,
-    timestamp: timestamp, meta: meta))
+    timestamp: timestamp, meta: meta, ephemeral: ephemeral))
 
 #### Serialization and deserialization
 
@@ -68,6 +71,8 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: RelayWakuMessage)
     writer.writeField("timestamp", value.timestamp.get())
   if value.meta.isSome():
     writer.writeField("meta", value.meta.get())
+  if value.ephemeral.isSome():
+    writer.writeField("ephemeral", value.ephemeral.get())
   writer.endRecord()
 
 proc readValue*(reader: var JsonReader[RestJson], value: var RelayWakuMessage)
@@ -78,6 +83,7 @@ proc readValue*(reader: var JsonReader[RestJson], value: var RelayWakuMessage)
     version = none(Natural)
     timestamp = none(int64)
     meta = none(Base64String)
+    ephemeral = none(bool)
 
   var keys = initHashSet[string]()
   for fieldName in readObjectFields(reader):
@@ -98,6 +104,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var RelayWakuMessage)
       timestamp = some(reader.readValue(int64))
     of "meta":
       meta = some(reader.readValue(Base64String))
+    of "ephemeral":
+      ephemeral = some(reader.readValue(bool))
     else:
       unrecognizedFieldWarning()
 
@@ -112,5 +120,6 @@ proc readValue*(reader: var JsonReader[RestJson], value: var RelayWakuMessage)
     contentTopic: contentTopic,
     version: version,
     timestamp: timestamp,
-    meta: meta
+    meta: meta,
+    ephemeral: ephemeral
   )


### PR DESCRIPTION
# Description
Adds support to use the `ephemeral` field in the Waku messages with REST api as described in https://github.com/waku-org/waku-rest-api/pull/2

## Issue

closes #2436
