### PR TITLE
chore: add ARM64 Docker support for Linux/MacOS 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # BUILD NIM APP ----------------------------------------------------------------
-
-# alpine:edge supports building rust binaries, alpine:3.16 doesn't for some reason
-FROM alpine@sha256:3e44438281baf26907675b99c9a4a421c4d4a57c954120327e703aa8329086bd  AS nim-build
+FROM rust:1.77.1-alpine3.18  AS nim-build
 
 ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2
@@ -9,7 +7,7 @@ ARG NIM_COMMIT
 ARG LOG_LEVEL=TRACE
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq rust cargo
+RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq
 
 WORKDIR /app
 COPY . .
@@ -29,7 +27,7 @@ RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="
 
 # PRODUCTION IMAGE -------------------------------------------------------------
 
-FROM alpine:3.16 as prod
+FROM alpine:3.18 as prod
 
 ARG MAKE_TARGET=wakunode2
 
@@ -66,7 +64,7 @@ CMD ["--help"]
 # DEBUG IMAGE ------------------------------------------------------------------
 
 # Build debug tools: heaptrack
-FROM alpine:3.16 AS heaptrack-build
+FROM alpine:3.18 AS heaptrack-build
 
 RUN apk update
 RUN apk add -- gdb git g++ make cmake zlib-dev boost-dev libunwind-dev


### PR DESCRIPTION
# Description
Updated Dockerfile to enable Docker image build and run for Linux/MacOS on ARM64. Tested with Apple M1 and Raspberry Pi4.

# Changes
- Build image is based on out of the box Rust images.
- Alpine Linux is still being used, bumped the version a bit. 

# Build Logs Apple M1/Ubuntu 22@VMware Fusion
```
[+] Building 937.6s (20/20) FINISHED                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                    0.0s
 => => transferring dockerfile: 2.90kB                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/rust:1.77.1-alpine3.18                                                                               2.7s
 => [internal] load metadata for docker.io/library/alpine:3.18                                                                                          4.0s
 => [internal] load .dockerignore                                                                                                                       0.0s
 => => transferring context: 129B                                                                                                                       0.0s
 => [nim-build 1/8] FROM docker.io/library/rust:1.77.1-alpine3.18@sha256:ec24f50c9ccff465ce8307b0e80bbebef6d33c4c2c8b436951a9c67e01cf3a7d               0.0s
 => [internal] load build context                                                                                                                       0.2s
 => => transferring context: 15.66MB                                                                                                                    0.2s
 => [prod 1/6] FROM docker.io/library/alpine:3.18@sha256:11e21d7b981a59554b3f822c49f6e9f57b6068bb74f49c4cd5cc4c663c7e5160                               0.0s
 => CACHED [prod 2/6] RUN apk add --no-cache libgcc pcre-dev libpq-dev                                                                                  0.0s
 => CACHED [prod 3/6] RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3                                                                               0.0s
 => CACHED [nim-build 2/8] RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq                                                    0.0s
 => CACHED [nim-build 3/8] WORKDIR /app                                                                                                                 0.0s
 => [nim-build 4/8] COPY . .                                                                                                                            0.1s
 => [nim-build 5/8] RUN apk update && apk upgrade                                                                                                       8.4s
 => [nim-build 6/8] RUN git submodule update --init --recursive                                                                                       275.5s
 => [nim-build 7/8] RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1                                                                               196.5s
 => [nim-build 8/8] RUN make -j$(nproc)  wakunode2 LOG_LEVEL=TRACE NIMFLAGS="-d:chronicles_colors:none -d:insecure -d:postgres "                      451.8s
 => [prod 4/6] COPY --from=nim-build /app/build/wakunode2 /usr/local/bin/                                                                               0.1s
 => [prod 5/6] COPY --from=nim-build /app/migrations/ /app/migrations/                                                                                  0.0s
 => [prod 6/6] RUN ln -sv /usr/local/bin/wakunode2 /usr/bin/wakunode                                                                                    0.1s
 => exporting to image                                                                                                                                  0.3s
 => => exporting layers                                                                                                                                 0.3s
 => => writing image sha256:787f125653cec9b2fdbb0e65768130adbcb7772fc287219806f4c67dadde219d                                                            0.0s
 => => naming to docker.io/wakuorg/nwaku:wakunode2-24f6fe                                                                                               0.0s
roman@ub22:~/sources/nwaku$ uname -a
Linux ub22 5.15.0-102-generic #112-Ubuntu SMP Tue Mar 5 16:49:56 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux

```

