### PR TITLE
fix: multi nat initialization causing dead lock in waku tests + serialize test runs to avoid timing and port occupied issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ concurrency:
 
 env:
   NPROC: 1
-  MAKEFLAGS: ""
-  NIMFLAGS: "--colors:off -d:chronicles_colors:none"
+  MAKEFLAGS: "-j${NPROC}"
+  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none"
 
 jobs:
   changes: # changes detection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NPROC: 1
+  NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
   NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none"
 
@@ -111,15 +111,15 @@ jobs:
 
       - name: Run tests
         run: |
-          if [ ${{ runner.os }} == "Linux" ]; then
-            sudo docker run --rm -d -e POSTGRES_PASSWORD=test123 -p 5432:5432 postgres:15.4-alpine3.18
-          fi
-
           postgres_enabled=0
           if [ ${{ runner.os }} == "Linux" ]; then
+            sudo docker run --rm -d -e POSTGRES_PASSWORD=test123 -p 5432:5432 postgres:15.4-alpine3.18
             postgres_enabled=1
           fi
 
+          export MAKEFLAGS="-j1"
+          export NIMFLAGS="--colors:off -d:chronicles_colors:none"
+          
           make RLN_V${{matrix.rln_version}}=true V=1 LOG_LEVEL=DEBUG QUICK_AND_DIRTY_COMPILER=1 POSTGRES=$postgres_enabled test testwakunode2
 
   build-docker-image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NPROC: 2
-  MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none"
+  NPROC: 1
+  MAKEFLAGS: ""
+  NIMFLAGS: "--colors:off -d:chronicles_colors:none"
 
 jobs:
   changes: # changes detection

--- a/waku/common/utils/nat.nim
+++ b/waku/common/utils/nat.nim
@@ -9,12 +9,12 @@ import chronicles, eth/net/nat, stew/results, nativesockets
 logScope:
   topics = "nat"
 
-## Do to the design of nim-eth/nat module we must ensure it is only initialized once.
+## Due to the design of nim-eth/nat module we must ensure it is only initialized once.
 ## see: https://github.com/waku-org/nwaku/issues/2628
 ## Details: nim-eth/nat module starts a meaintenance thread for refreshing the NAT mappings, but everything in the module is global,
 ## there is no room to store multiple configurations.
-## Exact mean: redirectPorts cannot be called twice in a program lifetime.
-## During waku tests we happen to start several node instances parallel thus result in multiple NAT configurations and multiple threads.
+## Exact meaning: redirectPorts cannot be called twice in a program lifetime.
+## During waku tests we happen to start several node instances in parallel thus resulting in multiple NAT configurations and multiple threads.
 ## Those threads will dead lock each other in tear down.
 var singletonNat: bool = false
 


### PR DESCRIPTION
# Description

### Multiple NAT module initialization cause dead lock in tests
In case nat setup found proper device to make the port mapping (that does not happens in jenkins CI) could cause multiple initilalization of nim-eth/nat module.
That module is not designed for that and changing this needs a bigger rework of that module.
The root cause of the issue with multiple initialization inside one application run leads to multiple remapping thread created. That thread is responsible for refreshing the port mapping on the router if needed.
As such multiple thread created but only the last one tracked caused dead lock in the shut down mechanism of it as the used Channel[bool] single module variable locking mechanism do not handle such situation and remains blocked.

Simple workaround is applied: waku nat module prevents multiple initialization of nim-eth/nat module and will behave as no proper device would be found (which is still an ok case for testing).

### Reduce tests flakyness

In order to reduce probability of timing issue during CI test runs also possibility of failed tests because of ports already in use we made test execution sequential.


## How to test

1. make testwakunode2

## Issue
https://github.com/waku-org/nwaku/issues/2628
