### PR TITLE
chore: archive legacy run report metrics every 30 minutes instead of 1

### DIFF
--- a/waku/waku_archive_legacy/archive.nim
+++ b/waku/waku_archive_legacy/archive.nim
@@ -29,7 +29,7 @@ const
   WakuArchiveDefaultRetentionPolicyInterval* = chronos.minutes(30)
 
   # Metrics reporting
-  WakuArchiveDefaultMetricsReportInterval* = chronos.minutes(1)
+  WakuArchiveDefaultMetricsReportInterval* = chronos.minutes(30)
 
   # Message validation
   # 20 seconds maximum allowable sender timestamp "drift"


### PR DESCRIPTION
### Description
Simple PR to reduce the stress on the database and only count the number of messages every 30 minutes instead of each minute.