### PR TITLE
fix: regex for rpc endpoint

### DIFF
--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -680,9 +680,9 @@ proc parseCmdArg*(T: type EthRpcUrl, s: string): T =
   ## disallowed patterns:
   ## any valid/invalid ws or wss url
   var httpPattern =
-    re2"^(https?):\/\/((localhost)|([\w_-]+(?:(?:\.[\w_-]+)+)))(:[0-9]{1,5})?([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])*"
+    re2"^(https?):\/\/([\w-]+(\.[\w-]+)*)(:[0-9]{1,5})?(\/[\w.,@?^=%&:\/~+#-]*)?$"
   var wsPattern =
-    re2"^(wss?):\/\/((localhost)|([\w_-]+(?:(?:\.[\w_-]+)+)))(:[0-9]{1,5})?([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])*"
+    re2"^(wss?):\/\/([\w-]+(\.[\w-]+)+)(:[0-9]{1,5})?(\/[\w.,@?^=%&:\/~+#-]*)?$"
   if regex.match(s, wsPattern):
     raise newException(
       ValueError, "Websocket RPC URL is not supported, Please use an HTTP URL"


### PR DESCRIPTION
# Description
* The regex matching `--rln-relay-eth-client-address` flag was not allowing some valid RPC urls.
* Example, this should be valid `http://foundry:8545`
* But was failing:
```
Error while processing the rln-relay-eth-client-address=http://foundry:8545 parameter: Invalid HTTP RPC URL
```
* This PR fixes it so that it allows such URLs.

It can be also reproduced with:

```bash
docker run harbor.status.im/wakuorg/nwaku@sha256:d193792202726c51cd656c48f4ffd04f261ec2d8663a00591947a5aab3677dc5 --rln-relay-eth-client-address="http://foundry:3000"

Error while processing the rln-relay-eth-client-address=http://foundry:3000 parameter: Invalid HTTP RPC URL
Try wakunode2 --help for more information
```