# Build Logs Apple M1/Mac OS 13.6.6
```
[+] Building 638.2s (22/22) FINISHED                                                                                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                    0.0s
 => => transferring dockerfile: 2.91kB                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/rust:1.77.1-alpine3.18                                                                               2.7s
 => [internal] load metadata for docker.io/library/alpine:3.18                                                                                          2.9s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                           0.0s
 => [auth] library/rust:pull token for registry-1.docker.io                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                       0.0s
 => => transferring context: 129B                                                                                                                       0.0s
 => CACHED [nim-build 1/8] FROM docker.io/library/rust:1.77.1-alpine3.18@sha256:ec24f50c9ccff465ce8307b0e80bbebef6d33c4c2c8b436951a9c67e01cf3a7d        0.0s
 => [internal] load build context                                                                                                                       0.2s
 => => transferring context: 15.66MB                                                                                                                    0.2s
 => [prod 1/6] FROM docker.io/library/alpine:3.18@sha256:11e21d7b981a59554b3f822c49f6e9f57b6068bb74f49c4cd5cc4c663c7e5160                               0.0s
 => [nim-build 2/8] RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq rust cargo                                               73.3s
 => CACHED [prod 2/6] RUN apk add --no-cache libgcc pcre-dev libpq-dev                                                                                  0.0s
 => CACHED [prod 3/6] RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3                                                                               0.0s
 => [nim-build 3/8] WORKDIR /app                                                                                                                        0.0s
 => [nim-build 4/8] COPY . .                                                                                                                            0.1s
 => [nim-build 5/8] RUN apk update && apk upgrade                                                                                                       4.8s
 => [nim-build 6/8] RUN git submodule update --init --recursive                                                                                       176.5s
 => [nim-build 7/8] RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1                                                                               130.8s
 => [nim-build 8/8] RUN make -j$(nproc)  wakunode2 LOG_LEVEL=TRACE NIMFLAGS="-d:chronicles_colors:none -d:insecure -d:postgres "                      248.8s
 => [prod 4/6] COPY --from=nim-build /app/build/wakunode2 /usr/local/bin/                                                                               0.2s
 => [prod 5/6] COPY --from=nim-build /app/migrations/ /app/migrations/                                                                                  0.0s
 => [prod 6/6] RUN ln -sv /usr/local/bin/wakunode2 /usr/bin/wakunode                                                                                    0.1s
 => exporting to image                                                                                                                                  0.2s
 => => exporting layers                                                                                                                                 0.2s
 => => writing image sha256:68151f6f392ac50954493fb3afd65b43441b4813b68b659e51292afb09e1db7c                                                            0.0s
 => => naming to docker.io/wakuorg/nwaku:wakunode2-24f6fe                                                                                               0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
(base) roman@Brumla nwaku % uname -a
Darwin Brumla.local 22.6.0 Darwin Kernel Version 22.6.0: Mon Feb 19 19:45:09 PST 2024; root:xnu-8796.141.3.704.6~1/RELEASE_ARM64_T6000 arm64
```

# Build Logs Cortex-A72/Debian 12

