### PR TITLE
chore: change nim-libp2p branch from unstable to master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	path = vendor/nim-libp2p
 	url = https://github.com/vacp2p/nim-libp2p.git
 	ignore = dirty
-	branch = unstable
+	branch = master
 [submodule "vendor/nim-stew"]
 	path = vendor/nim-stew
 	url = https://github.com/status-im/nim-stew.git


### PR DESCRIPTION
changes the default branch of libp2p from unstable to master.
See https://github.com/vacp2p/nim-libp2p/issues/1088
