### PR TITLE
chore: test_client - add nil error handling after serverSwitch.start() clientSwitch.start()

### DIFF
--- a/tests/waku_store/test_client.nim
+++ b/tests/waku_store/test_client.nim
@@ -74,6 +74,14 @@ suite "Store Client":
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
 
+    if serverSwitch.peerInfo.isNil():
+      error "serverSwitch.peerInfo is nil"
+      raise newException(CatchableError, "serverSwitch.peerInfo is nil")
+
+    if clientSwitch.peerInfo.isNil():
+      error "clientSwitch.peerInfo is nil"
+      raise newException(CatchableError, "clientSwitch.peerInfo is nil")
+
     serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
     clientPeerInfo = clientSwitch.peerInfo.toRemotePeerInfo()
 

--- a/tests/waku_store_legacy/test_client.nim
+++ b/tests/waku_store_legacy/test_client.nim
@@ -54,6 +54,14 @@ suite "Store Client":
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
 
+    if serverSwitch.peerInfo.isNil():
+      error "serverSwitch.peerInfo is nil"
+      raise newException(CatchableError, "serverSwitch.peerInfo is nil")
+
+    if clientSwitch.peerInfo.isNil():
+      error "clientSwitch.peerInfo is nil"
+      raise newException(CatchableError, "clientSwitch.peerInfo is nil")
+
     serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
     clientPeerInfo = clientSwitch.peerInfo.toRemotePeerInfo()
 


### PR DESCRIPTION
## Description
Simple PR to help debug flaky crashes on mac-os tests.
This is based on previous studies made by @gabrielmer 

