### PR TITLE
chore(rln-relay): health check should account for window of roots

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -586,7 +586,7 @@ proc getNewBlockCallback(g: OnchainGroupManager): proc =
     g.retryWrapper(handleBlockRes, "Failed to handle new block"):
       await g.getAndHandleEvents(fromBlock, latestBlock)
 
-    # cannot use isOkOr here because results in a compile-time error that 
+    # cannot use isOkOr here because results in a compile-time error that
     # shows the error is void for some reason
     let setMetadataRes = g.setMetadata()
     if setMetadataRes.isErr():
@@ -855,7 +855,8 @@ method isReady*(g: OnchainGroupManager): Future[bool] {.async.} =
   g.retryWrapper(currentBlock, "Failed to get the current block number"):
     cast[BlockNumber](await g.ethRpc.get().provider.eth_blockNumber())
 
-  if g.latestProcessedBlock < currentBlock:
+  # the node is still able to process messages if it is behind the latest block by a factor of the valid roots
+  if g.latestProcessedBlock < currentBlock - g.validRoots.len:
     return false
 
   return not (await g.isSyncing())

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -856,7 +856,7 @@ method isReady*(g: OnchainGroupManager): Future[bool] {.async.} =
     cast[BlockNumber](await g.ethRpc.get().provider.eth_blockNumber())
 
   # the node is still able to process messages if it is behind the latest block by a factor of the valid roots
-  if g.latestProcessedBlock < currentBlock - g.validRoots.len:
+  if uint(g.latestProcessedBlock) < uint(currentBlock) - uint(g.validRoots.len):
     return false
 
   return not (await g.isSyncing())

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -856,7 +856,7 @@ method isReady*(g: OnchainGroupManager): Future[bool] {.async.} =
     cast[BlockNumber](await g.ethRpc.get().provider.eth_blockNumber())
 
   # the node is still able to process messages if it is behind the latest block by a factor of the valid roots
-  if uint(g.latestProcessedBlock) < uint(currentBlock) - uint(g.validRoots.len):
+  if u256(g.latestProcessedBlock) < u256(currentBlock) - u256(g.validRoots.len):
     return false
 
   return not (await g.isSyncing())

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -856,7 +856,7 @@ method isReady*(g: OnchainGroupManager): Future[bool] {.async.} =
     cast[BlockNumber](await g.ethRpc.get().provider.eth_blockNumber())
 
   # the node is still able to process messages if it is behind the latest block by a factor of the valid roots
-  if u256(g.latestProcessedBlock) < u256(currentBlock) - u256(g.validRoots.len):
+  if u256(g.latestProcessedBlock) < (u256(currentBlock) - u256(g.validRoots.len)):
     return false
 
   return not (await g.isSyncing())


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR modifies the `ready` behaviour of rln-relay's onchain mode. If the node is behind the tip of the blockchain by `window` blocks, it should still be marked as ready IMO.

# Changes

<!-- List of detailed changes -->

- [x] returns `ready` if the node is behind the tip of the blockchain by `window` blocks

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
