### PR TITLE
fix(rln-relay): persist metadata every batch during initial sync

### DIFF
--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -328,7 +328,10 @@ suite "Onchain group manager":
     let merkleRootAfter = manager.rlnInstance.getMerkleRoot().valueOr:
       raiseAssert $error
 
+    let metadataOpt = manager.rlnInstance.getMetadata().valueOr:
+      raiseAssert $error
     check:
+      metadataOpt.get().validRoots == manager.validRoots.toSeq()
       merkleRootBefore != merkleRootAfter
     await manager.stop()
 
@@ -481,13 +484,8 @@ suite "Onchain group manager":
     except Exception, CatchableError:
       assert false, "exception raised: " & getCurrentExceptionMsg()
 
-    await fut
+    check await fut.withTimeout(5.seconds)
 
-    let metadataOpt = manager.rlnInstance.getMetadata().valueOr:
-      raiseAssert $error
-    assert metadataOpt.isSome(), "metadata is not set"
-    check:
-      metadataOpt.get().validRoots == manager.validRoots.toSeq()
     await manager.stop()
 
   asyncTest "withdraw: should guard against uninitialized state":

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -586,9 +586,8 @@ proc getNewBlockCallback(g: OnchainGroupManager): proc =
     g.retryWrapper(handleBlockRes, "Failed to handle new block"):
       await g.getAndHandleEvents(fromBlock, latestBlock)
 
-    let setMetadataRes = g.setMetadata()
-    if setMetadataRes.isErr():
-      error "failed to persist rln metadata", error = setMetadataRes.error
+    g.setMetadata().isOkOr:
+      error "failed to persist rln metadata", error = $error
 
     return handleBlockRes
 
@@ -663,9 +662,8 @@ proc startOnchainSync(
       futs.add(g.getAndHandleEvents(fromBlock, toBlock))
       if futs.len >= maxFutures or toBlock == currentLatestBlock:
         await g.batchAwaitBlockHandlingFuture(futs)
-        let setMetadataRes = g.setMetadata(lastProcessedBlock = some(toBlock))
-        if setMetadataRes.isErr():
-          error "failed to persist rln metadata", error = setMetadataRes.error
+        g.setMetadata(lastProcessedBlock = some(toBlock)).isOkOr:
+          error "failed to persist rln metadata", error = $error
         futs = newSeq[Future[bool]]()
       fromBlock = toBlock + 1
   except CatchableError:


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR offloads the `setMetadata` proc from the `atomicBatch` proc to the callsites of the `getAndHandleEvents` so that it is not called twice, and during the initial sync when we parallelize the rpc calls we want to ensure the metadata is set in increasing block number counts to avoid race conditions and missed blocks.

# Changes

<!-- List of detailed changes -->

- [x] set metadata appropriately when parallelizing rpc calls

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
