### PR TITLE
chore: content_script_version_2: add simple protection and rm messages_backup if exists

### DIFF
--- a/migrations/message_store_postgres/content_script_version_2.nim
+++ b/migrations/message_store_postgres/content_script_version_2.nim
@@ -1,4 +1,5 @@
 const ContentScriptVersion_2* = """
+DROP TABLE IF EXISTS messages_backup;
 ALTER TABLE messages RENAME TO messages_backup;
 ALTER TABLE messages_backup DROP CONSTRAINT messageIndex;
 


### PR DESCRIPTION

## Description
This is aimed to add a simple protection. If the `messages_backup` exists, then delete it.
Notice that this would only protect the users that are now running a version lower than `v0.26.0`, and update their nodes to a version >= `v0.27.0`.

## How to test

1. Run a node with store protocol enabled for a while and version ' v0.25.0`. Wait until some messages are written (I've tested it with ~3.6GB database.)
2. Run a node from this branch and 


## Issue

closes https://github.com/waku-org/nwaku-compose/issues/75
