### PR TITLE
refactor: addition of waku_api/rest/builder.nim and reduce app.nim

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -144,11 +144,12 @@ when isMainModule:
       error "Starting app failed", error = error
       quit(QuitFailure)
 
-    rest_server_builder.startRestServerProtocolSupport(
-      restServer, wakunode2.node, wakunode2.wakuDiscv5, conf
-    ).isOkOr:
-      error "Starting protocols support REST server failed.", error = $error
-      quit(QuitFailure)
+    if conf.rest:
+      rest_server_builder.startRestServerProtocolSupport(
+        restServer, wakunode2.node, wakunode2.wakuDiscv5, conf
+      ).isOkOr:
+        error "Starting protocols support REST server failed.", error = $error
+        quit(QuitFailure)
 
     wakunode2.startMetricsServerAndLogging().isOkOr:
       error "Starting monitoring and external interfaces failed", error = error

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -138,6 +138,8 @@ when isMainModule:
       error "App initialization failed", error = error
       quit(QuitFailure)
 
+    wakunode2.restServer = restServer
+
     nodeHealthMonitor.setNode(wakunode2.node)
 
     wakunode2.startApp().isOkOr:

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -146,12 +146,11 @@ when isMainModule:
       error "Starting app failed", error = error
       quit(QuitFailure)
 
-    if conf.rest:
-      rest_server_builder.startRestServerProtocolSupport(
-        restServer, wakunode2.node, wakunode2.wakuDiscv5, conf
-      ).isOkOr:
-        error "Starting protocols support REST server failed.", error = $error
-        quit(QuitFailure)
+    rest_server_builder.startRestServerProtocolSupport(
+      restServer, wakunode2.node, wakunode2.wakuDiscv5, conf
+    ).isOkOr:
+      error "Starting protocols support REST server failed.", error = $error
+      quit(QuitFailure)
 
     wakunode2.startMetricsServerAndLogging().isOkOr:
       error "Starting monitoring and external interfaces failed", error = error

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -51,7 +51,7 @@ suite "Wakunode2 - App initialization":
     wakunode2.startApp().isOkOr:
       raiseAssert error
 
-    let mountRes = wakunode2.setupMonitoringAndExternalInterfaces()
+    let mountRes = wakunode2.startMetricsServerAndLogging()
     assert mountRes.isOk(), mountRes.error
 
     ## Then

--- a/waku/waku_api/rest/builder.nim
+++ b/waku/waku_api/rest/builder.nim
@@ -35,6 +35,9 @@ restServerNotInstalledTab = newTable[string, string]()
 proc startRestServerEsentials*(
     nodeHealthMonitor: WakuNodeHealthMonitor, conf: WakuNodeConf
 ): Result[WakuRestServerRef, string] =
+  if not conf.rest:
+    return
+
   let requestErrorHandler: RestRequestErrorHandler = proc(
       error: RestRequestError, request: HttpRequestRef
   ): Future[HttpResponseRef] {.async: (raises: [CancelledError]).} =
@@ -112,6 +115,9 @@ proc startRestServerProtocolSupport*(
     wakuDiscv5: Option[WakuDiscoveryV5],
     conf: WakuNodeConf,
 ): Result[void, string] =
+  if not conf.rest:
+    return
+
   var router = restServer.router
   ## Admin REST API
   if conf.restAdmin:

