### PR TITLE
chore: Update master from release v0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.30.2 (2024-07-08)
+
+### Release highlights
+
+* Patch to avoid exclusive access when creating new partitions in the postgres messages table.
+
+### Changes
+
+- fix: postgres_driver better partition creation without exclusive access [28bdb70b](https://github.com/waku-org/nwaku/commit/28bdb70be46d3fb3a6f992b3f9f2de1defd85a30)
+
+This release supports the following [libp2p protocols](https://docs.libp2p.io/concepts/protocols/):
+| Protocol | Spec status | Protocol id |
+| ---: | :---: | :--- |
+| [`11/WAKU2-RELAY`](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/11/relay.md) | `stable` | `/vac/waku/relay/2.0.0` |
+| [`12/WAKU2-FILTER`](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/12/filter.md) | `draft` | `/vac/waku/filter/2.0.0-beta1` <br />`/vac/waku/filter-subscribe/2.0.0-beta1` <br />`/vac/waku/filter-push/2.0.0-beta1` |
+| [`13/WAKU2-STORE`](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/13/store.md) | `draft` | `/vac/waku/store/2.0.0-beta4` |
+| [`19/WAKU2-LIGHTPUSH`](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/19/lightpush.md) | `draft` | `/vac/waku/lightpush/2.0.0-beta1` |
+| [`66/WAKU2-METADATA`](https://github.com/waku-org/specs/blob/master/standards/core/metadata.md) | `raw` | `/vac/waku/metadata/1.0.0` |
+
 ## v0.30.1 (2024-07-03)
 
 ### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ### Release highlights
 
-* Patch to avoid exclusive access when creating new partitions in the postgres messages table.
+* RLN message limit to 100 mesages per epoch.
+* Avoid exclusive access when creating new partitions in the postgres messages table.
 
 ### Changes
 
+- chore(rln): rln message limit to 100 ([#2883](https://github.com/waku-org/nwaku/pull/2883))
 - fix: postgres_driver better partition creation without exclusive access [28bdb70b](https://github.com/waku-org/nwaku/commit/28bdb70be46d3fb3a6f992b3f9f2de1defd85a30)
 
 This release supports the following [libp2p protocols](https://docs.libp2p.io/concepts/protocols/):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-## v0.30.2 (2024-07-08)
+## v0.30.2 (2024-07-12)
 
 ### Release highlights
 
-* RLN message limit to 100 mesages per epoch.
-* Avoid exclusive access when creating new partitions in the postgres messages table.
+* RLN message limit to 100 messages per epoch.
+* Avoid exclusive access when creating new partitions in the PostgreSQL messages table.
 
 ### Changes
 

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -27,7 +27,7 @@ proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
     rlnRelayChainId: 11155111,
     rlnRelayBandwidthThreshold: 0,
     rlnEpochSizeSec: 600,
-    rlnRelayUserMessageLimit: 20,
+    rlnRelayUserMessageLimit: 100,
     pubsubTopics:
       @[
         "/waku/2/rs/1/0", "/waku/2/rs/1/1", "/waku/2/rs/1/2", "/waku/2/rs/1/3",

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1,3 +1,4 @@
+
 {.push raises: [].}
 
 import
@@ -1047,6 +1048,32 @@ proc addPartition(
       return ok()
 
     return err(fmt"error adding partition [{partitionName}]: " & $error)
+
+  ## Add constraint to the partition table so that EXCLUSIVE ACCESS is not performed when
+  ## the partition is attached to the main table.
+  let constraintName = partitionName & "_by_range_check"
+  let addTimeConstraintQuery =
+    "ALTER TABLE " & partitionName & " ADD CONSTRAINT " & constraintName &
+    " CHECK ( storedAt >= " & fromInNanoSec & " AND storedAt < " & untilInNanoSec & " );"
+
+  (await self.performWriteQueryWithLock(addTimeConstraintQuery)).isOkOr:
+    return err(fmt"error creating constraint [{partitionName}]: " & $error)
+
+  ## Attaching the new created table as a new partition. That does not require EXCLUSIVE ACCESS.
+  let attachPartitionQuery =
+    "ALTER TABLE messages ATTACH PARTITION " & partitionName & " FOR VALUES FROM (" &
+    fromInNanoSec & ") TO (" & untilInNanoSec & ");"
+
+  (await self.performWriteQueryWithLock(attachPartitionQuery)).isOkOr:
+    return err(fmt"error attaching partition [{partitionName}]: " & $error)
+
+  ## Dropping the check constraint as it was only necessary to prevent full scan,
+  ## and EXCLUSIVE ACCESS, to the whole messages table, when the new partition was attached.
+  let dropConstraint =
+    "ALTER TABLE " & partitionName & " DROP CONSTRAINT " & constraintName & ";"
+
+  (await self.performWriteQueryWithLock(dropConstraint)).isOkOr:
+    return err(fmt"error dropping constraint [{partitionName}]: " & $error)
 
   ## Add constraint to the partition table so that EXCLUSIVE ACCESS is not performed when
   ## the partition is attached to the main table.

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1013,6 +1013,24 @@ proc performWriteQueryWithLock*(
       debug "skip performWriteQuery because the advisory lock is acquired by other"
       return ok()
 
+    if error.contains("already exists"):
+      ## expected to happen when trying to add a partition table constraint that already exists
+      ## e.g., constraint "constraint_name" for relation "messages_1720364735_1720364740" already exists
+      debug "skip already exists error", error = error
+      return ok()
+
+    if error.contains("is already a partition"):
+      ## expected to happen when a node tries to add a partition that is already attached,
+      ## e.g., "messages_1720364735_1720364740" is already a partition
+      debug "skip is already a partition error", error = error
+      return ok()
+
+    if error.contains("does not exist"):
+      ## expected to happen when trying to drop a constraint that has already been dropped by other
+      ## constraint "constraint_name" of relation "messages_1720364735_1720364740" does not exist
+      debug "skip does not exist error", error = error
+      return ok()
+
     debug "protected query ended with error", error = $error
     return err("protected query ended with error:" & $error)
 
@@ -1043,10 +1061,6 @@ proc addPartition(
     " (LIKE messages INCLUDING DEFAULTS INCLUDING CONSTRAINTS);"
 
   (await self.performWriteQueryWithLock(createPartitionQuery)).isOkOr:
-    if error.contains("already exists"):
-      debug "skip create new partition as it already exists: ", skipped_error = $error
-      return ok()
-
     return err(fmt"error adding partition [{partitionName}]: " & $error)
 
   ## Add constraint to the partition table so that EXCLUSIVE ACCESS is not performed when


### PR DESCRIPTION
### Description
This PR is needed to aggregate the changes and enhancements made in the `release/v0.30` branch for the version `v0.30.2`.
I'm using a separate branch because a merge from `master` was required and I didn't want to pollute the `v0.30.2` branch.

In other words, we are retrieving the following changes to `master`:
- set max limit to 100 messages per epoch in RLN
- skip Postgres feedback errors that can be caused when another nwaku instance accesses the same database, as in Status.