### PR TITLE
fix: parse shards properly in enr config for non twn

### DIFF
--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -37,7 +37,8 @@ proc enrConfiguration*(
       if shardsRes.isOk() and shardsRes.get().isSome():
         shardsLocal = shardsRes.get().get().shardIds
       else:
-        error "failed to parse pubsubTopic", error = shardsRes.error
+        error "failed to parse pubsub topic, please format according to static shard specification",
+          error = shardsRes.error
       shardsLocal
 
     # some shards configured


### PR DESCRIPTION
# Description
Fix for https://github.com/waku-org/nwaku/issues/2618

# Changes

<!-- List of detailed changes -->

- [x] Parse shardinfo from pubsubTopics to be used in ENR generation

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->