### PR TITLE
chore: ignore arbitrary data stored in `multiaddrs` enr key

### DIFF
--- a/waku/waku_enr/multiaddr.nim
+++ b/waku/waku_enr/multiaddr.nim
@@ -55,7 +55,8 @@ func decodeMultiaddrs(buffer: seq[byte]): EnrResult[seq[MultiAddress]] =
       return err("malformed multiaddr field: invalid length")
 
     let addrRaw = ?readBytes(buffer, addrLen.int, pos)
-    let address = MultiAddress.init(addrRaw).get()
+    let address = MultiAddress.init(addrRaw).valueOr:
+      continue # Not a valid multiaddress
 
     multiaddrs.add(address)
 


### PR DESCRIPTION
# Description
This would allow reading the `multiaddrs` key and not fail if one of the values encoded in that key is not a multiaddress.
The reason why this change is being proposed is that it would allow storing some data which can be translated to multiaddresses, for example circuit relay addresses which could be stored with this format:
```
- 4 bytes for the IP address
- 2 bytes for the Port
- 33 bytes for a secp256 compressed public key
```
which would mean storing 39 bytes compared to storing 50 bytes which would be the bytes encoding of a multiaddress containing the same information. (In ENRs the less bytes we use the better)

cc: @fryorcraken 