### PR TITLE
feat: sync use subranges

### DIFF
--- a/tests/waku_sync/test_protocol.nim
+++ b/tests/waku_sync/test_protocol.nim
@@ -414,13 +414,6 @@ suite "Waku Sync":
       let s2 = s2Res.value
       assert s2Res.isOk(), $s2Res.error
 
-      let ng1Res = Negentropy.new(s1, 10000)
-      assert ng1Res.isOk(), $ng1Res.error
-      let ng1 = ng1Res.value
-      let ng2Res = Negentropy.new(s2, 10000)
-      assert ng2Res.isOk(), $ng2Res.error
-      let ng2 = ng2Res.value
-
       let msg1 = fakeWakuMessage(contentTopic = DefaultContentTopic)
       let msgHash: WakuMessageHash =
         computeMessageHash(pubsubTopic = DefaultPubsubTopic, msg1)
@@ -435,6 +428,21 @@ suite "Waku Sync":
 
       check:
         s2.insert(msg2.timestamp, msgHash2).isOk()
+
+      let subrange1Res = SubRange.new(s1, 0, int64.high)
+      assert subrange1Res.isOk(), $subrange1Res.error
+      let subrange1 = subrange1Res.value
+      let subrange2Res = SubRange.new(s2, 0, int64.high)
+      assert subrange2Res.isOk(), $subrange2Res.error
+
+      let subrange2 = subrange2Res.value
+
+      let ng1Res = NegentropySubRange.new(subrange1, 10000)
+      assert ng1Res.isOk(), $ng1Res.error
+      let ng1 = ng1Res.value
+      let ng2Res = NegentropySubRange.new(subrange2, 10000)
+      assert ng2Res.isOk(), $ng2Res.error
+      let ng2 = ng2Res.value
 
       let ng1_q1 = ng1.initiate()
       check:

--- a/waku/waku_sync/raw_bindings.nim
+++ b/waku/waku_sync/raw_bindings.nim
@@ -335,10 +335,10 @@ proc clientReconcile*(
 proc new*(
     T: type SubRange,
     storage: Storage,
-    startTime: int64 = 0,
-    endTime: int64, #TODO: Set default to MAX_UINT64
+    startTime: uint64 = uint64.low,
+    endTime: uint64 = uint64.high,
 ): Result[T, string] =
-  let subrange = subrange_init(storage, uint64(startTime), uint64(endTime))
+  let subrange = subrange_init(storage, startTime, endTime)
 
   #[ TODO: Uncomment once we move to lmdb   
   if storage == nil:

--- a/waku/waku_sync/session.nim
+++ b/waku/waku_sync/session.nim
@@ -39,7 +39,7 @@ proc initializeNegentropy(
     self: SyncSession, storage: Storage, syncStartTime: int64, syncEndTime: int64
 ): Result[void, string] =
   #TODO Create a subrange
-  let subrange = SubRange.new(storage, syncStartTime, syncEndTime).valueOr:
+  let subrange = SubRange.new(storage, uint64(syncStartTime), uint64(syncEndTime)).valueOr:
     return err(error)
   let negentropy = NegentropySubrange.new(subrange, self.frameSize).valueOr:
     return err(error)


### PR DESCRIPTION
# Description
Use negentropy subrange which gives flexibility to choose sync time.
Still some optimizations are needed in negentropy side, but functionally this change has passed all existing tests.


@SionoiS SubRange seems to work with just timestamp alone, i think the ID argument may not be required then.

# Changes

<!-- List of detailed changes -->

- [x] Use a subrange instead of maintaining different storages
- [x] Use negentropy subrange wrappers

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->