### PR TITLE
chore: workflow to autoassign PR

### DIFF
--- a/.github/workflows/auto_assign_pr.yml
+++ b/.github/workflows/auto_assign_pr.yml
@@ -1,0 +1,12 @@
+name: Auto Assign PR to Creator
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  assign_creator:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2


### PR DESCRIPTION
# Description
This avoids a manual step of assigning PR by auto-assigning it to the creator.
