### PR TITLE
chore: setting fail-fast to false in matrixed github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 concurrency:
-  group:  ${{ github.workflow }}-${{ matrix.os }}-rln-v${{ matrix.rln_version }}-${{ github.head_ref || github.run_id }} # ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group:  ${{ github.workflow }}-${{ matrix.os }}-rln-v${{ matrix.rln_version }}-${{ github.head_ref || github.run_id }} # ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -52,6 +52,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
         rln_version: [1, 2]
         os: [ubuntu-latest, macos-13]
@@ -83,6 +84,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
         rln_version: [1, 2]
         os: [ubuntu-latest, macos-13]

--- a/waku/waku_node.nim
+++ b/waku/waku_node.nim
@@ -2,6 +2,6 @@ import
   ./node/config,
   ./node/waku_switch as switch,
   ./node/waku_node as node,
-  ./node/health_monitor as health_monitor
+  ./node/health_monitor as health_monitor #
 
 export config, switch, node, health_monitor

--- a/waku/waku_node.nim
+++ b/waku/waku_node.nim
@@ -2,6 +2,6 @@ import
   ./node/config,
   ./node/waku_switch as switch,
   ./node/waku_node as node,
-  ./node/health_monitor as health_monitor #
+  ./node/health_monitor as health_monitor
 
 export config, switch, node, health_monitor


### PR DESCRIPTION
# Description
Simple change in the CI to avoid cancelling matrixed jobs when one of their variants fails

# Changes

<!-- List of detailed changes -->

- [x] set `fail-fast` strategy to false 




<!--
## Issue

closes #
-->