### PR TITLE
fix: add `meta` to sqlite migration scripts

### DIFF
--- a/migrations/message_store/00009_addMetaColumn.up.sql
+++ b/migrations/message_store/00009_addMetaColumn.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE message ADD COLUMN meta BLOB;

--- a/waku/waku_archive/driver/sqlite_driver/migrations.nim
+++ b/waku/waku_archive/driver/sqlite_driver/migrations.nim
@@ -10,7 +10,7 @@ import ../../../common/databases/db_sqlite, ../../../common/databases/common
 logScope:
   topics = "waku archive migration"
 
-const SchemaVersion* = 8 # increase this when there is an update in the database schema
+const SchemaVersion* = 9 # increase this when there is an update in the database schema
 
 template projectRoot(): string =
   currentSourcePath.rsplit(DirSep, 1)[0] / ".." / ".." / ".." / ".."


### PR DESCRIPTION
# Description
While running `./build/waku --store` on latest master, i ran into the following error:
```
/home/richard/waku-org/nwaku/apps/wakunode2/wakunode2.nim(138) wakunode2
/home/richard/waku-org/nwaku/waku/factory/waku.nim(95) init
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(432) setupNode
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(113) setupProtocols
/home/richard/waku-org/nwaku/vendor/nim-chronos/chronos/internal/asyncfutures.nim(382) futureContinue
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(231) setupProtocols
/home/richard/waku-org/nwaku/waku/waku_archive/driver/builder.nim(24) new
/home/richard/waku-org/nwaku/vendor/nim-chronos/chronos/internal/asyncfutures.nim(382) futureContinue
/home/richard/waku-org/nwaku/waku/waku_archive/driver/builder.nim(81) new
/home/richard/waku-org/nwaku/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim(53) new
/home/richard/waku-org/nwaku/waku/waku_archive/driver/sqlite_driver/queries.nim(159) prepareInsertMessageStmt
/home/richard/waku-org/nwaku/vendor/nim-results/results.nim(376) raiseResultDefect
[[reraised from:
/home/richard/waku-org/nwaku/apps/wakunode2/wakunode2.nim(138) wakunode2
/home/richard/waku-org/nwaku/waku/factory/waku.nim(95) init
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(432) setupNode
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(113) setupProtocols
/home/richard/waku-org/nwaku/vendor/nim-chronos/chronos/internal/asyncfutures.nim(382) futureContinue
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(231) setupProtocols
/home/richard/waku-org/nwaku/waku/waku_archive/driver/builder.nim(24) new
/home/richard/waku-org/nwaku/vendor/nim-chronos/chronos/internal/asyncfutures.nim(382) futureContinue
/home/richard/waku-org/nwaku/waku/waku_archive/driver/builder.nim(125) new
]]
[[reraised from:
/home/richard/waku-org/nwaku/apps/wakunode2/wakunode2.nim(138) wakunode2
/home/richard/waku-org/nwaku/waku/factory/waku.nim(95) init
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(432) setupNode
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(113) setupProtocols
/home/richard/waku-org/nwaku/vendor/nim-chronos/chronos/internal/asyncfutures.nim(382) futureContinue
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(334) setupProtocols
]]
[[reraised from:
/home/richard/waku-org/nwaku/apps/wakunode2/wakunode2.nim(138) wakunode2
/home/richard/waku-org/nwaku/waku/factory/waku.nim(95) init
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(432) setupNode
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(113) setupProtocols
/home/richard/waku-org/nwaku/vendor/nim-chronos/chronos/internal/asyncfutures.nim(382) futureContinue
/home/richard/waku-org/nwaku/waku/factory/node_factory.nim(334) setupProtocols
]]
Error: unhandled exception: this is a valid statement: SQL logic error [ResultDefect]
```
When I browsed the db, and executed `.schema message` I saw that the problem was that the `meta` column did not exist. 



Something curious tho, @Ivansete-status and @gabrielmer: when running sqlite, it seems that we use the .sql migration scripts, however we also have this `createTableQuery` proc: https://github.com/waku-org/nwaku/blob/38f8b08c7c818c2d3cb8460e972357e5a373c2b4/waku/waku_archive/driver/sqlite_driver/queries.nim#L86-L92 and `createOldestMessageTimestampIndexQuery`

Should we get rid of both of these so it's the migration scripts the ones responsible for updating the db schema for sqlite? based on the behavior before this fix, i'd say that it is highly likely that `createTableQuery` is not being used at all.


