### PR TITLE
chore: Extend release process with the need of merging back release branch to master

### DIFF
--- a/docs/contributors/release-process.md
+++ b/docs/contributors/release-process.md
@@ -57,11 +57,15 @@ Ensure all items in this list are ticked:
     ```
 
 1. Once the release-candidate has been validated, create a final release tag and push it.
+We also need to merge release branch back to master as a final step.
 
     ```
     git checkout release/v0.1.0
     git tag -as v0.1.0 -m "Initial release."
     git push origin v0.1.0
+    git switch master
+    git pull
+    git merge release/v0.1.0
     ```
 
 1. Create a [Github release](https://github.com/waku-org/nwaku/releases) from the release tag.


### PR DESCRIPTION
Just to simple fix of our release notation gone wrong on releases/images made from master, there is a need to merge the release branch - that got tagged with the release tag - back to master. 
This helps git to find the last relevant tag on the path for versioning the build.