### PR TITLE
chore: adding observers for message logging

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -394,7 +394,7 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
     for msg in msgs.messages:
       let msg_id = w.msgIdProvider(msg).valueOr:
         warn "Error generating message id",
-          from_peer = peer.peerId, topic = msg.topic, error = $error
+          from_peer_id = peer.peerId, topic = msg.topic, error = $error
         continue
 
       let msg_id_short = shortLog(msg_id)
@@ -402,7 +402,7 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
       let wakuMessage = WakuMessage.decode(msg.data).valueOr:
         warn "Error decoding to Waku Message",
           msg_id = msg_id_short,
-          from_peer = peer.peerId,
+          from_peer_id = peer.peerId,
           topic = msg.topic,
           error = $error
         continue
@@ -410,16 +410,16 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
       let msg_hash = computeMessageHash(msg.topic, wakuMessage).to0xHex()
 
       if onRecv:
-        info "received message",
+        notice "received relay message",
           msg_hash = msg_hash,
           msg_id = msg_id_short,
-          from_peer = peer.peerId,
+          from_peer_id = peer.peerId,
           topic = msg.topic
       else:
-        info "sent message",
+        notice "sent relay message",
           msg_hash = msg_hash,
           msg_id = msg_id_short,
-          to_peer = peer.peerId,
+          to_peer_id = peer.peerId,
           topic = msg.topic
 
   proc onRecv(peer: PubSubPeer, msgs: var RPCMsg) =

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -394,11 +394,14 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
     for msg in msgs.messages:
       let msg_id = w.msgIdProvider(msg).valueOr:
         warn "Error generating message id",
-          from_peer = msg.fromPeer, topic = msg.topic, peer_id = peer.peerId
+          from_peer = msg.fromPeer,
+          topic = msg.topic,
+          peer_id = peer.peerId,
+          error = $error
         continue
 
       let wakuMessage = WakuMessage.decode(msg.data).valueOr:
-        error "Error decoding to Waku Message",
+        warn "Error decoding to Waku Message",
           msg_id = msg_id,
           from_peer = msg.fromPeer,
           topic = msg.topic,

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -450,7 +450,7 @@ proc mountRelay*(
 
   node.wakuRelay = initRes.value
 
-  # register rln validator as default validator
+  # register relay observers for logging
   debug "Registering Relay observers"
   let observerLogger = node.wakuRelay.generateRelayObserver()
   node.wakuRelay.addObserver(observerLogger)

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -400,9 +400,11 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
           error = $error
         continue
 
+      let msg_id_short = shortLog(msg_id)
+
       let wakuMessage = WakuMessage.decode(msg.data).valueOr:
         warn "Error decoding to Waku Message",
-          msg_id = msg_id,
+          msg_id = msg_id_short,
           from_peer = msg.fromPeer,
           topic = msg.topic,
           peer_id = peer.peerId,
@@ -413,7 +415,7 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
 
       info "received message",
         msg_hash = msg_hash,
-        msg_id = msg_id,
+        msg_id = msg_id_short,
         from_peer = msg.fromPeer,
         topic = msg.topic,
         peer_id = peer.peerId

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -419,7 +419,7 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
         info "sent message",
           msg_hash = msg_hash,
           msg_id = msg_id_short,
-          from_peer = peer.peerId,
+          to_peer = peer.peerId,
           topic = msg.topic
 
   proc onRecv(peer: PubSubPeer, msgs: var RPCMsg) =

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -394,10 +394,7 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
     for msg in msgs.messages:
       let msg_id = w.msgIdProvider(msg).valueOr:
         warn "Error generating message id",
-          from_peer = msg.fromPeer,
-          topic = msg.topic,
-          peer_id = peer.peerId,
-          error = $error
+          from_peer = peer.peerId, topic = msg.topic, error = $error
         continue
 
       let msg_id_short = shortLog(msg_id)
@@ -405,9 +402,8 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
       let wakuMessage = WakuMessage.decode(msg.data).valueOr:
         warn "Error decoding to Waku Message",
           msg_id = msg_id_short,
-          from_peer = msg.fromPeer,
+          from_peer = peer.peerId,
           topic = msg.topic,
-          peer_id = peer.peerId,
           error = $error
         continue
 
@@ -416,9 +412,8 @@ proc generateRelayObserver(w: WakuRelay): PubSubObserver =
       info "received message",
         msg_hash = msg_hash,
         msg_id = msg_id_short,
-        from_peer = msg.fromPeer,
-        topic = msg.topic,
-        peer_id = peer.peerId
+        from_peer = peer.peerId,
+        topic = msg.topic
 
   proc onSend(peer: PubSubPeer, msgs: var RPCMsg) {.gcsafe, raises: [].} =
     echo "-------------- Sent message --------------"

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -180,6 +180,9 @@ proc addValidator*(
 ) {.gcsafe.} =
   w.wakuValidators.add((handler, errorMessage))
 
+proc addObserver*(w: WakuRelay, observer: PubSubObserver) {.gcsafe.} =
+  procCall GossipSub(w).addObserver(observer)
+
 method start*(w: WakuRelay) {.async, base.} =
   debug "start"
   await procCall GossipSub(w).start()


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Adding observers so the hash and origin/destination of every message sent and received is logged. This will help with our reliability simulation efforts.

This adds lots of logs, so there's always the option to have it under a compilation flag. Let me know if that's preferable or if it's ok for now and we'll make them optional at a later stage.

### Note
We're finally adding observers only for messages received, as no additional valuable information is currently added by logging sent messages. If necessary at any point, they can be easily activated.


<!-- List of detailed changes -->

# Changes

- [x] added `nim-libp2p` observers for incoming and outgoing messages to log message data

<!--
## How to test

1.
1.
1.

-->
Example output:

<img width="1512" alt="image" src="https://github.com/waku-org/nwaku/assets/101006718/8414af3e-7db7-4194-8330-f3ef634158ed">



<!--
## Issue

closes #
-->