### PR TITLE
chore: adding discv5 logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,10 @@ ifeq ($(POSTGRES), 1)
 NIM_PARAMS := $(NIM_PARAMS) -d:postgres -d:nimDebugDlOpen
 endif
 
+ifeq ($(DEBUG_DISCV5), 1)
+NIM_PARAMS := $(NIM_PARAMS) -d:debugDiscv5
+endif
+
 clean: | clean-libbacktrace
 
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -180,11 +180,19 @@ proc findRandomPeers*(
 
   var discoveredRecords = discoveredNodes.mapIt(it.record)
 
+  echo "------------- DISCV5 FOUND PEERS ---------------"
+  for enr in discoveredRecords:
+    echo "Found Peer: ", $enr
+
   # Filter out nodes that do not match the predicate
   if overridePred.isSome():
     discoveredRecords = discoveredRecords.filter(overridePred.get())
   elif wd.predicate.isSome():
     discoveredRecords = discoveredRecords.filter(wd.predicate.get())
+
+  echo "------------- DISCV5 PEERS AFTER FILTERING ---------------"
+  for enr in discoveredRecords:
+    echo "Found Peer: ", $enr
 
   return discoveredRecords
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -65,6 +65,21 @@ proc shardingPredicate*(
   debug "peer filtering updated"
 
   let predicate = proc(record: waku_enr.Record): bool =
+    echo "-------- analyzing discv5 returned node ----------"
+    echo "record: ", record
+    echo "capabilities: ", record.getCapabilities()
+
+    let typedRecord = record.toTyped().valueOr:
+      echo "could not parse to typed record. error: ", error
+      return false
+
+    echo "typed record: ", typedRecord
+    let rs = typedRecord.relaySharding()
+    if rs.isSome():
+      echo "shards: ", rs.get()
+    else:
+      echo "no shards found"
+
     bootnodes.contains(record) or # Temp. Bootnode exception
     (
       record.getCapabilities().len > 0 and #RFC 31 requirement

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -274,6 +274,7 @@ proc subscriptionsListener(wd: WakuDiscoveryV5) {.async.} =
   wd.topicSubscriptionQueue.unregister(key)
 
 proc start*(wd: WakuDiscoveryV5): Future[Result[void, string]] {.async: (raises: []).} =
+  echo "----------- start*(wd: WakuDiscoveryV5) -----------------"
   if wd.listening:
     return err("already listening")
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -188,8 +188,18 @@ proc logDiscv5FoundPeers(discoveredRecords: seq[waku_enr.Record]) =
       else:
         "no shards found"
 
+    let multiaddress = typedRecord.multiaddrs()
+    let multiaddressStr =
+      if multiaddress.isSome():
+        $multiaddress.get()
+      else:
+        "could not parse multiaddress"
+
     notice "Received discv5 node",
-      enr = recordUri, capabilities = capabilities, shards = shardsStr
+      multiaddress = multiaddressStr,
+      enr = recordUri,
+      capabilities = capabilities,
+      shards = shardsStr
 
 proc findRandomPeers*(
     wd: WakuDiscoveryV5, overridePred = none(WakuDiscv5Predicate)

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -219,7 +219,7 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
   info "Starting discovery v5 search"
 
   while wd.listening:
-    info "running discv5 discovery loop"
+    trace "running discv5 discovery loop"
     let discoveredRecords = await wd.findRandomPeers()
 
     var discoveredPeers: seq[RemotePeerInfo]
@@ -234,11 +234,11 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
 
       discoveredPeers.add(peerInfo)
 
-    info "discv5 discovered peers",
+    trace "discv5 discovered peers",
       num_discovered_peers = discoveredPeers.len,
       peers = toSeq(discoveredPeers.mapIt(shortLog(it.peerId)))
 
-    info "discv5 discarded wrong records",
+    trace "discv5 discarded wrong records",
       wrong_records =
         wrongRecordsReasons.mapIt("(" & it.record & "," & it.errorDescription & ")")
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -205,7 +205,7 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
   info "Starting discovery v5 search"
 
   while wd.listening:
-    trace "running discv5 discovery loop"
+    info "running discv5 discovery loop"
     let discoveredRecords = await wd.findRandomPeers()
 
     var discoveredPeers: seq[RemotePeerInfo]
@@ -220,11 +220,11 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
 
       discoveredPeers.add(peerInfo)
 
-    trace "discv5 discovered peers",
+    info "discv5 discovered peers",
       num_discovered_peers = discoveredPeers.len,
       peers = toSeq(discoveredPeers.mapIt(shortLog(it.peerId)))
 
-    trace "discv5 discarded wrong records",
+    info "discv5 discarded wrong records",
       wrong_records =
         wrongRecordsReasons.mapIt("(" & it.record & "," & it.errorDescription & ")")
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -66,7 +66,7 @@ proc shardingPredicate*(
 
   let predicate = proc(record: waku_enr.Record): bool =
     echo "-------- analyzing discv5 returned node ----------"
-    echo "record: ", record
+    echo "record: ", record.toURI()
     echo "capabilities: ", record.getCapabilities()
 
     let typedRecord = record.toTyped().valueOr:
@@ -198,6 +198,7 @@ proc findRandomPeers*(
   echo "------------- DISCV5 FOUND PEERS ---------------"
   for enr in discoveredRecords:
     echo "Found Peer: ", $enr
+    echo "enr: ", enr.toURI()
 
   # Filter out nodes that do not match the predicate
   if overridePred.isSome():

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -178,12 +178,12 @@ proc logDiscv5FoundPeers(discoveredRecords: seq[waku_enr.Record]) =
     let capabilities = record.getCapabilities()
 
     let typedRecord = record.toTyped().valueOr:
-      warn "could not parse to typed record. error: ", error = error, enr = recordUri
-      return
+      warn "Could not parse to typed record", error = error, enr = recordUri
+      continue
 
     let peerInfo = record.toRemotePeerInfo().valueOr:
-      warn "could not get generate remote peer info", error = error, enr = recordUri
-      return
+      warn "Could not generate remote peer info", error = error, enr = recordUri
+      continue
 
     let addrs = peerInfo.constructMultiaddrStr()
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -178,7 +178,7 @@ proc logDiscv5FoundPeers(discoveredRecords: seq[waku_enr.Record]) =
     let capabilities = record.getCapabilities()
 
     let typedRecord = record.toTyped().valueOr:
-      trace "could not parse to typed record. error: ", error = error, enr = recordUri
+      notice "could not parse to typed record. error: ", error = error, enr = recordUri
       return
 
     let rs = typedRecord.relaySharding()
@@ -188,7 +188,7 @@ proc logDiscv5FoundPeers(discoveredRecords: seq[waku_enr.Record]) =
       else:
         "no shards found"
 
-    trace "Recieved discv5 node",
+    notice "Recieved discv5 node",
       enr = recordUri, capabilities = capabilities, shards = shardsStr
 
 proc findRandomPeers*(
@@ -199,7 +199,8 @@ proc findRandomPeers*(
 
   var discoveredRecords = discoveredNodes.mapIt(it.record)
 
-  logDiscv5FoundPeers(discoveredRecords)
+  when defined(debugDiscv5):
+    logDiscv5FoundPeers(discoveredRecords)
 
   # Filter out nodes that do not match the predicate
   if overridePred.isSome():

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -188,7 +188,7 @@ proc logDiscv5FoundPeers(discoveredRecords: seq[waku_enr.Record]) =
       else:
         "no shards found"
 
-    notice "Recieved discv5 node",
+    notice "Received discv5 node",
       enr = recordUri, capabilities = capabilities, shards = shardsStr
 
 proc findRandomPeers*(

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -224,6 +224,7 @@ proc updateWaku(waku: ptr Waku): Result[void, string] =
   return ok()
 
 proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: []).} =
+  echo "-------------- startWaku -------------"
   (await startNode(waku.node, waku.conf, waku.dynamicBootstrapNodes)).isOkOr:
     return err("error while calling startNode: " & $error)
 
@@ -233,13 +234,16 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: 
 
   ## Discv5
   if waku[].conf.discv5Discovery:
+    echo "-------------- startWaku: setting up discv5 -------------"
     waku[].wakuDiscV5 = waku_discv5.setupDiscoveryV5(
       waku.node.enr, waku.node.peerManager, waku.node.topicSubscriptionQueue, waku.conf,
       waku.dynamicBootstrapNodes, waku.rng, waku.key,
     )
 
+    echo "-------------- startWaku: starting discv5 -------------"
     (await waku.wakuDiscV5.start()).isOkOr:
       return err("failed to start waku discovery v5: " & $error)
+    echo "-------------- startWaku: started discv5 -------------"
 
   return ok()
 

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -224,7 +224,6 @@ proc updateWaku(waku: ptr Waku): Result[void, string] =
   return ok()
 
 proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: []).} =
-  echo "-------------- startWaku -------------"
   (await startNode(waku.node, waku.conf, waku.dynamicBootstrapNodes)).isOkOr:
     return err("error while calling startNode: " & $error)
 
@@ -234,16 +233,13 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: 
 
   ## Discv5
   if waku[].conf.discv5Discovery:
-    echo "-------------- startWaku: setting up discv5 -------------"
     waku[].wakuDiscV5 = waku_discv5.setupDiscoveryV5(
       waku.node.enr, waku.node.peerManager, waku.node.topicSubscriptionQueue, waku.conf,
       waku.dynamicBootstrapNodes, waku.rng, waku.key,
     )
 
-    echo "-------------- startWaku: starting discv5 -------------"
     (await waku.wakuDiscV5.start()).isOkOr:
       return err("failed to start waku discovery v5: " & $error)
-    echo "-------------- startWaku: started discv5 -------------"
 
   return ok()
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -737,8 +737,7 @@ proc connectToRelayPeers*(pm: PeerManager) {.async.} =
   if outRelayPeers.len >= pm.outRelayPeersTarget:
     return
 
-  let notConnectedPeers =
-    pm.peerStore.getNotConnectedPeers().mapIt(RemotePeerInfo.init(it.peerId, it.addrs))
+  let notConnectedPeers = pm.peerStore.getNotConnectedPeers()
 
   var outsideBackoffPeers = notConnectedPeers.filterIt(pm.canBeConnected(it.peerId))
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -649,18 +649,29 @@ proc connectToNodes*(
   info "Dialing multiple peers", numOfPeers = nodes.len
 
   var futConns: seq[Future[bool]]
+  var connectedPeers: seq[RemotePeerInfo]
   for node in nodes:
     let node = parsePeerInfo(node)
     if node.isOk():
       futConns.add(pm.connectRelay(node.value))
+      connectedPeers.add(node.value)
     else:
       error "Couldn't parse node info", error = node.error
 
   await allFutures(futConns)
-  let successfulConns = futConns.mapIt(it.read()).countIt(it == true)
+
+  # Filtering connectedPeers based on futConns
+  let combined = zip(connectedPeers, futConns)
+  connectedPeers = combined.filterIt(it[1].read() == true).mapIt(it[0])
+
+  when defined(debugDiscv5):
+    let peerIds = connectedPeers.mapIt(it.peerId)
+    let origin = connectedPeers.mapIt(it.origin)
+    notice "established connections with found peers",
+      peerIds = peerIds, origin = origin
 
   info "Finished dialing multiple peers",
-    successfulConns = successfulConns, attempted = nodes.len
+    successfulConns = connectedPeers.len, attempted = nodes.len
 
   # The issue seems to be around peers not being fully connected when
   # trying to subscribe. So what we do is sleep to guarantee nodes are

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -660,7 +660,7 @@ proc connectToNodes*(
 
   await allFutures(futConns)
 
-  # Filtering connectedPeers based on futConns
+  # Filtering successful connectedPeers based on futConns
   let combined = zip(connectedPeers, futConns)
   connectedPeers = combined.filterIt(it[1].read() == true).mapIt(it[0])
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Adding logs when discv5 finds new peers and when the node connects to new peers. These logs will be under the compilation flag `DEBUG_DISCV5` so it is used for DST simulations.

It can be tested in the following image:

```
harbor.status.im/wakuorg/nwaku:discv5-debug-logs
```

Example logs
```
nwaku-1  | NTC 2024-06-25 12:07:43.869+00:00 Received discv5 node                       topics="waku discv5" tid=1 file=waku_discv5.nim:197 addrs=/ip4/195.201.172.178/tcp/30304/p2p/16Uiu2HAmKQAGsUAoUVMt6j7FLRWmou2z3a1WE6CGUiG1YKxWtq2u enr=enr:-LW4QK7dmsv43R2qQknllshhYx9IDEu1cD1t6Ao601ppx8oWYr_joTyfKXjoxQAST1iuGTXfs0ETtJ1fCrZef-GYHrsBgmlkgnY0gmlwhMPJrLKKbXVsdGlhZGRyc4CCcnOTAAEIAAAAAQACAAMABAAFAAYAB4lzZWNwMjU2azGhA2Q1UTaE09UZWli2y5AZFwE-3RGoGGvwrQ_9B5YAy_VWg3RjcIJ2YIN1ZHCCIy2Fd2FrdTIP capabilities="@[Relay, Store, Filter, Lightpush]" shards="(clusterId: 1, shardIds: @[0, 1, 2, 3, 4, 5, 6, 7])"
```

```
nwaku-1  | NTC 2024-06-25 12:08:53.816+00:00 established connections with found peers   topics="waku node peer_manager" tid=1 file=peer_manager.nim:670 peerIds="@[16Uiu2HAmB7Ur9HQqo3cWDPovRQjo57fxWWDaQx27WxSzDGhN4JKg, 16Uiu2HAmNTpGnyZ8W1BK2sXEmgSCNWiyDKgRU3NBR2DXST2HzxRU]" origin="@[Discv5, Discv5]"
```

CC @AlbertoSoutullo 


<!--

# Changes
- [ ] ...
- [ ] ...
## How to test

1.
1.
1.

-->


## Issue

related to #2810 
closes #2841 
