### PR TITLE
refactor: metrics server. Simplify app.nim module

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -20,6 +20,7 @@ import
   ../../waku/factory/networks_config,
   ../../waku/factory/app,
   ../../waku/node/health_monitor,
+  ../../waku/node/waku_metrics,
   ../../waku/waku_api/rest/builder as rest_server_builder
 
 logScope:
@@ -152,7 +153,7 @@ when isMainModule:
       error "Starting protocols support REST server failed.", error = $error
       quit(QuitFailure)
 
-    wakunode2.startMetricsServerAndLogging().isOkOr:
+    wakunode2.metricsServer = waku_metrics.startMetricsServerAndLogging(conf).valueOr:
       error "Starting monitoring and external interfaces failed", error = error
       quit(QuitFailure)
 

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -51,8 +51,8 @@ suite "Wakunode2 - App initialization":
     wakunode2.startApp().isOkOr:
       raiseAssert error
 
-    let mountRes = wakunode2.startMetricsServerAndLogging()
-    assert mountRes.isOk(), mountRes.error
+    wakunode2.metricsServer = waku_metrics.startMetricsServerAndLogging(conf).valueOr:
+      raiseAssert error
 
     ## Then
     let node = wakunode2.node


### PR DESCRIPTION
## Description
Simplify `app.nim` and move the "metrics factory" procs to an already existing `waku_metrics` module

