### PR TITLE
fix: update peers ENRs in peer store in case they are updated

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -128,9 +128,14 @@ proc addPeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo, origin = UnknownO
   if pm.peerStore[AddressBook][remotePeerInfo.peerId] == remotePeerInfo.addrs and
       pm.peerStore[KeyBook][remotePeerInfo.peerId] == remotePeerInfo.publicKey and
       pm.peerStore[ENRBook][remotePeerInfo.peerId].raw.len > 0:
-    trace "peer already managed and ENR info is already saved",
-      remote_peer_id = $remotePeerInfo.peerId
-    return
+    if remotePeerInfo.enr.isNone():
+      trace "peer already managed and incoming ENR is empty"
+      return
+
+    if remotePeerInfo.enr.get().raw == pm.peerStore[ENRBook][remotePeerInfo.peerId].raw:
+      trace "peer already managed and ENR info is already saved",
+        remote_peer_id = $remotePeerInfo.peerId
+      return
 
   trace "Adding peer to manager",
     peerId = remotePeerInfo.peerId, addresses = remotePeerInfo.addrs

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -132,7 +132,10 @@ proc addPeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo, origin = UnknownO
       trace "peer already managed and incoming ENR is empty"
       return
 
-    if remotePeerInfo.enr.get().raw == pm.peerStore[ENRBook][remotePeerInfo.peerId].raw:
+    let incomingEnr = remotePeerInfo.enr.get()
+
+    if pm.peerStore[ENRBook][remotePeerInfo.peerId].raw == incomingEnr.raw or
+        pm.peerStore[ENRBook][remotePeerInfo.peerId].seqNum > incomingEnr.seqNum:
       trace "peer already managed and ENR info is already saved",
         remote_peer_id = $remotePeerInfo.peerId
       return

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -129,7 +129,8 @@ proc addPeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo, origin = UnknownO
       pm.peerStore[KeyBook][remotePeerInfo.peerId] == remotePeerInfo.publicKey and
       pm.peerStore[ENRBook][remotePeerInfo.peerId].raw.len > 0:
     let incomingEnr = remotePeerInfo.enr.valueOr:
-      trace "peer already managed and incoming ENR is empty"
+      trace "peer already managed and incoming ENR is empty",
+        remote_peer_id = $remotePeerInfo.peerId
       return
 
     if pm.peerStore[ENRBook][remotePeerInfo.peerId].raw == incomingEnr.raw or

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -128,11 +128,9 @@ proc addPeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo, origin = UnknownO
   if pm.peerStore[AddressBook][remotePeerInfo.peerId] == remotePeerInfo.addrs and
       pm.peerStore[KeyBook][remotePeerInfo.peerId] == remotePeerInfo.publicKey and
       pm.peerStore[ENRBook][remotePeerInfo.peerId].raw.len > 0:
-    if remotePeerInfo.enr.isNone():
+    let incomingEnr = remotePeerInfo.enr.valueOr:
       trace "peer already managed and incoming ENR is empty"
       return
-
-    let incomingEnr = remotePeerInfo.enr.get()
 
     if pm.peerStore[ENRBook][remotePeerInfo.peerId].raw == incomingEnr.raw or
         pm.peerStore[ENRBook][remotePeerInfo.peerId].seqNum > incomingEnr.seqNum:


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Checking if the ENR of an incoming peer is the same as the one we have saved and if not, update it in the peer store.

# Changes


- [x] updating peer store for existing peers with changed ENRs

## Issue

closes #2817 
