### PR TITLE
chore: libwaku - allow to properly set the log level in libwaku and unify a little

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[options, strutils, os, sequtils, net],
+  std/[options, strutils, sequtils, net],
   chronicles,
   chronos,
   metrics,
@@ -43,16 +43,8 @@ when isMainModule:
     error "failure while loading the configuration", error = error
     quit(QuitFailure)
 
-  ## Logging setup
-  # Adhere to NO_COLOR initiative: https://no-color.org/
-  let color =
-    try:
-      not parseBool(os.getEnv("NO_COLOR", "false"))
-    except CatchableError:
-      true
-
-  logging.setupLogLevel(conf.logLevel)
-  logging.setupLogFormat(conf.logFormat, color)
+  ## Also called within Waku.init. The call to startRestServerEsentials needs the following line
+  logging.setupLog(conf.logLevel, conf.logFormat)
 
   case conf.cmd
   of generateRlnKeystore:

--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -276,7 +276,8 @@ int main(int argc, char** argv) {
                                     \"store\": %s,       \
                                     \"storeMessageDbUrl\": \"%s\",  \
                                     \"storeMessageRetentionPolicy\": \"%s\",  \
-                                    \"storeMaxNumDbConnections\": %d \
+                                    \"storeMaxNumDbConnections\": %d , \
+                                    \"logLevel\": \"DEBUG\" \
                                 }", cfgNode.host,
                                     cfgNode.port,
                                     cfgNode.key,

--- a/examples/cpp/waku.cpp
+++ b/examples/cpp/waku.cpp
@@ -219,6 +219,7 @@ int main(int argc, char** argv) {
                                     \"port\": %d,       \
                                     \"key\": \"%s\",    \
                                     \"relay\": %s,      \
+                                    \"logLevel\": \"DEBUG\" \
                                 }", cfgNode.host,
                                     cfgNode.port,
                                     cfgNode.key,

--- a/examples/filter_subscriber.nim
+++ b/examples/filter_subscriber.nim
@@ -69,7 +69,7 @@ proc maintainSubscription(
 proc setupAndSubscribe(rng: ref HmacDrbgContext) =
   let filterPeer = parsePeerInfo(FilterPeer).get()
 
-  setupLogLevel(logging.LogLevel.NOTICE)
+  setupLog(logging.LogLevel.NOTICE, logging.LogFormat.TEXT)
   notice "starting filter subscriber"
 
   var

--- a/examples/golang/waku.go
+++ b/examples/golang/waku.go
@@ -193,6 +193,7 @@ type WakuConfig struct {
 	Port        int    `json:"port,omitempty"`
 	NodeKey     string `json:"key,omitempty"`
 	EnableRelay bool   `json:"relay"`
+	LogLevel    string `json:"logLevel"`
 }
 
 type WakuNode struct {
@@ -447,6 +448,7 @@ func main() {
 		Port:        30304,
 		NodeKey:     "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
 		EnableRelay: true,
+		LogLevel:    "DEBUG",
 	}
 
 	node, err := WakuNew(config)

--- a/examples/lightpush_publisher.nim
+++ b/examples/lightpush_publisher.nim
@@ -42,7 +42,7 @@ proc publishMessages(
 proc setupAndPublish(rng: ref HmacDrbgContext) =
   let lightpushPeer = parsePeerInfo(LightpushPeer).get()
 
-  setupLogLevel(logging.LogLevel.NOTICE)
+  setupLog(logging.LogLevel.NOTICE, logging.LogFormat.TEXT)
   notice "starting lightpush publisher"
 
   var

--- a/examples/nodejs/waku.js
+++ b/examples/nodejs/waku.js
@@ -21,6 +21,7 @@ var cfg = `{
     "port": 60001,
     "key": "364d111d729a6eb6d3e6113e163f017b5ef03a6f94c9b5b7bb1bb36fa5cb07a9",
     "relay": true
+    "logLevel": "DEBUG"
 }`
 
 function event_handler(event) {

--- a/examples/publisher.nim
+++ b/examples/publisher.nim
@@ -38,7 +38,8 @@ const discv5Port = 9000
 
 proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
   # use notice to filter all waku messaging
-  setupLogLevel(logging.LogLevel.NOTICE)
+  setupLog(logging.LogLevel.NOTICE, logging.LogFormat.TEXT)
+
   notice "starting publisher", wakuPort = wakuPort, discv5Port = discv5Port
   let
     nodeKey = crypto.PrivateKey.random(Secp256k1, rng[]).get()

--- a/examples/python/waku.py
+++ b/examples/python/waku.py
@@ -49,7 +49,8 @@ json_config = "{ \
                 \"host\": \"%s\",   \
                 \"port\": %d,       \
                 \"key\": \"%s\",    \
-                \"relay\": %s      \
+                \"relay\": %s      ,\
+                \"logLevel\": \"DEBUG\" \
             }" % (args.host,
                   int(args.port),
                   args.key,

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -63,7 +63,8 @@ fn main() {
         \"host\": \"127.0.0.1\",\
         \"port\": 60000, \
         \"key\": \"0d714a1fada214dead6dc9c7274581ec20ff292451866e7d6d677dc818e8ccd2\", \
-        \"relay\": true \
+        \"relay\": true ,\
+        \"logLevel\": \"DEBUG\"
     }";
 
     unsafe {

--- a/examples/subscriber.nim
+++ b/examples/subscriber.nim
@@ -36,7 +36,8 @@ const discv5Port = 8000
 
 proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
   # use notice to filter all waku messaging
-  setupLogLevel(logging.LogLevel.NOTICE)
+  setupLog(logging.LogLevel.NOTICE, logging.LogFormat.TEXT)
+
   notice "starting subscriber", wakuPort = wakuPort, discv5Port = discv5Port
   let
     nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]

--- a/examples/wakustealthcommitments/wakustealthcommitments.nim
+++ b/examples/wakustealthcommitments/wakustealthcommitments.nim
@@ -11,16 +11,7 @@ logScope:
 
 when isMainModule:
   ## Logging setup
-
-  # Adhere to NO_COLOR initiative: https://no-color.org/
-  let color =
-    try:
-      not parseBool(os.getEnv("NO_COLOR", "false"))
-    except CatchableError:
-      true
-
-  logging.setupLogLevel(logging.LogLevel.INFO)
-  logging.setupLogFormat(logging.LogFormat.TEXT, color)
+  setupLog(logging.LogLevel.NOTICE, logging.LogFormat.TEXT)
 
   info "Starting Waku Stealth Commitment Protocol"
   info "Starting Waku Node"

--- a/waku.nimble
+++ b/waku.nimble
@@ -109,4 +109,7 @@ task libwakuStatic, "Build the cbindings waku node library":
 
 task libwakuDynamic, "Build the cbindings waku node library":
   let name = "libwaku"
-  buildLibrary name, "library/", "-d:chronicles_log_level=ERROR", "dynamic"
+  buildLibrary name,
+    "library/",
+    """-d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client" """,
+    "dynamic"

--- a/waku.nimble
+++ b/waku.nimble
@@ -105,7 +105,10 @@ task chat2bridge, "Build chat2bridge":
 ### C Bindings
 task libwakuStatic, "Build the cbindings waku node library":
   let name = "libwaku"
-  buildLibrary name, "library/", "-d:chronicles_log_level=ERROR", "static"
+  buildLibrary name,
+    "library/",
+    """-d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client" """,
+    "static"
 
 task libwakuDynamic, "Build the cbindings waku node library":
   let name = "libwaku"

--- a/waku/common/logging.nim
+++ b/waku/common/logging.nim
@@ -1,6 +1,10 @@
 ## This code has been copied and addapted from `status-im/nimbu-eth2` project.
 ## Link: https://github.com/status-im/nimbus-eth2/blob/c585b0a5b1ae4d55af38ad7f4715ad455e791552/beacon_chain/nimbus_binary_common.nim
-import std/typetraits, chronicles, chronicles/log_output, chronicles/topics_registry
+import
+  std/[typetraits, os, strutils],
+  chronicles,
+  chronicles/log_output,
+  chronicles/topics_registry
 
 export chronicles.LogLevel
 
@@ -61,11 +65,11 @@ proc writeAndFlush(f: File, s: LogOutputStr) =
 
 ## Setup
 
-proc setupLogLevel*(level: LogLevel) =
+proc setupLogLevel(level: LogLevel) =
   # TODO: Support per topic level configuratio
   topics_registry.setLogLevel(level)
 
-proc setupLogFormat*(format: LogFormat, color = true) =
+proc setupLogFormat(format: LogFormat, color = true) =
   proc noOutputWriter(logLevel: LogLevel, msg: LogOutputStr) =
     discard
 
@@ -90,3 +94,15 @@ proc setupLogFormat*(format: LogFormat, color = true) =
         "the present module should be compiled with '-d:chronicles_default_output_device=dynamic' " &
         "and '-d:chronicles_sinks=\"textlines,json\"' options"
     .}
+
+proc setupLog*(level: LogLevel, format: LogFormat) =
+  ## Logging setup
+  # Adhere to NO_COLOR initiative: https://no-color.org/
+  let color =
+    try:
+      not parseBool(os.getEnv("NO_COLOR", "false"))
+    except CatchableError:
+      true
+
+  setupLogLevel(level)
+  setupLogFormat(format, color)

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -92,7 +92,7 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
   var confCopy = conf
   let rng = crypto.newRng()
 
-  logging.setupLogLevel(confCopy.logLevel)
+  logging.setupLog(conf.logLevel, conf.logFormat)
 
   case confCopy.clusterId
 


### PR DESCRIPTION
## Description
- Set compilation flags to properly compile chronicles for `libwaku`
- Unify the code in the sense that we only expose one proc from the `logging` module and have a standard logging setup.
- The log is configured in `waku.nim` within `init` proc.
- In `wakunode2` we also set the log before "waku.init" is invoked because we need to setup the logs properly for the "essential rest server" that we start at the beginning

## Issue
closes https://github.com/waku-org/nwaku/issues/2411
