### PR TITLE
fix: duplicate message forwarding in filter service

### DIFF
--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -179,9 +179,7 @@ proc pushToPeers(
     messagePush.pubsubTopic.computeMessageHash(messagePush.wakuMessage).to0xHex()
 
   wf.messageCache.expire(Moment.now())
-  let isDuplicate = wf.messageCache.contains(msgHash)
-
-  if isDuplicate:
+  let wf.messageCache.contains(msgHash):
     notice "duplicate message found, not-pushing message to subscribed peers",
       pubsubTopic = messagePush.pubsubTopic,
       contentTopic = messagePush.wakuMessage.contentTopic,

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -179,7 +179,7 @@ proc pushToPeers(
     messagePush.pubsubTopic.computeMessageHash(messagePush.wakuMessage).to0xHex()
 
   wf.messageCache.expire(Moment.now())
-  let wf.messageCache.contains(msgHash):
+  if wf.messageCache.contains(msgHash):
     notice "duplicate message found, not-pushing message to subscribed peers",
       pubsubTopic = messagePush.pubsubTopic,
       contentTopic = messagePush.wakuMessage.contentTopic,

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -186,7 +186,6 @@ proc pushToPeers(
       target_peer_ids = targetPeerIds,
       msg_hash = msgHash
   else:
-    discard wf.messageCache.put(msgHash, Moment.now())
     notice "pushing message to subscribed peers",
       pubsubTopic = messagePush.pubsubTopic,
       contentTopic = messagePush.wakuMessage.contentTopic,
@@ -199,8 +198,10 @@ proc pushToPeers(
     for peerId in peers:
       let pushFut = wf.pushToPeer(peerId, bufferToPublish)
       pushFuts.add(pushFut)
-
     await allFutures(pushFuts)
+
+  ## expiration refreshed that's why update cache every time, even if it has a value.
+  discard wf.messageCache.put(msgHash, Moment.now())
 
 proc maintainSubscriptions*(wf: WakuFilter) =
   trace "maintaining subscriptions"


### PR DESCRIPTION
close #2320 

PR Description:

We identified a duplicate issue in the filter node service, which has been resolved in this fix. 