### PR TITLE
chore: don't establish connections in non-relay bootstrap nodes

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -93,8 +93,11 @@ when isMainModule:
     ## Stop node gracefully on shutdown.
 
     proc asyncStopper(node: Waku) {.async: (raises: [Exception]).} =
+      echo "----------- asyncStopper 1 ------------"
       nodeHealthMonitor.setOverallHealth(HealthStatus.SHUTTING_DOWN)
+      echo "----------- asyncStopper 2 ------------"
       await node.stop()
+      echo "----------- asyncStopper 3 ------------"
       quit(QuitSuccess)
 
     # Handle Ctrl-C SIGINT

--- a/examples/wakustealthcommitments/node_spec.nim
+++ b/examples/wakustealthcommitments/node_spec.nim
@@ -34,7 +34,6 @@ proc setup*(): Waku =
   # Override configuration
   conf.maxMessageSize = twnClusterConf.maxMessageSize
   conf.clusterId = twnClusterConf.clusterId
-  conf.rlnRelay = twnClusterConf.rlnRelay
   conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
   conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
   conf.rlnRelayBandwidthThreshold = twnClusterConf.rlnRelayBandwidthThreshold
@@ -43,6 +42,10 @@ proc setup*(): Waku =
     conf.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
   conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
   conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
+
+  # Only set rlnRelay to true if relay is configured
+  if conf.relay:
+    conf.rlnRelay = twnClusterConf.rlnRelay
 
   debug "Starting node"
   var waku = Waku.init(conf).valueOr:

--- a/tests/factory/test_node_factory.nim
+++ b/tests/factory/test_node_factory.nim
@@ -16,7 +16,7 @@ suite "Node Factory":
       node.wakuArchive.isNil()
       node.wakuStore.isNil()
       node.wakuFilter.isNil()
-      not node.wakuStoreClient.isNil()
+      node.wakuStoreClient.isNil()
       not node.rendezvous.isNil()
 
   test "Set up a node with Store enabled":

--- a/tests/node/test_wakunode_filter.nim
+++ b/tests/node/test_wakunode_filter.nim
@@ -52,10 +52,10 @@ suite "Waku Filter - End to End":
     clientClone = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(23451))
       # Used for testing client restarts
 
-    await allFutures(server.start(), client.start())
-
     await server.mountFilter()
     await client.mountFilterClient()
+
+    await allFutures(server.start(), client.start())
 
     client.wakuFilterClient.registerPushHandler(messagePushHandler)
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()

--- a/tests/node/test_wakunode_lightpush.nim
+++ b/tests/node/test_wakunode_lightpush.nim
@@ -56,12 +56,11 @@ suite "Waku Lightpush - End To End":
     server = newTestWakuNode(serverKey, ValidIpAddress.init("0.0.0.0"), Port(0))
     client = newTestWakuNode(clientKey, ValidIpAddress.init("0.0.0.0"), Port(0))
 
-    await allFutures(server.start(), client.start())
-    await server.start()
-
     await server.mountRelay()
     await server.mountLightpush() # without rln-relay
     client.mountLightpushClient()
+
+    await allFutures(server.start(), client.start())
 
     serverRemotePeerInfo = server.peerInfo.toRemotePeerInfo()
     pubsubTopic = DefaultPubsubTopic

--- a/tests/node/test_wakunode_peer_manager.nim
+++ b/tests/node/test_wakunode_peer_manager.nim
@@ -30,9 +30,6 @@ import
   ./peer_manager/peer_store/utils,
   ./utils
 
-const DEFAULT_PROTOCOLS: seq[string] =
-  @["/ipfs/id/1.0.0", "/libp2p/autonat/1.0.0", "/libp2p/circuit/relay/0.2.0/hop"]
-
 let
   listenIp = ValidIpAddress.init("0.0.0.0")
   listenPort = Port(0)
@@ -302,7 +299,7 @@ suite "Peer Manager":
         # Then the stored protocols should be the default (libp2p) ones
         check:
           clientPeerStore.peerExists(serverPeerId)
-          clientPeerStore.get(serverPeerId).protocols == DEFAULT_PROTOCOLS
+          clientPeerStore.get(serverPeerId).protocols == DefaultSwitchProtocols
 
       asyncTest "Peer Protocol Support Verification (Before Connection)":
         # Given the server has mounted some Waku protocols
@@ -316,7 +313,7 @@ suite "Peer Manager":
         check:
           clientPeerStore.peerExists(serverPeerId)
           clientPeerStore.get(serverPeerId).protocols ==
