### PR TITLE
chore: set msg_hash logs to notice level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,6 @@ ifeq ($(POSTGRES), 1)
 NIM_PARAMS := $(NIM_PARAMS) -d:postgres -d:nimDebugDlOpen
 endif
 
-ifeq ($(LOG_MSG_HASHES), 1)
-NIM_PARAMS := $(NIM_PARAMS) -d:logMessageHashes
-endif
-
 clean: | clean-libbacktrace
 
 

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,10 @@ ifeq ($(POSTGRES), 1)
 NIM_PARAMS := $(NIM_PARAMS) -d:postgres -d:nimDebugDlOpen
 endif
 
+ifeq ($(LOG_HASH), 1)
+NIM_PARAMS := $(NIM_PARAMS) -d:log_msg_hash
+endif
+
 clean: | clean-libbacktrace
 
 

--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,8 @@ ifeq ($(POSTGRES), 1)
 NIM_PARAMS := $(NIM_PARAMS) -d:postgres -d:nimDebugDlOpen
 endif
 
-ifeq ($(LOG_HASH), 1)
-NIM_PARAMS := $(NIM_PARAMS) -d:log_msg_hash
+ifeq ($(LOG_MSG_HASHES), 1)
+NIM_PARAMS := $(NIM_PARAMS) -d:logMessageHashes
 endif
 
 clean: | clean-libbacktrace

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -225,13 +225,12 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
     return
 
   proc traceHandler(topic: PubsubTopic, msg: WakuMessage) {.async, gcsafe.} =
-    when defined(logMessageHashes):
-      info "waku.relay received",
-        my_peer_id = node.peerId,
-        pubsubTopic = topic,
-        msg_hash = topic.computeMessageHash(msg).to0xHex(),
-        receivedTime = getNowInNanosecondTime(),
-        payloadSizeBytes = msg.payload.len
+    notice "waku.relay received",
+      my_peer_id = node.peerId,
+      pubsubTopic = topic,
+      msg_hash = topic.computeMessageHash(msg).to0xHex(),
+      receivedTime = getNowInNanosecondTime(),
+      payloadSizeBytes = msg.payload.len
 
     let msgSizeKB = msg.payload.len / 1000
 
