### PR TITLE
chore: saving agent and protoVersion in peerStore

### DIFF
--- a/tests/node/test_wakunode_peer_manager.nim
+++ b/tests/node/test_wakunode_peer_manager.nim
@@ -351,7 +351,7 @@ suite "Peer Manager":
         await server2.stop()
 
     suite "Tracked Peer Metadata":
-      xasyncTest "Metadata Recording":
+      asyncTest "Metadata Recording":
         # When adding a peer other than self to the peer store
         serverRemotePeerInfo.enr = some(server.enr)
         client.peerManager.addPeer(serverRemotePeerInfo)

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -142,6 +142,8 @@ proc addPeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo, origin = UnknownO
   pm.peerStore[AddressBook][remotePeerInfo.peerId] = remotePeerInfo.addrs
   pm.peerStore[KeyBook][remotePeerInfo.peerId] = remotePeerInfo.publicKey
   pm.peerStore[SourceBook][remotePeerInfo.peerId] = origin
+  pm.peerStore[ProtoVersionBook][remotePeerInfo.peerId] = remotePeerInfo.protoVersion
+  pm.peerStore[AgentBook][remotePeerInfo.peerId] = remotePeerInfo.agent
 
   if remotePeerInfo.protocols.len > 0:
     pm.peerStore[ProtoBook][remotePeerInfo.peerId] = remotePeerInfo.protocols


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Filling `ProtoVersionBook` and `AgentBook` in the peer store

# Changes

<!-- List of detailed changes -->

- [x] filling `ProtoVersionBook` and `AgentBook` in the peer store
- [x] enabled test

<!--
## How to test


1.
1.
1.

-->


## Issue

closes #2591 
