### PR TITLE
fix: refactor shard parsing

### DIFF
--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -29,23 +29,21 @@ proc enrConfiguration*(
 
   enrBuilder.withMultiaddrs(netConfig.enrMultiaddrs)
 
-  let shards: seq[uint16] =
-    # no shards configured
-    if conf.shards.len == 0:
-      var shardsLocal = newSeq[uint16]()
-      let shardsRes = topicsToRelayShards(conf.pubsubTopics)
-      if shardsRes.isOk() and shardsRes.get().isSome():
-        shardsLocal = shardsRes.get().get().shardIds
-      elif shardsRes.get().isNone():
-        info "no pubsub topics specified or pubsubtopic is of type Named sharding "
-      else:
-        error "failed to parse pubsub topic, please format according to static shard specification",
-          error = shardsRes.error
-      shardsLocal
+  var shards = newSeq[uint16]()
 
-    # some shards configured
+  # no shards configured
+  if conf.shards.len == 0:
+    let shardsOpt = topicsToRelayShards(conf.pubsubTopics).valueOr:
+      error "failed to parse pubsub topic, please format according to static shard specification",
+        error = $error
+      return err("failed to parse pubsub topic: " & $error)
+    if shardsOpt.isSome():
+      shards = shardsOpt.get().shardIds
     else:
-      toSeq(conf.shards.mapIt(uint16(it)))
+      info "no pubsub topics specified or pubsubtopic is of type Named sharding "
+  # some shards configured
+  else:
+    shards = toSeq(conf.shards.mapIt(uint16(it)))
 
   enrBuilder.withWakuRelaySharding(
     RelayShards(clusterId: uint16(conf.clusterId), shardIds: shards)


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
When running the invalid configuration

```
./build/wakunode2 --pubsub-topic=/waku/2/rs/2/0 --pubsub-topic=/waku/2/rs/3/0 --cluster-id=2
```

I get

```
Error: unhandled exception: Trying to access value with err Result: use shards with the same cluster Id. [ResultDefect]
```

Refactoring the code to avoid this unhandled exception and handle the error gracefully.

# Changes

<!-- List of detailed changes -->

- [x] refactor shard parsing logic in order to avoid unhandled exception 
<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->