@@ -357,12 +356,11 @@ proc publish*(
   #TODO instead of discard return error when 0 peers received the message
   discard await node.wakuRelay.publish(pubsubTopic, message)
 
-  when defined(logMessageHashes):
-    info "waku.relay published",
-      peerId = node.peerId,
-      pubsubTopic = pubsubTopic,
-      msg_hash = pubsubTopic.computeMessageHash(message).to0xHex(),
-      publishTime = getNowInNanosecondTime()
+  notice "waku.relay published",
+    peerId = node.peerId,
+    pubsubTopic = pubsubTopic,
+    msg_hash = pubsubTopic.computeMessageHash(message).to0xHex(),
+    publishTime = getNowInNanosecondTime()
 
   return ok()
 
@@ -953,10 +951,9 @@ proc mountLightPush*(
 
       if publishedCount == 0:
         ## Agreed change expected to the lightpush protocol to better handle such case. https://github.com/waku-org/pm/issues/93
-        when defined(logMessageHashes):
-          let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
-          info "Lightpush request has not been published to any peers",
-            msg_hash = msgHash
+        let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
+        notice "Lightpush request has not been published to any peers",
+          msg_hash = msgHash
 
       return ok()
 
@@ -997,21 +994,19 @@ proc lightpushPublish*(
   ): Future[WakuLightPushResult[void]] {.async, gcsafe.} =
     let msgHash = pubsubTopic.computeMessageHash(message).to0xHex()
     if not node.wakuLightpushClient.isNil():
-      when defined(logMessageHashes):
-        info "publishing message with lightpush",
-          pubsubTopic = pubsubTopic,
-          contentTopic = message.contentTopic,
-          target_peer_id = peer.peerId,
-          msg_hash = msgHash
+      notice "publishing message with lightpush",
+        pubsubTopic = pubsubTopic,
+        contentTopic = message.contentTopic,
+        target_peer_id = peer.peerId,
+        msg_hash = msgHash
       return await node.wakuLightpushClient.publish(pubsubTopic, message, peer)
 
     if not node.wakuLightPush.isNil():
-      when defined(logMessageHashes):
-        info "publishing message with self hosted lightpush",
-          pubsubTopic = pubsubTopic,
-          contentTopic = message.contentTopic,
-          target_peer_id = peer.peerId,
-          msg_hash = msgHash
+      notice "publishing message with self hosted lightpush",
+        pubsubTopic = pubsubTopic,
+        contentTopic = message.contentTopic,
+        target_peer_id = peer.peerId,
+        msg_hash = msgHash
       return await node.wakuLightPush.handleSelfLightPushRequest(pubsubTopic, message)
 
   if pubsubTopic.isSome():

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -225,7 +225,7 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
     return
 
   proc traceHandler(topic: PubsubTopic, msg: WakuMessage) {.async, gcsafe.} =
-    when defined(log_msg_hash):
+    when defined(logMessageHashes):
       info "waku.relay received",
         my_peer_id = node.peerId,
         pubsubTopic = topic,
@@ -357,7 +357,7 @@ proc publish*(
   #TODO instead of discard return error when 0 peers received the message
   discard await node.wakuRelay.publish(pubsubTopic, message)
 
-  when defined(log_msg_hash):
+  when defined(logMessageHashes):
     info "waku.relay published",
       peerId = node.peerId,
       pubsubTopic = pubsubTopic,
@@ -953,7 +953,7 @@ proc mountLightPush*(
 
       if publishedCount == 0:
         ## Agreed change expected to the lightpush protocol to better handle such case. https://github.com/waku-org/pm/issues/93
-        when defined(log_msg_hash):
+        when defined(logMessageHashes):
           let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
           info "Lightpush request has not been published to any peers",
             msg_hash = msgHash
@@ -997,7 +997,7 @@ proc lightpushPublish*(
   ): Future[WakuLightPushResult[void]] {.async, gcsafe.} =
     let msgHash = pubsubTopic.computeMessageHash(message).to0xHex()
     if not node.wakuLightpushClient.isNil():
-      when defined(log_msg_hash):
+      when defined(logMessageHashes):
         info "publishing message with lightpush",
           pubsubTopic = pubsubTopic,
           contentTopic = message.contentTopic,
@@ -1006,7 +1006,7 @@ proc lightpushPublish*(
       return await node.wakuLightpushClient.publish(pubsubTopic, message, peer)
 
     if not node.wakuLightPush.isNil():
-      when defined(log_msg_hash):
+      when defined(logMessageHashes):
         info "publishing message with self hosted lightpush",
           pubsubTopic = pubsubTopic,
           contentTopic = message.contentTopic,

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -103,13 +103,14 @@ proc handleMessage*(
       else:
         getNanosecondTime(getTime().toUnixFloat())
 
-  trace "handling message",
-    msg_hash = msgHashHex,
-    pubsubTopic = pubsubTopic,
-    contentTopic = msg.contentTopic,
-    msgTimestamp = msg.timestamp,
-    usedTimestamp = msgTimestamp,
-    digest = msgDigestHex
+  when defined(log_msg_hash):
+    info "archive handling message",
+      msg_hash = msgHashHex,
+      pubsubTopic = pubsubTopic,
+      contentTopic = msg.contentTopic,
+      msgTimestamp = msg.timestamp,
+      usedTimestamp = msgTimestamp,
+      digest = msgDigestHex
 
   let insertStartTime = getTime().toUnixFloat()
 
@@ -117,13 +118,14 @@ proc handleMessage*(
     waku_archive_errors.inc(labelValues = [insertFailure])
     error "failed to insert message", error = error
 
-  debug "message archived",
-    msg_hash = msgHashHex,
-    pubsubTopic = pubsubTopic,
-    contentTopic = msg.contentTopic,
-    msgTimestamp = msg.timestamp,
-    usedTimestamp = msgTimestamp,
-    digest = msgDigestHex
+  when defined(log_msg_hash):
+    info "message archived",
+      msg_hash = msgHashHex,
+      pubsubTopic = pubsubTopic,
+      contentTopic = msg.contentTopic,
+      msgTimestamp = msg.timestamp,
+      usedTimestamp = msgTimestamp,
+      digest = msgDigestHex
 
   let insertDuration = getTime().toUnixFloat() - insertStartTime
   waku_archive_insert_duration_seconds.observe(insertDuration)

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -103,7 +103,7 @@ proc handleMessage*(
       else:
         getNanosecondTime(getTime().toUnixFloat())
 
-  when defined(log_msg_hash):
+  when defined(logMessageHashes):
     info "archive handling message",
       msg_hash = msgHashHex,
       pubsubTopic = pubsubTopic,
@@ -118,7 +118,7 @@ proc handleMessage*(
     waku_archive_errors.inc(labelValues = [insertFailure])
     error "failed to insert message", error = error
 
-  when defined(log_msg_hash):
+  when defined(logMessageHashes):
     info "message archived",
       msg_hash = msgHashHex,
       pubsubTopic = pubsubTopic,

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -103,14 +103,13 @@ proc handleMessage*(
       else:
         getNanosecondTime(getTime().toUnixFloat())
 
-  when defined(logMessageHashes):
-    info "archive handling message",
-      msg_hash = msgHashHex,
-      pubsubTopic = pubsubTopic,
-      contentTopic = msg.contentTopic,
-      msgTimestamp = msg.timestamp,
-      usedTimestamp = msgTimestamp,
-      digest = msgDigestHex
+  notice "archive handling message",
+    msg_hash = msgHashHex,
+    pubsubTopic = pubsubTopic,
+    contentTopic = msg.contentTopic,
+    msgTimestamp = msg.timestamp,
+    usedTimestamp = msgTimestamp,
+    digest = msgDigestHex
 
   let insertStartTime = getTime().toUnixFloat()
 
@@ -118,14 +117,13 @@ proc handleMessage*(
     waku_archive_errors.inc(labelValues = [insertFailure])
     error "failed to insert message", error = error
 
-  when defined(logMessageHashes):
-    info "message archived",
-      msg_hash = msgHashHex,
-      pubsubTopic = pubsubTopic,
-      contentTopic = msg.contentTopic,
-      msgTimestamp = msg.timestamp,
-      usedTimestamp = msgTimestamp,
-      digest = msgDigestHex
+  notice "message archived",
+    msg_hash = msgHashHex,
+    pubsubTopic = pubsubTopic,
+    contentTopic = msg.contentTopic,
+    msgTimestamp = msg.timestamp,
+    usedTimestamp = msgTimestamp,
+    digest = msgDigestHex
 
   let insertDuration = getTime().toUnixFloat() - insertStartTime
   waku_archive_insert_duration_seconds.observe(insertDuration)

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -172,7 +172,7 @@ proc pushToPeer(wf: WakuFilter, peer: PeerId, buffer: seq[byte]) {.async.} =
 proc pushToPeers(
     wf: WakuFilter, peers: seq[PeerId], messagePush: MessagePush
 ) {.async.} =
-  when defined(log_msg_hash):
+  when defined(logMessageHashes):
     let targetPeerIds = peers.mapIt(shortLog(it))
     let msgHash =
       messagePush.pubsubTopic.computeMessageHash(messagePush.wakuMessage).to0xHex()
@@ -217,7 +217,7 @@ proc handleMessage*(
 ) {.async.} =
   let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
 
-  when defined(log_msg_hash):
+  when defined(logMessageHashes):
     info "handling message", pubsubTopic = pubsubTopic, msg_hash = msgHash
 
   let handleMessageStartTime = Moment.now()
@@ -227,7 +227,7 @@ proc handleMessage*(
     let subscribedPeers =
       wf.subscriptions.findSubscribedPeers(pubsubTopic, message.contentTopic)
     if subscribedPeers.len == 0:
-      when defined(log_msg_hash):
+      when defined(logMessageHashes):
         info "no subscribed peers found",
           pubsubTopic = pubsubTopic,
           contentTopic = message.contentTopic,
@@ -247,7 +247,7 @@ proc handleMessage*(
         target_peer_ids = subscribedPeers.mapIt(shortLog(it))
       waku_filter_errors.inc(labelValues = [pushTimeoutFailure])
     else:
-      when defined(log_msg_hash):
+      when defined(logMessageHashes):
         info "pushed message succesfully to all subscribers",
           pubsubTopic = pubsubTopic,
           contentTopic = message.contentTopic,

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -172,16 +172,15 @@ proc pushToPeer(wf: WakuFilter, peer: PeerId, buffer: seq[byte]) {.async.} =
 proc pushToPeers(
     wf: WakuFilter, peers: seq[PeerId], messagePush: MessagePush
 ) {.async.} =
-  when defined(logMessageHashes):
-    let targetPeerIds = peers.mapIt(shortLog(it))
-    let msgHash =
-      messagePush.pubsubTopic.computeMessageHash(messagePush.wakuMessage).to0xHex()
+  let targetPeerIds = peers.mapIt(shortLog(it))
+  let msgHash =
+    messagePush.pubsubTopic.computeMessageHash(messagePush.wakuMessage).to0xHex()
 
-    info "pushing message to subscribed peers",
-      pubsubTopic = messagePush.pubsubTopic,
-      contentTopic = messagePush.wakuMessage.contentTopic,
-      target_peer_ids = targetPeerIds,
-      msg_hash = msgHash
+  notice "pushing message to subscribed peers",
+    pubsubTopic = messagePush.pubsubTopic,
+    contentTopic = messagePush.wakuMessage.contentTopic,
+    target_peer_ids = targetPeerIds,
+    msg_hash = msgHash
 
   let bufferToPublish = messagePush.encode().buffer
 
@@ -217,8 +216,7 @@ proc handleMessage*(
 ) {.async.} =
   let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
 
-  when defined(logMessageHashes):
-    info "handling message", pubsubTopic = pubsubTopic, msg_hash = msgHash
+  notice "handling message", pubsubTopic = pubsubTopic, msg_hash = msgHash
 
   let handleMessageStartTime = Moment.now()
 
@@ -227,11 +225,10 @@ proc handleMessage*(
     let subscribedPeers =
       wf.subscriptions.findSubscribedPeers(pubsubTopic, message.contentTopic)
     if subscribedPeers.len == 0:
-      when defined(logMessageHashes):
-        info "no subscribed peers found",
-          pubsubTopic = pubsubTopic,
-          contentTopic = message.contentTopic,
-          msg_hash = msgHash
+      notice "no subscribed peers found",
+        pubsubTopic = pubsubTopic,
+        contentTopic = message.contentTopic,
+        msg_hash = msgHash
       return
 
     let messagePush = MessagePush(pubsubTopic: pubsubTopic, wakuMessage: message)
@@ -247,13 +244,12 @@ proc handleMessage*(
         target_peer_ids = subscribedPeers.mapIt(shortLog(it))
       waku_filter_errors.inc(labelValues = [pushTimeoutFailure])
     else:
-      when defined(logMessageHashes):
-        info "pushed message succesfully to all subscribers",
-          pubsubTopic = pubsubTopic,
-          contentTopic = message.contentTopic,
-          msg_hash = msgHash,
-          numPeers = subscribedPeers.len,
-          target_peer_ids = subscribedPeers.mapIt(shortLog(it))
+      notice "pushed message succesfully to all subscribers",
+        pubsubTopic = pubsubTopic,
+        contentTopic = message.contentTopic,
+        msg_hash = msgHash,
+        numPeers = subscribedPeers.len,
+        target_peer_ids = subscribedPeers.mapIt(shortLog(it))
 
   let
     handleMessageDuration = Moment.now() - handleMessageStartTime

--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -50,11 +50,12 @@ proc handleRequest*(
       pubSubTopic = request.get().pubSubTopic
       message = request.get().message
     waku_lightpush_messages.inc(labelValues = ["PushRequest"])
-    debug "push request",
-      peerId = peerId,
-      requestId = requestId,
-      pubsubTopic = pubsubTopic,
-      hash = pubsubTopic.computeMessageHash(message).to0xHex()
+    when defined(log_msg_hash):
+      info "lightpush request",
+        peer_id = peerId,
+        requestId = requestId,
+        pubsubTopic = pubsubTopic,
+        msg_hash = pubsubTopic.computeMessageHash(message).to0xHex()
 
     let handleRes = await wl.pushHandler(peerId, pubsubTopic, message)
     isSuccess = handleRes.isOk()

--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -50,12 +50,11 @@ proc handleRequest*(
       pubSubTopic = request.get().pubSubTopic
       message = request.get().message
     waku_lightpush_messages.inc(labelValues = ["PushRequest"])
-    when defined(logMessageHashes):
-      info "lightpush request",
-        peer_id = peerId,
-        requestId = requestId,
-        pubsubTopic = pubsubTopic,
-        msg_hash = pubsubTopic.computeMessageHash(message).to0xHex()
+    notice "lightpush request",
+      peer_id = peerId,
+      requestId = requestId,
+      pubsubTopic = pubsubTopic,
+      msg_hash = pubsubTopic.computeMessageHash(message).to0xHex()
 
     let handleRes = await wl.pushHandler(peerId, pubsubTopic, message)
     isSuccess = handleRes.isOk()

--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -50,7 +50,7 @@ proc handleRequest*(
       pubSubTopic = request.get().pubSubTopic
       message = request.get().message
     waku_lightpush_messages.inc(labelValues = ["PushRequest"])
-    when defined(log_msg_hash):
+    when defined(logMessageHashes):
       info "lightpush request",
         peer_id = peerId,
         requestId = requestId,

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -308,7 +308,7 @@ proc publish*(
 ): Future[int] {.async.} =
   let data = message.encode().buffer
 
-  when defined(log_msg_hash):
+  when defined(logMessageHashes):
     let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
     info "start publish Waku message", msg_hash = msgHash, pubsubTopic = pubsubTopic
 

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -308,8 +308,7 @@ proc publish*(
 ): Future[int] {.async.} =
   let data = message.encode().buffer
 
-  when defined(logMessageHashes):
-    let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
-    info "start publish Waku message", msg_hash = msgHash, pubsubTopic = pubsubTopic
+  let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
+  notice "start publish Waku message", msg_hash = msgHash, pubsubTopic = pubsubTopic
 
   return await procCall GossipSub(w).publish(pubsubTopic, data)


### PR DESCRIPTION
## Description
This is needed to help the Distributed Systems Testing team, DST, to have less logs when analysing thousands of nodes. With that, the DST team will set the log level to NOTICE and that will avoid printing too many logs.

## Changes
- set log level to `notice` when logging `msg_hash`.
- add error string in case of validation failure in `waku/waku_relay/protocol.nim`

## Issue
closes https://github.com/waku-org/nwaku/issues/2678
