### PR TITLE
chore: archive.nim - increase the max limit of content topics per query to 100

### DIFF
--- a/tests/waku_archive/test_waku_archive.nim
+++ b/tests/waku_archive/test_waku_archive.nim
@@ -233,13 +233,13 @@ procSuite "Waku Archive - find messages":
       response.messages.anyIt(it == msg1)
       response.messages.anyIt(it == msg3)
 
-  test "handle query with more than 10 content filters":
+  test "handle query with more than 100 content filters":
     ## Setup
     let
       driver = newSqliteArchiveDriver()
       archive = newWakuArchive(driver)
 
-    let queryTopics = toSeq(1 .. 15).mapIt(ContentTopic($it))
+    let queryTopics = toSeq(1 .. 150).mapIt(ContentTopic($it))
 
     ## Given
     let req = ArchiveQuery(contentTopics: queryTopics)

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -141,7 +141,7 @@ proc findMessages*(
 
   let isAscendingOrder = query.direction.into()
 
-  if query.contentTopics.len > 10:
+  if query.contentTopics.len > 100:
     return err(ArchiveError.invalidQuery("too many content topics"))
 
   if query.cursor.isSome() and query.cursor.get().hash.len != 32:
@@ -229,7 +229,7 @@ proc findMessagesV2*(
 
   let isAscendingOrder = query.direction.into()
 
-  if query.contentTopics.len > 10:
+  if query.contentTopics.len > 100:
     return err(ArchiveError.invalidQuery("too many content topics"))
 
   let queryStartTime = getTime().toUnixFloat()


### PR DESCRIPTION
### Description
The _Status_ app tend to perform _Store_ queries multiple content topics. In this tiny PR we are increasing the max number of content topics in a query from 10 to 100

cc @chaitanyaprem 


