### PR TITLE
fix: missing rate limit setting for legacy store protocol

### DIFF
--- a/waku/common/ratelimit.nim
+++ b/waku/common/ratelimit.nim
@@ -11,7 +11,8 @@ export tokenbucket
 
 type RateLimitSetting* = tuple[volume: int, period: Duration]
 
-let DefaultGlobalNonRelayRateLimit*: RateLimitSetting = (60, 1.minutes)
+# Set the default to switch off rate limiting for now
+let DefaultGlobalNonRelayRateLimit*: RateLimitSetting = (0, 0.minutes)
 
 proc newTokenBucket*(setting: Option[RateLimitSetting]): Option[TokenBucket] =
   if setting.isNone:

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -244,15 +244,15 @@ proc setupProtocols(
       return err("failed to mount waku archive protocol: " & mountArcRes.error)
 
     # Store setup
+    let rateLimitSetting: RateLimitSetting =
+      (conf.requestRateLimit, chronos.seconds(conf.requestRatePeriod))
     try:
-      let rateLimitSetting: RateLimitSetting =
-        (conf.requestRateLimit, chronos.seconds(conf.requestRatePeriod))
       await mountStore(node, rateLimitSetting)
     except CatchableError:
       return err("failed to mount waku store protocol: " & getCurrentExceptionMsg())
 
     try:
-      await mountLegacyStore(node)
+      await mountLegacyStore(node, rateLimitSetting)
     except CatchableError:
       return
         err("failed to mount waku legacy store protocol: " & getCurrentExceptionMsg())


### PR DESCRIPTION
# Description
https://github.com/waku-org/nwaku/pull/2431 missed setting rate limit configuration for legacy store protocol mount.

Also set default rate limit setting to zero in order to let rate limit checks switched off for now.