### PR TITLE
fix: node restart test issue

### DIFF
--- a/tests/waku_relay/utils.nim
+++ b/tests/waku_relay/utils.nim
@@ -12,7 +12,6 @@ proc noopRawHandler*(): WakuRelayHandler =
 
 proc newTestWakuRelay*(switch = newTestSwitch()): Future[WakuRelay] {.async.} =
   let proto = WakuRelay.new(switch).tryGet()
-  await proto.start()
 
   let protocolMatcher = proc(proto: string): bool {.gcsafe.} =
     return proto.startsWith(WakuRelayCodec)

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -61,7 +61,6 @@ const TopicParameters = TopicParams(
 
 # see: https://rfc.vac.dev/spec/29/#gossipsub-v10-parameters
 const GossipsubParameters = GossipSubParams.init(
-  explicit = true,
   pruneBackoff = chronos.minutes(1),
   unsubscribeBackoff = chronos.seconds(5),
   floodPublish = true,


### PR DESCRIPTION
## Description
It has been detected an issue regarding node restart and reconnection. After reconnecting, the messages didn't get its destination.

# Changes

- [x] The actual fix is provided by nim-libp2p update, and particularly the following commit: https://github.com/vacp2p/nim-libp2p/commit/b30b2656d52ee304bd56f8f8bbf59ab82b658a36
- [x] Simplify the `test_protocol.nim` so that it doesn't start things twice, f.e. the relay

## Issue

Special thanks to @AlejandroCabeza for such a great issue description :partying_face: 

closes https://github.com/waku-org/nwaku/issues/2145
