### PR TITLE
fix(rln-relay): enforce error callback to remove exception raised from retryWrapper

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -637,7 +637,7 @@ proc startOnchainSync(
   var currentLatestBlock: BlockNumber
   g.retryWrapper(currentLatestBlock, "Failed to get the latest block number"):
     cast[BlockNumber](await ethRpc.provider.eth_blockNumber())
-  
+
   try:
     # we always want to sync from last processed block => latest
     # chunk events
@@ -646,11 +646,10 @@ proc startOnchainSync(
       # then fetch the new toBlock
       if fromBlock >= currentLatestBlock:
         break
-      
+
       if fromBlock + blockChunkSize.uint > currentLatestBlock.uint:
         g.retryWrapper(currentLatestBlock, "Failed to get the latest block number"):
           cast[BlockNumber](await ethRpc.provider.eth_blockNumber())
-      
 
       let toBlock = min(fromBlock + BlockNumber(blockChunkSize), currentLatestBlock)
       debug "fetching events", fromBlock = fromBlock, toBlock = toBlock

--- a/waku/waku_rln_relay/group_manager/on_chain/retry_wrapper.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/retry_wrapper.nim
@@ -13,7 +13,7 @@ template retryWrapper*(
     res: auto,
     retryStrategy: RetryStrategy,
     errStr: string,
-    errCallback: OnFatalErrorHandler = nil,
+    errCallback: OnFatalErrorHandler,
     body: untyped,
 ): auto =
   var retryCount = retryStrategy.retryCount
@@ -29,10 +29,5 @@ template retryWrapper*(
       exceptionMessage = getCurrentExceptionMsg()
       await sleepAsync(retryStrategy.retryDelay)
   if shouldRetry:
-    if errCallback == nil:
-      raise newException(
-        CatchableError, errStr & " errCallback == nil: " & exceptionMessage
-      )
-    else:
-      errCallback(errStr & ": " & exceptionMessage)
-      return
+    errCallback(errStr & ": " & exceptionMessage)
+    return


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
To address something that is blocking #2607, this is necessary to remove possibilities of exceptions being raised in the `retryWrapper` template.

# Changes

<!-- List of detailed changes -->

- [x] remove default value for errCallback

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
