### PR TITLE
chore: Improving liteprotocolteseter stats

### DIFF
--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -125,7 +125,7 @@ proc echoStat*(self: Statistics) =
   let printable = catch:
     """*-----------------------------------------------------------------------------*
 |  Expected  |  Received  |    Loss    |  Misorder  |    Late    |  Duplicate |
-|{self.helper.prevIndex+1:>11} |{self.receivedMessages:>11} |{self.lossCount():>11} |{self.misorderCount:>11} |{self.lateCount:>11} |{self.duplicateCount:>11} |
+|{self.helper.prevIndex:>11} |{self.receivedMessages:>11} |{self.lossCount():>11} |{self.misorderCount:>11} |{self.lateCount:>11} |{self.duplicateCount:>11} |
 *-----------------------------------------------------------------------------*
 | Latency stat:                                                               |
 |    avg latency: {$self.averageLatency():<60}|
@@ -140,7 +140,7 @@ proc echoStat*(self: Statistics) =
 
 proc jsonStat*(self: Statistics): string =
   let json = catch:
-    """{{"expected":{self.helper.prevIndex+1},
+    """{{"expected":{self.helper.prevIndex},
          "received": {self.receivedMessages},
          "loss": {self.lossCount()},
          "misorder": {self.misorderCount},

--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -126,15 +126,15 @@ proc averageLatency*(self: Statistics): Duration =
 
 proc echoStat*(self: Statistics) =
   let printable = catch:
-    """*----------------------------------------------------------------------------------------*
+    """*------------------------------------------------------------------------------------------*
 |  Expected  |  Received  |   Target   |    Loss    |  Misorder  |    Late    |  Duplicate |
 |{self.helper.maxIndex:>11} |{self.receivedMessages:>11} |{self.allMessageCount:>11} |{self.lossCount():>11} |{self.misorderCount:>11} |{self.lateCount:>11} |{self.duplicateCount:>11} |
-*----------------------------------------------------------------------------------------*
-| Latency stat:                                                               |
-|    avg latency: {$self.averageLatency():<70}|
-|    min latency: {$self.maxLatency:<70}|
-|    max latency: {$self.minLatency:<70}|
-*----------------------------------------------------------------------------------------*""".fmt()
+*------------------------------------------------------------------------------------------*
+| Latency stat:                                                                            |
+|    avg latency: {$self.averageLatency():<73}|
+|    min latency: {$self.maxLatency:<73}|
+|    max latency: {$self.minLatency:<73}|
+*------------------------------------------------------------------------------------------*""".fmt()
 
   if printable.isErr():
     echo "Error while printing statistics: " & printable.error().msg

--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -114,7 +114,7 @@ proc addMessage*(
     self[peerId].addMessage(msg)
 
 proc lossCount*(self: Statistics): uint32 =
-  self.allMessageCount - self.receivedMessages
+  self.helper.prevIndex + 1 - self.receivedMessages
 
 proc averageLatency*(self: Statistics): Duration =
   if self.receivedMessages == 0:
@@ -124,8 +124,8 @@ proc averageLatency*(self: Statistics): Duration =
 proc echoStat*(self: Statistics) =
   let printable = catch:
     """*-----------------------------------------------------------------------------*
-|  Expected  |  Reveived  |    Loss    |  Misorder  |    Late    |  Duplicate |
-|{self.allMessageCount:>11} |{self.receivedMessages:>11} |{self.lossCount():>11} |{self.misorderCount:>11} |{self.lateCount:>11} |{self.duplicateCount:>11} |
+|  Expected  |  Received  |    Loss    |  Misorder  |    Late    |  Duplicate |
+|{self.helper.prevIndex+1:>11} |{self.receivedMessages:>11} |{self.lossCount():>11} |{self.misorderCount:>11} |{self.lateCount:>11} |{self.duplicateCount:>11} |
 *-----------------------------------------------------------------------------*
 | Latency stat:                                                               |
 |    avg latency: {$self.averageLatency():<60}|
@@ -140,7 +140,7 @@ proc echoStat*(self: Statistics) =
 
 proc jsonStat*(self: Statistics): string =
   let json = catch:
-    """{{"expected":{self.allMessageCount},
+    """{{"expected":{self.helper.prevIndex+1},
          "received": {self.receivedMessages},
          "loss": {self.lossCount()},
          "misorder": {self.misorderCount},

--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -145,6 +145,7 @@ proc jsonStat*(self: Statistics): string =
   let json = catch:
     """{{"expected":{self.helper.maxIndex},
          "received": {self.receivedMessages},
+         "target": {self.allMessageCount},
          "loss": {self.lossCount()},
          "misorder": {self.misorderCount},
          "late": {self.lateCount},

--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -126,15 +126,15 @@ proc averageLatency*(self: Statistics): Duration =
 
 proc echoStat*(self: Statistics) =
   let printable = catch:
-    """*-----------------------------------------------------------------------------*
+    """*----------------------------------------------------------------------------------------*
 |  Expected  |  Received  |   Target   |    Loss    |  Misorder  |    Late    |  Duplicate |
 |{self.helper.maxIndex:>11} |{self.receivedMessages:>11} |{self.allMessageCount:>11} |{self.lossCount():>11} |{self.misorderCount:>11} |{self.lateCount:>11} |{self.duplicateCount:>11} |
-*-----------------------------------------------------------------------------*
+*----------------------------------------------------------------------------------------*
 | Latency stat:                                                               |
-|    avg latency: {$self.averageLatency():<60}|
-|    min latency: {$self.maxLatency:<60}|
-|    max latency: {$self.minLatency:<60}|
-*-----------------------------------------------------------------------------*""".fmt()
+|    avg latency: {$self.averageLatency():<70}|
+|    min latency: {$self.maxLatency:<70}|
+|    max latency: {$self.minLatency:<70}|
+*----------------------------------------------------------------------------------------*""".fmt()
 
   if printable.isErr():
     echo "Error while printing statistics: " & printable.error().msg

--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -127,8 +127,8 @@ proc averageLatency*(self: Statistics): Duration =
 proc echoStat*(self: Statistics) =
   let printable = catch:
     """*-----------------------------------------------------------------------------*
-|  Expected  |  Received  |    Loss    |  Misorder  |    Late    |  Duplicate |
-|{self.helper.maxIndex:>11} |{self.receivedMessages:>11} |{self.lossCount():>11} |{self.misorderCount:>11} |{self.lateCount:>11} |{self.duplicateCount:>11} |
+|  Expected  |  Received  |   Target   |    Loss    |  Misorder  |    Late    |  Duplicate |
+|{self.helper.maxIndex:>11} |{self.receivedMessages:>11} |{self.allMessageCount:>11} |{self.lossCount():>11} |{self.misorderCount:>11} |{self.lateCount:>11} |{self.duplicateCount:>11} |
 *-----------------------------------------------------------------------------*
 | Latency stat:                                                               |
 |    avg latency: {$self.averageLatency():<60}|

--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -114,7 +114,7 @@ proc addMessage*(
     self[peerId].addMessage(msg)
 
 proc lossCount*(self: Statistics): uint32 =
-  self.helper.prevIndex + 1 - self.receivedMessages
+  self.helper.prevIndex - self.receivedMessages
 
 proc averageLatency*(self: Statistics): Duration =
   if self.receivedMessages == 0:


### PR DESCRIPTION
# Description

Running `liteprotocoltester`, we have seen lately in the `receivernode` periodic stats that there seems to be a message loss.

For example
```
receivernode-1  | *-----------------------------------------------------------------------------*
receivernode-1  | |  Expected  |  Reveived  |    Loss    |  Misorder  |    Late    |  Duplicate |
receivernode-1  | |        120 |         16 |        104 |          0 |          0 |          0 |
receivernode-1  | *-----------------------------------------------------------------------------*
receivernode-1  | | Latency stat:                                                               |
receivernode-1  | |    avg latency: 0ns                                                         |
receivernode-1  | |    min latency: 0ns                                                         |
receivernode-1  | |    max latency: 0ns                                                         |
receivernode-1  | *-----------------------------------------------------------------------------*
```

This happens because when the stats are printed (every 20 seconds), all messages haven't been sent yet (default is 120 messages, 1 message per second).

Therefore, to avoid confusion, changed the calculation of messages lost to be the diff between the maximum index received (index starts at 1) minus the amount of messages received.
In other words, if we have received up to the message number N, we expect to have received N messages in total.

Added the `Target` column to the stats, so we are also aware of how many messages we expect to receive during the whole run. The output currently looks the following way

```
receivernode-1  | *------------------------------------------------------------------------------------------*
receivernode-1  | |  Expected  |  Received  |   Target   |    Loss    |  Misorder  |    Late    |  Duplicate |
receivernode-1  | |         16 |         16 |        120 |          0 |          0 |          0 |          0 |
receivernode-1  | *------------------------------------------------------------------------------------------*
receivernode-1  | | Latency stat:                                                                            |
receivernode-1  | |    avg latency: 0ns                                                                      |
receivernode-1  | |    min latency: 0ns                                                                      |
receivernode-1  | |    max latency: 0ns                                                                      |
receivernode-1  | *------------------------------------------------------------------------------------------*
```



<!--
## Issue

closes #
-->