### PR TITLE
fix: waku_node - first of all stop the waku-switch when stopping the waku-node

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1217,6 +1217,9 @@ proc start*(node: WakuNode) {.async.} =
   info "Node started successfully"
 
 proc stop*(node: WakuNode) {.async.} =
+  ## By stopping the switch we are stopping all the underlying mounted protocols
+  await node.switch.stop()
+
   node.peerManager.stop()
 
   if not node.wakuRlnRelay.isNil():
@@ -1227,9 +1230,6 @@ proc stop*(node: WakuNode) {.async.} =
 
   if not node.wakuArchive.isNil():
     await node.wakuArchive.stopWait()
-
-  ## By stopping the switch we are stopping all the underlying mounted protocols
-  await node.switch.stop()
 
   node.started = false
 


### PR DESCRIPTION
## Description
This is aimed to avoid having flaky tests by keeping the original invocation order that we had before applying the following change: https://github.com/waku-org/nwaku/pull/2645/files

![image](https://github.com/waku-org/nwaku/assets/128452529/a0dccd3e-d254-443c-8338-a53dd5baefd6)


