### PR TITLE
fix(filter): log is too large

### DIFF
--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -217,7 +217,7 @@ proc handleMessage*(
   let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
 
   debug "handling message",
-    pubsubTopic = pubsubTopic, message = message, msg_hash = msgHash
+    pubsubTopic = pubsubTopic, msg_hash = msgHash
 
   let handleMessageStartTime = Moment.now()
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
the filter protocol logs out the whole message, this is bad

![image](https://github.com/waku-org/nwaku/assets/43716372/330c5ab6-6440-41e0-b6ff-f9df2fa81e09)

identified this is the offending log -
![image](https://github.com/waku-org/nwaku/assets/43716372/8f70e816-36ba-4640-b134-5459d153b18a)


# Changes

<!-- List of detailed changes -->

- [x] removes the message  from the "handling message" filter log 

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->