### PR TITLE
fix(rln_keystore_generator): improve error handling for unrecoverable failure

### DIFF
--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -197,6 +197,8 @@ proc setup(): Future[OnchainGroupManager] {.async.} =
     chainId: CHAIN_ID,
     ethPrivateKey: pk,
     rlnInstance: rlnInstance,
+    onFatalErrorAction: proc (errStr: string) =
+      raiseAssert errStr
   )
 
   return manager
@@ -256,6 +258,8 @@ suite "Onchain group manager":
       ethClientUrl: EthClient,
       ethContractAddress: $differentContractAddress,
       rlnInstance: manager.rlnInstance,
+      onFatalErrorAction: proc (errStr: string) =
+        raiseAssert errStr
     )
     (await manager2.init()).isErrOr:
       raiseAssert "Expected error when contract address doesn't match"

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -612,7 +612,7 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
     g.validRoots = metadata.validRoots.toDeque()
 
   var deployedBlockNumber: Uint256
-  g.retryWrapper(deployedBlockNumber, "Failed to get the deployed block number"):
+  g.retryWrapper(deployedBlockNumber, "Failed to get the deployed block number. Have you set the correct contract address?"):
     await wakuRlnContract.deployedBlockNumber().call()
   debug "using rln contract", deployedBlockNumber, rlnContractAddress = contractAddress
   g.rlnContractDeployedBlockNumber = cast[BlockNumber](deployedBlockNumber)

--- a/waku/waku_rln_relay/group_manager/on_chain/retry_wrapper.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/retry_wrapper.nim
@@ -17,6 +17,8 @@ template retryWrapper*(
     errCallback: OnFatalErrorHandler,
     body: untyped,
 ): auto =
+  if errCallback == nil:
+    raise newException(CatchableError, "Ensure that the errCallback is set")
   var retryCount = retryStrategy.retryCount
   var shouldRetry = retryStrategy.shouldRetry
   var exceptionMessage = ""


### PR DESCRIPTION

# Description
<!--- Describe your changes to provide context for reviewrs -->
The `rln_keystore_generator` previously did not pass in an `onFatalErrorHandler`, which was leading to segfaults since we don't have a `not nil` check on the callback. Now, this PR introduces the `not nil` check, and also provides an `onFatalError` callback to the `OnchainGroupManager` when it is constructed.

# Changes

<!-- List of detailed changes -->

- [x] `rln_keystore_generator` now handles fatal errors appropriately
- [x] `retryWrapper` checks if the `errCallback` is nil, and handles the invariant appropriately

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->
