### PR TITLE
chore: setting filter handling logs to trace

### DIFF
--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -222,7 +222,7 @@ proc handleMessage*(
 ) {.async.} =
   let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
 
-  notice "handling message", pubsubTopic = pubsubTopic, msg_hash = msgHash
+  trace "handling message", pubsubTopic = pubsubTopic, msg_hash = msgHash
 
   let handleMessageStartTime = Moment.now()
 
@@ -231,7 +231,7 @@ proc handleMessage*(
     let subscribedPeers =
       wf.subscriptions.findSubscribedPeers(pubsubTopic, message.contentTopic)
     if subscribedPeers.len == 0:
-      notice "no subscribed peers found",
+      trace "no subscribed peers found",
         pubsubTopic = pubsubTopic,
         contentTopic = message.contentTopic,
         msg_hash = msgHash


### PR DESCRIPTION
# Description
Setting filter handler logs to trace for cases in which we don't have anywhere to push the messages.


## Issue

closes #2907 