-            DEFAULT_PROTOCOLS & @[WakuRelayCodec, WakuFilterSubscribeCodec]
+            DefaultSwitchProtocols & @[WakuRelayCodec, WakuFilterSubscribeCodec]
 
       asyncTest "Service-Specific Peer Addition":
         # Given a server mounts some Waku protocols
@@ -342,10 +339,10 @@ suite "Peer Manager":
         check:
           clientPeerStore.peerExists(serverPeerId)
           clientPeerStore.get(serverPeerId).protocols ==
-            DEFAULT_PROTOCOLS & @[WakuFilterSubscribeCodec]
+            DefaultSwitchProtocols & @[WakuFilterSubscribeCodec]
           clientPeerStore.peerExists(server2PeerId)
           clientPeerStore.get(server2PeerId).protocols ==
-            DEFAULT_PROTOCOLS & @[WakuRelayCodec]
+            DefaultSwitchProtocols & @[WakuRelayCodec]
 
         # Cleanup
         await server2.stop()
@@ -367,7 +364,7 @@ suite "Peer Manager":
           chainedComparison(
             clientPeerStore[ProtoBook][serverPeerId],
             serverRemotePeerInfo.protocols,
-            DEFAULT_PROTOCOLS,
+            DefaultSwitchProtocols,
           )
           chainedComparison(
             clientPeerStore[AgentBook][serverPeerId], # FIXME: Not assigned
@@ -433,7 +430,7 @@ suite "Peer Manager":
           chainedComparison(
             clientPeerStore[ProtoBook][serverPeerId],
             serverRemotePeerInfo.protocols,
-            DEFAULT_PROTOCOLS,
+            DefaultSwitchProtocols,
           )
           chainedComparison(
             clientPeerStore[AgentBook][serverPeerId], # FIXME: Not assigned
@@ -484,7 +481,7 @@ suite "Peer Manager":
           chainedComparison(
             clientPeerStore[ProtoBook][server2PeerId],
             server2RemotePeerInfo.protocols,
-            DEFAULT_PROTOCOLS,
+            DefaultSwitchProtocols,
           )
           chainedComparison(
             clientPeerStore[AgentBook][server2PeerId], # FIXME: Not assigned
@@ -833,7 +830,7 @@ suite "Mount Order":
     check:
       clientPeerStore.peerExists(serverPeerId)
       clientPeerStore.get(serverPeerId).protocols ==
-        DEFAULT_PROTOCOLS & @[WakuRelayCodec]
+        DefaultSwitchProtocols & @[WakuRelayCodec]
 
     # Cleanup
     await server.stop()
@@ -857,7 +854,7 @@ suite "Mount Order":
     check:
       clientPeerStore.peerExists(serverPeerId)
       clientPeerStore.get(serverPeerId).protocols ==
-        DEFAULT_PROTOCOLS & @[WakuRelayCodec]
+        DefaultSwitchProtocols & @[WakuRelayCodec]
 
     # Cleanup
     await server.stop()
@@ -881,7 +878,7 @@ suite "Mount Order":
     check:
       clientPeerStore.peerExists(serverPeerId)
       clientPeerStore.get(serverPeerId).protocols ==
-        DEFAULT_PROTOCOLS & @[WakuRelayCodec]
+        DefaultSwitchProtocols & @[WakuRelayCodec]
 
     # Cleanup
     await server.stop()
@@ -905,7 +902,7 @@ suite "Mount Order":
     check:
       clientPeerStore.peerExists(serverPeerId)
       clientPeerStore.get(serverPeerId).protocols ==
-        DEFAULT_PROTOCOLS & @[WakuRelayCodec]
+        DefaultSwitchProtocols & @[WakuRelayCodec]
 
     # Cleanup
     await server.stop()
@@ -928,7 +925,7 @@ suite "Mount Order":
     # Then the peer store should contain the peer but not the mounted protocol
     check:
       clientPeerStore.peerExists(serverPeerId)
-      clientPeerStore.get(serverPeerId).protocols == DEFAULT_PROTOCOLS
+      clientPeerStore.get(serverPeerId).protocols == DefaultSwitchProtocols
 
     # Cleanup
     await server.stop()
@@ -951,7 +948,7 @@ suite "Mount Order":
     # Then the peer store should contain the peer but not the mounted protocol
     check:
       clientPeerStore.peerExists(serverPeerId)
-      clientPeerStore.get(serverPeerId).protocols == DEFAULT_PROTOCOLS
+      clientPeerStore.get(serverPeerId).protocols == DefaultSwitchProtocols
 
     # Cleanup
     await server.stop()

--- a/tests/waku_store/test_wakunode_store.nim
+++ b/tests/waku_store/test_wakunode_store.nim
@@ -74,14 +74,14 @@ procSuite "WakuNode - Store":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountStore()
 
     client.mountStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Given
     let req =
@@ -109,14 +109,14 @@ procSuite "WakuNode - Store":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountStore()
 
     client.mountStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Given
     let req = StoreQueryRequest(
@@ -165,14 +165,14 @@ procSuite "WakuNode - Store":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountStore()
 
     client.mountStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Given
     let req = StoreQueryRequest(

--- a/tests/waku_store/test_wakunode_store.nim
+++ b/tests/waku_store/test_wakunode_store.nim
@@ -225,8 +225,6 @@ procSuite "WakuNode - Store":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start(), filterSource.start())
-
     waitFor filterSource.mountFilter()
     let driver = newSqliteArchiveDriver()
 
@@ -236,6 +234,8 @@ procSuite "WakuNode - Store":
     waitFor server.mountStore()
     waitFor server.mountFilterClient()
     client.mountStoreClient()
+
+    waitFor allFutures(client.start(), server.start(), filterSource.start())
 
     ## Given
     let message = fakeWakuMessage()
@@ -297,14 +297,14 @@ procSuite "WakuNode - Store":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountStore()
 
     client.mountStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Forcing a bad cursor with empty digest data
     var cursor: WakuMessageHash = [
@@ -340,14 +340,14 @@ procSuite "WakuNode - Store":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountStore((4, 500.millis))
 
     client.mountStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Given
     let req =
@@ -384,14 +384,14 @@ procSuite "WakuNode - Store":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountStore((3, 500.millis))
 
     client.mountStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Given
     let req =

--- a/tests/waku_store_legacy/test_wakunode_store.nim
+++ b/tests/waku_store_legacy/test_wakunode_store.nim
@@ -65,14 +65,14 @@ procSuite "WakuNode - Store Legacy":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountLegacyArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountLegacyStore()
 
     client.mountLegacyStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Given
     let req = HistoryQuery(contentTopics: @[DefaultContentTopic])
@@ -99,14 +99,14 @@ procSuite "WakuNode - Store Legacy":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountLegacyArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountLegacyStore()
 
     client.mountLegacyStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Given
     let req = HistoryQuery(
@@ -154,14 +154,14 @@ procSuite "WakuNode - Store Legacy":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountLegacyArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountLegacyStore()
 
     client.mountLegacyStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Given
     let req = HistoryQuery(
@@ -213,8 +213,6 @@ procSuite "WakuNode - Store Legacy":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start(), filterSource.start())
-
     waitFor filterSource.mountFilter()
     let driver = newSqliteArchiveDriver()
 
@@ -224,6 +222,8 @@ procSuite "WakuNode - Store Legacy":
     waitFor server.mountLegacyStore()
     waitFor server.mountFilterClient()
     client.mountLegacyStoreClient()
+
+    waitFor allFutures(client.start(), server.start(), filterSource.start())
 
     ## Given
     let message = fakeWakuMessage()
@@ -279,14 +279,14 @@ procSuite "WakuNode - Store Legacy":
       clientKey = generateSecp256k1Key()
       client = newTestWakuNode(clientKey, parseIpAddress("0.0.0.0"), Port(0))
 
-    waitFor allFutures(client.start(), server.start())
-
     let mountArchiveRes = server.mountLegacyArchive(archiveA)
     assert mountArchiveRes.isOk(), mountArchiveRes.error
 
     waitFor server.mountLegacyStore()
 
     client.mountLegacyStoreClient()
+
+    waitFor allFutures(client.start(), server.start())
 
     ## Forcing a bad cursor with empty digest data
     var data: array[32, byte] = [

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -105,7 +105,6 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
     # Override configuration
     confCopy.maxMessageSize = twnClusterConf.maxMessageSize
     confCopy.clusterId = twnClusterConf.clusterId
-    confCopy.rlnRelay = twnClusterConf.rlnRelay
     confCopy.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
     confCopy.rlnRelayChainId = twnClusterConf.rlnRelayChainId
     confCopy.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -241,14 +241,22 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: 
 # Waku shutdown
 
 proc stop*(waku: Waku): Future[void] {.async: (raises: [Exception]).} =
+  echo "---------- Waku stop 1 --------"
+
   if not waku.restServer.isNil():
+    echo "---------- Waku stop 2 --------"
     await waku.restServer.stop()
 
+  echo "---------- Waku stop 3 --------"
   if not waku.metricsServer.isNil():
+    echo "---------- Waku stop 4 --------"
     await waku.metricsServer.stop()
 
+  echo "---------- Waku stop 5 --------"
   if not waku.wakuDiscv5.isNil():
+    echo "---------- Waku stop 6 --------"
     await waku.wakuDiscv5.stop()
 
+  echo "---------- Waku stop 7 --------"
   if not waku.node.isNil():
     await waku.node.stop()

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -115,6 +115,10 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
       confCopy.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
     confCopy.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
     confCopy.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
+
+    # Only set rlnRelay to true if relay is configured
+    if confCopy.relay:
+      confCopy.rlnRelay = twnClusterConf.rlnRelay
   else:
     discard
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1261,15 +1261,22 @@ proc printNodeNetworkInfo*(node: WakuNode): void =
   info "Announcing addresses", full = announcedStr
   info "DNS: discoverable ENR ", enr = node.enr.toUri()
 
-proc isBootstrapOnly(node: WakuNode): bool =
+proc isBootstrapOnly*(node: WakuNode): bool =
   # Check if no protocols are mounted
-  if node.wakuRelay.isNil() and node.wakuStore.isNil() and node.wakuArchive.isNil() and
+  #[ if node.wakuRelay.isNil() and node.wakuStore.isNil() and node.wakuArchive.isNil() and
       node.wakuLegacyStore.isNil() and node.wakuFilter.isNil() and
       node.wakuRlnRelay.isNil() and node.wakuLightPush.isNil() and
       node.wakuMetadata.isNil() and node.wakuStoreClient.isNil() and
       node.wakuLegacyStoreClient.isNil() and node.wakuFilterClient.isNil() and
       node.wakuLightpushClient.isNil():
-    return true
+    return true ]#
+  #[ for nodeField, fieldValue in fieldPairs(node[]):
+    # echo "nodeField ", nodeField
+    if fieldValue is LPProtocol:
+      echo "nodeField ", nodeField, " is of LPProtocol" ]#
+
+  echo "node.switch.peerInfo.protocols: ", node.switch.peerInfo.protocols
+
   return false
 
 proc start*(node: WakuNode) {.async.} =

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1261,6 +1261,16 @@ proc printNodeNetworkInfo*(node: WakuNode): void =
   info "Announcing addresses", full = announcedStr
   info "DNS: discoverable ENR ", enr = node.enr.toUri()
 
+proc isBootstrapOnly(node: WakuNode) =
+  # Check if no protocols are mounted
+  if node.wakuRelay.isNil() and node.wakuStore.isNil() and node.wakuArchive.isNil() and
+      node.wakuLegacyStore.isNil() and node.wakuFilter.isNil() and
+      node.wakuRlnRelay.isNil() and node.wakuLightPush.isNil() and
+      node.wakuMetadata.isNil():
+    return true
+  else:
+    return false
+
 proc start*(node: WakuNode) {.async.} =
   ## Starts a created Waku Node and
   ## all its mounted protocols.
@@ -1290,7 +1300,7 @@ proc start*(node: WakuNode) {.async.} =
 
   # Start the switch only if there's libp2p protocols mounted
   # TO DO: verify rest of protocols. Maybe write a proc isBootstrapOnly() that checks it
-  if not node.wakuRelay.isNil() or not node.wakuStore.isNil():
+  if not node.isBootstrapOnly():
     ## The switch will update addresses after start using the addressMapper
     await node.switch.start()
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1270,8 +1270,7 @@ proc isBootstrapOnly(node: WakuNode): bool =
       node.wakuLegacyStoreClient.isNil() and node.wakuFilterClient.isNil() and
       node.wakuLightpushClient.isNil():
     return true
-  else:
-    return false
+  return false
 
 proc start*(node: WakuNode) {.async.} =
   ## Starts a created Waku Node and

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1261,7 +1261,7 @@ proc printNodeNetworkInfo*(node: WakuNode): void =
   info "Announcing addresses", full = announcedStr
   info "DNS: discoverable ENR ", enr = node.enr.toUri()
 
-proc isBootstrapOnly(node: WakuNode) =
+proc isBootstrapOnly(node: WakuNode): bool =
   # Check if no protocols are mounted
   if node.wakuRelay.isNil() and node.wakuStore.isNil() and node.wakuArchive.isNil() and
       node.wakuLegacyStore.isNil() and node.wakuFilter.isNil() and

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1328,20 +1328,26 @@ proc start*(node: WakuNode) {.async.} =
   info "Node started successfully"
 
 proc stop*(node: WakuNode) {.async.} =
+  echo "--------------- STOP 1 -------------"
   ## By stopping the switch we are stopping all the underlying mounted protocols
-  await node.switch.stop()
+  if not node.isBootstrapOnly():
+    await node.switch.stop()
 
+  echo "--------------- STOP 2 -------------"
   node.peerManager.stop()
 
+  echo "--------------- STOP 3 -------------"
   if not node.wakuRlnRelay.isNil():
     try:
       await node.wakuRlnRelay.stop() ## this can raise an exception
     except Exception:
       error "exception stopping the node", error = getCurrentExceptionMsg()
 
+  echo "--------------- STOP 4 -------------"
   if not node.wakuArchive.isNil():
     await node.wakuArchive.stopWait()
 
+  echo "--------------- STOP 5 -------------"
   node.started = false
 
 proc isReady*(node: WakuNode): Future[bool] {.async: (raises: [Exception]).} =

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1266,7 +1266,9 @@ proc isBootstrapOnly(node: WakuNode): bool =
   if node.wakuRelay.isNil() and node.wakuStore.isNil() and node.wakuArchive.isNil() and
       node.wakuLegacyStore.isNil() and node.wakuFilter.isNil() and
       node.wakuRlnRelay.isNil() and node.wakuLightPush.isNil() and
-      node.wakuMetadata.isNil():
+      node.wakuMetadata.isNil() and node.wakuStoreClient.isNil() and
+      node.wakuLegacyStoreClient.isNil() and node.wakuFilterClient.isNil() and
+      node.wakuLightpushClient.isNil():
     return true
   else:
     return false

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1288,8 +1288,11 @@ proc start*(node: WakuNode) {.async.} =
     return node.announcedAddresses
   node.switch.peerInfo.addressMappers.add(addressMapper)
 
-  ## The switch will update addresses after start using the addressMapper
-  await node.switch.start()
+  # Start the switch only if there's libp2p protocols mounted
+  # TO DO: verify rest of protocols. Maybe write a proc isBootstrapOnly() that checks it
+  if not node.wakuRelay.isNil() or not node.wakuStore.isNil():
+    ## The switch will update addresses after start using the addressMapper
+    await node.switch.start()
 
   node.started = true
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1305,6 +1305,8 @@ proc start*(node: WakuNode) {.async.} =
   if not node.isBootstrapOnly():
     ## The switch will update addresses after start using the addressMapper
     await node.switch.start()
+  else:
+    warn "Did not start libp2p switch as no protocols are mounted"
 
   node.started = true
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -15,8 +15,8 @@ import
   libp2p/protocols/ping,
   libp2p/protocols/pubsub/gossipsub,
   libp2p/protocols/pubsub/rpc/messages,
-  libp2p/protocols/connectivity/autonat/client,
-  libp2p/protocols/connectivity/autonat/service,
+  libp2p/protocols/connectivity/autonat/[client, service, server],
+  libp2p/protocols/connectivity/relay/utils,
   libp2p/protocols/rendezvous,
   libp2p/builders,
   libp2p/transports/transport,
@@ -75,6 +75,10 @@ const git_version* {.strdefine.} = "n/a"
 const clientId* = "Nimbus Waku v2 node"
 
 const WakuNodeVersionString* = "version / git commit hash: " & git_version
+
+# Default protocols mounted into a Waku Switch 
+const DefaultSwitchProtocols*: seq[string] =
+  @[IdentifyCodec, AutonatCodec, RelayV2HopCodec]
 
 # key and crypto modules different
 type
@@ -1275,8 +1279,8 @@ proc isBootstrapOnly*(node: WakuNode): bool =
     if fieldValue is LPProtocol:
       echo "nodeField ", nodeField, " is of LPProtocol" ]#
 
-  echo "node.switch.peerInfo.protocols: ", node.switch.peerInfo.protocols
-
+  if toHashSet(node.switch.peerInfo.protocols) == toHashSet(DefaultSwitchProtocols):
+    return true
   return false
 
 proc start*(node: WakuNode) {.async.} =


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Don't start the switch if relay is not configured to avoid unnecessary connections

# Changes

<!-- List of detailed changes -->

- [x] only configure rln-relay if relay is configured

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #2892 
