### PR TITLE
chore: Add new custom built and test target to make in order to enable easy build or test single nim modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ testcommon: | build deps
 ##########
 ## Waku ##
 ##########
-.PHONY: testwaku wakunode2 testwakunode2 example2 chat2 chat2bridge
+.PHONY: testwaku wakunode2 testwakunode2 example2 chat2 chat2bridge liteprotocoltester
 
 # install anvil only for the testwaku target
 testwaku: | build deps anvil librln
@@ -218,6 +218,13 @@ liteprotocoltester: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim liteprotocoltester $(NIM_PARAMS) waku.nims
 
+build/%: | build deps librln
+	echo -e $(BUILD_MSG) "build/$*" && \
+		$(ENV_SCRIPT) nim buildone $(NIM_PARAMS) waku.nims $*
+
+test/%: | build deps librln
+	echo -e $(BUILD_MSG) "test/$*" && \
+		$(ENV_SCRIPT) nim testone $(NIM_PARAMS) waku.nims $*
 
 ################
 ## Waku tools ##

--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ If everything went well, you should see your prompt suffixed with `[Nimbus env]$
 make test
 ```
 
+### Building single test files
+
+During development it is handful to build and run a single test file.
+To support this make has a specific target:
+
+targets:
+- `build/<relative path to your test file.nim>`
+- `test/<relative path to your test file.nim>`
+
+Binary will be created as `<path to your test file.nim>.bin` under the `build` directory .
+
+```bash
+# Build and run your test file separately
+make test/tests/common/test_enr_builder.nim
+```
+
 ### Examples
 
 Examples can be found in the examples folder.

--- a/waku.nimble
+++ b/waku.nimble
@@ -26,7 +26,7 @@ requires "nim >= 2.0.8",
   "db_connector"
 
 ### Helper functions
-proc buildModule(filePath, params = "", lang = "c") =
+proc buildModule(filePath, params = "", lang = "c"): bool =
   if not dirExists "build":
     mkDir "build"
   # allow something like "nim nimbus --verbosity:0 --hints:off nimbus.nims"
@@ -36,10 +36,13 @@ proc buildModule(filePath, params = "", lang = "c") =
 
   if not fileExists(filePath):
     echo "File to build not found: " & filePath
-    return
+    return false
 
   exec "nim " & lang & " --out:build/" & filepath & ".bin --mm:refc " & extra_params &
     " " & filePath
+
+  # exec will raise exception if anything goes wrong
+  return true
 
 proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
   if not dirExists "build":
@@ -146,12 +149,12 @@ task liteprotocoltester, "Build liteprotocoltester":
 
 task buildone, "Build custom target":
   let filepath = paramStr(paramCount())
-  buildModule filepath
+  discard buildModule filepath
 
 task testone, "Test custom target":
   let filepath = paramStr(paramCount())
-  buildModule filepath
-  exec "build/" & filepath & ".bin"
+  if buildModule(filepath):
+    exec "build/" & filepath & ".bin"
 
 ### C Bindings
 task libwakuStatic, "Build the cbindings waku node library":


### PR DESCRIPTION
# Description
While chating with @fryorcraken, he popped up, why don't we have an easy way of running single tests.
We all do this in different ways, like me I'm using some alias to achieve this.

So I made this little experiment to add custom targets to our makefile to ease and make common and available this task.

While it's a bit tricky to achieve such with make and nimscript I found a usable solution.

So the target is to check if a single file you're working on builds or you may write unit test and want to run first separately from other tests.

With this enhancement, you just need to run

`make build/<path-to-your-file>` or `make test/<path-to-your-file>`

Why is it good?
- no prerequisite knowledge needed how we build our software. All knowledge is coded into Makefile and waku.nimble files.
- It will always follow the changes made to build arguments anytime in the future.
- Simplify ramp-up for anybody newly contributing to the project.

# Changes

- [x] Makefile - added `build/...` and `test/...` targets
- [x] Extended waku.nimble with new task that can build any arbitrary single file or even it can run it.

## How to test

run:
1a. make build/tests/common/test_tokenbucket.nim
1b. make test/tests/common/test_tokenbucket.nim

Check: ./build/tests/common/test_tokenbucket.nim.bin exists

# Suggestions/ideas are welcome
It is not trivial to add parametric target to make, but still possible I'm not aware of the proper solution. If you have any better idea or addon to this, I'm happy to discuss.