### PR TITLE
chore: making clusterId and shardId uint32

### DIFF
--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -91,7 +91,7 @@ type LiteProtocolTesterConf* = object
   #   desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
   #   defaultValue: @[],
   #   name: "shard"
-  # .}: seq[ShardIdx]
+  # .}: seq[uint32]
   contentTopics* {.
     desc: "Default content topic to subscribe to. Argument may be repeated.",
     defaultValue: @[LiteContentTopic],

--- a/tests/test_waku_enr.nim
+++ b/tests/test_waku_enr.nim
@@ -295,7 +295,7 @@ suite "Waku ENR - Relay static sharding":
     ## Then
     check:
       shardsTopics.clusterId == clusterId
-      shardsTopics.shardIds == @[1u16]
+      shardsTopics.shardIds == @[1u32]
 
     let topics = shardsTopics.topics.mapIt($it)
     check:
@@ -303,8 +303,8 @@ suite "Waku ENR - Relay static sharding":
 
     check:
       shardsTopics.contains(clusterId, shardId)
-      not shardsTopics.contains(clusterId, 33u16)
-      not shardsTopics.contains(20u16, 33u16)
+      not shardsTopics.contains(clusterId, 33u32)
+      not shardsTopics.contains(20u32, 33u32)
 
       shardsTopics.contains(topic)
       shardsTopics.contains("/waku/2/rs/22/1")
@@ -313,7 +313,7 @@ suite "Waku ENR - Relay static sharding":
     ## Given
     let
       clusterId: uint32 = 22
-      shardIds: seq[uint32] = @[1u16, 2u16, 2u16, 3u16, 3u16, 3u16]
+      shardIds: seq[uint32] = @[1u32, 2u32, 2u32, 3u32, 3u32, 3u32]
 
     ## When
     let shardsTopics = RelayShards.init(clusterId, shardIds).expect("Valid Shards")
@@ -321,7 +321,7 @@ suite "Waku ENR - Relay static sharding":
     ## Then
     check:
       shardsTopics.clusterId == clusterId
-      shardsTopics.shardIds == @[1u16, 2u16, 3u16]
+      shardsTopics.shardIds == @[1u32, 2u32, 3u32]
 
   test "cannot decode relay shards from record if not present":
     ## Given
@@ -348,7 +348,7 @@ suite "Waku ENR - Relay static sharding":
 
     let
       clusterId: uint32 = 22
-      shardIds: seq[uint32] = @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16]
+      shardIds: seq[uint32] = @[1u32, 1u32, 2u32, 3u32, 5u32, 8u32]
 
     let shardsTopics = RelayShards.init(clusterId, shardIds).expect("Valid Shards")
 
@@ -377,7 +377,7 @@ suite "Waku ENR - Relay static sharding":
       enrPrivKey = generatesecp256k1key()
 
     let shardsTopics =
-      RelayShards.init(33, toSeq(0u16 ..< 64u16)).expect("Valid Shards")
+      RelayShards.init(33, toSeq(0u32 ..< 64u32)).expect("Valid Shards")
 
     var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)
     require builder.withWakuRelaySharding(shardsTopics).isOk()
@@ -406,10 +406,10 @@ suite "Waku ENR - Relay static sharding":
 
     let
       relayShardsIndicesList = RelayShards
-        .init(22, @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16])
+        .init(22, @[1u32, 1u32, 2u32, 3u32, 5u32, 8u32])
         .expect("Valid Shards")
       relayShardsBitVector = RelayShards
-        .init(33, @[13u16, 24u16, 37u16, 61u16, 98u16, 159u16])
+        .init(33, @[13u32, 24u32, 37u32, 61u32, 98u32, 159u32])
         .expect("Valid Shards")
 
     var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)

--- a/tests/test_waku_enr.nim
+++ b/tests/test_waku_enr.nim
@@ -260,8 +260,8 @@ suite "Waku ENR - Relay static sharding":
   test "new relay shards object with single invalid shard id":
     ## Given
     let
