### PR TITLE
fix: content_script_version_4.nim: migration failed when dropping unexisting constraing

### DIFF
--- a/migrations/message_store_postgres/content_script_version_4.nim
+++ b/migrations/message_store_postgres/content_script_version_4.nim
@@ -63,6 +63,8 @@ INSERT INTO messages (
                        storedAt
                    FROM messages_backup;
 
+CREATE INDEX IF NOT EXISTS i_query ON messages (contentTopic, pubsubTopic, storedAt, id);
+
 DROP TABLE messages_backup;
 
 UPDATE version SET version = 4 WHERE version = 3;

--- a/migrations/message_store_postgres/content_script_version_4.nim
+++ b/migrations/message_store_postgres/content_script_version_4.nim
@@ -2,7 +2,6 @@ const ContentScriptVersion_4* =
   """
 ALTER TABLE IF EXISTS messages_backup RENAME TO messages;
 ALTER TABLE messages RENAME TO messages_backup;
-ALTER TABLE messages_backup DROP CONSTRAINT messageIndex;
 
 CREATE TABLE IF NOT EXISTS messages (
    pubsubTopic VARCHAR NOT NULL,

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -616,6 +616,7 @@ proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
 proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
+# change to force image creation in CI
 proc parseCmdArg*(T: type ProtectedTopic, p: string): T =
   let elements = p.split(":")
   if elements.len != 2:

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -616,7 +616,6 @@ proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
 proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
-# change to force image creation in CI
 proc parseCmdArg*(T: type ProtectedTopic, p: string): T =
   let elements = p.split(":")
   if elements.len != 2:


### PR DESCRIPTION
## Description
There appeared _Postgres_ schema migration issue when going from schema version 3 to 4.

The problem occurred while trying to remove an index that doesn't seem to exist in version 3.

Aside from that, I'm adding the following line, which is part of the script for version 3, to make sure that index is created in case it doesn't exist. I've notice that when testing in `waku.test`:
`CREATE INDEX IF NOT EXISTS i_query ON messages (contentTopic, pubsubTopic, storedAt, id);`


