### PR TITLE
chore: closing ping streams

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1132,7 +1132,6 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
     let peers =
       node.peerManager.peerStore.peers().filterIt(it.connectedness == Connected)
 
-      node.peerManager.connectedPeers(PingCodec)
     for peer in peers:
       try:
         let conn = await node.switch.dial(peer.peerId, peer.addrs, PingCodec)

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1128,6 +1128,10 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
     # Keep all connected peers alive while running
     trace "Running keepalive"
 
+    echo "------------------ Entering keepalive -----------"
+    echo "----------- ping connections: (in, out): ",
+      node.peerManager.getNumStreams(PingCodec)
+
     # First get a list of connected peer infos
     let peers =
       node.peerManager.peerStore.peers().filterIt(it.connectedness == Connected)

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1128,15 +1128,10 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
     # Keep all connected peers alive while running
     trace "Running keepalive"
 
-    echo "------------------ Entering keepalive -----------"
-    echo "----------- ping connections: (in, out): ",
-      node.peerManager.getNumStreams(PingCodec)
-
     # First get a list of connected peer infos
     let peers =
       node.peerManager.peerStore.peers().filterIt(it.connectedness == Connected)
 
-    echo "----------- physical connections before: ",
       node.peerManager.connectedPeers(PingCodec)
     for peer in peers:
       try:
@@ -1146,8 +1141,6 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
       except CatchableError as exc:
         waku_node_errors.inc(labelValues = ["keep_alive_failure"])
 
-    echo "----------- physical connections after: ",
-      node.peerManager.connectedPeers(PingCodec)
     await sleepAsync(keepalive)
 
 proc startKeepalive*(node: WakuNode) =


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->

We're opening ping streams every 2 minutes but not closing them. This means we get an ever increasing amount of stale streams. Therefore, closing the stream after the ping.

# Changes

<!-- List of detailed changes -->

- [x] close ping stream after usage

## Testing
Tested it by calling https://github.com/waku-org/nwaku/blob/a37c9ba91158a90879a9e78f124a6e11e1900279/waku/node/peer_manager/peer_manager.nim#L655-L671 and https://github.com/waku-org/nwaku/blob/a37c9ba91158a90879a9e78f124a6e11e1900279/waku/node/peer_manager/peer_manager.nim#L673-L685

inside `keepaliveLoop()` and logging the outputs

The conclusions were:
- without calling `conn.close()`, the output of `getNumStreams()` grew indefinitely
- calling `conn.close()`, the output of `getNumStreams()` varied but was stable
- calling `conn.close()`did not affect the output of `connectedPeers()`, which means that indeed it didn't affect the physical connections




## Issue

closes #2462 
