### PR TITLE
test: remove some API message validation checks

### DIFF
--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -21,7 +21,8 @@ import
   ../serdes,
   ../responses,
   ../rest_serdes,
-  ./types
+  ./types,
+  ../../../../../tests/waku_rln_relay/rln/waku_rln_relay_utils
 
 from std/times import getTime
 from std/times import toUnix
@@ -155,7 +156,7 @@ proc installRelayApiHandlers*(
     if not node.wakuRlnRelay.isNil():
       # append the proof to the message
 
-      node.wakuRlnRelay.appendRLNProof(message, float64(getTime().toUnix())).isOkOr:
+      node.wakuRlnRelay.unsafeAppendRLNProof(message, float64(getTime().toUnix())).isOkOr:
         return RestApiResponse.internalServerError(
           "Failed to publish: error appending RLN proof to message: " & $error
         )
@@ -266,7 +267,7 @@ proc installRelayApiHandlers*(
 
     # if RLN is mounted, append the proof to the message
     if not node.wakuRlnRelay.isNil():
-      node.wakuRlnRelay.appendRLNProof(message, float64(getTime().toUnix())).isOkOr:
+      node.wakuRlnRelay.unsafeAppendRLNProof(message, float64(getTime().toUnix())).isOkOr:
         return RestApiResponse.internalServerError(
           "Failed to publish: error appending RLN proof to message: " & $error
         )

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -160,8 +160,8 @@ proc installRelayApiHandlers*(
           "Failed to publish: error appending RLN proof to message: " & $error
         )
 
-    (await node.wakuRelay.validateMessage(pubsubTopic, message)).isOkOr:
-      return RestApiResponse.badRequest("Failed to publish: " & error)
+    # (await node.wakuRelay.validateMessage(pubsubTopic, message)).isOkOr:
+    #   return RestApiResponse.badRequest("Failed to publish: " & error)
 
     # if we reach here its either a non-RLN message or a RLN message with a valid proof
     debug "Publishing message",
@@ -271,8 +271,8 @@ proc installRelayApiHandlers*(
           "Failed to publish: error appending RLN proof to message: " & $error
         )
 
-    (await node.wakuRelay.validateMessage(pubsubTopic, message)).isOkOr:
-      return RestApiResponse.badRequest("Failed to publish: " & error)
+    # (await node.wakuRelay.validateMessage(pubsubTopic, message)).isOkOr:
+    #   return RestApiResponse.badRequest("Failed to publish: " & error)
 
     # if we reach here its either a non-RLN message or a RLN message with a valid proof
     debug "Publishing message",

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -156,7 +156,7 @@ proc installRelayApiHandlers*(
     if not node.wakuRlnRelay.isNil():
       # append the proof to the message
 
-      node.wakuRlnRelay.unsafeAppendRLNProof(message, float64(getTime().toUnix())).isOkOr:
+      node.wakuRlnRelay.appendRLNProof(message, float64(getTime().toUnix())).isOkOr:
         return RestApiResponse.internalServerError(
           "Failed to publish: error appending RLN proof to message: " & $error
         )
@@ -267,7 +267,7 @@ proc installRelayApiHandlers*(
 
     # if RLN is mounted, append the proof to the message
     if not node.wakuRlnRelay.isNil():
-      node.wakuRlnRelay.unsafeAppendRLNProof(message, float64(getTime().toUnix())).isOkOr:
+      node.wakuRlnRelay.appendRLNProof(message, float64(getTime().toUnix())).isOkOr:
         return RestApiResponse.internalServerError(
           "Failed to publish: error appending RLN proof to message: " & $error
         )

--- a/waku/waku_rln_relay/group_manager/group_manager_base.nim
+++ b/waku/waku_rln_relay/group_manager/group_manager_base.nim
@@ -3,8 +3,9 @@ import
   ../protocol_types,
   ../protocol_metrics,
   ../constants,
+  ../conversion_utils,
   ../rln
-import options, chronos, stew/results, std/[deques, sequtils]
+import options, chronos, chronicles, stew/results, std/[deques, sequtils]
 
 export options, chronos, results, protocol_types, protocol_metrics, deques
 
@@ -191,6 +192,12 @@ method generateProof*(
     return err("membership index is not set")
   if g.userMessageLimit.isNone():
     return err("user message limit is not set")
+  debug "generating proof params",
+    epoch = fromEpoch(epoch),
+    messageId = messageId,
+    userMessageLimit = g.userMessageLimit.get(),
+    idCommitment = inHex(g.idCredentials.get().idCommitment),
+    index = g.membershipIndex.get()
   waku_rln_proof_generation_duration_seconds.nanosecondTime:
     let proof = proofGen(
       rlnInstance = g.rlnInstance,
@@ -203,7 +210,6 @@ method generateProof*(
     ).valueOr:
       return err("proof generation failed: " & $error)
   return ok(proof)
-
 
 method isReady*(g: GroupManager): Future[bool] {.base, async.} =
   raise newException(

--- a/waku/waku_rln_relay/nonce_manager.nim
+++ b/waku/waku_rln_relay/nonce_manager.nim
@@ -48,14 +48,15 @@ proc getNonce*(n: NonceManager): NonceManagerResult[Nonce] =
   n.nextNonce = retNonce + 1
   n.lastNonceTime = now
 
-  if retNonce >= n.nonceLimit:
-    return err(
-      NonceManagerError(
-        kind: NonceLimitReached,
-        error:
-          "Nonce limit reached. Please wait for the next epoch. requested nonce: " &
-          $retNonce & " & nonceLimit: " & $n.nonceLimit,
-      )
-    )
+  # This is commented out only for testing purposes
+  # if retNonce >= n.nonceLimit:
+  #   return err(
+  #     NonceManagerError(
+  #       kind: NonceLimitReached,
+  #       error:
+  #         "Nonce limit reached. Please wait for the next epoch. requested nonce: " &
+  #         $retNonce & " & nonceLimit: " & $n.nonceLimit,
+  #     )
+  #   )
 
   return ok(retNonce)

--- a/waku/waku_rln_relay/nonce_manager.nim
+++ b/waku/waku_rln_relay/nonce_manager.nim
@@ -3,7 +3,7 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import chronos, stew/results, times
+import chronos, chronicles, stew/results, times
 import ./constants
 
 export chronos, times, results, constants
@@ -48,8 +48,9 @@ proc getNonce*(n: NonceManager): NonceManagerResult[Nonce] =
   n.nextNonce = retNonce + 1
   n.lastNonceTime = now
 
-  # This is commented out only for testing purposes
-  # if retNonce >= n.nonceLimit:
+  # This is modified for testing purposes, once the limit is reached the nonce value is reset to 0
+  if retNonce >= n.nonceLimit:
+    retNonce = 0
   #   return err(
   #     NonceManagerError(
   #       kind: NonceLimitReached,

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -357,7 +357,7 @@ proc generateRlnValidator*(
       payload = string.fromBytes(message.payload)
     case validationRes
     of Valid:
-      trace "message validity is verified, relaying:",
+      debug "message validity is verified, relaying:",
         proof = proof,
         root = root,
         shareX = shareX,
@@ -365,7 +365,7 @@ proc generateRlnValidator*(
         nullifier = nullifier
       return pubsub.ValidationResult.Accept
     of Invalid:
-      trace "message validity could not be verified, discarding:",
+      debug "message validity could not be verified, discarding:",
         proof = proof,
         root = root,
         shareX = shareX,
@@ -373,7 +373,7 @@ proc generateRlnValidator*(
         nullifier = nullifier
       return pubsub.ValidationResult.Reject
     of Spam:
-      trace "A spam message is found! yay! discarding:",
+      debug "A spam message is found! yay! discarding:",
         proof = proof,
         root = root,
         shareX = shareX,

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -331,7 +331,7 @@ proc clearNullifierLog(rlnPeer: WakuRlnRelay) =
   # note: the epochs are ordered ascendingly
   debug "clearing nullifier log",
     count = rlnPeer.nullifierLog.len().uint, maxGap = rlnPeer.rlnMaxEpochGap
-  if rlnPeer.nullifierLog.len().uint < rlnPeer.rlnMaxEpochGap:
+  if rlnPeer.nullifierLog.len().uint <= rlnPeer.rlnMaxEpochGap:
     return
 
   debug "clearing epochs from the nullifier log", count = rlnPeer.rlnMaxEpochGap


### PR DESCRIPTION
# Description
DO NOT MERGE, only for RLNv2 epoch testing

# Changes
The following message validation checks are commented out:

- nonceLimit check in nonce_manager.nim
- message validation in handlers.nim

## How to test

1. This procedure can be used for testing: https://www.notion.so/Waku-RLNv2-Testnet1-d11b3108a6ed4c39b378417db82302a6


## Issue
Relates to https://github.com/waku-org/waku-simulator/issues/44
