### PR TITLE
chore(rln): update submodule + rln patch version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,9 +135,9 @@ clean: | clean-libbacktrace
 
 LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit
 ifeq ($(RLN_V2),true)
-LIBRLN_VERSION := v0.4.2
+LIBRLN_VERSION := v0.4.3
 else
-LIBRLN_VERSION := v0.3.6
+LIBRLN_VERSION := v0.3.7
 endif
 
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
An error reported by @IvanSete-status provided an opportunity to drop unused crates from zerokit that were initially used for testing of hypotheses.


# Changes

<!-- List of detailed changes -->

- [x] bump rln-v1 to v0.3.7
- [x] bump rln-v2 to 0.4.3

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
