### PR TITLE
fix: mount metadata in wakucanary

### DIFF
--- a/apps/wakucanary/README.md
+++ b/apps/wakucanary/README.md
@@ -19,7 +19,7 @@ The following options are available:
      --websocket-secure-key-path  Secure websocket key path:   '/path/to/key.txt' .
      --websocket-secure-cert-path  Secure websocket Certificate path:   '/path/to/cert.txt' .
  -c, --cluster-id     Cluster ID of the fleet node to check status [Default=1]
- -s, --shards         Shards index to subscribe to topics [ Argument may be repeated ]
+ -s, --shard         Shards index to subscribe to topics [ Argument may be repeated ]
 
 ```
 

--- a/apps/wakucanary/README.md
+++ b/apps/wakucanary/README.md
@@ -15,9 +15,11 @@ The following options are available:
  -p, --protocol       Protocol required to be supported: store,relay,lightpush,filter (can be used
                       multiple times).
  -l, --log-level      Sets the log level [=LogLevel.DEBUG].
- -np, --node-port      Listening port for waku node [=60000].
+ -np, --node-port     Listening port for waku node [=60000].
      --websocket-secure-key-path  Secure websocket key path:   '/path/to/key.txt' .
      --websocket-secure-cert-path  Secure websocket Certificate path:   '/path/to/cert.txt' .
+ -c, --cluster-id     Cluster ID of the fleet node to check status [Default=1]
+ -s, --shards         Shards index to subscribe to topics [ Argument may be repeated ]
 
 ```
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -380,8 +380,8 @@ proc onPeerMetadata(pm: PeerManager, peerId: PeerId) {.async.} =
       pm.peerStore.hasPeer(peerId, WakuRelayCodec) and
       not metadata.shards.anyIt(pm.wakuMetadata.shards.contains(it))
     ):
-      let myShardsString = "[ " & toSeq(pm.wakuMetadata.shards).join(", ") & "]"
-      let otherShardsString = "[ " & metadata.shards.join(", ") & "]"
+      let myShardsString = "[ " & toSeq(pm.wakuMetadata.shards).join(", ") & " ]"
+      let otherShardsString = "[ " & metadata.shards.join(", ") & " ]"
       reason =
         "no shards in common: my_shards = " & myShardsString & " others_shards = " &
         otherShardsString


### PR DESCRIPTION
closes https://github.com/waku-org/nwaku/issues/2720

Add cluster ID and shards in the Wakucanary configuration, and then mount this metadata information to Wakunode.