### PR TITLE
chore: move code from wakunode2 to a more generic place, waku

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -17,7 +17,6 @@ import
   ../../tools/rln_db_inspector/rln_db_inspector,
   ../../waku/common/logging,
   ../../waku/factory/external_config,
-  ../../waku/factory/networks_config,
   ../../waku/factory/waku,
   ../../waku/node/health_monitor,
   ../../waku/node/waku_metrics,
@@ -26,31 +25,7 @@ import
 logScope:
   topics = "wakunode main"
 
-proc logConfig(conf: WakuNodeConf) =
-  info "Configuration: Enabled protocols",
-    relay = conf.relay,
-    rlnRelay = conf.rlnRelay,
-    store = conf.store,
-    filter = conf.filter,
-    lightpush = conf.lightpush,
-    peerExchange = conf.peerExchange
-
-  info "Configuration. Network", cluster = conf.clusterId, maxPeers = conf.maxRelayPeers
-
-  for shard in conf.pubsubTopics:
-    info "Configuration. Shards", shard = shard
-
-  for i in conf.discv5BootstrapNodes:
-    info "Configuration. Bootstrap nodes", node = i
-
-  if conf.rlnRelay and conf.rlnRelayDynamic:
-    info "Configuration. Validation",
-      mechanism = "onchain rln",
-      contract = conf.rlnRelayEthContractAddress,
-      maxMessageSize = conf.maxMessageSize,
-      rlnEpochSizeSec = conf.rlnEpochSizeSec,
-      rlnRelayUserMessageLimit = conf.rlnRelayUserMessageLimit,
-      rlnRelayEthClientAddress = string(conf.rlnRelayEthClientAddress)
+const git_version* {.strdefine.} = "n/a"
 
 {.pop.}
   # @TODO confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError
@@ -65,15 +40,11 @@ when isMainModule:
 
   const versionString = "version / git commit hash: " & waku.git_version
 
-  let confRes = WakuNodeConf.load(version = versionString)
-  if confRes.isErr():
-    error "failure while loading the configuration", error = confRes.error
+  var conf = WakuNodeConf.load(version = versionString).valueOr:
+    error "failure while loading the configuration", error = error
     quit(QuitFailure)
 
-  var conf = confRes.get()
-
   ## Logging setup
-
   # Adhere to NO_COLOR initiative: https://no-color.org/
   let color =
     try:
@@ -90,38 +61,6 @@ when isMainModule:
   of inspectRlnDb:
     doInspectRlnDb(conf)
   of noCommand:
-    case conf.clusterId
-    # cluster-id=0
-    of 0:
-      let clusterZeroConf = ClusterConf.ClusterZeroConf()
-      conf.pubsubTopics = clusterZeroConf.pubsubTopics
-      # TODO: Write some template to "merge" the configs
-    # cluster-id=1 (aka The Waku Network)
-    of 1:
-      let twnClusterConf = ClusterConf.TheWakuNetworkConf()
-      if len(conf.shards) != 0:
-        conf.pubsubTopics = conf.shards.mapIt(twnClusterConf.pubsubTopics[it.uint16])
-      else:
-        conf.pubsubTopics = twnClusterConf.pubsubTopics
-
-      # Override configuration
-      conf.maxMessageSize = twnClusterConf.maxMessageSize
-      conf.clusterId = twnClusterConf.clusterId
-      conf.rlnRelay = twnClusterConf.rlnRelay
-      conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
-      conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
-      conf.rlnRelayBandwidthThreshold = twnClusterConf.rlnRelayBandwidthThreshold
-      conf.discv5Discovery = twnClusterConf.discv5Discovery
-      conf.discv5BootstrapNodes =
-        conf.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
-      conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
-      conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
-    else:
-      discard
-
-    info "Running nwaku node", version = waku.git_version
-    logConfig(conf)
-
     # NOTE: {.threadvar.} is used to make the global variable GC safe for the closure uses it
     # It will always be called from main thread anyway.
     # Ref: https://nim-lang.org/docs/manual.html#threads-gc-safety

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -26,6 +26,9 @@ type Context* = object
   eventCallback*: pointer
   eventUserdata*: pointer
 
+const git_version* {.strdefine.} = "n/a"
+const versionString = "version / git commit hash: " & waku.git_version
+
 # To control when the thread is running
 var running: Atomic[bool]
 
@@ -47,6 +50,7 @@ proc waku_init() =
 proc run(ctx: ptr Context) {.thread.} =
   ## This is the worker thread body. This thread runs the Waku node
   ## and attends library user requests (stop, connect_to, etc.)
+  info "Starting Waku", version = versionString
 
   var waku: Waku
 

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -33,7 +33,8 @@ proc defaultTestWakuNodeConf*(): WakuNodeConf =
     maxConnections: 50,
     maxMessageSize: "1024 KiB",
     clusterId: 0.uint32,
-      # set cluster-id == 0 to not use TWN as that needs a background chain (e.g. anvil) running
+      ## set cluster-id == 0 to not use TWN as that needs a background blockchain (e.g. anvil)
+      ## running because RLN is mounted if TWN (cluster-id == 1) is configured.
     pubsubTopics: @["/waku/2/rs/1/0"],
     relay: true,
     storeMessageDbUrl: "sqlite://store.sqlite3",

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -32,7 +32,8 @@ proc defaultTestWakuNodeConf*(): WakuNodeConf =
     nat: "any",
     maxConnections: 50,
     maxMessageSize: "1024 KiB",
-    clusterId: 1.uint32,
+    clusterId: 0.uint32,
+      # set cluster-id == 0 to not use TWN as that needs a background chain (e.g. anvil) running
     pubsubTopics: @["/waku/2/rs/1/0"],
     relay: true,
     storeMessageDbUrl: "sqlite://store.sqlite3",

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -21,6 +21,8 @@ import
 # Waku node
 
 proc defaultTestWakuNodeConf*(): WakuNodeConf =
+  ## set cluster-id == 0 to not use TWN as that needs a background blockchain (e.g. anvil)
+  ## running because RLN is mounted if TWN (cluster-id == 1) is configured.
   WakuNodeConf(
     cmd: noCommand,
     tcpPort: Port(60000),
@@ -33,8 +35,6 @@ proc defaultTestWakuNodeConf*(): WakuNodeConf =
     maxConnections: 50,
     maxMessageSize: "1024 KiB",
     clusterId: 0.uint32,
-      ## set cluster-id == 0 to not use TWN as that needs a background blockchain (e.g. anvil)
-      ## running because RLN is mounted if TWN (cluster-id == 1) is configured.
     pubsubTopics: @["/waku/2/rs/1/0"],
     relay: true,
     storeMessageDbUrl: "sqlite://store.sqlite3",


### PR DESCRIPTION
## Description
This PR moves some initialization logic from `apps/wakunode2/wakunode2.nim` to `waku/factory/waku.nim`, aiming to achieve same behaviour between `wakunode2` and `libwaku`.