--- a/waku/waku_api/rest/builder.nim
+++ b/waku/waku_api/rest/builder.nim
@@ -1,0 +1,185 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import net, tables
+import presto
+import
+  ../../waku/common/utils/nat,
+  ../../waku/waku_node,
+  ../../waku/discovery/waku_discv5,
+  ../../waku/factory/external_config,
+  ../../waku/waku_api/message_cache,
+  ../../waku/waku_api/handlers,
+  ../../waku/waku_api/rest/server,
+  ../../waku/waku_api/rest/debug/handlers as rest_debug_api,
+  ../../waku/waku_api/rest/relay/handlers as rest_relay_api,
+  ../../waku/waku_api/rest/filter/handlers as rest_filter_api,
+  ../../waku/waku_api/rest/lightpush/handlers as rest_lightpush_api,
+  ../../waku/waku_api/rest/store/handlers as rest_store_api,
+  ../../waku/waku_api/rest/health/handlers as rest_health_api,
+  ../../waku/waku_api/rest/admin/handlers as rest_admin_api,
+  ../../waku/waku_core/topics
+
+## Monitoring and external interfaces
+
+# Used to register api endpoints that are not currently installed as keys,
+# values are holding error messages to be returned to the client
+# NOTE: {.threadvar.} is used to make the global variable GC safe for the closure uses it
+# It will always be called from main thread anyway.
+# Ref: https://nim-lang.org/docs/manual.html#threads-gc-safety
+var restServerNotInstalledTab {.threadvar.}: TableRef[string, string]
+restServerNotInstalledTab = newTable[string, string]()
+
+proc startRestServerEsentials*(
+    nodeHealthMonitor: WakuNodeHealthMonitor, conf: WakuNodeConf
+): Result[WakuRestServerRef, string] =
+  let requestErrorHandler: RestRequestErrorHandler = proc(
+      error: RestRequestError, request: HttpRequestRef
+  ): Future[HttpResponseRef] {.async: (raises: [CancelledError]).} =
+    try:
+      case error
+      of RestRequestError.Invalid:
+        return await request.respond(Http400, "Invalid request", HttpTable.init())
+      of RestRequestError.NotFound:
+        let paths = request.rawPath.split("/")
+        let rootPath =
+          if len(paths) > 1:
+            paths[1]
+          else:
+            ""
+        restServerNotInstalledTab[].withValue(rootPath, errMsg):
+          return await request.respond(Http404, errMsg[], HttpTable.init())
+        do:
+          return await request.respond(
+            Http400,
+            "Bad request initiated. Invalid path or method used.",
+            HttpTable.init(),
+          )
+      of RestRequestError.InvalidContentBody:
+        return await request.respond(Http400, "Invalid content body", HttpTable.init())
+      of RestRequestError.InvalidContentType:
+        return await request.respond(Http400, "Invalid content type", HttpTable.init())
+      of RestRequestError.Unexpected:
+        return defaultResponse()
+    except HttpWriteError:
+      error "Failed to write response to client", error = getCurrentExceptionMsg()
+      discard
+
+    return defaultResponse()
+
+  let allowedOrigin =
+    if len(conf.restAllowOrigin) > 0:
+      some(conf.restAllowOrigin.join(","))
+    else:
+      none(string)
+
+  let address = conf.restAddress
+  let port = Port(conf.restPort + conf.portsShift)
+  let server =
+    ?newRestHttpServer(
+      address,
+      port,
+      allowedOrigin = allowedOrigin,
+      requestErrorHandler = requestErrorHandler,
+    )
+
+  ## Health REST API
+  installHealthApiHandler(server.router, nodeHealthMonitor)
+
+  restServerNotInstalledTab["admin"] =
+    "/admin endpoints are not available while initializing."
+  restServerNotInstalledTab["debug"] =
+    "/debug endpoints are not available while initializing."
+  restServerNotInstalledTab["relay"] =
+    "/relay endpoints are not available while initializing."
+  restServerNotInstalledTab["filter"] =
+    "/filter endpoints are not available while initializing."
+  restServerNotInstalledTab["lightpush"] =
+    "/lightpush endpoints are not available while initializing."
+  restServerNotInstalledTab["store"] =
+    "/store endpoints are not available while initializing."
+
+  server.start()
+  info "Starting REST HTTP server", url = "http://" & $address & ":" & $port & "/"
+
+  ok(server)
+
+proc startRestServerProtocolSupport*(
+    restServer: WakuRestServerRef,
+    node: WakuNode,
+    wakuDiscv5: Option[WakuDiscoveryV5],
+    conf: WakuNodeConf,
+): Result[void, string] =
+  var router = restServer.router
+  ## Admin REST API
+  if conf.restAdmin:
+    installAdminApiHandlers(router, node)
+  else:
+    restServerNotInstalledTab["admin"] =
+      "/admin endpoints are not available. Please check your configuration: --rest-admin=true"
+
+  ## Debug REST API
+  installDebugApiHandlers(router, node)
+
+  ## Relay REST API
+  if conf.relay:
+    let cache = MessageCache.init(int(conf.restRelayCacheCapacity))
+
+    let handler = messageCacheHandler(cache)
+
+    for pubsubTopic in conf.pubsubTopics:
+      cache.pubsubSubscribe(pubsubTopic)
+      node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(handler))
+
+    for contentTopic in conf.contentTopics:
+      cache.contentSubscribe(contentTopic)
+      node.subscribe((kind: ContentSub, topic: contentTopic), some(handler))
+
+    installRelayApiHandlers(router, node, cache)
+  else:
+    restServerNotInstalledTab["relay"] =
+      "/relay endpoints are not available. Please check your configuration: --relay"
+
+  ## Filter REST API
+  if conf.filternode != "" and node.wakuFilterClient != nil:
+    let filterCache = MessageCache.init()
+
+    let filterDiscoHandler =
+      if wakuDiscv5.isSome():
+        some(defaultDiscoveryHandler(wakuDiscv5.get(), Filter))
+      else:
+        none(DiscoveryHandler)
+
+    rest_filter_api.installFilterRestApiHandlers(
+      router, node, filterCache, filterDiscoHandler
+    )
+  else:
+    restServerNotInstalledTab["filter"] =
+      "/filter endpoints are not available. Please check your configuration: --filternode"
+
+  ## Store REST API
+  let storeDiscoHandler =
+    if wakuDiscv5.isSome():
+      some(defaultDiscoveryHandler(wakuDiscv5.get(), Store))
+    else:
+      none(DiscoveryHandler)
+
+  installStoreApiHandlers(router, node, storeDiscoHandler)
+
+  ## Light push API
+  if conf.lightpushnode != "" and node.wakuLightpushClient != nil:
+    let lightDiscoHandler =
+      if wakuDiscv5.isSome():
+        some(defaultDiscoveryHandler(wakuDiscv5.get(), Lightpush))
+      else:
+        none(DiscoveryHandler)
+
+    rest_lightpush_api.installLightPushRequestHandler(router, node, lightDiscoHandler)
+  else:
+    restServerNotInstalledTab["lightpush"] =
+      "/lightpush endpoints are not available. Please check your configuration: --lightpushnode"
+
+  info "REST services are installed"
+  return ok()


### PR DESCRIPTION
## Description
Extract some REST logic from app.nim, aiming for simplify app.nim a little.
I will submit a couple of similar PRs simplifying app.nim.

note: this has the same goal as https://github.com/waku-org/nwaku/pull/2610 but I decided to submit a different one just to keep the original one as a temporary reference. I will drop the initial PR once this gets merged

