### PR TITLE
fix: remove subscription queue limit

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -153,7 +153,7 @@ proc new*(
 
   info "Initializing networking", addrs = $netConfig.announcedAddresses
 
-  let queue = newAsyncEventQueue[SubscriptionEvent](30)
+  let queue = newAsyncEventQueue[SubscriptionEvent](0)
 
   let node = WakuNode(
     peerManager: peerManager,


### PR DESCRIPTION
# Description
I removed the limit on the number of subscription events the queue can handle.

Close https://github.com/waku-org/nwaku/issues/2550