### PR TITLE
refactor: big refactor to add waku component in libwaku instead of onlu waku node

### DIFF
--- a/examples/wakustealthcommitments/node_spec.nim
+++ b/examples/wakustealthcommitments/node_spec.nim
@@ -3,8 +3,8 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import ../../apps/wakunode2/[networks_config, app, external_config]
-import ../../waku/common/logging
+import
+  ../../waku/common/logging, ../../waku/factory/[waku, networks_config, external_config]
 import
   std/[options, strutils, os, sequtils],
   stew/shims/net as stewNet,
@@ -15,11 +15,11 @@ import
   libp2p/crypto/crypto
 
 export
-  networks_config, app, logging, options, strutils, os, sequtils, stewNet, chronicles,
+  networks_config, waku, logging, options, strutils, os, sequtils, stewNet, chronicles,
   chronos, metrics, libbacktrace, crypto
 
-proc setup*(): App =
-  const versionString = "version / git commit hash: " & app.git_version
+proc setup*(): Waku =
+  const versionString = "version / git commit hash: " & waku.git_version
   let rng = crypto.newRng()
 
   let confRes = WakuNodeConf.load(version = versionString)
@@ -48,48 +48,17 @@ proc setup*(): App =
   conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
   conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
 
-  var wakunode2 = App.init(rng, conf)
-  ## Peer persistence
-  let res1 = wakunode2.setupPeerPersistence()
-  if res1.isErr():
-    error "1/5 Setting up storage failed", error = $res1.error
+  debug "Starting node"
+  var waku = Waku.init(conf).valueOr:
+    error "Waku initialization failed", error = error
     quit(QuitFailure)
 
-  debug "2/5 Retrieve dynamic bootstrap nodes"
-
-  let res3 = wakunode2.setupDyamicBootstrapNodes()
-  if res3.isErr():
-    error "2/5 Retrieving dynamic bootstrap nodes failed", error = $res3.error
+  (waitFor startWaku(addr waku)).isOkOr:
+    error "Starting waku failed", error = error
     quit(QuitFailure)
-
-  debug "3/5 Initializing node"
-
-  let res4 = wakunode2.setupWakuApp()
-  if res4.isErr():
-    error "3/5 Initializing node failed", error = $res4.error
-    quit(QuitFailure)
-
-  debug "4/5 Mounting protocols"
-
-  var res5: Result[void, string]
-  try:
-    res5 = waitFor wakunode2.setupAndMountProtocols()
-    if res5.isErr():
-      error "4/5 Mounting protocols failed", error = $res5.error
-      quit(QuitFailure)
-  except Exception:
-    error "4/5 Mounting protocols failed", error = getCurrentExceptionMsg()
-    quit(QuitFailure)
-
-  debug "5/5 Starting node and mounted protocols"
 
   # set triggerSelf to false, we don't want to process our own stealthCommitments
-  wakunode2.node.wakuRelay.triggerSelf = false
-
-  let res6 = wakunode2.startApp()
-  if res6.isErr():
-    error "5/5 Starting node and protocols failed", error = $res6.error
-    quit(QuitFailure)
+  waku.node.wakuRelay.triggerSelf = false
 
   info "Node setup complete"
-  return wakunode2
+  return waku

--- a/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
@@ -1,6 +1,6 @@
 import std/[options, sequtils, strutils, json]
 import chronicles, chronos, stew/results, stew/shims/net
-import ../../../../waku/node/waku_node, ../../../alloc
+import ../../../../waku/factory/waku, ../../../../waku/node/waku_node, ../../../alloc
 
 type DebugNodeMsgType* = enum
   RETRIEVE_LISTENING_ADDRESSES
@@ -20,13 +20,13 @@ proc getMultiaddresses(node: WakuNode): seq[string] =
   return node.info().listenAddresses
 
 proc process*(
-    self: ptr DebugNodeRequest, node: WakuNode
+    self: ptr DebugNodeRequest, waku: Waku
 ): Future[Result[string, string]] {.async.} =
   defer:
     destroyShared(self)
 
   case self.operation
   of RETRIEVE_LISTENING_ADDRESSES:
-    return ok($(%*node.getMultiaddresses()))
+    return ok($(%*waku.node.getMultiaddresses()))
 
   return err("unsupported operation in DebugNodeRequest")

