### PR TITLE
fix: mount metadata in the wakucanary app

### DIFF
--- a/apps/wakucanary/README.md
+++ b/apps/wakucanary/README.md
@@ -15,10 +15,10 @@ The following options are available:
  -p, --protocol       Protocol required to be supported: store,relay,lightpush,filter (can be used
                       multiple times).
  -l, --log-level      Sets the log level [=LogLevel.DEBUG].
- -np, --node-port      Listening port for waku node [=60000].
+ -np, --node-port     Listening port for waku node [=60000].
      --websocket-secure-key-path  Secure websocket key path:   '/path/to/key.txt' .
      --websocket-secure-cert-path  Secure websocket Certificate path:   '/path/to/cert.txt' .
-
+ -c, --cluster-id     Cluster ID of the fleet node to check status [Default=1].
 ```
 
 The tool can be built as:

--- a/apps/wakucanary/wakucanary.nim
+++ b/apps/wakucanary/wakucanary.nim
@@ -84,6 +84,14 @@ type WakuCanaryConf* = object
     desc: "Ping the peer node to measure latency", defaultValue: true, name: "ping"
   .}: bool
 
+  clusterId* {.
+    desc:
+      "Cluster id that the node is running in. Node in a different cluster id is disconnected.",
+    defaultValue: 1,
+    name: "cluster-id",
+    abbr: "c"
+  .}: uint16
+
 proc parseCmdArg*(T: type chronos.Duration, p: string): T =
   try:
     result = chronos.seconds(parseInt(p))
@@ -221,6 +229,9 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
     except CatchableError:
       error "failed to mount libp2p ping protocol: " & getCurrentExceptionMsg()
       return 1
+
+  node.mountMetadata(conf.clusterId).isOkOr:
+    error "failed to mount waku metadata protocol: ", err = error
 
   await node.start()
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -380,7 +380,11 @@ proc onPeerMetadata(pm: PeerManager, peerId: PeerId) {.async.} =
       pm.peerStore.hasPeer(peerId, WakuRelayCodec) and
       not metadata.shards.anyIt(pm.wakuMetadata.shards.contains(it))
     ):
-      reason = "no shards in common"
+      let myShardsString = "[ " & toSeq(pm.wakuMetadata.shards).join(", ") & "]"
+      let otherShardsString = "[ " & metadata.shards.join(", ") & "]"
+      reason =
+        "no shards in common: my_shards = " & myShardsString & " others_shards = " &
+        otherShardsString
       break guardClauses
 
     return


### PR DESCRIPTION
closes #2720 

Mount metadata in the Wakucanary app, similar to NetworkMonitor.