### PR TITLE
chore: simple library cleanup of unused imports and duplicated code

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -2,7 +2,7 @@
 {.pragma: callback, cdecl, raises: [], gcsafe.}
 {.passc: "-fPIC".}
 
-import std/[json, sequtils, times, strformat, options, atomics, strutils]
+import std/[json, strformat, strutils]
 import chronicles, chronos
 import
   ../../waku/common/base64,
@@ -10,7 +10,6 @@ import
   ../../waku/node/waku_node,
   ../../waku/waku_core/topics/pubsub_topic,
   ../../../waku/waku_relay/protocol,
-  ./events/json_base_event,
   ./events/json_message_event,
   ./waku_thread/waku_thread,
   ./waku_thread/inter_thread_communication/requests/node_lifecycle_request,

--- a/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
@@ -1,6 +1,6 @@
-import std/[options, sequtils, strutils, json]
-import chronicles, chronos, stew/results, stew/shims/net
-import ../../../../waku/factory/waku, ../../../../waku/node/waku_node, ../../../alloc
+import std/json
+import chronicles, chronos, stew/results
+import ../../../../waku/factory/waku, ../../../../waku/node/waku_node
 
 type DebugNodeMsgType* = enum
   RETRIEVE_LISTENING_ADDRESSES

--- a/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
@@ -1,29 +1,12 @@
-import std/[options, sequtils, json, strutils]
-import chronos, chronicles, stew/results, stew/shims/net, confutils, confutils/std/net
+import std/[options, sequtils, json, strutils, net]
+import chronos, chronicles, stew/results, confutils, confutils/std/net
 
 import
-  ../../../../waku/common/enr/builder,
-  ../../../../waku/waku_enr/capabilities,
-  ../../../../waku/waku_enr/multiaddr,
-  ../../../../waku/waku_enr/sharding,
-  ../../../../waku/waku_core/message/message,
-  ../../../../waku/waku_core/message/default_values,
-  ../../../../waku/waku_core/topics/pubsub_topic,
   ../../../../waku/node/peer_manager/peer_manager,
-  ../../../../waku/waku_core,
   ../../../../waku/factory/external_config,
   ../../../../waku/factory/waku,
-  ../../../../waku/node/config,
-  ../../../../waku/waku_archive/driver/builder,
-  ../../../../waku/waku_archive/driver,
-  ../../../../waku/waku_archive/retention_policy/builder,
-  ../../../../waku/waku_archive/retention_policy,
-  ../../../../waku/waku_relay/protocol,
-  ../../../../waku/waku_store,
-  ../../../../waku/factory/builder,
   ../../../../waku/factory/node_factory,
   ../../../../waku/factory/networks_config,
-  ../../../events/[json_message_event, json_base_event],
   ../../../alloc
 
 type NodeLifecycleMsgType* = enum
@@ -64,28 +47,6 @@ proc createWaku(configJson: cstring): Future[Result[Waku, string]] {.async.} =
         confValue = parseCmdArg(typeof(confValue), formattedString)
   except Exception:
     return err("exception parsing configuration: " & getCurrentExceptionMsg())
-
-  # The Waku Network config (cluster-id=1)
-  if conf.clusterId == 1:
-    ## TODO: This section is duplicated in wakunode2.nim. We need to move this to a common module
-    let twnClusterConf = ClusterConf.TheWakuNetworkConf()
-    if len(conf.shards) != 0:
-      conf.pubsubTopics = conf.shards.mapIt(twnClusterConf.pubsubTopics[it.uint16])
-    else:
-      conf.pubsubTopics = twnClusterConf.pubsubTopics
-
-    # Override configuration
-    conf.maxMessageSize = twnClusterConf.maxMessageSize
-    conf.clusterId = twnClusterConf.clusterId
-    conf.rlnRelay = twnClusterConf.rlnRelay
-    conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
-    conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
-    conf.rlnRelayBandwidthThreshold = twnClusterConf.rlnRelayBandwidthThreshold
-    conf.discv5Discovery = twnClusterConf.discv5Discovery
-    conf.discv5BootstrapNodes =
-      conf.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
-    conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
-    conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
 
   let wakuRes = Waku.init(conf).valueOr:
     error "waku initialization failed", error = error

--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -1,5 +1,5 @@
-import std/[options, sequtils, strutils]
-import chronicles, chronos, stew/results, stew/shims/net
+import std/[sequtils, strutils]
+import chronicles, chronos, stew/results
 import ../../../../waku/factory/waku, ../../../../waku/node/waku_node, ../../../alloc
 
 type PeerManagementMsgType* = enum

--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -1,5 +1,5 @@
-import std/[options, sequtils, strutils]
-import chronicles, chronos, stew/byteutils, stew/results, stew/shims/net
+import std/net
+import chronicles, chronos, stew/byteutils, stew/results
 import
   ../../../../../waku/waku_core/message/message,
   ../../../../../waku/factory/waku,

--- a/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
@@ -1,13 +1,5 @@
-import std/[options, sequtils, strutils]
-import chronos, stew/results, stew/shims/net
-import
-  ../../../../../waku/factory/waku,
-  ../../../../../waku/waku_archive/driver/builder,
-  ../../../../../waku/waku_archive/driver,
-  ../../../../../waku/waku_archive/retention_policy/builder,
-  ../../../../../waku/waku_archive/retention_policy,
-  ../../../../alloc,
-  ../../../../callback
+import chronos, stew/results
+import ../../../../../waku/factory/waku, ../../../../alloc, ../../../../callback
 
 type StoreReqType* = enum
   REMOTE_QUERY ## to perform a query to another Store node

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -2,17 +2,11 @@
 {.pragma: callback, cdecl, raises: [], gcsafe.}
 {.passc: "-fPIC".}
 
-import std/[json, sequtils, times, strformat, options, atomics, strutils, os]
+import std/[options, atomics, os, net]
 import
-  chronicles,
-  chronos,
-  chronos/threadsync,
-  taskpools/channels_spsc_single,
-  stew/results,
-  stew/shims/net
+  chronicles, chronos, chronos/threadsync, taskpools/channels_spsc_single, stew/results
 import
   ../../../waku/factory/waku,
-  ../events/[json_message_event, json_base_event],
   ./inter_thread_communication/waku_thread_request,
   ./inter_thread_communication/waku_thread_response
 


### PR DESCRIPTION
## Description
Simple cleanup to remove unused imports and duplicated code in `library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim`