-      clusterId: uint16 = 22
-      shard: uint16 = 1024
+      clusterId: uint32 = 22
+      shard: uint32 = 1024
 
     ## When
     let shardsTopics = RelayShards.init(clusterId, shard)
@@ -272,8 +272,8 @@ suite "Waku ENR - Relay static sharding":
   test "new relay shards object with single invalid shard id in list":
     ## Given
     let
-      clusterId: uint16 = 22
-      shardIds: seq[uint16] = @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16, 1024u16]
+      clusterId: uint32 = 22
+      shardIds: seq[uint32] = @[1u32, 1u32, 2u32, 3u32, 5u32, 8u32, 1024u32]
 
     ## When
     let shardsTopics = RelayShards.init(clusterId, shardIds)
@@ -284,8 +284,8 @@ suite "Waku ENR - Relay static sharding":
   test "new relay shards object with single valid shard id":
     ## Given
     let
-      clusterId: uint16 = 22
-      shardId: uint16 = 1
+      clusterId: uint32 = 22
+      shardId: uint32 = 1
 
     let topic = NsPubsubTopic.staticSharding(clusterId, shardId)
 
@@ -312,8 +312,8 @@ suite "Waku ENR - Relay static sharding":
   test "new relay shards object with repeated but valid shard ids":
     ## Given
     let
-      clusterId: uint16 = 22
-      shardIds: seq[uint16] = @[1u16, 2u16, 2u16, 3u16, 3u16, 3u16]
+      clusterId: uint32 = 22
+      shardIds: seq[uint32] = @[1u16, 2u16, 2u16, 3u16, 3u16, 3u16]
 
     ## When
     let shardsTopics = RelayShards.init(clusterId, shardIds).expect("Valid Shards")
@@ -347,8 +347,8 @@ suite "Waku ENR - Relay static sharding":
       enrPrivKey = generatesecp256k1key()
 
     let
-      clusterId: uint16 = 22
-      shardIds: seq[uint16] = @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16]
+      clusterId: uint32 = 22
+      shardIds: seq[uint32] = @[1u16, 1u16, 2u16, 3u16, 5u16, 8u16]
 
     let shardsTopics = RelayShards.init(clusterId, shardIds).expect("Valid Shards")
 

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -79,7 +79,7 @@ proc newTestWakuNode*(
     if pubsubTopics.len() > 0:
       NsPubsubTopic.parse(pubsubTopics[0]).get().clusterId
     else:
-      1.uint16
+      1.uint32
 
   conf.clusterId = clusterId
   conf.pubsubTopics = pubsubTopics

--- a/tests/waku_discv5/test_waku_discv5.nim
+++ b/tests/waku_discv5/test_waku_discv5.nim
@@ -45,8 +45,8 @@ procSuite "Waku Discovery v5":
           enrPrivKey = generatesecp256k1key()
 
         let
-          clusterId: uint16 = 21
-          shardIds: seq[uint16] = @[1u16, 2u16, 5u16, 7u16, 9u16, 11u16]
+          clusterId: uint32 = 21
+          shardIds: seq[uint32] = @[1u32, 2u32, 5u32, 7u32, 9u32, 11u32]
 
         let shardsTopics =
           RelayShards.init(clusterId, shardIds).expect("Valid shardIds")
@@ -65,8 +65,8 @@ procSuite "Waku Discovery v5":
           enrPrivKey = generatesecp256k1key()
 
         let
-          clusterId: uint16 = 22
-          shardIds: seq[uint16] = @[2u16, 4u16, 5u16, 8u16, 10u16, 12u16]
+          clusterId: uint32 = 22
+          shardIds: seq[uint32] = @[2u32, 4u32, 5u32, 8u32, 10u32, 12u32]
 
         let shardsTopics =
           RelayShards.init(clusterId, shardIds).expect("Valid shardIds")
@@ -85,8 +85,8 @@ procSuite "Waku Discovery v5":
           enrPrivKey = generatesecp256k1key()
 
         let
-          clusterId: uint16 = 22
-          shardIds: seq[uint16] = @[1u16, 3u16, 6u16, 7u16, 9u16, 11u16]
+          clusterId: uint32 = 22
+          shardIds: seq[uint32] = @[1u32, 3u32, 6u32, 7u32, 9u32, 11u32]
 
         let shardsTopics =
           RelayShards.init(clusterId, shardIds).expect("Valid shardIds")

--- a/tests/waku_enr/test_sharding.nim
+++ b/tests/waku_enr/test_sharding.nim
@@ -121,7 +121,7 @@ suite "Discovery Mechanisms for Shards":
     let
       indicesList: seq[uint8] = @[0, 73, 2, 0, 1, 0, 10]
       clusterId: uint32 = 73 # bitVector's clusterId
-      shardIds: seq[uint32] = @[1u16, 10u16] # bitVector's shardIds
+      shardIds: seq[uint32] = @[1u32, 10u32] # bitVector's shardIds
 
     let
       enrSeqNum = 1u64
@@ -150,7 +150,7 @@ suite "Discovery Mechanisms for Shards":
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ]
       clusterId: uint32 = 73 # bitVector's clusterId
