### PR TITLE
fix: cluster-id 0 discv5 issue

### DIFF
--- a/apps/wakunode2/networks_config.nim
+++ b/apps/wakunode2/networks_config.nim
@@ -16,7 +16,17 @@ type ClusterConf* = object
   discv5Discovery*: bool
   discv5BootstrapNodes*: seq[string]
 
-# cluster-id=1
+# cluster-id=0
+# Cluster configuration for the default pubsub topic. Note that it
+# overrides existing cli configuration
+proc ClusterZeroConf*(T: type ClusterConf): ClusterConf =
+  return ClusterConf(
+    clusterId: 0.uint32,
+    pubsubTopics: @["/waku/2/default-waku/proto"]
+    # TODO: Add more config such as bootstrap, etc
+  )
+
+# cluster-id=1 (aka The Waku Network)
 # Cluster configuration corresponding to The Waku Network. Note that it
 # overrides existing cli configuration
 proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -87,26 +87,34 @@ when isMainModule:
   of inspectRlnDb:
     doInspectRlnDb(conf)
   of noCommand:
-    # The Waku Network config (cluster-id=1)
-    if conf.clusterId == 1:
-      let twnClusterConf = ClusterConf.TheWakuNetworkConf()
-      if len(conf.shards) != 0:
-        conf.pubsubTopics = conf.shards.mapIt(twnClusterConf.pubsubTopics[it.uint16])
-      else:
-        conf.pubsubTopics = twnClusterConf.pubsubTopics
+    case conf.clusterId
+      # cluster-id=0
+      of 0:
+        let clusterZeroConf = ClusterConf.ClusterZeroConf()
+        conf.pubsubTopics = clusterZeroConf.pubsubTopics
+        # TODO: Write some template to "merge" the configs
+      # cluster-id=1 (aka The Waku Network)
+      of 1:
+        let twnClusterConf = ClusterConf.TheWakuNetworkConf()
+        if len(conf.shards) != 0:
+          conf.pubsubTopics = conf.shards.mapIt(twnClusterConf.pubsubTopics[it.uint16])
+        else:
+          conf.pubsubTopics = twnClusterConf.pubsubTopics
 
-      # Override configuration
-      conf.maxMessageSize = twnClusterConf.maxMessageSize
-      conf.clusterId = twnClusterConf.clusterId
-      conf.rlnRelay = twnClusterConf.rlnRelay
-      conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
-      conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
-      conf.rlnRelayBandwidthThreshold = twnClusterConf.rlnRelayBandwidthThreshold
-      conf.discv5Discovery = twnClusterConf.discv5Discovery
-      conf.discv5BootstrapNodes =
-        conf.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
-      conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
-      conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
+        # Override configuration
+        conf.maxMessageSize = twnClusterConf.maxMessageSize
+        conf.clusterId = twnClusterConf.clusterId
+        conf.rlnRelay = twnClusterConf.rlnRelay
+        conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
+        conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
+        conf.rlnRelayBandwidthThreshold = twnClusterConf.rlnRelayBandwidthThreshold
+        conf.discv5Discovery = twnClusterConf.discv5Discovery
+        conf.discv5BootstrapNodes =
+          conf.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
+        conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
+        conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
+      else:
+        discard
 
     info "Running nwaku node", version = app.git_version
     logConfig(conf)


### PR DESCRIPTION
# Description
* [This PR](https://github.com/waku-org/nwaku/pull/2556/files#diff-43f34e84eeb9a4b4061898c3bd78274e149e50bd6b5d24aeb0a982e07629172eL300) deprecated `topics` but introduced a regression.
* Since `topics` flag default value `/waku/2/default-waku/proto` was being used when constructing the ENR, after removing that flag, we no longer had a default value.
* This means that eg `wakunode2 --cluster-id=0 ...` discv5 was not working properly, since the node had no default pubsub topic configured.
* This PR fixes it, by setting the default pubsub topic for `cluster-id=0`.
* Other unknown clusters, would need to provide their desired `pubsub-topic`.
