### PR TITLE
chore(vendor): update nim-libp2p path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	branch = master
 [submodule "vendor/nim-libp2p"]
 	path = vendor/nim-libp2p
-	url = https://github.com/status-im/nim-libp2p.git
+	url = https://github.com/vacp2p/nim-libp2p.git
 	ignore = dirty
 	branch = unstable
 [submodule "vendor/nim-stew"]


### PR DESCRIPTION
# Description

Update nim-libp2p path.

nim-libp2p has been moved from status to the vacp2p github org.