```
make docker-image
.
.
.
Cloning into '/home/roman/sources/nwaku/vendor/zerokit/rln/vendor/rln'...
Submodule path 'vendor/zerokit/rln/vendor/rln': checked out 'fc86ad156ac55b7f805b82ff98501e4eb567bcef'

Sending build context to Docker daemon  16.01MB
Step 1/29 : FROM rust:1.77.1-alpine3.18  AS nim-build
1.77.1-alpine3.18: Pulling from library/rust
c6b39de5b339: Pull complete
30b1cd0d662b: Pull complete
cf79526e3247: Pull complete
Digest: sha256:ec24f50c9ccff465ce8307b0e80bbebef6d33c4c2c8b436951a9c67e01cf3a7d
Status: Downloaded newer image for rust:1.77.1-alpine3.18
 ---> 86a6a49fd843
Step 2/29 : ARG NIMFLAGS
 ---> Running in f95517474bc9
Removing intermediate container f95517474bc9
 ---> a070bbcbcaea
Step 3/29 : ARG MAKE_TARGET=wakunode2
 ---> Running in 81ff6cbb44ba
Removing intermediate container 81ff6cbb44ba
 ---> 4e1190fd0c75
Step 4/29 : ARG NIM_COMMIT
 ---> Running in ad6f0d569fc9
Removing intermediate container ad6f0d569fc9
 ---> b6b9d6104df0
Step 5/29 : ARG LOG_LEVEL=TRACE
 ---> Running in fec83668b24d
Removing intermediate container fec83668b24d
 ---> 04d5756a139b
Step 6/29 : RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq
 ---> Running in e168f252a84c
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
(1/32) Installing ncurses-terminfo-base (6.4_p20230506-r0)
(2/32) Installing libncursesw (6.4_p20230506-r0)
(3/32) Installing readline (8.2.1-r1)
(4/32) Installing bash (5.2.15-r5)
Executing bash-5.2.15-r5.post-install
(5/32) Installing libmagic (5.45-r0)
(6/32) Installing file (5.45-r0)
(7/32) Installing libstdc++-dev (12.2.1_git20220924-r10)
(8/32) Installing musl-dev (1.2.4-r2)
(9/32) Installing libc-dev (0.7.2-r5)
(10/32) Installing g++ (12.2.1_git20220924-r10)
(11/32) Installing make (4.4.1-r1)
(12/32) Installing fortify-headers (1.1-r3)
(13/32) Installing patch (2.7.6-r10)
(14/32) Installing build-base (0.5-r3)
(15/32) Installing brotli-libs (1.0.9-r14)
(16/32) Installing libunistring (1.1-r1)
(17/32) Installing libidn2 (2.3.4-r1)
(18/32) Installing nghttp2-libs (1.57.0-r0)
(19/32) Installing libcurl (8.5.0-r0)
(20/32) Installing curl (8.5.0-r0)
(21/32) Installing libexpat (2.6.2-r0)
(22/32) Installing pcre2 (10.42-r1)
(23/32) Installing git (2.40.1-r0)
(24/32) Installing oniguruma (6.9.8-r1)
(25/32) Installing jq (1.6-r4)
(26/32) Installing linux-headers (6.3-r0)
(27/32) Installing libpcre16 (8.45-r3)
(28/32) Installing libpcre32 (8.45-r3)
(29/32) Installing pcre (8.45-r3)
(30/32) Installing libpcrecpp (8.45-r3)
(31/32) Installing pkgconf (1.9.5-r0)
(32/32) Installing pcre-dev (8.45-r3)
Executing busybox-1.36.1-r5.trigger
OK: 269 MiB in 59 packages
Removing intermediate container e168f252a84c
 ---> f59df25910da
Step 7/29 : WORKDIR /app
 ---> Running in abcc6851cd46
Removing intermediate container abcc6851cd46
 ---> d019a9766c56
Step 8/29 : COPY . .
 ---> b66933170420
Step 9/29 : RUN apk update && apk upgrade
 ---> Running in 302e3f13d9a3
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
v3.18.6-146-g796e70ee040 [https://dl-cdn.alpinelinux.org/alpine/v3.18/main]
v3.18.6-147-gafcc0e405df [https://dl-cdn.alpinelinux.org/alpine/v3.18/community]
OK: 19951 distinct packages available
Upgrading critical system libraries and apk-tools:
(1/1) Upgrading apk-tools (2.14.0-r2 -> 2.14.3-r1)
Executing busybox-1.36.1-r5.trigger
Continuing the upgrade transaction with new apk-tools:
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
(1/4) Upgrading ca-certificates-bundle (20230506-r0 -> 20240226-r0)
(2/4) Upgrading libcrypto3 (3.1.4-r5 -> 3.1.4-r6)
(3/4) Upgrading libssl3 (3.1.4-r5 -> 3.1.4-r6)
(4/4) Upgrading ca-certificates (20230506-r0 -> 20240226-r0)
Executing busybox-1.36.1-r5.trigger
Executing ca-certificates-20240226-r0.trigger
OK: 269 MiB in 59 packages
Removing intermediate container 302e3f13d9a3
 ---> 1de987c6a1e1
Step 10/29 : RUN git submodule update --init --recursive
 ---> Running in 216592bd9d7c
.
.
.
Removing intermediate container 1471f7d810af
 ---> 1da30f87fd59
Step 13/29 : FROM alpine:3.18 as prod
3.18: Pulling from library/alpine
c6b39de5b339: Already exists
Digest: sha256:11e21d7b981a59554b3f822c49f6e9f57b6068bb74f49c4cd5cc4c663c7e5160
Status: Downloaded newer image for alpine:3.18
 ---> 33abbf032149
Step 14/29 : ARG MAKE_TARGET=wakunode2
 ---> Running in fa01544d3fc9
Removing intermediate container fa01544d3fc9
 ---> d3d020fe5fc5
Step 15/29 : LABEL maintainer="jakub@status.im"
 ---> Running in 8cad41182cac
Removing intermediate container 8cad41182cac
 ---> b9044d0bed09
Step 16/29 : LABEL source="https://github.com/waku-org/nwaku"
 ---> Running in 984cacdbc1d4
Removing intermediate container 984cacdbc1d4
 ---> 836aed50dbae
Step 17/29 : LABEL description="Wakunode: Waku client"
 ---> Running in ffb0d512bb93
Removing intermediate container ffb0d512bb93
 ---> 491abf1f44d5
Step 18/29 : LABEL commit="unknown"
 ---> Running in 63d7360f1dc5
Removing intermediate container 63d7360f1dc5
 ---> 086c8178e068
Step 19/29 : LABEL version="unknown"
 ---> Running in d33263925f59
Removing intermediate container d33263925f59
 ---> 23361ba22813
Step 20/29 : EXPOSE 30303 60000 8545
 ---> Running in b7a6bf7a9713
Removing intermediate container b7a6bf7a9713
 ---> b62673130518
Step 21/29 : RUN apk add --no-cache libgcc pcre-dev libpq-dev
 ---> Running in 2447dab9ac23
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
(1/13) Upgrading libcrypto3 (3.1.4-r5 -> 3.1.4-r6)
(2/13) Upgrading libssl3 (3.1.4-r5 -> 3.1.4-r6)
(3/13) Installing libgcc (12.2.1_git20220924-r10)
(4/13) Installing libpq (15.6-r0)
(5/13) Installing pkgconf (1.9.5-r0)
(6/13) Installing openssl-dev (3.1.4-r6)
(7/13) Installing libpq-dev (15.6-r0)
(8/13) Installing libpcre16 (8.45-r3)
(9/13) Installing libpcre32 (8.45-r3)
(10/13) Installing pcre (8.45-r3)
(11/13) Installing libstdc++ (12.2.1_git20220924-r10)
(12/13) Installing libpcrecpp (8.45-r3)
(13/13) Installing pcre-dev (8.45-r3)
Executing busybox-1.36.1-r5.trigger
OK: 17 MiB in 26 packages
Removing intermediate container 2447dab9ac23
 ---> 91a2abb2a7a9
Step 22/29 : RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 ---> Running in 2715e7349ff4
Removing intermediate container 2715e7349ff4
 ---> 6a9cac974c2e
Step 23/29 : COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 ---> 33e9c61abbbc
Step 24/29 : COPY --from=nim-build /app/migrations/ /app/migrations/
 ---> f591a7272653
Step 25/29 : RUN ln -sv /usr/local/bin/$MAKE_TARGET /usr/bin/wakunode
 ---> Running in 1eee0b92ea64
'/usr/bin/wakunode' -> '/usr/local/bin/wakunode2'
Removing intermediate container 1eee0b92ea64
 ---> 795a0913d892
Step 26/29 : ENTRYPOINT ["/usr/bin/wakunode"]
 ---> Running in 0583ed8c4c79
Removing intermediate container 0583ed8c4c79
 ---> 6ae0c8728944
Step 27/29 : CMD ["--help"]
 ---> Running in 48883b645e31
Removing intermediate container 48883b645e31
 ---> 31d4c28d48b6
Step 28/29 : LABEL commit=24f6fed89852ddbc6f9c00d669c76e33c5a47af3
 ---> Running in 5b138ecd0a86
Removing intermediate container 5b138ecd0a86
 ---> 3b9398acfa8a
Step 29/29 : LABEL version=24f6fe
 ---> Running in ba62995e4626
Removing intermediate container ba62995e4626
 ---> f656852593d5
Successfully built f656852593d5
Successfully tagged wakuorg/nwaku:wakunode2-24f6fe
roman@puncocha:~/sources/nwaku$ uname -a
Linux puncocha 6.1.0-17-arm64 #1 SMP Debian 6.1.69-1 (2023-12-30) aarch64 GNU/Linux
```



