### PR TITLE
feat(rln-relay): use arkzkey variant of zerokit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ clean: | clean-libbacktrace
 
 LIBRLN_BUILDDIR := $(CURDIR)/vendor/zerokit
 ifeq ($(RLN_V2),true)
-LIBRLN_VERSION := v0.4.3
+LIBRLN_VERSION := v0.4.4
 else
 LIBRLN_VERSION := v0.3.7
 endif

--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -17,17 +17,28 @@ output_filename=$3
 # Get the host triplet
 host_triplet=$(rustc --version --verbose | awk '/host:/{print $2}')
 
+tarball="${host_triplet}"
+
+# use arkzkey feature for v0.4.4
+# TODO: update this script in the future when arkzkey is default
+if [[ "${rln_version}" == "v0.4.4" ]]; then
+    tarball+="-arkzkey-rln.tar.gz"
+else
+    tarball+="-rln.tar.gz"
+fi
+
+
 # Download the prebuilt rln library if it is available
 if curl --silent --fail-with-body -L \
-  "https://github.com/vacp2p/zerokit/releases/download/$rln_version/${host_triplet}-rln.tar.gz" \
-  -o "${host_triplet}-rln.tar.gz";
+  "https://github.com/vacp2p/zerokit/releases/download/$rln_version/$tarball" \
+  -o "${tarball}";
 then
-    echo "Downloaded ${host_triplet}-rln.tar.gz"
-    tar -xzf "${host_triplet}-rln.tar.gz"
+    echo "Downloaded ${tarball}"
+    tar -xzf "${tarball}"
     mv "release/librln.a" "${output_filename}"
-    rm -rf "${host_triplet}-rln.tar.gz" release
+    rm -rf "${tarball}" release
 else
-    echo "Failed to download ${host_triplet}-rln.tar.gz"
+    echo "Failed to download ${tarball}"
     # Build rln instead
     # first, check if submodule version = version in Makefile
     cargo metadata --format-version=1 --no-deps --manifest-path "${build_dir}/rln/Cargo.toml"


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR includes the new zerokit release v0.4.4, which brings a speedup of ~50% while running tests and deserialization for the circuit logic.

# Changes

<!-- List of detailed changes -->

- [x] updated Makefile entry
- [x] updated build_rln.sh to use arkzkey if version is v0.4.4

# Comparison 

While running `tests/waku_rln_relay/test_all.nim` with RLN_V2 enabled

Without arkzkey: `[Summary] 68 tests run (377.2s): 68 OK, 0 FAILED, 0 SKIPPED`
With arkzkey: `[Summary] 68 tests run (219.9s): 68 OK, 0 FAILED, 0 SKIPPED`


<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
