### PR TITLE
fix: peer-exchange issue

### DIFF
--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -32,7 +32,7 @@ const
   DefaultMaxRpcSize* = 10 * DefaultMaxWakuMessageSize + 64 * 1024
     # TODO what is the expected size of a PX message? As currently specified, it can contain an arbitary number of ENRs...
   MaxPeersCacheSize = 60
-  CacheRefreshInterval = 10.minutes
+  CacheRefreshInterval = 5.minutes
 
   WakuPeerExchangeCodec* = "/vac/waku/peer-exchange/2.0.0-alpha1"
 

--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -32,7 +32,7 @@ const
   DefaultMaxRpcSize* = 10 * DefaultMaxWakuMessageSize + 64 * 1024
     # TODO what is the expected size of a PX message? As currently specified, it can contain an arbitary number of ENRs...
   MaxPeersCacheSize = 60
-  CacheRefreshInterval = 5.minutes
+  CacheRefreshInterval = 10.minutes
 
   WakuPeerExchangeCodec* = "/vac/waku/peer-exchange/2.0.0-alpha1"
 

--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -32,7 +32,7 @@ const
   DefaultMaxRpcSize* = 10 * DefaultMaxWakuMessageSize + 64 * 1024
     # TODO what is the expected size of a PX message? As currently specified, it can contain an arbitary number of ENRs...
   MaxPeersCacheSize = 60
-  CacheRefreshInterval = 15.minutes
+  CacheRefreshInterval = 5.minutes
 
   WakuPeerExchangeCodec* = "/vac/waku/peer-exchange/2.0.0-alpha1"
 


### PR DESCRIPTION
closes #2414 

This implementation will enhance the reliability of the peers shared by the peer-exchange protocol with its clients. because now the cache updates every 5 min.

After the resolution of the peer_manager issue #2905, the reliability of peer exchanges has also been improved.