### PR TITLE
fix: postgres_driver.nim  make sure the partition list is loaded in correct order

### DIFF
--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -245,6 +245,7 @@ proc getPartitionsList(
                           JOIN pg_namespace nmsp_parent   ON nmsp_parent.oid  = parent.relnamespace
                           JOIN pg_namespace nmsp_child    ON nmsp_child.oid   = child.relnamespace
                           WHERE parent.relname='messages'
+                          ORDER BY partition_name ASC
                           """,
       newSeq[string](0),
       rowCallback,


### PR DESCRIPTION
## Description
This PR fixes an issue where the list of partitions wasn't obtained correctly.
A node operator, @redwhiteeee , informed about the error:

![image](https://github.com/waku-org/nwaku/assets/128452529/ce80e5c5-8357-4803-b681-7807c47ea7f7)

That was caused because the list of partitions was obtained in random order, as can be seen in the following image:

![image](https://github.com/waku-org/nwaku/assets/128452529/452cf57f-0797-4cfd-b62e-eb5bb2f3b44f)

## Changes

- [x] Obtain the current partition set ordered chronologically.
