### PR TITLE
chore: add ARM64 Docker support for Linux/MacOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # BUILD NIM APP ----------------------------------------------------------------
-
-# alpine:edge supports building rust binaries, alpine:3.16 doesn't for some reason
-FROM alpine@sha256:3e44438281baf26907675b99c9a4a421c4d4a57c954120327e703aa8329086bd  AS nim-build
+FROM rust:1.77.1-alpine3.18  AS nim-build
 
 ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2
@@ -9,7 +7,7 @@ ARG NIM_COMMIT
 ARG LOG_LEVEL=TRACE
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq rust cargo
+RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq
 
 WORKDIR /app
 COPY . .
@@ -29,7 +27,7 @@ RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="
 
 # PRODUCTION IMAGE -------------------------------------------------------------
 
-FROM alpine:3.16 as prod
+FROM alpine:3.18 as prod
 
 ARG MAKE_TARGET=wakunode2
 
@@ -66,7 +64,7 @@ CMD ["--help"]
 # DEBUG IMAGE ------------------------------------------------------------------
 
 # Build debug tools: heaptrack
-FROM alpine:3.16 AS heaptrack-build
+FROM alpine:3.18 AS heaptrack-build
 
 RUN apk update
 RUN apk add -- gdb git g++ make cmake zlib-dev boost-dev libunwind-dev


### PR DESCRIPTION
# Description
Updated Dockerfile to enable Docker image build and run for Linux/MacOS running on ARM64. Tested with Apple M1. 

# Changes
- Build image is based on out of the box Rust images.
- Alpine Linux is still being used, bumped the version a bit. 

# Logs ARM64/Ubuntu 22@VMware Fusion
```
[+] Building 937.6s (20/20) FINISHED                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                    0.0s
 => => transferring dockerfile: 2.90kB                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/rust:1.77.1-alpine3.18                                                                               2.7s
 => [internal] load metadata for docker.io/library/alpine:3.18                                                                                          4.0s
 => [internal] load .dockerignore                                                                                                                       0.0s
 => => transferring context: 129B                                                                                                                       0.0s
 => [nim-build 1/8] FROM docker.io/library/rust:1.77.1-alpine3.18@sha256:ec24f50c9ccff465ce8307b0e80bbebef6d33c4c2c8b436951a9c67e01cf3a7d               0.0s
 => [internal] load build context                                                                                                                       0.2s
 => => transferring context: 15.66MB                                                                                                                    0.2s
 => [prod 1/6] FROM docker.io/library/alpine:3.18@sha256:11e21d7b981a59554b3f822c49f6e9f57b6068bb74f49c4cd5cc4c663c7e5160                               0.0s
 => CACHED [prod 2/6] RUN apk add --no-cache libgcc pcre-dev libpq-dev                                                                                  0.0s
 => CACHED [prod 3/6] RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3                                                                               0.0s
 => CACHED [nim-build 2/8] RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq                                                    0.0s
 => CACHED [nim-build 3/8] WORKDIR /app                                                                                                                 0.0s
 => [nim-build 4/8] COPY . .                                                                                                                            0.1s
 => [nim-build 5/8] RUN apk update && apk upgrade                                                                                                       8.4s
 => [nim-build 6/8] RUN git submodule update --init --recursive                                                                                       275.5s
 => [nim-build 7/8] RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1                                                                               196.5s
 => [nim-build 8/8] RUN make -j$(nproc)  wakunode2 LOG_LEVEL=TRACE NIMFLAGS="-d:chronicles_colors:none -d:insecure -d:postgres "                      451.8s
 => [prod 4/6] COPY --from=nim-build /app/build/wakunode2 /usr/local/bin/                                                                               0.1s
 => [prod 5/6] COPY --from=nim-build /app/migrations/ /app/migrations/                                                                                  0.0s
 => [prod 6/6] RUN ln -sv /usr/local/bin/wakunode2 /usr/bin/wakunode                                                                                    0.1s
 => exporting to image                                                                                                                                  0.3s
 => => exporting layers                                                                                                                                 0.3s
 => => writing image sha256:787f125653cec9b2fdbb0e65768130adbcb7772fc287219806f4c67dadde219d                                                            0.0s
 => => naming to docker.io/wakuorg/nwaku:wakunode2-24f6fe                                                                                               0.0s
roman@ub22:~/sources/nwaku$ uname -a
Linux ub22 5.15.0-102-generic #112-Ubuntu SMP Tue Mar 5 16:49:56 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux

```

# Logs ARM64/Mac OS 13.6.6
```
[+] Building 638.2s (22/22) FINISHED                                                                                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                    0.0s
 => => transferring dockerfile: 2.91kB                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/rust:1.77.1-alpine3.18                                                                               2.7s
 => [internal] load metadata for docker.io/library/alpine:3.18                                                                                          2.9s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                           0.0s
 => [auth] library/rust:pull token for registry-1.docker.io                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                       0.0s
 => => transferring context: 129B                                                                                                                       0.0s
 => CACHED [nim-build 1/8] FROM docker.io/library/rust:1.77.1-alpine3.18@sha256:ec24f50c9ccff465ce8307b0e80bbebef6d33c4c2c8b436951a9c67e01cf3a7d        0.0s
 => [internal] load build context                                                                                                                       0.2s
 => => transferring context: 15.66MB                                                                                                                    0.2s
 => [prod 1/6] FROM docker.io/library/alpine:3.18@sha256:11e21d7b981a59554b3f822c49f6e9f57b6068bb74f49c4cd5cc4c663c7e5160                               0.0s
 => [nim-build 2/8] RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq rust cargo                                               73.3s
 => CACHED [prod 2/6] RUN apk add --no-cache libgcc pcre-dev libpq-dev                                                                                  0.0s
 => CACHED [prod 3/6] RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3                                                                               0.0s
 => [nim-build 3/8] WORKDIR /app                                                                                                                        0.0s
 => [nim-build 4/8] COPY . .                                                                                                                            0.1s
 => [nim-build 5/8] RUN apk update && apk upgrade                                                                                                       4.8s
 => [nim-build 6/8] RUN git submodule update --init --recursive                                                                                       176.5s
 => [nim-build 7/8] RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1                                                                               130.8s
 => [nim-build 8/8] RUN make -j$(nproc)  wakunode2 LOG_LEVEL=TRACE NIMFLAGS="-d:chronicles_colors:none -d:insecure -d:postgres "                      248.8s
 => [prod 4/6] COPY --from=nim-build /app/build/wakunode2 /usr/local/bin/                                                                               0.2s
 => [prod 5/6] COPY --from=nim-build /app/migrations/ /app/migrations/                                                                                  0.0s
 => [prod 6/6] RUN ln -sv /usr/local/bin/wakunode2 /usr/bin/wakunode                                                                                    0.1s
 => exporting to image                                                                                                                                  0.2s
 => => exporting layers                                                                                                                                 0.2s
 => => writing image sha256:68151f6f392ac50954493fb3afd65b43441b4813b68b659e51292afb09e1db7c                                                            0.0s
 => => naming to docker.io/wakuorg/nwaku:wakunode2-24f6fe                                                                                               0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
(base) roman@Brumla nwaku % uname -a
Darwin Brumla.local 22.6.0 Darwin Kernel Version 22.6.0: Mon Feb 19 19:45:09 PST 2024; root:xnu-8796.141.3.704.6~1/RELEASE_ARM64_T6000 arm64
```



