### PR TITLE
chore: test_waku_store.nim - add logs to better analyse uncertain flaky tests

### DIFF
--- a/tests/waku_store/test_waku_store.nim
+++ b/tests/waku_store/test_waku_store.nim
@@ -17,12 +17,15 @@ import
 
 suite "Waku Store - query handler":
   asyncTest "history query handler should be called":
+    info "check point" # log added to track flaky test
     ## Setup
     let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
+    info "check point" # log added to track flaky test
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
+    info "check point" # log added to track flaky test
 
     ## Given
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
@@ -52,7 +55,9 @@ suite "Waku Store - query handler":
     )
 
     ## When
+    info "check point" # log added to track flaky test
     let queryRes = await client.query(req, peer = serverPeerInfo)
+    info "check point" # log added to track flaky test
 
     ## Then
     check:
@@ -69,15 +74,20 @@ suite "Waku Store - query handler":
       response.messages == @[kv]
 
     ## Cleanup
+    info "check point" # log added to track flaky test
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
+    info "check point" # log added to track flaky test
 
   asyncTest "history query handler should be called and return an error":
+    info "check point" # log added to track flaky test
     ## Setup
     let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
+    info "check point" # log added to track flaky test
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
+    info "check point" # log added to track flaky test
 
     ## Given
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
@@ -116,4 +126,6 @@ suite "Waku Store - query handler":
       error.kind == ErrorCode.BAD_REQUEST
 
     ## Cleanup
+    info "check point" # log added to track flaky test
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
+    info "check point" # log added to track flaky test

--- a/tests/waku_store_legacy/test_waku_store.nim
+++ b/tests/waku_store_legacy/test_waku_store.nim
@@ -13,17 +13,21 @@ import
   ../testlib/[common, wakucore],
   ./store_utils
 
-suite "Waku Store - query handler":
+suite "Waku Store - query handler legacy":
   asyncTest "history query handler should be called":
+    info "check point" # log added to track flaky test
     ## Setup
     let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
+    info "check point" # log added to track flaky test
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
+    info "check point" # log added to track flaky test
 
     ## Given
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
+    info "check point" # log added to track flaky test
 
     let msg = fakeWakuMessage(contentTopic = DefaultContentTopic)
 
@@ -44,7 +48,9 @@ suite "Waku Store - query handler":
     )
 
     ## When
+    info "check point" # log added to track flaky test
     let queryRes = await client.query(req, peer = serverPeerInfo)
+    info "check point" # log added to track flaky test
 
     ## Then
     check:
@@ -61,15 +67,19 @@ suite "Waku Store - query handler":
       response.messages == @[msg]
 
     ## Cleanup
+    info "check point" # log added to track flaky test
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
+    info "check point" # log added to track flaky test
 
   asyncTest "history query handler should be called and return an error":
+    info "check point" # log added to track flaky test
     ## Setup
     let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
+    info "check point" # log added to track flaky test
 
     ## Given
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
@@ -89,8 +99,10 @@ suite "Waku Store - query handler":
       contentTopics: @[DefaultContentTopic], direction: PagingDirection.FORWARD
     )
 
+    info "check point" # log added to track flaky test
     ## When
     let queryRes = await client.query(req, peer = serverPeerInfo)
+    info "check point" # log added to track flaky test
 
     ## Then
     check:
@@ -106,4 +118,6 @@ suite "Waku Store - query handler":
       error.kind == HistoryErrorKind.BAD_REQUEST
 
     ## Cleanup
+    info "check point" # log added to track flaky test
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
+    info "check point" # log added to track flaky test


### PR DESCRIPTION
Very simple PR that aims to better catch where a flaky test is actually failing. That flaky test only happens on CI MacOS