-      shardIds: seq[uint32] = @[1u16, 10u16] # bitVector's shardIds
+      shardIds: seq[uint32] = @[1u32, 10u32] # bitVector's shardIds
 
     let
       enrSeqNum = 1u64

--- a/tests/waku_enr/test_sharding.nim
+++ b/tests/waku_enr/test_sharding.nim
@@ -27,7 +27,7 @@ suite "Sharding":
       let empty: seq[string] = @[]
 
       let shardsTopics =
-        RelayShards.init(0, @[uint16(2), uint16(4), uint16(8)]).expect("Valid shardIds")
+        RelayShards.init(0, @[uint32(2), uint32(4), uint32(8)]).expect("Valid shardIds")
 
       ## When
 
@@ -120,8 +120,8 @@ suite "Discovery Mechanisms for Shards":
     # Given a valid index list and its representation
     let
       indicesList: seq[uint8] = @[0, 73, 2, 0, 1, 0, 10]
-      clusterId: uint16 = 73 # bitVector's clusterId
-      shardIds: seq[uint16] = @[1u16, 10u16] # bitVector's shardIds
+      clusterId: uint32 = 73 # bitVector's clusterId
+      shardIds: seq[uint32] = @[1u16, 10u16] # bitVector's shardIds
 
     let
       enrSeqNum = 1u64
@@ -149,8 +149,8 @@ suite "Discovery Mechanisms for Shards":
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ]
-      clusterId: uint16 = 73 # bitVector's clusterId
-      shardIds: seq[uint16] = @[1u16, 10u16] # bitVector's shardIds
+      clusterId: uint32 = 73 # bitVector's clusterId
+      shardIds: seq[uint32] = @[1u16, 10u16] # bitVector's shardIds
 
     let
       enrSeqNum = 1u64

