### PR TITLE
fix: create options api for cors preflight request.

### DIFF
--- a/tests/wakunode_rest/test_rest_cors.nim
+++ b/tests/wakunode_rest/test_rest_cors.nim
@@ -86,7 +86,9 @@ proc checkResponse(
       expectedOrigin.isSome() and
       response.headers.contains("Access-Control-Allow-Origin") and
       response.headers.getLastString("Access-Control-Allow-Origin") ==
-      expectedOrigin.get()
+        expectedOrigin.get() and
+      response.headers.contains("Access-Control-Allow-Headers") and
+      response.headers.getLastString("Access-Control-Allow-Headers") == "Content-Type"
     )
   ):
     echo(

--- a/waku/waku_api/rest/origin_handler.nim
+++ b/waku/waku_api/rest/origin_handler.nim
@@ -93,12 +93,14 @@ proc originMiddlewareProc(
       if origin.len == 1:
         if self.everyOriginAllowed:
           response.addHeader("Access-Control-Allow-Origin", "*")
+          response.addHeader("Access-Control-Allow-Headers", "Content-Type")
         elif self.originsMatch(origin[0]):
           # The Vary: Origin header to must be set to prevent
           # potential cache poisoning attacks:
           # https://textslashplain.com/2018/08/02/cors-and-vary/
           response.addHeader("Vary", "Origin")
           response.addHeader("Access-Control-Allow-Origin", origin[0])
+          response.addHeader("Access-Control-Allow-Headers", "Content-Type")
         else:
           return await request.respond(Http403, "Origin not allowed")
       elif origin.len == 0:

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -46,6 +46,9 @@ const ROUTE_RELAY_AUTO_MESSAGESV1_NO_TOPIC* = "/relay/v1/auto/messages"
 proc installRelayApiHandlers*(
     router: var RestRouter, node: WakuNode, cache: MessageCache
 ) =
+  router.api(MethodOptions, ROUTE_RELAY_SUBSCRIPTIONSV1) do() -> RestApiResponse:
+    return RestApiResponse.ok()
+
   router.api(MethodPost, ROUTE_RELAY_SUBSCRIPTIONSV1) do(
     contentBody: Option[ContentBody]
   ) -> RestApiResponse:
@@ -90,6 +93,11 @@ proc installRelayApiHandlers*(
       node.unsubscribe((kind: PubsubUnsub, topic: pubsubTopic))
 
     # Successfully unsubscribed from all requested topics
+    return RestApiResponse.ok()
+
+  router.api(MethodOptions, ROUTE_RELAY_MESSAGESV1) do(
+    pubsubTopic: string
+  ) -> RestApiResponse:
     return RestApiResponse.ok()
 
   router.api(MethodGet, ROUTE_RELAY_MESSAGESV1) do(
@@ -166,6 +174,9 @@ proc installRelayApiHandlers*(
 
   # Autosharding API
 
+  router.api(MethodOptions, ROUTE_RELAY_AUTO_SUBSCRIPTIONSV1) do() -> RestApiResponse:
+    return RestApiResponse.ok()
+
   router.api(MethodPost, ROUTE_RELAY_AUTO_SUBSCRIPTIONSV1) do(
     contentBody: Option[ContentBody]
   ) -> RestApiResponse:
@@ -203,6 +214,11 @@ proc installRelayApiHandlers*(
 
     return RestApiResponse.ok()
 
+  router.api(MethodOptions, ROUTE_RELAY_AUTO_MESSAGESV1) do(
+    contentTopic: string
+  ) -> RestApiResponse:
+    return RestApiResponse.ok()
+
   router.api(MethodGet, ROUTE_RELAY_AUTO_MESSAGESV1) do(
     contentTopic: string
   ) -> RestApiResponse:
@@ -223,6 +239,9 @@ proc installRelayApiHandlers*(
     return RestApiResponse.jsonResponse(data, status = Http200).valueOr:
       debug "An error ocurred while building the json respose", error = error
       return RestApiResponse.internalServerError($error)
+
+  router.api(MethodOptions, ROUTE_RELAY_AUTO_MESSAGESV1_NO_TOPIC) do() -> RestApiResponse:
+    return RestApiResponse.ok()
 
   router.api(MethodPost, ROUTE_RELAY_AUTO_MESSAGESV1_NO_TOPIC) do(
     contentBody: Option[ContentBody]


### PR DESCRIPTION
# Description
CORS request triggers an Options request to same endpoint. [More context](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS#preflighted_requests_in_cors).
The changes here will fix send REST API request from web browser to local nwaku node.


# Changes

<!-- List of detailed changes -->

- [x] Access-Control-Allow-Headers set to Content-Type, this is needed to fix error `Reason: header ‘content-type’ is not allowed according to header ‘Access-Control-Allow-Headers’`
- [x] Options method enabled in relay rest api.

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->