### PR TITLE
fix: more detailed logs to differentiate shards with peers

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -380,7 +380,11 @@ proc onPeerMetadata(pm: PeerManager, peerId: PeerId) {.async.} =
       pm.peerStore.hasPeer(peerId, WakuRelayCodec) and
       not metadata.shards.anyIt(pm.wakuMetadata.shards.contains(it))
     ):
-      reason = "no shards in common"
+      let myShardsString = "[ " & toSeq(pm.wakuMetadata.shards).join(", ") & "]"
+      let otherShardsString = "[ " & metadata.shards.join(", ") & "]"
+      reason =
+        "no shards in common: my_shards = " & myShardsString & " others_shards = " &
+        otherShardsString
       break guardClauses
 
     return


### PR DESCRIPTION
Adds more information to the log, allowing users to differentiate shards and their connections.

Example :- 

If shards match the peer, the previous log entry would be :- "reason = no shards in common"  
Now it's look like this :- "reason = no shards in common: my_shards =  [ x, y, z ]  others_shards = [ a, b, c ]"

where the number within brackets represents the shard number.

