### PR TITLE
docs: release-process.md - add step to merge the release branch back to master

### DIFF
--- a/docs/contributors/release-process.md
+++ b/docs/contributors/release-process.md
@@ -95,6 +95,7 @@ We also need to merge release branch back to master as a final step.
    - Deploy release to the `waku.sandbox` fleet from [Jenkins](https://ci.infra.status.im/job/nim-waku/job/deploy-waku-sandbox/).
    - Ensure that nodes successfully start up and monitor health using [Grafana](https://grafana.infra.status.im/d/qrp_ZCTGz/nim-waku-v2?orgId=1) and [Kibana](https://kibana.infra.status.im/goto/a7728e70-eb26-11ec-81d1-210eb3022c76).
    - If necessary, revert by deploying the previous release. Download logs and open a bug report issue.
+5. Submit a PR to merge the release branch back to `master`. Make sure you use the option `Merge pull request (Create a merge commit)` to perform such merge.
 
 ### Performing a patch release
 


### PR DESCRIPTION
## Description
Adding a step to make it clearer the kind of merge that needs to be applied after a release has been completed.
Notice that this is needed to make sure the following command retrieves the appropriate information when running from `master`:
```code
git describe --abbrev=6 --always --tags
```

In other words, we need to use the following merge option when merging the release branch into master:
![image](https://github.com/waku-org/nwaku/assets/128452529/8f7a3ff5-ef45-469e-b5e6-e8fb3adbc02d)

But, it is important to bear in mind that we should use the "Squash and merge" option for the regular PR's:
![image](https://github.com/waku-org/nwaku/assets/128452529/519f1088-ffa2-44fd-a95c-6999f9e55586)


