### PR TITLE
chore: simplify migration script

### DIFF
--- a/migrations/message_store_postgres/content_script_version_4.nim
+++ b/migrations/message_store_postgres/content_script_version_4.nim
@@ -1,6 +1,6 @@
 const ContentScriptVersion_4* =
   """
-ALTER TABLE messages ADD meta VARCHAR;
+ALTER TABLE messages ADD meta VARCHAR default null;
 
 CREATE INDEX IF NOT EXISTS i_query ON messages (contentTopic, pubsubTopic, storedAt, id);
 

--- a/migrations/message_store_postgres/content_script_version_4.nim
+++ b/migrations/message_store_postgres/content_script_version_4.nim
@@ -1,71 +1,8 @@
 const ContentScriptVersion_4* =
   """
-ALTER TABLE IF EXISTS messages_backup RENAME TO messages;
-ALTER TABLE messages RENAME TO messages_backup;
-
-CREATE TABLE IF NOT EXISTS messages (
-   pubsubTopic VARCHAR NOT NULL,
-   contentTopic VARCHAR NOT NULL,
-   payload VARCHAR,
-   version INTEGER NOT NULL,
-   timestamp BIGINT NOT NULL,
-   id VARCHAR NOT NULL,
-   messageHash VARCHAR NOT NULL,
-   storedAt BIGINT NOT NULL,
-   meta VARCHAR,
-   CONSTRAINT messageIndex PRIMARY KEY (messageHash, storedAt)
-  ) PARTITION BY RANGE (storedAt);
-
-DO $$
-DECLARE
-     min_storedAt numeric;
-     max_storedAt numeric;
-     min_storedAtSeconds integer = 0;
-     max_storedAtSeconds integer = 0;
-     partition_name TEXT;
-     create_partition_stmt TEXT;
-BEGIN
-    SELECT MIN(storedAt) into min_storedAt
-    FROM messages_backup;
-
-    SELECT MAX(storedAt) into max_storedAt
-    FROM messages_backup;
-
-    min_storedAtSeconds := min_storedAt / 1000000000;
-    max_storedAtSeconds := max_storedAt / 1000000000;
-
-    partition_name := 'messages_' || min_storedAtSeconds || '_' || max_storedAtSeconds;
-    create_partition_stmt := 'CREATE TABLE ' || partition_name ||
-                            ' PARTITION OF messages FOR VALUES FROM (' ||
-                            min_storedAt || ') TO (' || (max_storedAt + 1) || ')';
-    IF min_storedAtSeconds > 0 AND max_storedAtSeconds > 0 THEN
-    	EXECUTE create_partition_stmt USING partition_name, min_storedAt, max_storedAt;
-    END IF;
-END $$;
-
-INSERT INTO messages (
-                        pubsubTopic,
-                        contentTopic,
-                        payload,
-                        version,
-                        timestamp,
-                        id,
-                        messageHash,
-                        storedAt
-                     )
-                SELECT pubsubTopic,
-                       contentTopic,
-                       payload,
-                       version,
-                       timestamp,
-                       id,
-                       messageHash,
-                       storedAt
-                   FROM messages_backup;
+ALTER TABLE messages ADD meta VARCHAR;
 
 CREATE INDEX IF NOT EXISTS i_query ON messages (contentTopic, pubsubTopic, storedAt, id);
-
-DROP TABLE messages_backup;
 
 UPDATE version SET version = 4 WHERE version = 3;
 

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -616,6 +616,7 @@ proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
 proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
+## temporary comment to force creating image
 proc parseCmdArg*(T: type ProtectedTopic, p: string): T =
   let elements = p.split(":")
   if elements.len != 2:

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -616,7 +616,6 @@ proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
 proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
-## temporary comment to force creating image
 proc parseCmdArg*(T: type ProtectedTopic, p: string): T =
   let elements = p.split(":")
   if elements.len != 2:


### PR DESCRIPTION
## Description
While running migration scripts we noticed that is better to try to change the table schema directly in the `messages` table. The reason is that is not possible to keep handle a table backup when the `message` table occupies 45GiB and the max size allowed in 50GiB

With this PR we try to allow database migration with low disk availability constraints.

We want to avoid errors like:
```
nim-waku  | ERR 2024-05-06 17:22:42.470+00:00 failed to execute migration statement      topics="waku archive migration" tid=1 file=migrations.nim:81 statement="INSERT INTO messages (\n                        pubsubTopic,\n                        contentTopic,\n                        payload,\n                        version,\n                        timestamp,\n                        id,\n                        messageHash,\n                        storedAt\n                     )\n                SELECT pubsubTopic,\n                       contentTopic,\n                       payload,\n                       version,\n                       timestamp,\n                       id,\n                       messageHash,\n                       storedAt\n                   FROM messages_backup;" error="error in performWriteQuery: error in asyncpool query: error in dbConnQuery calling waitQueryToFinish: error in query: ERROR:  could not extend file \"base/16385/1332673.15\": No space left on device\nHINT:  Check free disk space.\n"
nim-waku  | ERR 2024-05-06 17:22:42.471+00:00 Mounting protocols failed                  tid=1 file=node_factory.nim:433 error="failed to setup archive driver: ArchiveDriver build failed in migration: failed to execute migration statement"
nim-waku  | ERR 2024-05-06 17:22:42.472+00:00 Failed setting up node                     topics="wakunode main" tid=1 file=waku.nim:97 error="Mounting protocols failed: failed to setup archive driver: ArchiveDriver build failed in migration: failed to execute migration statement"
nim-waku  | ERR 2024-05-06 17:22:42.472+00:00 Waku initialization failed                 topics="wakunode main" tid=1 file=wakunode2.nim:139 error="Failed setting up node: Mounting protocols failed: failed to setup archive driver: ArchiveDriver build failed in migration: failed to execute migration statement"
```


