### PR TITLE
fix: use await instead of waitFor in async tests

### DIFF
--- a/tests/node/peer_manager/test_peer_manager.nim
+++ b/tests/node/peer_manager/test_peer_manager.nim
@@ -34,10 +34,12 @@ suite "Peer Manager":
     asyncTest "light client is not disconnected":
       # Given two nodes with the same shardId
       let
-        server =
-          newTestWakuNode(serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0])
-        client =
-          newTestWakuNode(clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic1])
+        server = newTestWakuNode(
+          serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0]
+        )
+        client = newTestWakuNode(
+          clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic1]
+        )
 
       # And both mount metadata and filter
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic
@@ -46,7 +48,7 @@ suite "Peer Manager":
       await server.mountFilter()
 
       # And both nodes are started
-      waitFor allFutures(server.start(), client.start())
+      await allFutures(server.start(), client.start())
       await sleepAsync(FUTURE_TIMEOUT)
 
       # And the nodes are connected
@@ -67,10 +69,12 @@ suite "Peer Manager":
     asyncTest "relay with same shardId is not disconnected":
       # Given two nodes with the same shardId
       let
-        server =
-          newTestWakuNode(serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0])
-        client =
-          newTestWakuNode(clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0])
+        server = newTestWakuNode(
+          serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0]
+        )
+        client = newTestWakuNode(
+          clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0]
+        )
 
       # And both mount metadata and relay
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic
@@ -79,7 +83,7 @@ suite "Peer Manager":
       await server.mountRelay()
 
       # And both nodes are started
-      waitFor allFutures(server.start(), client.start())
+      await allFutures(server.start(), client.start())
       await sleepAsync(FUTURE_TIMEOUT)
 
       # And the nodes are connected
@@ -98,10 +102,12 @@ suite "Peer Manager":
     asyncTest "relay with different shardId is disconnected":
       # Given two nodes with different shardIds
       let
-        server =
-          newTestWakuNode(serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0])
-        client =
-          newTestWakuNode(clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic1])
+        server = newTestWakuNode(
+          serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0]
+        )
+        client = newTestWakuNode(
+          clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic1]
+        )
 
       # And both mount metadata and relay
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic
@@ -110,7 +116,7 @@ suite "Peer Manager":
       await server.mountRelay()
 
       # And both nodes are started
-      waitFor allFutures(server.start(), client.start())
+      await allFutures(server.start(), client.start())
       await sleepAsync(FUTURE_TIMEOUT)
 
       # And the nodes are connected

--- a/tests/node/test_wakunode_legacy_store.nim
+++ b/tests/node/test_wakunode_legacy_store.nim
@@ -76,16 +76,16 @@ suite "Waku Store - End to End - Sorted Archive":
     let mountArchiveResult = server.mountArchive(archiveDriver)
     assert mountArchiveResult.isOk()
 
-    waitFor server.mountLegacyStore()
+    await server.mountLegacyStore()
     client.mountLegacyStoreClient()
 
-    waitFor allFutures(server.start(), client.start())
+    await allFutures(server.start(), client.start())
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
     clientPeerId = client.peerInfo.toRemotePeerInfo().peerId
 
   asyncTeardown:
-    waitFor allFutures(client.stop(), server.stop())
+    await allFutures(client.stop(), server.stop())
 
   suite "Message Pagination":
     asyncTest "Forward Pagination":
@@ -448,9 +448,9 @@ suite "Waku Store - End to End - Sorted Archive":
             otherServer.mountArchive(otherArchiveDriverWithMessages)
         assert mountOtherArchiveResult.isOk()
 
-        waitFor otherServer.mountLegacyStore()
+        await otherServer.mountLegacyStore()
 
-        waitFor otherServer.start()
+        await otherServer.start()
         let otherServerRemotePeerInfo = otherServer.peerInfo.toRemotePeerInfo()
 
         # When making a history query to the first server node      
@@ -479,7 +479,7 @@ suite "Waku Store - End to End - Sorted Archive":
           otherQueryResponse.get().messages == archiveMessages[5 ..< 10]
 
         # Cleanup
-        waitFor otherServer.stop()
+        await otherServer.stop()
 
 suite "Waku Store - End to End - Unsorted Archive":
   var pubsubTopic {.threadvar.}: PubsubTopic
@@ -536,15 +536,15 @@ suite "Waku Store - End to End - Unsorted Archive":
 
     assert mountUnsortedArchiveResult.isOk()
 
-    waitFor server.mountLegacyStore()
+    await server.mountLegacyStore()
     client.mountLegacyStoreClient()
 
