### PR TITLE
chore(rln-relay): add chain-id flag to wakunode and restrict usage if mismatches rpc provider

### DIFF
--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -26,6 +26,8 @@ import
   ../testlib/common,
   ./utils
 
+const CHAIN_ID = 1337
+
 proc generateCredentials(rlnInstance: ptr RLN): IdentityCredential =
   let credRes = membershipKeyGen(rlnInstance)
   return credRes.get()
@@ -140,7 +142,7 @@ proc runAnvil(): Process =
       anvilPath,
       args = [
         "--port", "8540", "--gas-limit", "300000000000000", "--balance", "1000000000",
-        "--chain-id", "1337",
+        "--chain-id", $CHAIN_ID,
       ],
       options = {poUsePath},
     )
@@ -195,6 +197,7 @@ proc setup(): Future[OnchainGroupManager] {.async.} =
   let manager = OnchainGroupManager(
     ethClientUrl: EthClient,
     ethContractAddress: $contractAddress,
+    chainId: CHAIN_ID,
     ethPrivateKey: pk,
     rlnInstance: rlnInstance,
   )
@@ -217,6 +220,20 @@ suite "Onchain group manager":
       manager.rlnContractDeployedBlockNumber > 0
 
     await manager.stop()
+
+  asyncTest "should error on initialization when chainId does not match":
+    let manager = await setup()
+    manager.chainId = CHAIN_ID + 1
+
+    (await manager.init()).isErrOr:
+      raiseAssert "Expected error when chainId does not match"
+
+  asyncTest "should initialize when chainId is set to 0":
+    let manager = await setup()
+    manager.chainId = 0
+
+    (await manager.init()).isOkOr:
+      raiseAssert $error
 
   asyncTest "should error on initialization when loaded metadata does not match":
     let manager = await setup()

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -76,7 +76,7 @@ proc doRlnKeystoreGenerator*(conf: WakuNodeConf) =
   debug "Transaction hash", txHash = groupManager.registrationTxHash.get()
 
   info "Your membership has been registered on-chain.",
-    chainId = $groupManager.chainId.get(),
+    chainId = $groupManager.chainId,
     contractAddress = conf.rlnRelayEthContractAddress,
     membershipIndex = groupManager.membershipIndex.get()
   info "Your user message limit is", userMessageLimit = conf.rlnRelayUserMessageLimit
@@ -84,7 +84,7 @@ proc doRlnKeystoreGenerator*(conf: WakuNodeConf) =
   # 6. write to keystore
   let keystoreCred = KeystoreMembership(
     membershipContract: MembershipContract(
-      chainId: $groupManager.chainId.get(), address: conf.rlnRelayEthContractAddress
+      chainId: $groupManager.chainId, address: conf.rlnRelayEthContractAddress
     ),
     treeIndex: groupManager.membershipIndex.get(),
     identityCredential: credential,

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -76,6 +76,12 @@ type WakuNodeConf* = object
     name: "rln-relay-eth-contract-address"
   .}: string
 
