### PR TITLE
fix: postgres_driver - better sync lock in partition creation

### DIFF
--- a/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
+++ b/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
@@ -70,6 +70,9 @@ proc addPartitionInfo*(
   trace "Adding partition info"
   self.partitions.addLast(partitionInfo)
 
+proc clearPartitionInfo*(self: PartitionManager) =
+  self.partitions.clear()
+
 proc removeOldestPartitionName*(self: PartitionManager) =
   ## Simply removed the partition from the tracked/known partitions queue.
   ## Just remove it and ignore it.


### PR DESCRIPTION
# Description
With the previous approach it happened cases where one connection acquired the lock and other connection tried to release the same lock, causing an unrecoverable failure which made the node to end.

## Issue

closes https://github.com/waku-org/nwaku/issues/2783
