### PR TITLE
chore: stop connecting to out peers until target is reached

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -725,7 +725,8 @@ proc connectToRelayPeers*(pm: PeerManager) {.async.} =
   shuffle(outsideBackoffPeers)
 
   var index = 0
-  var numPendingConnReqs = outsideBackoffPeers.len
+  var numPendingConnReqs =
+    min(outsideBackoffPeers.len, pm.outRelayPeersTarget - outRelayPeers.len)
     ## number of outstanding connection requests
 
   while numPendingConnReqs > 0 and outRelayPeers.len < pm.outRelayPeersTarget:


### PR DESCRIPTION
# Description
We're currently attempting establish more `out connections` than our target. We are trying to connect 10 peers at a time, and we still dial 10 even if our target is less than 10.

When investigating https://github.com/waku-org/nwaku/issues/2780, I noticed that the issue started right after we tried to connect to more nodes than we could.

Making a small fix so we stick more precisely to our targets.

# Changes

<!-- List of detailed changes -->

- [x] only dial to the peers necessary to reach `outRelayPeersTarget`

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->