### PR TITLE
chore: Postgres enhance get oldest timestamp

### DIFF
--- a/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
+++ b/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
@@ -83,6 +83,9 @@ proc getLastMoment*(partition: Partition): int64 =
   let lastTimeInSec = partition.timeRange.`end`
   return lastTimeInSec
 
+proc getPartitionStartTimeInNanosec*(partition: Partition): int64 =
+  return partition.timeRange.beginning * 1_000_000_000
+
 proc containsMoment*(partition: Partition, time: int64): bool =
   ## Returns true if the given moment is contained within the partition window,
   ## 'false' otherwise.

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -702,7 +702,7 @@ proc getInt(
     retInt = parseInt(str)
   except ValueError:
     return err(
-      fmt"exception in getInt, parseInt, str:[{str}] query:[{query}]: " &
+      "exception in getInt, parseInt, str: " & str & " query: " & query & " exception: " &
         getCurrentExceptionMsg()
     )
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -876,8 +876,8 @@ proc initializePartitionsInfo(
 
     return ok()
 
-const DefaultDatabasePartitionCheckTimeInterval = timer.seconds(1)
-const PartitionsRangeInterval = timer.seconds(30) ## Time range covered by each parition
+const DefaultDatabasePartitionCheckTimeInterval = timer.minutes(10)
+const PartitionsRangeInterval = timer.hours(1) ## Time range covered by each parition
 
 proc loopPartitionFactory(
     self: PostgresDriver, onFatalError: OnFatalErrorHandler


### PR DESCRIPTION
## Description
This PR enhances the case where, for any reason, there are old empty partitions. In that case of empty partitions, they are not considered when getting the oldest timestamp. Instead, the oldest timestamp was only considered from the oldest row.

Therefore, when "time" retention policy is applied, we should also consider those old-empty partitions so that they can get erased properly.

## Issue
closes https://github.com/waku-org/nwaku/issues/2689