-    waitFor allFutures(server.start(), client.start())
+    await allFutures(server.start(), client.start())
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
 
   asyncTeardown:
-    waitFor allFutures(client.stop(), server.stop())
+    await allFutures(client.stop(), server.stop())
 
   asyncTest "Basic (Timestamp and Digest) Sorting Validation":
     # When making a history query
@@ -691,15 +691,15 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
 
     assert mountSortedArchiveResult.isOk()
 
-    waitFor server.mountLegacyStore()
+    await server.mountLegacyStore()
     client.mountLegacyStoreClient()
 
-    waitFor allFutures(server.start(), client.start())
+    await allFutures(server.start(), client.start())
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
 
   asyncTeardown:
-    waitFor allFutures(client.stop(), server.stop())
+    await allFutures(client.stop(), server.stop())
 
   suite "Validation of Content Filtering":
     asyncTest "Basic Content Filtering":
@@ -935,8 +935,8 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
           ephemeralServer.mountArchive(ephemeralArchiveDriver)
       assert mountEphemeralArchiveResult.isOk()
 
-      waitFor ephemeralServer.mountLegacyStore()
-      waitFor ephemeralServer.start()
+      await ephemeralServer.mountLegacyStore()
+      await ephemeralServer.start()
       let ephemeralServerRemotePeerInfo = ephemeralServer.peerInfo.toRemotePeerInfo()
 
       # When making a history query to the server with only ephemeral messages
@@ -948,7 +948,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         queryResponse.get().messages.len == 0
 
       # Cleanup
-      waitFor ephemeralServer.stop()
+      await ephemeralServer.stop()
 
     xasyncTest "Mixed messages":
       # Given an archive with both ephemeral and non-ephemeral messages
@@ -977,8 +977,8 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         mountMixedArchiveResult = mixedServer.mountArchive(mixedArchiveDriver)
       assert mountMixedArchiveResult.isOk()
 
-      waitFor mixedServer.mountLegacyStore()
-      waitFor mixedServer.start()
+      await mixedServer.mountLegacyStore()
+      await mixedServer.start()
       let mixedServerRemotePeerInfo = mixedServer.peerInfo.toRemotePeerInfo()
 
       # When making a history query to the server with mixed messages
@@ -989,7 +989,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         queryResponse.get().messages == nonEphemeralMessages
 
       # Cleanup
-      waitFor mixedServer.stop()
+      await mixedServer.stop()
 
   suite "Edge Case Scenarios":
     asyncTest "Empty Message Store":
@@ -1004,8 +1004,8 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         mountEmptyArchiveResult = emptyServer.mountArchive(emptyArchiveDriver)
       assert mountEmptyArchiveResult.isOk()
 
-      waitFor emptyServer.mountLegacyStore()
-      waitFor emptyServer.start()
+      await emptyServer.mountLegacyStore()
+      await emptyServer.start()
       let emptyServerRemotePeerInfo = emptyServer.peerInfo.toRemotePeerInfo()
 
       # When making a history query to the server with an empty archive
@@ -1016,7 +1016,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         queryResponse.get().messages.len == 0
 
       # Cleanup
-      waitFor emptyServer.stop()
+      await emptyServer.stop()
 
     asyncTest "Voluminous Message Store":
       # Given a voluminous archive (1M+ messages)
@@ -1036,8 +1036,8 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
           voluminousServer.mountArchive(voluminousArchiveDriverWithMessages)
       assert mountVoluminousArchiveResult.isOk()
 
-      waitFor voluminousServer.mountLegacyStore()
-      waitFor voluminousServer.start()
+      await voluminousServer.mountLegacyStore()
+      await voluminousServer.start()
       let voluminousServerRemotePeerInfo = voluminousServer.peerInfo.toRemotePeerInfo()
 
       # Given the following history query
@@ -1060,7 +1060,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
           ]
 
       # Cleanup
-      waitFor voluminousServer.stop()
+      await voluminousServer.stop()
 
     asyncTest "Large contentFilters Array":
       # Given a history query with the max contentFilters len, 10

--- a/tests/node/test_wakunode_lightpush.nim
+++ b/tests/node/test_wakunode_lightpush.nim
@@ -56,8 +56,8 @@ suite "Waku Lightpush - End To End":
     await allFutures(server.start(), client.start())
     await server.start()
 
-    waitFor server.mountRelay()
-    waitFor server.mountLightpush()
+    await server.mountRelay()
+    await server.mountLightpush()
     client.mountLightpushClient()
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()

