### PR TITLE
chore: postgres_driver - acquire/release advisory lock when creating partitions

### DIFF
--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -866,7 +866,7 @@ proc acquireDatabaseLock*(
 proc releaseDatabaseLock*(
     s: PostgresDriver, lockId: int = 841886
 ): Future[ArchiveDriverResult[void]] {.async.} =
-  ## Acquire an advisory lock (useful to avoid more than one application running migrations at the same time)
+  ## Release an advisory lock (useful to avoid more than one application running migrations at the same time)
   let unlocked = (
     await s.getStr(
       fmt"""


### PR DESCRIPTION
## Description
Add additional protection, in the shape of an advisory lock, when adding new partitions to the database.
This is interesting from the PoV of multiple nodes accessing the same database.

## Issue
Not evidence that this PR will fix the following issue but it will help
https://github.com/waku-org/nwaku/issues/2783