### PR TITLE
chore: better descriptive log

### DIFF
--- a/tests/waku_core/test_namespaced_topics.nim
+++ b/tests/waku_core/test_namespaced_topics.nim
@@ -69,7 +69,7 @@ suite "Waku Message - Content topics namespacing":
     let err = ns.tryError()
     check:
       err.kind == ParsingErrorKind.InvalidFormat
-      err.cause == "topic must start with slash"
+      err.cause == "content-topic '" & topic & "' must start with slash"
 
   test "Parse content topic string - Invalid string: not namespaced":
     ## Given

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -511,11 +511,12 @@ suite "Waku v2 Rest API - Relay":
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
+    let invalidContentTopic = "invalidContentTopic"
     # When
     let response = await client.relayPostAutoMessagesV1(
       RelayWakuMessage(
         payload: base64.encode("TEST-PAYLOAD"),
-        contentTopic: some("invalidContentTopic"),
+        contentTopic: some(invalidContentTopic),
         timestamp: some(int64(2022)),
       )
     )
@@ -525,7 +526,8 @@ suite "Waku v2 Rest API - Relay":
       response.status == 400
       $response.contentType == $MIMETYPE_TEXT
       response.data ==
-        "Failed to publish. Autosharding error: invalid format: topic must start with slash"
+        "Failed to publish. Autosharding error: invalid format: content-topic '" &
+        invalidContentTopic & "' must start with slash"
 
     await restServer.stop()
     await restServer.closeWait()

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -149,6 +149,8 @@ proc setupProtocols(
       conf.contentTopics.mapIt(node.wakuSharding.getShard(it).expect("Valid Shard"))
     let pubsubTopics = conf.pubsubTopics & shards
 
+    debug "Shards created for content filter", shards = shards
+
     let parsedMaxMsgSize = parseMsgSize(conf.maxMessageSize).valueOr:
       return err("failed to parse 'max-num-bytes-msg-size' param: " & $error)
 

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -149,7 +149,8 @@ proc setupProtocols(
       conf.contentTopics.mapIt(node.wakuSharding.getShard(it).expect("Valid Shard"))
     let pubsubTopics = conf.pubsubTopics & shards
 
-    debug "Shards created for content filter", shards = shards
+    debug "Shards created from content topics",
+      contentTopics = conf.contentTopics, shards = shards
 
     let parsedMaxMsgSize = parseMsgSize(conf.maxMessageSize).valueOr:
       return err("failed to parse 'max-num-bytes-msg-size' param: " & $error)

--- a/waku/waku_core/topics/content_topic.nim
+++ b/waku/waku_core/topics/content_topic.nim
@@ -68,7 +68,9 @@ proc parse*(
   ## Autosharding adds 1 optional prefix `/<gen#>
 
   if not topic.startsWith("/"):
-    return err(ParsingError.invalidFormat("topic must start with slash"))
+    return err(
+      ParsingError.invalidFormat("content-topic '" & topic & "' must start with slash")
+    )
 
   let parts = topic[1 ..< topic.len].split("/")
 


### PR DESCRIPTION

Previously, there was confusion in distinguishing between the content and the pubsub topic in logs. Now, the logs are more descriptive, clearly specifying which content-topic pair has the issue.