### PR TITLE
chore: Enabling to use a full node for lightpush via rest api without lightpush client configured

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -843,6 +843,9 @@ proc lightpushPublish*(
   ## Returns whether relaying was successful or not.
   ## `WakuMessage` should contain a `contentTopic` field for light node
   ## functionality.
+  if node.wakuLightpushClient.isNil() and node.wakuLightPush.isNil():
+    return err("Waku lightpush not available")
+
   let internalPublish = proc(
       node: WakuNode,
       pubsubTopic: PubsubTopic,
@@ -860,9 +863,6 @@ proc lightpushPublish*(
       debug "publishing message with self hosted lightpush",
         pubsubTopic = pubsubTopic, contentTopic = message.contentTopic
       return await node.wakuLightPush.handleSelfLightPushRequest(pubsubTopic, message)
-
-  if node.wakuLightpushClient.isNil() and node.wakuLightPush.isNil():
-    return err("waku lightpush not available")
 
   if pubsubTopic.isSome():
     debug "publishing message with lightpush",

--- a/waku/waku_api/rest/builder.nim
+++ b/waku/waku_api/rest/builder.nim
@@ -175,7 +175,10 @@ proc startRestServerProtocolSupport*(
   installStoreApiHandlers(router, node, storeDiscoHandler)
 
   ## Light push API
-  if conf.lightpushnode != "" and node.wakuLightpushClient != nil:
+  ## Install it either if lightpushnode (lightpush service node) is configured and client is mounted)
+  ## or install it to be used with self-hosted lightpush service
+  if (conf.lightpushnode != "" and node.wakuLightpushClient != nil) or
+      (conf.lightpush and node.wakuLightPush != nil):
     let lightDiscoHandler =
       if wakuDiscv5.isSome():
         some(defaultDiscoveryHandler(wakuDiscv5.get(), Lightpush))

--- a/waku/waku_api/rest/builder.nim
+++ b/waku/waku_api/rest/builder.nim
@@ -178,7 +178,7 @@ proc startRestServerProtocolSupport*(
   ## Install it either if lightpushnode (lightpush service node) is configured and client is mounted)
   ## or install it to be used with self-hosted lightpush service
   if (conf.lightpushnode != "" and node.wakuLightpushClient != nil) or
-      (conf.lightpush and node.wakuLightPush != nil):
+      (conf.lightpush and node.wakuLightPush != nil and node.wakuRelay != nil):
     let lightDiscoHandler =
       if wakuDiscv5.isSome():
         some(defaultDiscoveryHandler(wakuDiscv5.get(), Lightpush))

--- a/waku/waku_lightpush/self_req_handler.nim
+++ b/waku/waku_lightpush/self_req_handler.nim
@@ -1,17 +1,16 @@
-##
-## This file is aimed to attend the requests that come directly
-## from the 'self' node. It is expected to attend the store requests that
-## come from REST-store endpoint when those requests don't indicate
-## any store-peer address.
-##
-## Notice that the REST-store requests normally assume that the REST
-## server is acting as a store-client. In this module, we allow that
-## such REST-store node can act as store-server as well by retrieving
-## its own stored messages. The typical use case for that is when
-## using `nwaku-compose`, which spawn a Waku node connected to a local
-## database, and the user is interested in retrieving the messages
-## stored by that local store node.
-##
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+## Notice that the REST /lightpush requests normally assume that the node
+## is acting as a lightpush-client that will trigger the service provider node
+## to relay the message.
+## In this module, we allow that a lightpush service node (full node) can be
+## triggered directly through the  REST /lightpush endpoint.
+## The typical use case for that is when using `nwaku-compose`,
+## which spawn a full service Waku node
+## that could be used also as a lightpush client, helping testing and development.
 
 import stew/results, chronos, chronicles, std/options, metrics
 import

--- a/waku/waku_lightpush/self_req_handler.nim
+++ b/waku/waku_lightpush/self_req_handler.nim
@@ -1,0 +1,54 @@
+##
+## This file is aimed to attend the requests that come directly
+## from the 'self' node. It is expected to attend the store requests that
+## come from REST-store endpoint when those requests don't indicate
+## any store-peer address.
+##
+## Notice that the REST-store requests normally assume that the REST
+## server is acting as a store-client. In this module, we allow that
+## such REST-store node can act as store-server as well by retrieving
+## its own stored messages. The typical use case for that is when
+## using `nwaku-compose`, which spawn a Waku node connected to a local
+## database, and the user is interested in retrieving the messages
+## stored by that local store node.
+##
+
+import stew/results, chronos, chronicles, std/options, metrics
+import
+  ../waku_core,
+  ./protocol,
+  ./common,
+  ./rpc,
+  ./rpc_codec,
+  ./protocol_metrics,
+  ../utils/requests
+
+proc handleSelfLightPushRequest*(
+    self: WakuLightPush, pubSubTopic: PubsubTopic, message: WakuMessage
+): Future[WakuLightPushResult[void]] {.async.} =
+  ## Handles the lightpush requests made by the node to itself.
+  ## Normally used in REST-lightpush requests
+
+  try:
+    # provide self peerId as now this node is used directly, thus there is no light client sender peer.
+    let selfPeerId = self.peerManager.switch.peerInfo.peerId
+
+    let req = PushRequest(pubSubTopic: pubSubTopic, message: message)
+    let rpc = PushRPC(requestId: generateRequestId(self.rng), request: some(req))
+
+    let respRpc = await self.handleRequest(selfPeerId, rpc.encode().buffer)
+
+    if respRpc.response.isNone():
+      waku_lightpush_errors.inc(labelValues = [emptyResponseBodyFailure])
+      return err(emptyResponseBodyFailure)
+
+    let response = respRpc.response.get()
+    if not response.isSuccess:
+      if response.info.isSome():
+        return err(response.info.get())
+      else:
+        return err("unknown failure")
+
+    return ok()
+  except Exception:
+    return err("exception in handleSelfLightPushRequest: " & getCurrentExceptionMsg())


### PR DESCRIPTION
# Description
This is helper enhancment for testing (rate limit specifically for me) on lightpush... similar to query self store node via REST API.
With this change one can issue lightpush request via REST API on a service node having lightpush protocol installed.

In contrast it was needed to run a full node with lightpush service and a light client (configured with the service node peerId) to be usable from REST API.
With this change a lightpush service node (with relay of course) can serve such lightpush API request and can relay such messages.

This can help in various way.
- easy develop on REST API with nwaku-compose (where a full node is set up)
- easy test lightpush features via rest api.

# Changes

- [X] /lightpush endpoint is enabled either lightpushclient or lightpush(protocol) mounted
- [X] lightpush protocol can handle such request by self hosted coming from REST API

## How to test

1. Run a full node or nwaku-compose with the right image
2. issue REST /lightpush POST message
3. check that relayed (can depend on various stuff)

## Open question:
- Currently relaying message via REST API will attach rln proof to the message. This is missing from lightpush, thus rest api user should be able to provide the proof.
- I think this can be think as, I'm using a thin layer towards the network via REST API by running a light node with my rln credentials. Such case lightpush service can attach proof to the message as in relay (REST API case).
