### PR TITLE
docs: nph - clarify the version that is needed 0.5.1

### DIFF
--- a/docs/contributors/nph.md
+++ b/docs/contributors/nph.md
@@ -8,6 +8,14 @@ https://marketplace.visualstudio.com/items?itemName=arnetheduck.vscode-nph
 ### GitHub
 https://github.com/arnetheduck/nph
 
+Make sure you use a binary from the following release:
+https://github.com/arnetheduck/nph/releases/tag/v0.5.1
+
+```bash
+$ nph --version
+v0.5.1-0-gde5cd48
+```
+
 ### Installation and configuration
 1. Ask the [nwaku team](https://discord.com/channels/1110799176264056863/1111541184490393691) about the required `nph` version.
 2. Download the desired release from _GitHub_ and place the binary in the PATH env var.


### PR DESCRIPTION
## Description
Thanks for the reminder @gabrielmer 
We need to make sure we always use the `0.5.1` version