### PR TITLE
fix: don't mount metadata for clusterID 0

### DIFF
--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -113,12 +113,11 @@ proc setupProtocols(
   ## Setup configured protocols on an existing Waku v2 node.
   ## Optionally include persistent message storage.
   ## No protocols are started yet.
-
-  node.mountMetadata(conf.clusterId).isOkOr:
-    return err("failed to mount waku metadata protocol: " & error)
-
-  node.mountSharding(conf.clusterId, uint32(conf.pubsubTopics.len)).isOkOr:
-    return err("failed to mount waku sharding: " & error)
+  if conf.clusterId != 0:
+    node.mountMetadata(conf.clusterId).isOkOr:
+      return err("failed to mount waku metadata protocol: " & error)
+    node.mountSharding(conf.clusterId, uint32(conf.pubsubTopics.len)).isOkOr:
+      return err("failed to mount waku sharding: " & error)
 
   # Mount relay on all nodes
   var peerExchangeHandler = none(RoutingRecordsHandler)


### PR DESCRIPTION
# Description
While debugging some issue with waku simulator, i had noticed that eventhough clusterID is set to 0 we are mounting metadata as it is indicated in the identify protocol.

`159 DBG 2024-04-18 17:47:35.862+00:00 identify: decoded message                  topics="libp2p identify" tid=1 file=identify.nim:180 c    onn=16U*oFR2ip:66215cb741a196224444402d pubkey=some(s...671d)) addresses=/ip4/10.1.0.20/tcp/60000 protocols=/ipfs/id/1.0.0,/libp2p/    autonat/1.0.0,/libp2p/circuit/relay/0.2.0/hop,/vac/waku/metadata/1.0.0,/vac/waku/relay/2.0.0,/rendezvous/1.0.0,/ipfs/ping/1.0.0 obs    ervable_address=some(/ip4/10.1.0.1/tcp/36914) proto_version=ipfs/0.1.0 agent_version=nwaku signedPeerRecord=None
`

# Changes

<!-- List of detailed changes -->

- [ ] ...
- [ ] ...

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->