### PR TITLE
fix: adding peer exchange peers to the peerStore

### DIFF
--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -135,11 +135,12 @@ proc setupProtocols(
         # only peers with populated records
         .mapIt(toRemotePeerInfo(it.record.get()))
 
-      debug "connecting to exchanged peers",
+      debug "adding exchanged peers",
         src = peer, topic = topic, numPeers = exchangedPeers.len
 
-      # asyncSpawn, as we don't want to block here
-      asyncSpawn node.connectToNodes(exchangedPeers, "peer exchange")
+      for peer in exchangedPeers:
+        # Peers added are filtered by the peer manager
+        node.peerManager.addPeer(peer, PeerOrigin.PeerExchange)
 
     peerExchangeHandler = some(handlePeerExchange)
 


### PR DESCRIPTION
# Description
As soon we receive peers in Peer Exchange, we currently try to connect to all of them directly in a very aggressive way.

This does not take into account our connection targets and limits. Therefore, we should first add the peers to the Peer Store, and the connectivity loop will be in charge to choose and connect to the amount of peers necessary to reach its targets.

# Changes

<!-- List of detailed changes -->

- [x] adding Peer Exchange peers to the Peer Store instead of trying to directly connect to all of them 

<!--
## How to test

1.
1.
1.

-->


## Issue

We saw this case happen and potentially cause issues in #2780 