### PR TITLE
fix: wakuy/factory/internal_config.nim: refactor enrConfiguration to avoid crash

### DIFF
--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -34,13 +34,15 @@ proc enrConfiguration*(
     if conf.shards.len == 0:
       var shardsLocal = newSeq[uint16]()
       let shardsRes = topicsToRelayShards(conf.pubsubTopics)
-      if shardsRes.isOk() and shardsRes.get().isSome():
-        shardsLocal = shardsRes.get().get().shardIds
-      elif not shardsRes.get().isNone():
-        info "no pubsub topics specified or pubsubtopic is of type Named sharding "
-      else:
+      if shardsRes.isErr():
         error "failed to parse pubsub topic, please format according to static shard specification",
-          error = shardsRes.error
+          error = $shardsRes.error
+      else:
+        if shardsRes.get().isSome():
+          shardsLocal = shardsRes.get().get().shardIds
+        else:
+          info "no pubsub topics specified or pubsubtopic is of type Named sharding "
+
       shardsLocal
 
     # some shards configured


### PR DESCRIPTION
## Description
It happened a crash when running `wakunode2` with the following params:
`./build/wakunode2 --config-file=cfg_node_a.txt`

And using the following config file:
[cfg_node_a.txt](https://github.com/waku-org/nwaku/files/15187642/cfg_node_a.txt)

The node crashed with the following because it was trying to log an `error-result` which actually was an `ok(none(...))`:
```
INF 2024-05-02 13:14:57.405+02:00 Running nwaku node                         topics="wakunode main" tid=351868 file=wakunode2.nim:122 version=v0.27.0-rc.0-38-g404810
INF 2024-05-02 13:14:57.406+02:00 Configuration: Enabled protocols           topics="wakunode main" tid=351868 file=wakunode2.nim:30 relay=true rlnRelay=false store=false filter=true lightpush=true peerExchange=false
INF 2024-05-02 13:14:57.406+02:00 Configuration. Network                     topics="wakunode main" tid=351868 file=wakunode2.nim:38 cluster=0 maxPeers=none(int)
INF 2024-05-02 13:14:57.406+02:00 Configuration. Shards                      topics="wakunode main" tid=351868 file=wakunode2.nim:41 shard=/waku/2/default-waku/proto
NTC 2024-05-02 13:14:57.406+02:00 REST service started                       tid=351868 file=server.nim:189 address=127.0.0.1:8646
INF 2024-05-02 13:14:57.406+02:00 Starting REST HTTP server                  tid=351868 file=builder.nim:109 url=http://127.0.0.1:8646/
DBG 2024-05-02 13:14:57.406+02:00 Retrieve dynamic bootstrap nodes           topics="wakunode main" tid=351868 file=app.nim:90
DBG 2024-05-02 13:14:57.406+02:00 No method for retrieving dynamic bootstrap nodes specified. topics="waku dnsdisc" tid=351868 file=waku_dnsdisc.nim:131
/home/ivansete/workspace/status/nwaku/apps/wakunode2/wakunode2.nim(138) wakunode2
/home/ivansete/workspace/status/nwaku/waku/factory/app.nim(101) init
/home/ivansete/workspace/status/nwaku/waku/factory/node_factory.nim(406) setupNode
/home/ivansete/workspace/status/nwaku/vendor/nim-chronicles/chronicles.nim(170) enrConfiguration
/home/ivansete/workspace/status/nwaku/vendor/nim-results/results.nim(906) error
/home/ivansete/workspace/status/nwaku/vendor/nim-results/results.nim(376) raiseResultDefect
Error: unhandled exception: Trying to access error when value is set: none(RelayShards) [ResultDefect]
```


