### PR TITLE
fix(rln-relay): clear nullifier log only if length is over max epoch gap

### DIFF
--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -886,3 +886,48 @@ suite "Waku rln relay":
     check:
       buckets.len == 5
       buckets == [2.0, 4.0, 6.0, 8.0, 10.0]
+  
+  asyncTest "nullifierLog clearing only after epoch has passed":
+    let index = MembershipIndex(0)
+
+    proc runTestForEpochSizeSec(rlnEpochSizeSec: uint) {.async.} =
+      let wakuRlnConfig = WakuRlnConfig(
+        rlnRelayDynamic: false,
+        rlnRelayCredIndex: some(index),
+        rlnRelayUserMessageLimit: 1,
+        rlnEpochSizeSec: rlnEpochSizeSec,
+        rlnRelayTreePath: genTempPath("rln_tree", "waku_rln_relay_4"),
+      )
+
+      let wakuRlnRelay = (await WakuRlnRelay.new(wakuRlnConfig)).valueOr:
+        raiseAssert $error
+
+      let rlnMaxEpochGap = wakuRlnRelay.rlnMaxEpochGap
+      let testProofMetadata = default(ProofMetadata)
+      let testProofMetadataTable = {testProofMetadata.nullifier: testProofMetadata}.toTable()
+
+      for i in 0..<rlnMaxEpochGap:
+        # we add epochs to the nullifierLog
+        let testEpoch =  wakuRlnRelay.calcEpoch(epochTime() + float(rlnEpochSizeSec * i))
+        wakuRlnRelay.nullifierLog[testEpoch] = testProofMetadataTable
+        check: wakuRlnRelay.nullifierLog.len().uint == i + 1
+
+      # clearing it now will be a no-op
+      wakuRlnRelay.clearNullifierLog()
+
+      check: wakuRlnRelay.nullifierLog.len().uint == rlnMaxEpochGap
+
+      # append one more now
+      let testEpoch =  wakuRlnRelay.calcEpoch(epochTime() + float(rlnMaxEpochGap * rlnEpochSizeSec))
+      wakuRlnRelay.nullifierLog[testEpoch] = testProofMetadataTable
+
+      check: wakuRlnRelay.nullifierLog.len().uint == rlnMaxEpochGap + 1
+      # clearing it now will be a no-op
+      wakuRlnRelay.clearNullifierLog()
+
+      check: wakuRlnRelay.nullifierLog.len().uint == rlnMaxEpochGap
+
+    var testEpochSizes: seq[uint] = @[1,5,10,30,60]
+    for i in testEpochSizes:
+      await runTestForEpochSizeSec(i)
+

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -906,23 +906,15 @@ suite "Waku rln relay":
       let testProofMetadata = default(ProofMetadata)
       let testProofMetadataTable = {testProofMetadata.nullifier: testProofMetadata}.toTable()
 
-      for i in 0..<rlnMaxEpochGap:
+      for i in 0..rlnMaxEpochGap:
         # we add epochs to the nullifierLog
         let testEpoch =  wakuRlnRelay.calcEpoch(epochTime() + float(rlnEpochSizeSec * i))
         wakuRlnRelay.nullifierLog[testEpoch] = testProofMetadataTable
         check: wakuRlnRelay.nullifierLog.len().uint == i + 1
 
-      # clearing it now will be a no-op
-      wakuRlnRelay.clearNullifierLog()
-
-      check: wakuRlnRelay.nullifierLog.len().uint == rlnMaxEpochGap
-
-      # append one more now
-      let testEpoch =  wakuRlnRelay.calcEpoch(epochTime() + float(rlnMaxEpochGap * rlnEpochSizeSec))
-      wakuRlnRelay.nullifierLog[testEpoch] = testProofMetadataTable
-
       check: wakuRlnRelay.nullifierLog.len().uint == rlnMaxEpochGap + 1
-      # clearing it now will be a no-op
+
+      # clearing it now will remove 1 epoch
       wakuRlnRelay.clearNullifierLog()
 
       check: wakuRlnRelay.nullifierLog.len().uint == rlnMaxEpochGap

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -316,7 +316,7 @@ proc clearNullifierLog(rlnPeer: WakuRlnRelay) =
   # clear the first MaxEpochGap epochs of the nullifer log
   # if more than MaxEpochGap epochs are in the log
   # note: the epochs are ordered ascendingly
-  if rlnPeer.nullifierLog.len().uint < rlnPeer.rlnMaxEpochGap:
+  if rlnPeer.nullifierLog.len().uint <= rlnPeer.rlnMaxEpochGap:
     return
 
   trace "clearing epochs from the nullifier log", count = rlnPeer.rlnMaxEpochGap

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -312,15 +312,16 @@ proc appendRLNProof*(
   msg.proof = proof.encode().buffer
   return ok()
 
-proc clearNullifierLog(rlnPeer: WakuRlnRelay) =
+proc clearNullifierLog*(rlnPeer: WakuRlnRelay) =
   # clear the first MaxEpochGap epochs of the nullifer log
   # if more than MaxEpochGap epochs are in the log
   # note: the epochs are ordered ascendingly
   if rlnPeer.nullifierLog.len().uint <= rlnPeer.rlnMaxEpochGap:
     return
 
-  trace "clearing epochs from the nullifier log", count = rlnPeer.rlnMaxEpochGap
-  let epochsToClear = rlnPeer.nullifierLog.keys().toSeq()[0 ..< rlnPeer.rlnMaxEpochGap]
+  let countToClear = rlnPeer.nullifierLog.len().uint - rlnPeer.rlnMaxEpochGap
+  trace "clearing epochs from the nullifier log", count = countToClear
+  let epochsToClear = rlnPeer.nullifierLog.keys().toSeq()[0 ..< countToClear]
   for epoch in epochsToClear:
     rlnPeer.nullifierLog.del(epoch)
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->

Fixes an edge case where the nullifier log was cleared when maxEpochGap == nullifierLog.len

# Changes

<!-- List of detailed changes -->

- [x] Adds unit tests for varied epoch sizes
- [x] fixes edge case

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
