### PR TITLE
fix: test_client - simple sleep to try avoid macos CI test failures

### DIFF
--- a/tests/waku_store/test_client.nim
+++ b/tests/waku_store/test_client.nim
@@ -74,13 +74,16 @@ suite "Store Client":
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
 
-    if serverSwitch.peerInfo.isNil():
-      error "serverSwitch.peerInfo is nil"
-      raise newException(CatchableError, "serverSwitch.peerInfo is nil")
-
-    if clientSwitch.peerInfo.isNil():
-      error "clientSwitch.peerInfo is nil"
-      raise newException(CatchableError, "clientSwitch.peerInfo is nil")
+    ## The following sleep is aimed to prevent macos failures in CI
+    #[
+2024-05-16T13:24:45.5106200Z INF 2024-05-16 13:24:45.509+00:00 Stopping AutonatService                    topics="libp2p autonatservice" tid=53712 file=service.nim:203
+2024-05-16T13:24:45.5107960Z WRN 2024-05-16 13:24:45.509+00:00 service is already stopped                 topics="libp2p switch" tid=53712 file=switch.nim:86
+2024-05-16T13:24:45.5109010Z . (1.68s)
+2024-05-16T13:24:45.5109320Z Store Client  (0.00s)
+2024-05-16T13:24:45.5109870Z SIGSEGV: Illegal storage access. (Attempt to read from nil?)
+2024-05-16T13:24:45.5111470Z stack trace: (most recent call last)
+    ]#
+    await sleepAsync(500.millis)
 
     serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
     clientPeerInfo = clientSwitch.peerInfo.toRemotePeerInfo()

--- a/tests/waku_store_legacy/test_client.nim
+++ b/tests/waku_store_legacy/test_client.nim
@@ -54,13 +54,16 @@ suite "Store Client":
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
 
-    if serverSwitch.peerInfo.isNil():
-      error "serverSwitch.peerInfo is nil"
-      raise newException(CatchableError, "serverSwitch.peerInfo is nil")
-
-    if clientSwitch.peerInfo.isNil():
-      error "clientSwitch.peerInfo is nil"
-      raise newException(CatchableError, "clientSwitch.peerInfo is nil")
+    ## The following sleep is aimed to prevent macos failures in CI
+    #[
+2024-05-16T13:24:45.5106200Z INF 2024-05-16 13:24:45.509+00:00 Stopping AutonatService                    topics="libp2p autonatservice" tid=53712 file=service.nim:203
+2024-05-16T13:24:45.5107960Z WRN 2024-05-16 13:24:45.509+00:00 service is already stopped                 topics="libp2p switch" tid=53712 file=switch.nim:86
+2024-05-16T13:24:45.5109010Z . (1.68s)
+2024-05-16T13:24:45.5109320Z Store Client  (0.00s)
+2024-05-16T13:24:45.5109870Z SIGSEGV: Illegal storage access. (Attempt to read from nil?)
+2024-05-16T13:24:45.5111470Z stack trace: (most recent call last)
+    ]#
+    await sleepAsync(500.millis)
 
     serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
     clientPeerInfo = clientSwitch.peerInfo.toRemotePeerInfo()


### PR DESCRIPTION
## Description
This is to prevent failures in CI macos tests

We are continuously seeing the following failure, which only happens on CI, but works well when tested locally:
```
INF 2024-05-16 13:24:45.449+00:00 received store query request               topics="waku store" tid=53712 file=protocol.nim:62 peerId=16U*HzvWFD requestId=91a1ab89cf519ea2ad3d request="(requestId: \"91a1ab89cf519ea2ad3d\", includeData: true, pubsubTopic: none(PubsubTopic), contentTopics: @[\"/waku/2/default-content/proto\"], startTime: none(CompiledIntTypes), endTime: none(CompiledIntTypes), messageHashes: @[], paginationCursor: none(WakuMessageHash), paginationForward: BACKWARD, paginationLimit: none(uint64))"
INF 2024-05-16 13:24:45.449+00:00 sending store query response               topics="waku store" tid=53712 file=protocol.nim:81 peerId=16U*HzvWFD requestId=91a1ab89cf519ea2ad3d messages=10
INF 2024-05-16 13:24:45.481+00:00 received store query request               topics="waku store" tid=53712 file=protocol.nim:62 peerId=16U*HzvWFD requestId=e747067dca94784e8bd3 request="(requestId: \"e747067dca94784e8bd3\", includeData: true, pubsubTopic: none(PubsubTopic), contentTopics: @[\"/waku/2/default-content/proto\"], startTime: none(CompiledIntTypes), endTime: none(CompiledIntTypes), messageHashes: @[], paginationCursor: none(WakuMessageHash), paginationForward: BACKWARD, paginationLimit: none(uint64))"
INF 2024-05-16 13:24:45.482+00:00 sending store query response               topics="waku store" tid=53712 file=protocol.nim:81 peerId=16U*HzvWFD requestId=e747067dca94784e8bd3 messages=10
INF 2024-05-16 13:24:45.506+00:00 Stopping AutonatService                    topics="libp2p autonatservice" tid=53712 file=service.nim:203
INF 2024-05-16 13:24:45.506+00:00 Stopping AutonatService                    topics="libp2p autonatservice" tid=53712 file=service.nim:203
INF 2024-05-16 13:24:45.509+00:00 Stopping AutonatService                    topics="libp2p autonatservice" tid=53712 file=service.nim:203
WRN 2024-05-16 13:24:45.509+00:00 service is already stopped                 topics="libp2p switch" tid=53712 file=switch.nim:86
INF 2024-05-16 13:24:45.509+00:00 Stopping AutonatService                    topics="libp2p autonatservice" tid=53712 file=service.nim:203
WRN 2024-05-16 13:24:45.509+00:00 service is already stopped                 topics="libp2p switch" tid=53712 file=switch.nim:86
. (1.68s)
Store Client  (0.00s)
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
stack trace: (most recent call last)
/Users/runner/work/nwaku/nwaku/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(429, 18)
/Users/runner/work/nwaku/nwaku/waku.nimble(82, 8) testTask
/Users/runner/work/nwaku/nwaku/waku.nimble(54, 8) test
/Users/runner/work/nwaku/nwaku/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(273, 7) exec
/Users/runner/work/nwaku/nwaku/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(273, 7) Error: unhandled exception: FAILED: build/all_tests_waku [OSError]
make: *** [testwaku] Error 1
HistoryQuery Creation and Execution 
```

