### PR TITLE
chore: update archive proc to raise nothing

### DIFF
--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -130,7 +130,7 @@ proc handleMessage*(
 
 proc findMessages*(
     self: WakuArchive, query: ArchiveQuery
-): Future[ArchiveResult] {.async, gcsafe.} =
+): Future[ArchiveResult] {.async: (raises: []), gcsafe.} =
   ## Search the archive to return a single page of messages matching the query criteria
 
   let maxPageSize =

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -55,7 +55,7 @@ method getMessages*(
     hashes = newSeq[WakuMessageHash](0),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
-): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async.} =
+): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async: (raises: []).} =
   discard
 
 method getMessagesCount*(

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -600,7 +600,7 @@ method getMessages*(
     hashes = newSeq[WakuMessageHash](0),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
-): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
+): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async: (raises: []).} =
   let hexHashes = hashes.mapIt(toHex(it))
 
   if contentTopicSeq.len == 1 and hexHashes.len == 1 and pubsubTopic.isSome() and

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -267,7 +267,7 @@ method getMessages*(
     hashes: seq[WakuMessageHash] = @[],
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
-): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
+): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async: (raises: []).} =
   let cursor = cursor.map(toIndex)
 
   let matchesQuery: QueryFilterMatcher =

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -120,7 +120,7 @@ method getMessages*(
     hashes = newSeq[WakuMessageHash](0),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
-): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
+): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async: (raises: []).} =
   let cursor =
     if cursor.isSome():
       some(cursor.get().hash)


### PR DESCRIPTION
An update needed for Waku Sync.

Archive's `getMessages` and all drivers are now forced to raise nothing.