### PR TITLE
fix(rln): set a minimum epoch gap

### DIFF
--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -452,14 +452,14 @@ proc mount(
       nonceManager:
         NonceManager.init(conf.rlnRelayUserMessageLimit, conf.rlnEpochSizeSec.float),
       rlnEpochSizeSec: conf.rlnEpochSizeSec,
-      rlnMaxEpochGap: uint64(MaxClockGapSeconds / float64(conf.rlnEpochSizeSec)),
+      rlnMaxEpochGap: max(uint64(MaxClockGapSeconds / float64(conf.rlnEpochSizeSec)), 1),
       onFatalErrorAction: conf.onFatalErrorAction,
     )
   else:
     return WakuRLNRelay(
       groupManager: groupManager,
       rlnEpochSizeSec: conf.rlnEpochSizeSec,
-      rlnMaxEpochGap: uint64(MaxClockGapSeconds / float64(conf.rlnEpochSizeSec)),
+      rlnMaxEpochGap: max(uint64(MaxClockGapSeconds / float64(conf.rlnEpochSizeSec)), 1),
       onFatalErrorAction: conf.onFatalErrorAction,
     )
 


### PR DESCRIPTION
# Description
* Fixes `rlnMaxEpochGap`, so that a minimum of `1` is set.
* This produced a bug noticed in `RLN v2` where setting a high `rlnEpochSizeSec` caused `rlnMaxEpochGap=0` which caused problems in `clearNullifierLog`.