--- a/tests/node/test_wakunode_store.nim
+++ b/tests/node/test_wakunode_store.nim
@@ -85,17 +85,16 @@ suite "Waku Store - End to End - Sorted Archive":
     let mountArchiveResult = server.mountArchive(archiveDriver)
     assert mountArchiveResult.isOk()
 
-    waitFor server.mountStore()
+    await server.mountStore()
     client.mountStoreClient()
 
-    waitFor allFutures(server.start(), client.start())
-    await sleepAsync(chronos.milliseconds(500))
+    await allFutures(server.start(), client.start())
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
     clientPeerId = client.peerInfo.toRemotePeerInfo().peerId
 
   asyncTeardown:
-    waitFor allFutures(client.stop(), server.stop())
+    await allFutures(client.stop(), server.stop())
 
   suite "Message Pagination":
     asyncTest "Forward Pagination":
@@ -489,9 +488,9 @@ suite "Waku Store - End to End - Sorted Archive":
             otherServer.mountArchive(otherArchiveDriverWithMessages)
         assert mountOtherArchiveResult.isOk()
 
-        waitFor otherServer.mountStore()
+        await otherServer.mountStore()
 
-        waitFor otherServer.start()
+        await otherServer.start()
         let otherServerRemotePeerInfo = otherServer.peerInfo.toRemotePeerInfo()
 
         # When making a history query to the first server node      
@@ -521,7 +520,7 @@ suite "Waku Store - End to End - Sorted Archive":
           otherQueryResponse.get().messages == archiveMessages[5 ..< 10]
 
         # Cleanup
-        waitFor otherServer.stop()
+        await otherServer.stop()
 
 suite "Waku Store - End to End - Unsorted Archive":
   var pubsubTopic {.threadvar.}: PubsubTopic
@@ -586,15 +585,15 @@ suite "Waku Store - End to End - Unsorted Archive":
 
     assert mountUnsortedArchiveResult.isOk()
 
-    waitFor server.mountStore()
+    await server.mountStore()
     client.mountStoreClient()
 
-    waitFor allFutures(server.start(), client.start())
+    await allFutures(server.start(), client.start())
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
 
   asyncTeardown:
-    waitFor allFutures(client.stop(), server.stop())
+    await allFutures(client.stop(), server.stop())
 
   asyncTest "Basic (Timestamp and Hash) Sorting Validation":
     # When making a history query
@@ -803,15 +802,15 @@ suite "Waku Store - End to End - Unsorted Archive without provided Timestamp":
 
     assert mountUnsortedArchiveResult.isOk()
 
-    waitFor server.mountStore()
+    await server.mountStore()
     client.mountStoreClient()
 
-    waitFor allFutures(server.start(), client.start())
+    await allFutures(server.start(), client.start())
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
 
   asyncTeardown:
-    waitFor allFutures(client.stop(), server.stop())
+    await allFutures(client.stop(), server.stop())
 
   asyncTest "Sorting using receiverTime":
     # When making a history query
@@ -952,16 +951,15 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
 
     assert mountUnsortedArchiveResult.isOk()
 
-    waitFor server.mountStore()
+    await server.mountStore()
     client.mountStoreClient()
 
-    waitFor allFutures(server.start(), client.start())
-    await sleepAsync(chronos.milliseconds(500))
+    await allFutures(server.start(), client.start())
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
 
   asyncTeardown:
-    waitFor allFutures(client.stop(), server.stop())
+    await allFutures(client.stop(), server.stop())
 
   suite "Validation of Content Filtering":
     asyncTest "Basic Content Filtering":
@@ -1199,8 +1197,8 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
           ephemeralServer.mountArchive(ephemeralArchiveDriver)
       assert mountEphemeralArchiveResult.isOk()
 
-      waitFor ephemeralServer.mountStore()
-      waitFor ephemeralServer.start()
+      await ephemeralServer.mountStore()
+      await ephemeralServer.start()
       let ephemeralServerRemotePeerInfo = ephemeralServer.peerInfo.toRemotePeerInfo()
 
       # When making a history query to the server with only ephemeral messages
@@ -1211,7 +1209,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         queryResponse.get().messages.len == 0
 
       # Cleanup
-      waitFor ephemeralServer.stop()
+      await ephemeralServer.stop()
 
     xasyncTest "Mixed messages":
       # Given an archive with both ephemeral and non-ephemeral messages
@@ -1240,8 +1238,8 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         mountMixedArchiveResult = mixedServer.mountArchive(mixedArchiveDriver)
       assert mountMixedArchiveResult.isOk()
 
