### PR TITLE
fix: postgres partitions: ensure the partition ranges are o'clock

### DIFF
--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -17,7 +17,8 @@ import
   ./waku_archive/test_driver_sqlite_query,
   ./waku_archive/test_driver_sqlite,
   ./waku_archive/test_retention_policy,
-  ./waku_archive/test_waku_archive
+  ./waku_archive/test_waku_archive,
+  ./waku_archive/test_partition_manager
 
 const os* {.strdefine.} = ""
 when os == "Linux" and

--- a/tests/waku_archive/test_partition_manager.nim
+++ b/tests/waku_archive/test_partition_manager.nim
@@ -1,0 +1,16 @@
+{.used.}
+
+import testutils/unittests, chronos
+import
+  ../../../waku/waku_archive/driver/postgres_driver/partitions_manager,
+  ../../../waku/waku_core/time
+
+suite "Partition Manager":
+  test "Calculate end partition time":
+    # 1717372850 == Mon Jun 03 2024 00:00:50 GMT+0000
+    # 1717376400 == Mon Jun 03 2024 01:00:00 GMT+0000
+    check 1717376400 == partitions_manager.calcEndPartitionTime(Timestamp(1717372850))
+
+    # 1717372800 == Mon Jun 03 2024 00:00:00 GMT+0000
+    # 1717376400 == Mon Jun 03 2024 01:00:00 GMT+0000
+    check 1717376400 == partitions_manager.calcEndPartitionTime(Timestamp(1717372800))


### PR DESCRIPTION
## Description
Also, skip the error "partition already exists" because that happens when multiple nodes interact with the same database.

## Changes

- Skip the error if the creation of a partition failed
- Perform partition creation considering o'clock time ranges and partition length of one hour each

## Issue

closes https://github.com/waku-org/nwaku/issues/2766
closes https://github.com/waku-org/nwaku/issues/2769