### PR TITLE
fix: only set disconnect time on left event

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -442,7 +442,9 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
 
   if not pm.storage.isNil:
     var remotePeerInfo = pm.peerStore.get(peerId)
-    remotePeerInfo.disconnectTime = getTime().toUnix
+
+    if event.kind == PeerEventKind.Left:
+      remotePeerInfo.disconnectTime = getTime().toUnix
 
     pm.storage.insertOrReplace(remotePeerInfo)
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Small fix to only set `disconnectTime` when a node is actually disconnecting

# Changes

<!-- List of detailed changes -->

- [x] only setting `disconnectTime` in peer storage when a node is disconnects


## Issue

advances https://github.com/waku-org/pm/issues/172