### PR TITLE
fix: use `when` instead of `if` for adding soname on linux

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -2,7 +2,7 @@
 {.pragma: callback, cdecl, raises: [], gcsafe.}
 {.passc: "-fPIC".}
 
-if defined(linux):
+when defined(linux):
   {.passl: "-Wl,-soname,libwaku.so".}
 
 import std/[json, sequtils, atomics, times, strformat, options, atomics, strutils, os]


### PR DESCRIPTION
Fixes build error on macos