### PR TITLE
fix: Dockerfile: workaround to allow creation of docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq rust c
 WORKDIR /app
 COPY . .
 
+# workaround for alpine issue: https://github.com/alpinelinux/docker-alpine/issues/383
+RUN apk update && apk upgrade
+
 # Ran separately from 'make' to avoid re-doing
 RUN git submodule update --init --recursive
 


### PR DESCRIPTION
## Description

Workaround to overcome a docker alpine issue that happened while creating images:
![image](https://github.com/waku-org/nwaku/assets/128452529/d57a3810-1626-4d3c-8853-8fd84cb93d14)