-      waitFor mixedServer.mountStore()
-      waitFor mixedServer.start()
+      await mixedServer.mountStore()
+      await mixedServer.start()
       let mixedServerRemotePeerInfo = mixedServer.peerInfo.toRemotePeerInfo()
 
       # When making a history query to the server with mixed messages
@@ -1252,7 +1250,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         queryResponse.get().messages == nonEphemeralMessages
 
       # Cleanup
-      waitFor mixedServer.stop()
+      await mixedServer.stop()
 
   suite "Edge Case Scenarios":
     asyncTest "Empty Message Store":
@@ -1267,8 +1265,8 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         mountEmptyArchiveResult = emptyServer.mountArchive(emptyArchiveDriver)
       assert mountEmptyArchiveResult.isOk()
 
-      waitFor emptyServer.mountStore()
-      waitFor emptyServer.start()
+      await emptyServer.mountStore()
+      await emptyServer.start()
       let emptyServerRemotePeerInfo = emptyServer.peerInfo.toRemotePeerInfo()
 
       # When making a history query to the server with an empty archive
@@ -1279,7 +1277,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
         queryResponse.get().messages.len == 0
 
       # Cleanup
-      waitFor emptyServer.stop()
+      await emptyServer.stop()
 
     asyncTest "Voluminous Message Store":
       # Given a voluminous archive (1M+ messages)
@@ -1308,8 +1306,8 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
           voluminousServer.mountArchive(voluminousArchiveDriverWithMessages)
       assert mountVoluminousArchiveResult.isOk()
 
-      waitFor voluminousServer.mountStore()
-      waitFor voluminousServer.start()
+      await voluminousServer.mountStore()
+      await voluminousServer.start()
       let voluminousServerRemotePeerInfo = voluminousServer.peerInfo.toRemotePeerInfo()
 
       # Given the following history query
@@ -1331,7 +1329,7 @@ suite "Waku Store - End to End - Archive with Multiple Topics":
           ]
 
       # Cleanup
-      waitFor voluminousServer.stop()
+      await voluminousServer.stop()
 
     asyncTest "Large contentFilters Array":
       # Given a history query with the max contentFilters len, 10

