### PR TITLE
doc: clarify max shard value on CLI args

### DIFF
--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -303,7 +303,7 @@ type WakuNodeConf* = object
 
     shards* {.
       desc: "Shards index to subscribe to [0.." & $MaxShardIndex & "]. Argument may be repeated.",
-      defaultValue: @[],
+      defaultValue: @[0.uint16, 1.uint16, 2.uint16, 3.uint16, 4.uint16, 5.uint16, 6.uint16, 7.uint16],
       name: "shard"
     .}: seq[uint16]
 

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -302,7 +302,7 @@ type WakuNodeConf* = object
     .}: seq[string]
 
     shards* {.
-      desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
+      desc: "Shards index to subscribe to [0.." & $MaxShardIndex & "]. Argument may be repeated.",
       defaultValue: @[],
       name: "shard"
     .}: seq[uint16]

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -68,7 +68,10 @@ proc logConfig(conf: WakuNodeConf) =
 
   info "Configuration. Network", cluster = conf.clusterId, maxPeers = conf.maxRelayPeers
 
-  for shard in conf.pubsubTopics:
+  for pubsubTopic in conf.pubsubTopics:
+    info "Configuration. pubsub topics", pubsubTopic = pubsubTopic
+
+  for shard in conf.shards:
     info "Configuration. Shards", shard = shard
 
   for i in conf.discv5BootstrapNodes:

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -423,7 +423,7 @@ proc mountRelay*(
 
   node.switch.mount(node.wakuRelay, protocolMatcher(WakuRelayCodec))
 
-  info "relay mounted successfully"
+  info "relay mounted successfully", pubsubTopics
 
   # Subscribe to topics
   for pubsubTopic in pubsubTopics:

--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -15,7 +15,7 @@ import ../common/enr, ../waku_core
 logScope:
   topics = "waku enr sharding"
 
-const MaxShardIndex: uint16 = 1023
+const MaxShardIndex*: uint16 = 1023
 
 const
   ShardingIndicesListEnrField* = "rs"


### PR DESCRIPTION
I started this PR because it bugged me that I could not simply start `wakunode2` and connect to it via `wakucanary` because `wakucanary` wants shards:

```
▶ ./build/wakucanary -a=...
INF 2024-06-28 13:59:19.881+10:00 Cli flags                                  tid=2317631 file=wakucanary.nim:164 address=/ip4/0.0.0.0/tcp/60000/p2p/16Uiu2HAm6AKL8iczGNguEwwcJGmCmgAS2cpTRve4UkMExtwt45gA timeout=10s protocols=@[] logLevel=INFO
ERR 2024-06-28 13:59:19.883+10:00 Relay shards initialization failed         tid=2317631 file=wakucanary.nim:209 error="invalid shard count"
ERR 2024-06-28 13:59:19.883+10:00 The node has some problems (see logs)      tid=2317631 file=wakucanary.nim:283
```

In the _good default value_ spirit, we should be able to run the binary with minimal config out of the box, without having to fiddle things.

The good default at the moment should either be:
1, TWN (aka RLN Relay protected network)
2. Status prod

There is value in doing either. However, for the sake of dogfooding and pushing RLN further, I believe (1) should be default. Until we can get RLN on Status network.

So, the proposal I'd like to make before I proceed forward is to change all default parameters to TWN, meaning that a user will have to pass a API address for eth client to play with nwaku.

This would mean something similar to nwaku-compose, but without postgres.

Cc @waku-org/nwaku-developers 

cc @gabrielmer some suggestions in there in terms of handlng shards, in reference to #2163 