### PR TITLE
chore(rln-db-inspector): add more logging to find zero leaf indices

### DIFF
--- a/tools/rln_db_inspector/rln_db_inspector.nim
+++ b/tools/rln_db_inspector/rln_db_inspector.nim
@@ -41,7 +41,7 @@ proc doInspectRlnDb*(conf: WakuNodeConf) =
   var index: uint = 0
   var hits: uint = 0
   var zeroLeafIndices: seq[uint] = @[]
-  var assumeEmptyAfter: uint = 0
+  var assumeEmptyAfter: uint = 10
   while true:
     let leaf = rlnInstance.getMember(index).valueOr:
       error "failure while getting RLN leaf", error

--- a/tools/rln_db_inspector/rln_db_inspector.nim
+++ b/tools/rln_db_inspector/rln_db_inspector.nim
@@ -38,4 +38,29 @@ proc doInspectRlnDb*(conf: WakuNodeConf) =
     contractAddress = metadata.contractAddress,
     validRoots = metadata.validRoots.mapIt(it.inHex())
 
+  var index: uint = 0
+  var hits: uint = 0
+  var zeroLeafIndices: seq[uint] = @[]
+  var assumeEmptyAfter: uint = 0
+  while true:
+    let leaf = rlnInstance.getMember(index).valueOr:
+      error "failure while getting RLN leaf", error
+      quit(1)
+
+    if leaf.inHex() == "0000000000000000000000000000000000000000000000000000000000000000":
+      zeroLeafIndices.add(index)
+      hits = hits + 1
+    else:
+      hits = 0
+
+    if hits > assumeEmptyAfter:
+      info "reached end of RLN tree", index = index - assumeEmptyAfter
+      # remove zeroLeafIndices that are not at the end of the tree
+      zeroLeafIndices = zeroLeafIndices.filterIt(it < index - assumeEmptyAfter)
+      break
+
+    index = index + 1
+
+  info "zero leaf indices", zeroLeafIndices
+
   quit(0)


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR adds logs to the rln-db-inspector which allows to find indices in the tree that have not been set.


# Changes

<!-- List of detailed changes -->

- [x] Checks if a leaf is zero, if it is, then adds to array
- [x] assumeEmptyAfter is set to 10

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