+  rlnRelayChainId* {.
+    desc: "Chain ID of the provided contract (optional, will fetch from RPC provider if not used)",
+    defaultValue: 0,
+    name: "rln-relay-chain-id"
+  .}: uint
+
   rlnRelayCredPassword* {.
     desc: "Password for encrypting RLN credentials",
     defaultValue: "",

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -8,6 +8,7 @@ type ClusterConf* = object
   clusterId*: uint16
   rlnRelay*: bool
   rlnRelayEthContractAddress*: string
+  rlnRelayChainId*: uint
   rlnRelayDynamic*: bool
   rlnRelayBandwidthThreshold*: int
   rlnEpochSizeSec*: uint64
@@ -37,6 +38,7 @@ proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
     rlnRelay: true,
     rlnRelayEthContractAddress: "0x4976Df0f61135EF3E5720D92eadE2e5F47A68Ef9",
     rlnRelayDynamic: true,
+    rlnRelayChainId: 2442, # https://chainlist.org/chain/2442
     rlnRelayBandwidthThreshold: 0,
     rlnEpochSizeSec: 600,
     rlnRelayUserMessageLimit: 20,

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -199,6 +199,7 @@ proc setupProtocols(
       rlnRelayDynamic: conf.rlnRelayDynamic,
       rlnRelayCredIndex: conf.rlnRelayCredIndex,
       rlnRelayEthContractAddress: conf.rlnRelayEthContractAddress,
+      rlnRelayChainId: conf.rlnRelayChainId,
       rlnRelayEthClientAddress: string(conf.rlnRelayethClientAddress),
       rlnRelayCredPath: conf.rlnRelayCredPath,
       rlnRelayCredPassword: conf.rlnRelayCredPassword,

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -116,6 +116,7 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
     confCopy.clusterId = twnClusterConf.clusterId
     confCopy.rlnRelay = twnClusterConf.rlnRelay
     confCopy.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
+    confCopy.rlnRelayChainId = twnClusterConf.rlnRelayChainId
     confCopy.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
     confCopy.rlnRelayBandwidthThreshold = twnClusterConf.rlnRelayBandwidthThreshold
     confCopy.discv5Discovery = twnClusterConf.discv5Discovery

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -61,7 +61,7 @@ type
     wakuRlnContract*: Option[WakuRlnContractWithSender]
     latestProcessedBlock*: BlockNumber
     registrationTxHash*: Option[TxHash]
-    chainId*: Option[Quantity]
+    chainId*: uint
     keystorePath*: Option[string]
     keystorePassword*: Option[string]
     registrationHandler*: Option[RegistrationHandler]
@@ -106,7 +106,7 @@ proc setMetadata*(
     let metadataSetRes = g.rlnInstance.setMetadata(
       RlnMetadata(
         lastProcessedBlock: normalizedBlock,
-        chainId: uint64(g.chainId.get()),
+        chainId: g.chainId,
         contractAddress: g.ethContractAddress,
         validRoots: g.validRoots.toSeq(),
       )
@@ -540,11 +540,18 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
   g.retryWrapper(ethRpc, "Failed to connect to the Ethereum client"):
     await newWeb3(g.ethClientUrl)
 
+  var fetchedChainId: uint
+  g.retryWrapper(fetchedChainId, "Failed to get the chain id"):
+    uint(await ethRpc.provider.eth_chainId())
+
   # Set the chain id
-  var chainId: Quantity
-  g.retryWrapper(chainId, "Failed to get the chain id"):
-    await ethRpc.provider.eth_chainId()
-  g.chainId = some(chainId)
+  if g.chainId == 0:
+    warn "Chain ID not set in config, using RPC Provider's Chain ID", providerChainId = fetchedChainId
+
+  if g.chainId != 0 and g.chainId != fetchedChainId:
+    return err("The RPC Provided a Chain ID which is different than the provided Chain ID: provided = " & $g.chainId & ", actual = " & $fetchedChainId)
+
+  g.chainId = fetchedChainId
 
   if g.ethPrivateKey.isSome():
     let pk = g.ethPrivateKey.get()
@@ -567,7 +574,7 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
 
     var keystoreQuery = KeystoreMembership(
       membershipContract:
-        MembershipContract(chainId: $g.chainId.get(), address: g.ethContractAddress)
+        MembershipContract(chainId: $g.chainId, address: g.ethContractAddress)
     )
     if g.membershipIndex.isSome():
       keystoreQuery.treeIndex = MembershipIndex(g.membershipIndex.get())
@@ -599,7 +606,7 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
     warn "could not initialize with persisted rln metadata"
   elif metadataGetOptRes.get().isSome():
     let metadata = metadataGetOptRes.get().get()
-    if metadata.chainId != uint64(g.chainId.get()):
+    if metadata.chainId != uint(g.chainId):
       return err("persisted data: chain id mismatch")
 
     if metadata.contractAddress != g.ethContractAddress.toLower():

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -40,6 +40,7 @@ type WakuRlnConfig* = object
   rlnRelayCredIndex*: Option[uint]
   rlnRelayEthContractAddress*: string
   rlnRelayEthClientAddress*: string
+  rlnRelayChainId*: uint
   rlnRelayCredPath*: string
   rlnRelayCredPassword*: string
   rlnRelayTreePath*: string
@@ -429,6 +430,7 @@ proc mount(
     groupManager = OnchainGroupManager(
       ethClientUrl: string(conf.rlnRelayethClientAddress),
       ethContractAddress: $conf.rlnRelayEthContractAddress,
+      chainId: conf.rlnRelayChainId,
       rlnInstance: rlnInstance,
       registrationHandler: registrationHandler,
       keystorePath: rlnRelayCredPath,


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->

As requested by @alrevuelta to restrict chainId usage and waku node initialization should fail if user erroneously passes in an rpc url for another chain.

# Changes

<!-- List of detailed changes -->

- [x] All config changes from WakuNodeConf down to GroupManager
- [x] Tests

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