--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -1,6 +1,6 @@
 import std/[options, sequtils, strutils]
 import chronicles, chronos, stew/results, stew/shims/net
-import ../../../../waku/node/waku_node, ../../../alloc
+import ../../../../waku/factory/waku, ../../../../waku/node/waku_node, ../../../alloc
 
 type PeerManagementMsgType* = enum
   CONNECT_TO
@@ -43,14 +43,14 @@ proc connectTo(
   return ok()
 
 proc process*(
-    self: ptr PeerManagementRequest, node: WakuNode
+    self: ptr PeerManagementRequest, waku: Waku
 ): Future[Result[string, string]] {.async.} =
   defer:
     destroyShared(self)
 
   case self.operation
   of CONNECT_TO:
-    let ret = node.connectTo($self[].peerMultiAddr, self[].dialTimeout)
+    let ret = waku.node.connectTo($self[].peerMultiAddr, self[].dialTimeout)
     if ret.isErr():
       return err(ret.error)
 

--- a/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
@@ -1,7 +1,7 @@
 import std/[options, sequtils, strutils]
 import chronos, stew/results, stew/shims/net
 import
-  ../../../../../waku/node/waku_node,
+  ../../../../../waku/factory/waku,
   ../../../../../waku/waku_archive/driver/builder,
   ../../../../../waku/waku_archive/driver,
   ../../../../../waku/waku_archive/retention_policy/builder,
@@ -50,20 +50,20 @@ proc destroyShared(self: ptr StoreQueryRequest) =
   deallocShared(self)
 
 proc process(
-    self: ptr StoreQueryRequest, node: ptr WakuNode
+    self: ptr StoreQueryRequest, waku: ptr Waku
 ): Future[Result[string, string]] {.async.} =
   defer:
     destroyShared(self)
 
 proc process*(
-    self: ptr StoreRequest, node: ptr WakuNode
+    self: ptr StoreRequest, waku: ptr Waku
 ): Future[Result[string, string]] {.async.} =
   defer:
     deallocShared(self)
 
   case self.operation
   of REMOTE_QUERY:
-    return await cast[ptr StoreQueryRequest](self[].storeReq).process(node)
+    return await cast[ptr StoreQueryRequest](self[].storeReq).process(waku)
   of LOCAL_QUERY:
     discard
     # cast[ptr StoreQueryRequest](request[].reqContent).process(node)

--- a/library/waku_thread/inter_thread_communication/waku_thread_request.nim
+++ b/library/waku_thread/inter_thread_communication/waku_thread_request.nim
@@ -5,7 +5,7 @@
 import std/json, stew/results
 import chronos
 import
-  ../../../waku/node/waku_node,
+  ../../../waku/factory/waku,
   ./requests/node_lifecycle_request,
   ./requests/peer_manager_request,
   ./requests/protocols/relay_request,
@@ -32,7 +32,7 @@ proc createShared*(
   return ret
 
 proc process*(
-    T: type InterThreadRequest, request: ptr InterThreadRequest, node: ptr WakuNode
+    T: type InterThreadRequest, request: ptr InterThreadRequest, waku: ptr Waku
 ): Future[Result[string, string]] {.async.} =
   ## Processes the request and deallocates its memory
   defer:
@@ -43,15 +43,15 @@ proc process*(
   let retFut =
     case request[].reqType
     of LIFECYCLE:
-      cast[ptr NodeLifecycleRequest](request[].reqContent).process(node)
+      cast[ptr NodeLifecycleRequest](request[].reqContent).process(waku)
     of PEER_MANAGER:
-      cast[ptr PeerManagementRequest](request[].reqContent).process(node[])
+      cast[ptr PeerManagementRequest](request[].reqContent).process(waku[])
     of RELAY:
-      cast[ptr RelayRequest](request[].reqContent).process(node)
+      cast[ptr RelayRequest](request[].reqContent).process(waku)
     of STORE:
-      cast[ptr StoreRequest](request[].reqContent).process(node)
+      cast[ptr StoreRequest](request[].reqContent).process(waku)
     of DEBUG:
-      cast[ptr DebugNodeRequest](request[].reqContent).process(node[])
+      cast[ptr DebugNodeRequest](request[].reqContent).process(waku[])
 
   return await retFut
 

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -11,7 +11,7 @@ import
   stew/results,
   stew/shims/net
 import
-  ../../../waku/node/waku_node,
+  ../../../waku/factory/waku,
   ../events/[json_message_event, json_base_event],
   ./inter_thread_communication/waku_thread_request,
   ./inter_thread_communication/waku_thread_response
@@ -48,7 +48,7 @@ proc run(ctx: ptr Context) {.thread.} =
   ## This is the worker thread body. This thread runs the Waku node
   ## and attends library user requests (stop, connect_to, etc.)
 
-  var node: WakuNode
+  var waku: Waku
 
   while running.load == true:
     ## Trying to get a request from the libwaku main thread
@@ -57,7 +57,7 @@ proc run(ctx: ptr Context) {.thread.} =
     waitFor ctx.reqSignal.wait()
     let recvOk = ctx.reqChannel.tryRecv(request)
     if recvOk == true:
-      let resultResponse = waitFor InterThreadRequest.process(request, addr node)
+      let resultResponse = waitFor InterThreadRequest.process(request, addr waku)
 
       ## Converting a `Result` into a thread-safe transferable response type
       let threadSafeResp = InterThreadResponse.createShared(resultResponse)

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -18,11 +18,11 @@ suite "Wakunode2 - Waku":
     ## Given
     let conf = defaultTestWakuNodeConf()
 
-    let wakunode2 = Waku.init(conf).valueOr:
+    let waku = Waku.init(conf).valueOr:
       raiseAssert error
 
     ## When
-    let version = wakunode2.version
+    let version = waku.version
 
     ## Then
     check:
@@ -34,28 +34,28 @@ suite "Wakunode2 - Waku initialization":
     var conf = defaultTestWakuNodeConf()
     conf.peerPersistence = true
 
-    let wakunode2 = Waku.init(conf).valueOr:
+    let waku = Waku.init(conf).valueOr:
       raiseAssert error
 
     check:
-      not wakunode2.node.peerManager.storage.isNil()
+      not waku.node.peerManager.storage.isNil()
 
   test "node setup is successful with default configuration":
     ## Given
     let conf = defaultTestWakuNodeConf()
 
     ## When
-    var wakunode2 = Waku.init(conf).valueOr:
+    var waku = Waku.init(conf).valueOr:
       raiseAssert error
 
-    (waitFor wakunode2.startWaku()).isOkOr:
+    (waitFor startWaku(addr waku)).isOkOr:
       raiseAssert error
 
-    wakunode2.metricsServer = waku_metrics.startMetricsServerAndLogging(conf).valueOr:
+    waku.metricsServer = waku_metrics.startMetricsServerAndLogging(conf).valueOr:
       raiseAssert error
 
     ## Then
-    let node = wakunode2.node
+    let node = waku.node
     check:
       not node.isNil()
       node.wakuArchive.isNil()
@@ -64,7 +64,7 @@ suite "Wakunode2 - Waku initialization":
       not node.rendezvous.isNil()
 
     ## Cleanup
-    waitFor wakunode2.stop()
+    waitFor waku.stop()
 
   test "app properly handles dynamic port configuration":
     ## Given
@@ -72,15 +72,15 @@ suite "Wakunode2 - Waku initialization":
     conf.tcpPort = Port(0)
 
     ## When
-    var wakunode2 = Waku.init(conf).valueOr:
+    var waku = Waku.init(conf).valueOr:
       raiseAssert error
 
-    (waitFor wakunode2.startWaku()).isOkOr:
+    (waitFor startWaku(addr waku)).isOkOr:
       raiseAssert error
 
     ## Then
     let
-      node = wakunode2.node
+      node = waku.node
       typedNodeEnr = node.enr.toTypedRecord()
 
     assert typedNodeEnr.isOk(), $typedNodeEnr.error
@@ -97,4 +97,4 @@ suite "Wakunode2 - Waku initialization":
       typedNodeEnr.get().tcp.get() != 0
 
     ## Cleanup
-    waitFor wakunode2.stop()
+    waitFor waku.stop()

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -11,14 +11,14 @@ import
   libp2p/switch
 import ../testlib/common, ../testlib/wakucore, ../testlib/wakunode
 
-include ../../waku/factory/app
+include ../../waku/factory/waku
 
-suite "Wakunode2 - App":
+suite "Wakunode2 - Waku":
   test "compilation version should be reported":
     ## Given
     let conf = defaultTestWakuNodeConf()
 
-    let wakunode2 = App.init(conf).valueOr:
+    let wakunode2 = Waku.init(conf).valueOr:
       raiseAssert error
 
     ## When
@@ -28,13 +28,13 @@ suite "Wakunode2 - App":
     check:
       version == git_version
 
-suite "Wakunode2 - App initialization":
+suite "Wakunode2 - Waku initialization":
   test "peer persistence setup should be successfully mounted":
     ## Given
     var conf = defaultTestWakuNodeConf()
     conf.peerPersistence = true
 
-    let wakunode2 = App.init(conf).valueOr:
+    let wakunode2 = Waku.init(conf).valueOr:
       raiseAssert error
 
     check:
@@ -45,10 +45,10 @@ suite "Wakunode2 - App initialization":
     let conf = defaultTestWakuNodeConf()
 
     ## When
-    var wakunode2 = App.init(conf).valueOr:
+    var wakunode2 = Waku.init(conf).valueOr:
       raiseAssert error
 
-    wakunode2.startApp().isOkOr:
+    (waitFor wakunode2.startWaku()).isOkOr:
       raiseAssert error
 
     wakunode2.metricsServer = waku_metrics.startMetricsServerAndLogging(conf).valueOr:
@@ -72,10 +72,10 @@ suite "Wakunode2 - App initialization":
     conf.tcpPort = Port(0)
 
     ## When
-    var wakunode2 = App.init(conf).valueOr:
+    var wakunode2 = Waku.init(conf).valueOr:
       raiseAssert error
 
-    wakunode2.startApp().isOkOr:
+    (waitFor wakunode2.startWaku()).isOkOr:
       raiseAssert error
 
     ## Then
@@ -86,7 +86,7 @@ suite "Wakunode2 - App initialization":
     assert typedNodeEnr.isOk(), $typedNodeEnr.error
 
     check:
-      # App started properly
+      # Waku started properly
       not node.isNil()
       node.wakuArchive.isNil()
       node.wakuStore.isNil()

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -337,7 +337,7 @@ proc setupProtocols(
 
 proc startNode*(
     node: WakuNode, conf: WakuNodeConf, dynamicBootstrapNodes: seq[RemotePeerInfo] = @[]
-): Future[Result[void, string]] {.async.} =
+): Future[Result[void, string]] {.async: (raises: []).} =
   ## Start a configured node and all mounted protocols.
   ## Connect to static nodes and start
   ## keep-alive, if configured.

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -168,7 +168,7 @@ proc updateWaku(waku: ptr Waku): Result[void, string] =
 
   return ok()
 
-proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async.} =
+proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: []).} =
   (await startNode(waku.node, waku.conf, waku.dynamicBootstrapNodes)).isOkOr:
     return err("error while calling startNode: " & $error)
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1063,7 +1063,7 @@ proc mountPeerExchange*(node: WakuNode) {.async, raises: [Defect, LPError].} =
 
 proc fetchPeerExchangePeers*(
     node: Wakunode, amount: uint64
-): Future[Result[int, string]] {.async, raises: [Defect].} =
+): Future[Result[int, string]] {.async: (raises: []).} =
   if node.wakuPeerExchange.isNil():
     error "could not get peers from px, waku peer-exchange is nil"
     return err("PeerExchange is not mounted")

--- a/waku/waku.nim
+++ b/waku/waku.nim
@@ -1,9 +1,0 @@
-# Waku
-#
-# Licenses:
-# - MIT ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
-# - APACHEv2 ([LICENSE-APACHEv2](../LICENSE-APACHEv2) or https://www.apache.org/licenses/LICENSE-2.0)
-
-## An implementation of [Waku v2](https://rfc.vac.dev/spec/10/) in nim.
-import waku_node as wakunode2
-export wakunode2


### PR DESCRIPTION
## Description
With this PR we:
  - rename the `app.nim` module to `waku.nim`
  - rename `App` type to `Waku` type. We start considering `Waku` as the type that contains `WakuNode`, discovery elements, and will contain an instance of `PeerManager` in the future. `Waku` type represents Waku ;P (very original name ;P)
  - refactor `libwaku` code so that we start dealing with the `Waku` object from within `libwaku` and therefore, start having a similar behaviour as the `wakunode2` app

## Issue

`migrate DiscV5 and DNS Discovery from app.nim to waku_node.nim` - https://github.com/waku-org/nwaku/issues/2452