### PR TITLE
fix: adding wait after starting node to avoid segfault

### DIFF
--- a/tests/node/test_wakunode_store.nim
+++ b/tests/node/test_wakunode_store.nim
@@ -87,6 +87,7 @@ suite "Waku Store - End to End - Sorted Archive":
     client.mountStoreClient()
 
     waitFor allFutures(server.start(), client.start())
+    await sleepAsync(chronos.milliseconds(500))
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
     clientPeerId = client.peerInfo.toRemotePeerInfo().peerId
@@ -941,6 +942,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
     client.mountStoreClient()
 
     waitFor allFutures(server.start(), client.start())
+    await sleepAsync(chronos.milliseconds(500))
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
 


### PR DESCRIPTION
## Description
Temporary workaround to avoid having flaky tests in MacOS
