### PR TITLE
chore: add new index to optimize the order by storedAt

### DIFF
--- a/migrations/message_store_postgres/content_script_version_5.nim
+++ b/migrations/message_store_postgres/content_script_version_5.nim
@@ -1,0 +1,6 @@
+const ContentScriptVersion_5* =
+  """
+CREATE INDEX IF NOT EXISTS i_query_storedAt ON messages (storedAt, id);
+
+UPDATE version SET version = 5 WHERE version = 4;
+"""

--- a/migrations/message_store_postgres/pg_migration_manager.nim
+++ b/migrations/message_store_postgres/pg_migration_manager.nim
@@ -1,6 +1,6 @@
 import
   content_script_version_1, content_script_version_2, content_script_version_3,
-  content_script_version_4
+  content_script_version_4, content_script_version_5
 
 type MigrationScript* = object
   version*: int
@@ -15,6 +15,7 @@ const PgMigrationScripts* =
     MigrationScript(version: 2, scriptContent: ContentScriptVersion_2),
     MigrationScript(version: 3, scriptContent: ContentScriptVersion_3),
     MigrationScript(version: 4, scriptContent: ContentScriptVersion_4),
+    MigrationScript(version: 5, scriptContent: ContentScriptVersion_5),
   ]
 
 proc getMigrationScripts*(currentVersion: int64, targetVersion: int64): seq[string] =

--- a/waku/waku_archive/driver/postgres_driver/migrations.nim
+++ b/waku/waku_archive/driver/postgres_driver/migrations.nim
@@ -9,7 +9,7 @@ import
 logScope:
   topics = "waku archive migration"
 
-const SchemaVersion* = 4 # increase this when there is an update in the database schema
+const SchemaVersion* = 5 # increase this when there is an update in the database schema
 
 proc breakIntoStatements*(script: string): seq[string] =
   ## Given a full migration script, that can potentially contain a list


### PR DESCRIPTION
## Description

Postgres optimization related to the `ORDER BY`

In a session with @cammellos and @richard-ramos , @cammellos recommended to add this index after seeing that `EXPLAIN ANALYZE SELECT ...` spent too much time in the sorting part. Then, after adding the offended index, the query time was enhanced.

## Issue
We don't have clear evidence that this PR will fix the following issue but it helps to have better query performance
https://github.com/waku-org/nwaku/issues/2783