# Tested on Docker versions
```
Client:
 Cloud integration: v1.0.35+desktop.11
 Version:           25.0.3
 API version:       1.44
 Go version:        go1.21.6
 Git commit:        4debf41
 Built:             Tue Feb  6 21:13:26 2024
 OS/Arch:           darwin/arm64
 Context:           desktop-linux

Server: Docker Desktop 4.28.0 (139021)
 Engine:
  Version:          25.0.3
  API version:      1.44 (minimum version 1.24)
  Go version:       go1.21.6
  Git commit:       f417435
  Built:            Tue Feb  6 21:14:22 2024
  OS/Arch:          linux/arm64
  Experimental:     false

---
Client: Docker Engine - Community
 Version:           26.0.0
 API version:       1.45
 Go version:        go1.21.8
 Git commit:        2ae903e
 Built:             Wed Mar 20 15:18:14 2024
 OS/Arch:           linux/arm64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          26.0.0
  API version:      1.45 (minimum version 1.24)
  Go version:       go1.21.8
  Git commit:       8b79278
  Built:            Wed Mar 20 15:18:14 2024
  OS/Arch:          linux/arm64
  Experimental:     false

---
Client:
 Version:           20.10.24+dfsg1
 API version:       1.41
 Go version:        go1.19.8
 Git commit:        297e128
 Built:             Thu May 18 08:41:26 2023
 OS/Arch:           linux/arm64
 Context:           default
 Experimental:      true

Server:
 Engine:
  Version:          20.10.24+dfsg1
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.19.8
  Git commit:       5d6db84
  Built:            Thu May 18 08:41:26 2023
  OS/Arch:          linux/arm64
  Experimental:     false

--- (Intel for regression)
Client: Docker Engine - Community
 Version:           26.0.0
 API version:       1.45
 Go version:        go1.21.8
 Git commit:        2ae903e
 Built:             Wed Mar 20 15:17:48 2024
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          26.0.0
  API version:      1.45 (minimum version 1.24)
  Go version:       go1.21.8
  Git commit:       8b79278
  Built:            Wed Mar 20 15:17:48 2024
  OS/Arch:          linux/amd64
  Experimental:     false

```