--- a/tests/waku_archive/test_driver_queue_query.nim
+++ b/tests/waku_archive/test_driver_queue_query.nim
@@ -1178,7 +1178,7 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence = messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = waitFor driver.put(
+      let retFut = await driver.put(
         DefaultPubsubTopic,
         msg,
         computeDigest(msg),
@@ -1188,7 +1188,7 @@ suite "Queue driver - query by time range":
       require retFut.isOk()
 
     ## When
-    let res = waitFor driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic = @[contentTopic],
       startTime = some(ts(15, timeOrigin)),
       maxPageSize = 10,
@@ -1203,7 +1203,7 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[2 .. 6]
 
     ## Cleanup
-    (waitFor driver.close()).expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
   test "time range start and content topic - descending order":
     ## Given
@@ -1287,7 +1287,7 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence = messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = waitFor driver.put(
+      let retFut = await driver.put(
         DefaultPubsubTopic,
         msg,
         computeDigest(msg),
@@ -1299,7 +1299,7 @@ suite "Queue driver - query by time range":
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[3])
 
     ## When
-    let res = waitFor driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic = @[contentTopic],
       cursor = some(cursor),
       startTime = some(ts(15, timeOrigin)),
@@ -1315,7 +1315,7 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[4 .. 9]
 
     ## Cleanup
-    (waitFor driver.close()).expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
   asynctest "time range start, single content topic and cursor - descending order":
     ## Given
@@ -1345,7 +1345,7 @@ suite "Queue driver - query by time range":
     debug "randomized message insertion sequence", sequence = messages.mapIt(it.payload)
 
     for msg in messages:
-      let retFut = waitFor driver.put(
+      let retFut = await driver.put(
         DefaultPubsubTopic,
         msg,
         computeDigest(msg),
@@ -1357,7 +1357,7 @@ suite "Queue driver - query by time range":
     let cursor = computeTestCursor(DefaultPubsubTopic, expected[6])
 
     ## When
-    let res = waitFor driver.getMessages(
+    let res = await driver.getMessages(
       contentTopic = @[contentTopic],
       cursor = some(cursor),
       startTime = some(ts(15, timeOrigin)),
@@ -1373,7 +1373,7 @@ suite "Queue driver - query by time range":
       filteredMessages == expected[3 .. 4].reversed()
 
     ## Cleanup
-    (waitFor driver.close()).expect("driver to close")
+    (await driver.close()).expect("driver to close")
 
   test "time range, content topic, pubsub topic and cursor":
     ## Given

--- a/tests/waku_filter_v2/test_waku_client.nim
+++ b/tests/waku_filter_v2/test_waku_client.nim
@@ -2153,8 +2153,8 @@ suite "Waku Filter - End to End":
           wakuFilter.subscriptions.isSubscribed(clientPeerId)
 
         # When both are stopped and started
-        waitFor allFutures(wakuFilter.stop(), wakuFilterClient.stop())
-        waitFor allFutures(wakuFilter.start(), wakuFilterClient.start())
+        await allFutures(wakuFilter.stop(), wakuFilterClient.stop())
+        await allFutures(wakuFilter.start(), wakuFilterClient.start())
 
         # Then the suscription is maintained
         check:

--- a/tests/waku_store/test_wakunode_store.nim
+++ b/tests/waku_store/test_wakunode_store.nim
@@ -358,7 +358,7 @@ procSuite "WakuNode - Store":
     let serverPeer = server.peerInfo.toRemotePeerInfo()
 
     let requestProc = proc() {.async.} =
-      let queryRes = waitFor client.query(req, peer = serverPeer)
+      let queryRes = await client.query(req, peer = serverPeer)
 
       assert queryRes.isOk(), queryRes.error
 
@@ -402,7 +402,7 @@ procSuite "WakuNode - Store":
     let serverPeer = server.peerInfo.toRemotePeerInfo()
 
     let successProc = proc() {.async.} =
-      let queryRes = waitFor client.query(req, peer = serverPeer)
+      let queryRes = await client.query(req, peer = serverPeer)
 
       check queryRes.isOk()
       let response = queryRes.get()
@@ -410,7 +410,7 @@ procSuite "WakuNode - Store":
         response.messages.mapIt(it.message.get()) == msgListA
 
     let failsProc = proc() {.async.} =
-      let queryRes = waitFor client.query(req, peer = serverPeer)
+      let queryRes = await client.query(req, peer = serverPeer)
 
       check queryRes.isOk()
       let response = queryRes.get()

--- a/tests/wakunode_rest/test_rest_store.nim
+++ b/tests/wakunode_rest/test_rest_store.nim
@@ -123,7 +123,7 @@ procSuite "Waku Rest API - Store v3":
         fakeWakuMessage(@[byte 9], contentTopic = ContentTopic("c2"), ts = 9),
       ]
     for msg in msgList:
-      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -195,7 +195,7 @@ procSuite "Waku Rest API - Store v3":
         fakeWakuMessage(@[byte 09], ts = ts(90, timeOrigin)),
       ]
     for msg in msgList:
-      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -282,7 +282,7 @@ procSuite "Waku Rest API - Store v3":
         fakeWakuMessage(@[byte 9], contentTopic = ContentTopic("2"), ts = 9),
       ]
     for msg in msgList:
-      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -354,7 +354,7 @@ procSuite "Waku Rest API - Store v3":
         fakeWakuMessage(@[byte 9], contentTopic = ContentTopic("ct2"), ts = 9),
       ]
     for msg in msgList:
-      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -442,7 +442,7 @@ procSuite "Waku Rest API - Store v3":
         fakeWakuMessage(@[byte 9], contentTopic = ContentTopic("ct2"), ts = 9),
       ]
     for msg in msgList:
-      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -513,7 +513,7 @@ procSuite "Waku Rest API - Store v3":
         fakeWakuMessage(@[byte 9], contentTopic = ContentTopic("ct2"), ts = 9),
       ]
     for msg in msgList:
-      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     # Sending no peer-store node address
     response = await client.getStoreMessagesV3(
@@ -560,7 +560,7 @@ procSuite "Waku Rest API - Store v3":
         fakeWakuMessage(@[byte 9], contentTopic = ContentTopic("ct2"), ts = 9),
       ]
     for msg in msgList:
-      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -616,7 +616,7 @@ procSuite "Waku Rest API - Store v3":
     let msg = fakeWakuMessage(
       @[byte 0], contentTopic = ContentTopic("ct1"), ts = 0, meta = (@[byte 8])
     )
-    require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+    require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
@@ -682,7 +682,7 @@ procSuite "Waku Rest API - Store v3":
         fakeWakuMessage(@[byte 09], ts = ts(90, timeOrigin)),
       ]
     for msg in msgList:
-      require (waitFor driver.put(DefaultPubsubTopic, msg)).isOk()
+      require (await driver.put(DefaultPubsubTopic, msg)).isOk()
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
In async functions, we should use `await` instead of `waitFor`. The usage of `waitFor` in async tests can generate crashes.

# Changes

<!-- List of detailed changes -->

- [x] change use of `waitFor` for `await` in async tests

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->