--- a/waku/common/envvar_serialization/reader.nim
+++ b/waku/common/envvar_serialization/reader.nim
@@ -72,7 +72,12 @@ proc readValue*[T](r: var EnvvarReader, value: var T) {.raises: [SerializationEr
   elif T is (seq or array):
     when uTypeIsPrimitives(T):
       let key = constructKey(r.prefix, r.key)
-      getValue(key, value)
+      try:
+        getValue(key, value)
+      except ValueError:
+        raise newException(
+          SerializationError, "Couldn't get value: " & getCurrentExceptionMsg()
+        )
     else:
       let key = r.key[^1]
       for i in 0 ..< value.len:

--- a/waku/common/envvar_serialization/utils.nim
+++ b/waku/common/envvar_serialization/utils.nim
@@ -42,7 +42,9 @@ proc getValue*(key: string, outVal: var string) {.raises: [ValueError].} =
   outVal.setLen(size)
   decodePaddedHex(hex, cast[ptr UncheckedArray[byte]](outVal[0].addr), size)
 
-proc getValue*[T: SomePrimitives](key: string, outVal: var seq[T]) =
+proc getValue*[T: SomePrimitives](
+    key: string, outVal: var seq[T]
+) {.raises: [ValueError].} =
   let hex = os.getEnv(key)
   let byteSize = (hex.len div 2) + (hex.len and 0x01)
   let size = (byteSize + sizeof(T) - 1) div sizeof(T)

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -30,8 +30,6 @@ type ProtectedTopic* = object
   topic*: string
   key*: secp256k1.SkPublicKey
 
-type ShardIdx = distinct uint16
-
 type EthRpcUrl* = distinct string
 
 type StartUpCommand* = enum
@@ -307,7 +305,7 @@ type WakuNodeConf* = object
       desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
       defaultValue: @[],
       name: "shard"
-    .}: seq[ShardIdx]
+    .}: seq[uint32]
 
     contentTopics* {.
       desc: "Default content topic to subscribe to. Argument may be repeated.",
@@ -663,15 +661,6 @@ proc defaultColocationLimit*(): int =
 proc completeCmdArg*(T: type Port, val: string): seq[string] =
   return @[]
 
-proc completeCmdArg*(T: type ShardIdx, val: string): seq[ShardIdx] =
-  return @[]
-
-proc parseCmdArg*(T: type ShardIdx, p: string): T =
-  try:
-    ShardIdx(parseInt(p))
-  except CatchableError:
-    raise newException(ValueError, "Invalid shard index")
-
 proc completeCmdArg*(T: type EthRpcUrl, val: string): seq[string] =
   return @[]
 
@@ -729,22 +718,6 @@ proc readValue*(
 ) {.raises: [SerializationError].} =
   try:
     value = parseCmdArg(ProtectedTopic, r.readValue(string))
-  except CatchableError:
-    raise newException(SerializationError, getCurrentExceptionMsg())
-
-proc readValue*(
-    r: var TomlReader, value: var ShardIdx
-) {.raises: [SerializationError].} =
-  try:
-    value = parseCmdArg(ShardIdx, r.readValue(string))
-  except CatchableError:
-    raise newException(SerializationError, getCurrentExceptionMsg())
-
-proc readValue*(
-    r: var EnvvarReader, value: var ShardIdx
-) {.raises: [SerializationError].} =
-  try:
-    value = parseCmdArg(ShardIdx, r.readValue(string))
   except CatchableError:
     raise newException(SerializationError, getCurrentExceptionMsg())
 

--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -28,7 +28,7 @@ proc enrConfiguration*(
 
   enrBuilder.withMultiaddrs(netConfig.enrMultiaddrs)
 
-  var shards = newSeq[uint16]()
+  var shards = newSeq[uint32]()
 
   # no shards configured
   if conf.shards.len == 0:
@@ -42,10 +42,10 @@ proc enrConfiguration*(
       info "no pubsub topics specified or pubsubtopic is of type Named sharding "
   # some shards configured
   else:
-    shards = toSeq(conf.shards.mapIt(uint16(it)))
+    shards = toSeq(conf.shards.mapIt(it))
 
   enrBuilder.withWakuRelaySharding(
-    RelayShards(clusterId: uint16(conf.clusterId), shardIds: shards)
+    RelayShards(clusterId: conf.clusterId, shardIds: shards)
   ).isOkOr:
     return err("could not initialize ENR with shards")
 

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -106,8 +106,7 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
   of 1:
     let twnClusterConf = ClusterConf.TheWakuNetworkConf()
     if len(confCopy.shards) != 0:
-      confCopy.pubsubTopics =
-        confCopy.shards.mapIt(twnClusterConf.pubsubTopics[it.uint16])
+      confCopy.pubsubTopics = confCopy.shards.mapIt(twnClusterConf.pubsubTopics[it])
     else:
       confCopy.pubsubTopics = twnClusterConf.pubsubTopics
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -749,13 +749,11 @@ proc manageRelayPeers*(pm: PeerManager) {.async.} =
 
   for shard in pm.wakuMetadata.shards.items:
     # Filter out peer not on this shard
-    let connectedInPeers = inPeers.filterIt(
-      pm.peerStore.hasShard(it, uint16(pm.wakuMetadata.clusterId), uint16(shard))
-    )
+    let connectedInPeers =
+      inPeers.filterIt(pm.peerStore.hasShard(it, pm.wakuMetadata.clusterId, shard))
 
-    let connectedOutPeers = outPeers.filterIt(
-      pm.peerStore.hasShard(it, uint16(pm.wakuMetadata.clusterId), uint16(shard))
-    )
+    let connectedOutPeers =
+      outPeers.filterIt(pm.peerStore.hasShard(it, pm.wakuMetadata.clusterId, shard))
 
     # Calculate the difference between current values and targets
     let inPeerDiff = connectedInPeers.len - inTarget
@@ -769,7 +767,7 @@ proc manageRelayPeers*(pm: PeerManager) {.async.} =
 
     # Get all peers for this shard
     var connectablePeers =
-      pm.peerStore.getPeersByShard(uint16(pm.wakuMetadata.clusterId), uint16(shard))
+      pm.peerStore.getPeersByShard(pm.wakuMetadata.clusterId, shard)
 
     let shardCount = connectablePeers.len
 
@@ -837,7 +835,7 @@ proc prunePeerStore*(pm: PeerManager) =
   shuffle(notConnected)
 
   var shardlessPeers: seq[PeerId]
-  var peersByShard = initTable[uint16, seq[PeerId]]()
+  var peersByShard = initTable[uint32, seq[PeerId]]()
 
   for peer in notConnected:
     if not pm.peerStore[ENRBook].contains(peer):

--- a/waku/node/peer_manager/waku_peer_store.nim
+++ b/waku/node/peer_manager/waku_peer_store.nim
@@ -105,7 +105,7 @@ proc peers*(peerStore: PeerStore, protocolMatcher: Matcher): seq[RemotePeerInfo]
 proc connectedness*(peerStore: PeerStore, peerId: PeerID): Connectedness =
   peerStore[ConnectionBook].book.getOrDefault(peerId, NotConnected)
 
-proc hasShard*(peerStore: PeerStore, peerId: PeerID, cluster, shard: uint16): bool =
+proc hasShard*(peerStore: PeerStore, peerId: PeerID, cluster, shard: uint32): bool =
   peerStore[ENRBook].book.getOrDefault(peerId).containsShard(cluster, shard)
 
 proc hasCapability*(peerStore: PeerStore, peerId: PeerID, cap: Capabilities): bool =
@@ -148,7 +148,7 @@ proc getReachablePeers*(peerStore: PeerStore): seq[RemotePeerInfo] =
   )
 
 proc getPeersByShard*(
-    peerStore: PeerStore, cluster, shard: uint16
+    peerStore: PeerStore, cluster, shard: uint32
 ): seq[RemotePeerInfo] =
   return peerStore.peers.filterIt(
     it.enr.isSome() and it.enr.get().containsShard(cluster, shard)

--- a/waku/waku_core/topics/pubsub_topic.nim
+++ b/waku/waku_core/topics/pubsub_topic.nim
@@ -27,12 +27,12 @@ type NsPubsubTopicKind* {.pure.} = enum
 type NsPubsubTopic* = object
   case kind*: NsPubsubTopicKind
   of NsPubsubTopicKind.StaticSharding:
-    clusterId*: uint16
-    shardId*: uint16
+    clusterId*: uint32
+    shardId*: uint32
   of NsPubsubTopicKind.NamedSharding:
     name*: string
 
-proc staticSharding*(T: type NsPubsubTopic, clusterId, shardId: uint16): T =
+proc staticSharding*(T: type NsPubsubTopic, clusterId: uint32, shardId: uint32): T =
   NsPubsubTopic(
     kind: NsPubsubTopicKind.StaticSharding, clusterId: clusterId, shardId: shardId
   )
@@ -73,7 +73,7 @@ proc parseStaticSharding*(
   if clusterPart.len == 0:
     return err(ParsingError.missingPart("cluster_id"))
   let clusterId =
-    ?Base10.decode(uint16, clusterPart).mapErr(
+    ?Base10.decode(uint32, clusterPart).mapErr(
       proc(err: auto): auto =
         ParsingError.invalidFormat($err)
     )
@@ -82,7 +82,7 @@ proc parseStaticSharding*(
   if shardPart.len == 0:
     return err(ParsingError.missingPart("shard_number"))
   let shardId =
-    ?Base10.decode(uint16, shardPart).mapErr(
+    ?Base10.decode(uint32, shardPart).mapErr(
       proc(err: auto): auto =
         ParsingError.invalidFormat($err)
     )

--- a/waku/waku_core/topics/sharding.nim
+++ b/waku/waku_core/topics/sharding.nim
@@ -30,7 +30,7 @@ proc getGenZeroShard*(s: Sharding, topic: NsContentTopic, count: int): NsPubsubT
   # This is equilavent to modulo shard count but faster
   let shard = hashValue and uint64((count - 1))
 
-  NsPubsubTopic.staticSharding(uint16(s.clusterId), uint16(shard))
+  NsPubsubTopic.staticSharding(s.clusterId, uint32(shard))
 
 proc getShard*(s: Sharding, topic: NsContentTopic): Result[NsPubsubTopic, string] =
   ## Compute the (pubsub topic) shard to use for this content topic.

--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -124,7 +124,7 @@ func fromIndicesList*(buf: seq[byte]): Result[RelayShards, string] =
   let clusterId = uint32.fromBytesBE(buf[0 .. 3])
   let length = int(buf[4])
 
-  if buf.len != 3 + 2 * length:
+  if buf.len != 5 + 4 * length:
     return err(
       "invalid data: `length` field is " & $length & " but " & $buf.len &
         " bytes were provided"
@@ -132,7 +132,7 @@ func fromIndicesList*(buf: seq[byte]): Result[RelayShards, string] =
 
   var shardIds: seq[uint32]
   for i in 0 ..< length:
-    shardIds.add(uint32.fromBytesBE(buf[5 + 2 * i ..< 9 + 2 * i]))
+    shardIds.add(uint32.fromBytesBE(buf[5 + 4 * i ..< 9 + 4 * i]))
 
   ok(RelayShards(clusterId: clusterId, shardIds: shardIds))
 

--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -160,8 +160,8 @@ func fromBitVector(buf: seq[byte]): EnrResult[RelayShards] =
   let clusterId = uint32.fromBytesBE(buf[0 .. 1])
   var shardIds: seq[uint32]
 
-  for i in 0u16 ..< 128u16:
-    for j in 0u16 ..< 8u16:
+  for i in 0u32 ..< 128u32:
+    for j in 0u32 ..< 8u32:
       if not buf[2 + i].testBit(j):
         continue
 

--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -121,8 +121,8 @@ func fromIndicesList*(buf: seq[byte]): Result[RelayShards, string] =
     return
       err("insufficient data: expected at least 3 bytes, got " & $buf.len & " bytes")
 
-  let clusterId = uint32.fromBytesBE(buf[0 .. 1])
-  let length = int(buf[2])
+  let clusterId = uint32.fromBytesBE(buf[0 .. 3])
+  let length = int(buf[4])
 
   if buf.len != 3 + 2 * length:
     return err(
@@ -132,7 +132,7 @@ func fromIndicesList*(buf: seq[byte]): Result[RelayShards, string] =
 
   var shardIds: seq[uint32]
   for i in 0 ..< length:
-    shardIds.add(uint32.fromBytesBE(buf[3 + 2 * i ..< 5 + 2 * i]))
+    shardIds.add(uint32.fromBytesBE(buf[5 + 2 * i ..< 9 + 2 * i]))
 
   ok(RelayShards(clusterId: clusterId, shardIds: shardIds))
 


### PR DESCRIPTION
# Description
Simple PR to make `clusterId` and `shardId` of type `uint32` everywhere to simplify the code and avoid casts.



## Issue

Helps the deprecation of named sharding in https://github.com/waku-org/nwaku/issues/2163
