### PR TITLE
fix: Use random ports in rest tests instead of fixed ones

### DIFF
--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -48,9 +48,10 @@ suite "Waku v2 Rest API - Admin":
     await allFutures(node1.start(), node2.start(), node3.start())
     await allFutures(node1.mountRelay(), node2.mountRelay(), node3.mountRelay())
 
-    let restPort = Port(58011)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("127.0.0.1")
     restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installAdminApiHandlers(restServer.router, node1)
 

--- a/tests/wakunode_rest/test_rest_cors.nim
+++ b/tests/wakunode_rest/test_rest_cors.nim
@@ -27,7 +27,7 @@ proc testWakuNode(): WakuNode =
     privkey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
     bindIp = parseIpAddress("0.0.0.0")
     extIp = parseIpAddress("127.0.0.1")
-    port = Port(58000)
+    port = Port(0)
 
   newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
@@ -86,8 +86,7 @@ proc checkResponse(
       expectedOrigin.isSome() and
       response.headers.contains("Access-Control-Allow-Origin") and
       response.headers.getLastString("Access-Control-Allow-Origin") ==
-        expectedOrigin.get() and
-      response.headers.contains("Access-Control-Allow-Headers") and
+      expectedOrigin.get() and response.headers.contains("Access-Control-Allow-Headers") and
       response.headers.getLastString("Access-Control-Allow-Headers") == "Content-Type"
     )
   ):
@@ -106,7 +105,7 @@ suite "Waku v2 REST API CORS Handling":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58001)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef
       .init(
@@ -116,6 +115,7 @@ suite "Waku v2 REST API CORS Handling":
           some("test.net:1234,https://localhost:*,http://127.0.0.1:?8,?waku*.net:*80*"),
       )
       .tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installDebugApiHandlers(restServer.router, node)
     restServer.start()
@@ -158,7 +158,7 @@ suite "Waku v2 REST API CORS Handling":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58001)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef
       .init(
@@ -168,6 +168,7 @@ suite "Waku v2 REST API CORS Handling":
           some("test.net:1234,https://localhost:*,http://127.0.0.1:?8,?waku*.net:*80*"),
       )
       .tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installDebugApiHandlers(restServer.router, node)
     restServer.start()
@@ -213,10 +214,11 @@ suite "Waku v2 REST API CORS Handling":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58001)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer =
       WakuRestServerRef.init(restAddress, restPort, allowedOrigin = some("*")).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installDebugApiHandlers(restServer.router, node)
     restServer.start()
@@ -259,7 +261,7 @@ suite "Waku v2 REST API CORS Handling":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58001)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef
       .init(
@@ -269,6 +271,7 @@ suite "Waku v2 REST API CORS Handling":
           some("test.net:1234,https://localhost:*,http://127.0.0.1:?8,?waku*.net:*80*"),
       )
       .tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installDebugApiHandlers(restServer.router, node)
     restServer.start()

--- a/tests/wakunode_rest/test_rest_debug.nim
+++ b/tests/wakunode_rest/test_rest_debug.nim
@@ -26,7 +26,7 @@ proc testWakuNode(): WakuNode =
     privkey = crypto.PrivateKey.random(Secp256k1, rng[]).tryGet()
     bindIp = parseIpAddress("0.0.0.0")
     extIp = parseIpAddress("127.0.0.1")
-    port = Port(58000)
+    port = Port(0)
 
   newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
@@ -37,9 +37,10 @@ suite "Waku v2 REST API - Debug":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58001)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installDebugApiHandlers(restServer.router, node)
     restServer.start()
@@ -65,9 +66,10 @@ suite "Waku v2 REST API - Debug":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58002)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installDebugApiHandlers(restServer.router, node)
     restServer.start()

--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -59,13 +59,17 @@ proc init(T: type RestFilterTest): Future[T] {.async.} =
     testSetup.serviceNode.peerInfo.toRemotePeerInfo(), WakuFilterSubscribeCodec
   )
 
-  let restPort = Port(58011)
+  var restPort = Port(0)
   let restAddress = parseIpAddress("127.0.0.1")
   testSetup.restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+  restPort = testSetup.restServer.httpServer.address.port
+    # update with bound port for client use
 
-  let restPort2 = Port(58012)
+  var restPort2 = Port(0)
   testSetup.restServerForService =
     WakuRestServerRef.init(restAddress, restPort2).tryGet()
+  restPort2 = testSetup.restServerForService.httpServer.address.port
+    # update with bound port for client use
 
   # through this one we will see if messages are pushed according to our content topic sub
   testSetup.messageCache = MessageCache.init()

--- a/tests/wakunode_rest/test_rest_health.nim
+++ b/tests/wakunode_rest/test_rest_health.nim
@@ -45,9 +45,10 @@ suite "Waku v2 REST API - health":
 
     healthMonitor.setOverallHealth(HealthStatus.INITIALIZING)
 
-    let restPort = Port(58001)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installHealthApiHandler(restServer.router, healthMonitor)
     restServer.start()

--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -74,9 +74,11 @@ proc init(
     testSetup.serviceNode.peerInfo.toRemotePeerInfo(), WakuLightPushCodec
   )
 
-  let restPort = Port(58011)
+  var restPort = Port(0)
   let restAddress = parseIpAddress("127.0.0.1")
   testSetup.restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+  restPort = testSetup.restServer.httpServer.address.port
+    # update with bound port for client use
 
   installLightPushRequestHandler(testSetup.restServer.router, testSetup.pushNode)
 

--- a/tests/wakunode_rest/test_rest_store.nim
+++ b/tests/wakunode_rest/test_rest_store.nim
@@ -92,9 +92,10 @@ procSuite "Waku Rest API - Store v3":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58011)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -170,9 +171,10 @@ procSuite "Waku Rest API - Store v3":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58011)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -239,9 +241,10 @@ procSuite "Waku Rest API - Store v3":
     let node = testWakuNode()
     await node.start()
 
-    let restPort = Port(58012)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -334,9 +337,10 @@ procSuite "Waku Rest API - Store v3":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58013)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -406,9 +410,10 @@ procSuite "Waku Rest API - Store v3":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58014)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -494,9 +499,10 @@ procSuite "Waku Rest API - Store v3":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58015)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -549,9 +555,10 @@ procSuite "Waku Rest API - Store v3":
     await node.start()
     await node.mountRelay()
 
-    let restPort = Port(58016)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -617,9 +624,10 @@ procSuite "Waku Rest API - Store v3":
     let node = testWakuNode()
     await node.start()
 
-    let restPort = Port(58017)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()
@@ -680,7 +688,6 @@ procSuite "Waku Rest API - Store v3":
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
-
     restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
@@ -726,9 +733,10 @@ procSuite "Waku Rest API - Store v3":
     let node = testWakuNode()
     await node.start()
 
-    let restPort = Port(58018)
+    var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+    restPort = restServer.httpServer.address.port # update with bound port for client use
 
     installStoreApiHandlers(restServer.router, node)
     restServer.start()


### PR DESCRIPTION
# Description
Found that some of the random failures in CI comes from old fashioned REST API tests that use fixed ports for test setup.
Now this changed to OS selected random free ports all remaining places.

I expect more stable CI tests from this change. No functionality changed.

# Changes

- [X] All rest test port setup now uses Port(0)

## How to test

1. Just run all tests