### PR TITLE
fix(rln): nullifierlog vulnerability

### DIFF
--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -318,13 +318,17 @@ proc clearNullifierLog*(rlnPeer: WakuRlnRelay) =
   # if more than MaxEpochGap epochs are in the log
   let currentEpoch = fromEpoch(rlnPeer.getCurrentEpoch())
 
+  var epochsToRemove: seq[Epoch] = @[]
   for epoch in rlnPeer.nullifierLog.keys():
     let epochInt = fromEpoch(epoch)
 
     # clean all epochs that are +- rlnMaxEpochGap from the current epoch
-    if (currentEpoch+rlnPeer.rlnMaxEpochGap) < epochInt and epochInt < (currentEpoch-rlnPeer.rlnMaxEpochGap):
-      trace "clearing epochs from the nullifier log", cleanedEpoch = epochInt
-      rlnPeer.nullifierLog.del(epoch)
+    if (currentEpoch+rlnPeer.rlnMaxEpochGap) <= epochInt or epochInt <= (currentEpoch-rlnPeer.rlnMaxEpochGap):
+      epochsToRemove.add(epoch)
+  
+  for epochRemove in epochsToRemove:
+    trace "clearing epochs from the nullifier log", currentEpoch = currentEpoch, cleanedEpoch = epochInt
+    rlnPeer.nullifierLog.del(epochRemove)
 
 proc generateRlnValidator*(
     wakuRlnRelay: WakuRLNRelay, spamHandler = none(SpamHandler)

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[sequtils, tables, times, deques, algorithm],
+  std/[sequtils, tables, times, deques],
   chronicles,
   options,
   chronos,
@@ -312,14 +312,6 @@ proc appendRLNProof*(
 
   msg.proof = proof.encode().buffer
   return ok()
-
-proc compareKeys(a, b: Epoch): int =
-  for i in 0..<32:
-    if a[i] < b[i]:
-      return -1
-    elif a[i] > b[i]:
-      return 1
-  return 0
 
 proc clearNullifierLog*(rlnPeer: WakuRlnRelay) =
   # clear the first MaxEpochGap epochs of the nullifer log

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -327,7 +327,7 @@ proc clearNullifierLog*(rlnPeer: WakuRlnRelay) =
       epochsToRemove.add(epoch)
   
   for epochRemove in epochsToRemove:
-    trace "clearing epochs from the nullifier log", currentEpoch = currentEpoch, cleanedEpoch = epochInt
+    trace "clearing epochs from the nullifier log", currentEpoch = currentEpoch, cleanedEpoch = fromEpoch(epochRemove)
     rlnPeer.nullifierLog.del(epochRemove)
 
 proc generateRlnValidator*(


### PR DESCRIPTION
* Fixes bug in `nullifierLog`. Now instead of counting elements in the table and removing when > `epochGap`, we ensure that they correspond to the current epoch +- `epochGap`. Anything than that we remove. This protects the node from messages arriving out-of-order.
* Fixes bug in `validateMessageAndUpdateLog`. The `nullifierLog` table was updated with new epochs no matter if the message was rate-limited or not, and no matter if the message even contained a valid proof. This allowed an attacker to attack the `nullifierLog` table, that in conjunction with the previous bug caused rate-limited messages to be accepted. The attacker at no cost could fill the table with unused epochs, bypassing the rate-limit protection.