### PR TITLE
chore: Update bump_dependencies.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bump_dependencies.md
+++ b/.github/ISSUE_TEMPLATE/bump_dependencies.md
@@ -26,7 +26,7 @@ Update `nwaku` "vendor" dependencies.
 - [ ] nim-json-rpc
 - [ ] nim-json-serialization
 - [ ] nim-libbacktrace
-- [ ] nim-libp2p ( update to the unstable branch )
+- [ ] nim-libp2p
 - [ ] nim-metrics
 - [ ] nim-nat-traversal
 - [ ] nim-presto


### PR DESCRIPTION
## Description
We will start bumping the `nim-libp2p` from `master` branch.

From next month, June'24, we will start bumping from the latest available tag, rather than from `master`.

cc: @kaiserd 