### PR TITLE
chore: Remove filter-timeout configuration option as it remained after removing legacy filter where it belong to.

### DIFF
--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -366,13 +366,6 @@ type WakuNodeConf* = object
       name: "filternode"
     .}: string
 
-    filterTimeout* {.
-      desc:
-        "Filter clients will be wiped out if not able to receive push messages within this timeout. In seconds.",
-      defaultValue: 14400, # 4 hours
-      name: "filter-timeout"
-    .}: int64
-
     filterSubscriptionTimeout* {.
       desc:
         "Timeout for filter subscription without ping or refresh it, in seconds. Only for v2 filter protocol.",


### PR DESCRIPTION
# Description

Just found this anomaly in the code while looking up answers during our meeting...
It is a leftover, nowhere used config option, related to legacy filter that was removed versions before.

also in docs: https://github.com/waku-org/docs.waku.org/pull/200

# Changes

- [X] Removed CLI confif filter-timout