### PR TITLE
fix(rest): filter/v2/subscriptions response

### DIFF
--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -246,7 +246,7 @@ suite "Waku v2 Rest API - Filter V2":
       pingResponse.status == 200
       $pingResponse.contentType == $MIMETYPE_JSON
       pingResponse.data.requestId == "9999"
-      pingResponse.data.statusDesc.len() == 0
+      pingResponse.data.statusDesc == "OK"
 
     # When - error case
     let requestBodyUnsubAll = FilterUnsubscribeAllRequest(requestId: "9988")
@@ -288,7 +288,7 @@ suite "Waku v2 Rest API - Filter V2":
       pingResponse.status == 200
       $pingResponse.contentType == $MIMETYPE_JSON
       pingResponse.data.requestId == "9999"
-      pingResponse.data.statusDesc.len() == 0
+      pingResponse.data.statusDesc == "OK"
 
     # When - message push
     let testMessage = WakuMessage(

--- a/waku/waku_api/rest/filter/types.nim
+++ b/waku/waku_api/rest/filter/types.nim
@@ -47,7 +47,6 @@ type FilterUnsubscribeAllRequest* = object
 
 type FilterSubscriptionResponse* = object
   requestId*: string
-  statusCode*: uint32
   statusDesc*: string
 
 #### Type conversion
@@ -119,7 +118,6 @@ proc writeValue*(
 ) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("requestId", value.requestId)
-  writer.writeField("statusCode", value.statusCode)
   writer.writeField("statusDesc", value.statusDesc)
   writer.endRecord()
 
@@ -406,7 +404,6 @@ proc readValue*(
 ) {.raises: [SerializationError, IOError].} =
   var
     requestId = none(string)
-    statusCode = none(uint32)
     statusDesc = none(string)
 
   var keys = initHashSet[string]()
@@ -423,8 +420,6 @@ proc readValue*(
     case fieldName
     of "requestId":
       requestId = some(reader.readValue(string))
-    of "statusCode":
-      statusCode = some(reader.readValue(uint32))
     of "statusDesc":
       statusDesc = some(reader.readValue(string))
     else:
@@ -435,6 +430,5 @@ proc readValue*(
 
   value = FilterSubscriptionResponse(
     requestId: requestId.get(),
-    statusCode: statusCode.get(),
     statusDesc: statusDesc.get(""),
   )


### PR DESCRIPTION
# Description
Returns a "OK" for the response when subscription is succesful, and also removes the status code from the response as it is not part of the API. Ping responses also return "OK" when succesful.

## Issue

closes https://github.com/waku-org/nwaku/issues/2286