### PR TITLE
chore(wakucanary): fix fitler protocol, add storev3

### DIFF
--- a/apps/wakucanary/wakucanary.nim
+++ b/apps/wakucanary/wakucanary.nim
@@ -21,9 +21,10 @@ import
 # protocols and their tag
 const ProtocolsTable = {
   "store": "/vac/waku/store/",
+  "storev3": "/vac/waku/store-query/3",
   "relay": "/vac/waku/relay/",
   "lightpush": "/vac/waku/lightpush/",
-  "filter": "/vac/waku/filter/",
+  "filter": "/vac/waku/filter-subscribe/2",
 }.toTable
 
 const WebSocketPortOffset = 1000


### PR DESCRIPTION
# Description
While checking availability of nodes, I noticed the filter protocol cannot be matched and that wakucanary does not know about store v3
# Changes

- [x] update the protocol mapping to match current filter name and storev3



## How to test

1. `make wakucanary`
1. `./build/wakucanary -p=relay -p=filter -p=lightpush -p=store -p=storev3 -a=/dns4/waku.myrandomdemos.online/tcp/8000/wss/p2p/16Uiu2HAmKfC2QUvMVyBsVjuEzdo1hVhRddZxo69YkBuXYvuZ83sc`


<!--
## Issue

closes #
-->