### PR TITLE
refactor: waku_node.nim - simplify stop proc

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1217,13 +1217,6 @@ proc start*(node: WakuNode) {.async.} =
   info "Node started successfully"
 
 proc stop*(node: WakuNode) {.async.} =
-  if not node.wakuRelay.isNil():
-    await node.wakuRelay.stop()
-
-  if not node.wakuMetadata.isNil():
-    node.wakuMetadata.stop()
-
-  await node.switch.stop()
   node.peerManager.stop()
 
   if not node.wakuRlnRelay.isNil():
@@ -1234,6 +1227,9 @@ proc stop*(node: WakuNode) {.async.} =
 
   if not node.wakuArchive.isNil():
     await node.wakuArchive.stopWait()
+
+  ## By stopping the switch we are stopping all the underlying mounted protocols
+  await node.switch.stop()
 
   node.started = false
 


### PR DESCRIPTION

## Description
There is no need to explicitly stop mounted libp2p protocols because they are already being stopped after the switch.stop() is being called.

## Issue
I've noticed that while debugging:
Peer Reconnection not working - https://github.com/waku-org/nwaku/issues/2592
