### PR TITLE
fix(rln-relay): increase retries for 1 minute recovery time

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/retry_wrapper.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/retry_wrapper.nim
@@ -7,7 +7,7 @@ type RetryStrategy* = object
   retryCount*: uint
 
 proc new*(T: type RetryStrategy): RetryStrategy =
-  return RetryStrategy(shouldRetry: true, retryDelay: 1000.millis, retryCount: 3)
+  return RetryStrategy(shouldRetry: true, retryDelay: 4000.millis, retryCount: 15)
 
 template retryWrapper*(
     res: auto,


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR increases the values for `retryDelay` and `retryCount` to allow nodes to recover over a longer duration than before (3 seconds)

# Changes

<!-- List of detailed changes -->

- [x] increases `retryDelay` to `4000`ms
- [x] increases `retryCount` to 15, giving the nodes 1 minute to recover

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
