### PR TITLE
fix: don't decode plus sign for legacy store

### DIFF
--- a/waku/waku_api/rest/legacy_store/types.nim
+++ b/waku/waku_api/rest/legacy_store/types.nim
@@ -62,7 +62,7 @@ proc parseMsgDigest*(
   if not input.isSome() or input.get() == "":
     return ok(none(waku_store_common.MessageDigest))
 
-  let decodedUrl = decodeUrl(input.get())
+  let decodedUrl = decodeUrl(input.get(), false)
   let base64Decoded = base64.decode(Base64String(decodedUrl))
   var messageDigest = waku_store_common.MessageDigest()
 
@@ -87,7 +87,7 @@ proc parseMsgDigest*(
 # and this result is URL-encoded.
 proc toRestStringMessageDigest*(self: waku_store_common.MessageDigest): string =
   let base64Encoded = base64.encode(self.data)
-  encodeUrl($base64Encoded)
+  encodeUrl($base64Encoded, false)
 
 proc toWakuMessage*(message: StoreWakuMessage): WakuMessage =
   WakuMessage(


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Same decoding fix as in https://github.com/waku-org/nwaku/pull/2718 to avoid `Incorrect base64 string` error when a `+` is included.

# Changes

<!-- List of detailed changes -->

- [x] turn off the `decodePlus` flag when decoding and encoding url strings

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #2615 
