### PR TITLE
fix: Dockerfile: fix issue creating images due to missing semaphore dependency in zerokit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ COPY . .
 # Ran separately from 'make' to avoid re-doing
 RUN git submodule update --init --recursive
 
+# Temporary workaround to overcome building issues with zerokit
+RUN rm -r ./vendor/zerokit/semaphore
+RUN sed -i.bak -e '23,25d;5d' ./vendor/zerokit/Cargo.toml
+
 # Slowest build step for the sake of caching layers
 RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1 ${NIM_COMMIT}
 


### PR DESCRIPTION
## Description

Temporary workaround to overcome issues when creating images from Dockerfile

We got the following error in Jenkins job:

```
19:34:12  #13 0.598 package:   /app/vendor/zerokit/semaphore/Cargo.toml
19:34:12  #13 0.598 workspace: /app/vendor/zerokit/Cargo.toml
19:34:12  #13 0.632 warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
19:34:12  #13 0.632 package:   /app/vendor/zerokit/semaphore/Cargo.toml
19:34:12  #13 0.632 workspace: /app/vendor/zerokit/Cargo.toml
19:34:12  #13 0.709     Updating crates.io index
19:34:12  #13 0.709     Updating git repository `[https://github.com/gakonst/ark-circom`](https://github.com/gakonst/ark-circom%60)
19:34:14  #13 2.327     Updating git repository `[https://github.com/arkworks-rs/groth16`](https://github.com/arkworks-rs/groth16%60)
19:34:15  #13 3.652     Updating git repository `[https://github.com/worldcoin/semaphore-rs`](https://github.com/worldcoin/semaphore-rs%60)
19:34:16  #13 4.814     Updating git submodule `[https://github.com/appliedzkp/semaphore.git`](https://github.com/appliedzkp/semaphore.git%60)
19:34:17  #13 6.252 error: failed to get `semaphore` as a dependency of package `semaphore-wrapper v0.3.0 (/app/vendor/zerokit/semaphore)`
19:34:17  #13 6.252 
19:34:17  #13 6.252 Caused by:
19:34:17  #13 6.252   failed to load source for dependency `semaphore`
19:34:17  #13 6.252 
19:34:17  #13 6.252 Caused by:
19:34:17  #13 6.252   Unable to update https://github.com/worldcoin/semaphore-rs?rev=ee658c2#ee658c22
19:34:17  #13 6.252 
19:34:17  #13 6.252 Caused by:
19:34:17  #13 6.252   failed to update submodule `semaphore`
19:34:17  #13 6.252 
19:34:17  #13 6.252 Caused by:
19:34:17  #13 6.252   object not found - no match for id (5186a940ff495ff163bd5779631a716d0bf96507); class=Odb (9); code=NotFound (-3)
19:34:17  #13 6.257 make: *** [Makefile:150: librln_v0.3.6.a] Error 101
19:34:17  #13 ERROR: process "/bin/sh -c make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS=\"${NIMFLAGS}\"" did not complete successfully: exit code: 2
```
