### PR TITLE
fix(rln-relay): reduce sync time

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -606,6 +606,8 @@ proc startOnchainSync(
 
   # static block chunk size
   let blockChunkSize = 2_000
+  # delay between rpc calls to not overload the rate limit
+  let rpcDelay = 200.milliseconds
 
   var fromBlock =
     if g.latestProcessedBlock > g.rlnContractDeployedBlockNumber:
@@ -616,25 +618,42 @@ proc startOnchainSync(
         blockNumber = g.rlnContractDeployedBlockNumber
       g.rlnContractDeployedBlockNumber
 
+  var futs = newSeq[Future[bool]]()
+  var currentLatestBlock: BlockNumber
+  g.retryWrapper(currentLatestBlock, "Failed to get the latest block number"):
+    cast[BlockNumber](await ethRpc.provider.eth_blockNumber())
+  
   try:
     # we always want to sync from last processed block => latest
     # chunk events
     while true:
-      var currentLatestBlock: BlockNumber
-      g.retryWrapper(currentLatestBlock, "Failed to get the latest block number"):
-        cast[BlockNumber](await ethRpc.provider.eth_blockNumber())
+      # if the fromBlock is less than 2k blocks behind the current block
+      # then fetch the new toBlock
       if fromBlock >= currentLatestBlock:
         break
+      
+      if fromBlock + blockChunkSize.uint > currentLatestBlock.uint:
+        g.retryWrapper(currentLatestBlock, "Failed to get the latest block number"):
+          cast[BlockNumber](await ethRpc.provider.eth_blockNumber())
+      
 
       let toBlock = min(fromBlock + BlockNumber(blockChunkSize), currentLatestBlock)
       debug "fetching events", fromBlock = fromBlock, toBlock = toBlock
-      var handleBlockRes: bool
-      g.retryWrapper(handleBlockRes, "Failed to handle old blocks"):
-        await g.getAndHandleEvents(fromBlock, toBlock)
+      await sleepAsync(rpcDelay)
+      futs.add(g.getAndHandleEvents(fromBlock, toBlock))
       fromBlock = toBlock + 1
+    for fut in futs:
+      try:
+        var handleBlockRes: bool
+        g.retryWrapper(handleBlockRes, "Failed to handle block"):
+          await fut
+      except CatchableError:
+        raise newException(
+          CatchableError, "could not fetch events from block: " & getCurrentExceptionMsg()
+        )
   except CatchableError:
     raise newException(
-      ValueError,
+      CatchableError,
       "failed to get the history/reconcile missed blocks: " & getCurrentExceptionMsg(),
     )
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -656,7 +656,7 @@ proc startOnchainSync(
       debug "fetching events", fromBlock = fromBlock, toBlock = toBlock
       await sleepAsync(rpcDelay)
       futs.add(g.getAndHandleEvents(fromBlock, toBlock))
-      if futs.len >= maxFutures:
+      if futs.len >= maxFutures or toBlock == currentLatestBlock:
         await g.batchAwaitBlockHandlingFuture(futs)
         futs = newSeq[Future[bool]]()
       fromBlock = toBlock + 1


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Parallelizes RPC calls during initial sync while maintaining an RPC call delay to ensure client is not throttled.
We have to await them sequentially so we can retry the failed RPC call, maybe this can be improved.

Brings down sync time from 15 mins to ~ ~~2~~ 3 mins.
In retrospect, this is how it should have been done from the start, my fault!

# Changes

<!-- List of detailed changes -->

- [x] Collect futures of rpc calls into seq
- [x] await the futures

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
