### PR TITLE
chore: [WIP-for opinions] move push logic to lightpush

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -931,35 +931,8 @@ proc mountLightPush*(
 ) {.async.} =
   info "mounting light push"
 
-  var pushHandler: PushMessageHandler
-  if node.wakuRelay.isNil():
-    debug "mounting lightpush without relay (nil)"
-    pushHandler = proc(
-        peer: PeerId, pubsubTopic: string, message: WakuMessage
-    ): Future[WakuLightPushResult[void]] {.async.} =
-      return err("no waku relay found")
-  else:
-    pushHandler = proc(
-        peer: PeerId, pubsubTopic: string, message: WakuMessage
-    ): Future[WakuLightPushResult[void]] {.async.} =
-      let validationRes = await node.wakuRelay.validateMessage(pubSubTopic, message)
-      if validationRes.isErr():
-        return err(validationRes.error)
-
-      let publishedCount =
-        await node.wakuRelay.publish(pubsubTopic, message.encode().buffer)
-
-      if publishedCount == 0:
-        ## Agreed change expected to the lightpush protocol to better handle such case. https://github.com/waku-org/pm/issues/93
-        let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
-        debug "Lightpush request has not been published to any peers",
-          msg_hash = msgHash
-
-      return ok()
-
-  debug "mounting lightpush with relay"
   node.wakuLightPush =
-    WakuLightPush.new(node.peerManager, node.rng, pushHandler, some(rateLimit))
+    WakuLightPush.new(node.peerManager, node.rng, node.wakuRelay, some(rateLimit))
 
   if node.started:
     # Node has started already. Let's start lightpush too.


### PR DESCRIPTION
# Description
For gathering thoughts on whether to do this to resolve the unnecessary indirection created by the pushHandler, as per @jm-clius suggestion.
cc: @SionoiS @NagyZoltanPeter 
If we agree to go ahead with this, will modify the tests and whatever else is impacted by this change

# Changes
removed the pushHandler pattern in waku_node.nim by adding a reference to wakuRelay into the Lightpush module and moving all push logic to this module itself.