### PR TITLE
feat: add last online timestamp to archive and drivers

### DIFF
--- a/migrations/message_store_postgres/content_script_version_7.nim
+++ b/migrations/message_store_postgres/content_script_version_7.nim
@@ -1,0 +1,11 @@
+const ContentScriptVersion_7* =
+  """
+-- Create a new table to hold the last online timestamp
+CREATE TABLE last_online (timestamp BIGINT NOT NULL);
+
+-- Insert a placeholder first value
+INSERT INTO last_online (timestamp) VALUES(1);
+
+-- Update to new version 
+UPDATE version SET version = 7 WHERE version = 6;
+"""

--- a/migrations/message_store_postgres/pg_migration_manager.nim
+++ b/migrations/message_store_postgres/pg_migration_manager.nim
@@ -1,6 +1,7 @@
 import
   content_script_version_1, content_script_version_2, content_script_version_3,
-  content_script_version_4, content_script_version_5, content_script_version_6
+  content_script_version_4, content_script_version_5, content_script_version_6,
+  content_script_version_7
 
 type MigrationScript* = object
   version*: int
@@ -17,6 +18,7 @@ const PgMigrationScripts* =
     MigrationScript(version: 4, scriptContent: ContentScriptVersion_4),
     MigrationScript(version: 5, scriptContent: ContentScriptVersion_5),
     MigrationScript(version: 6, scriptContent: ContentScriptVersion_6),
+    MigrationScript(version: 7, scriptContent: ContentScriptVersion_7),
   ]
 
 proc getMigrationScripts*(currentVersion: int64, targetVersion: int64): seq[string] =

--- a/tests/waku_archive/archive_utils.nim
+++ b/tests/waku_archive/archive_utils.nim
@@ -1,13 +1,12 @@
 {.used.}
 
-import std/options, stew/results, chronos, libp2p/crypto/crypto
+import std/options, results, chronos, libp2p/crypto/crypto
 
 import
   waku/[
     node/peer_manager,
     waku_core,
     waku_archive,
-    waku_archive/common,
     waku_archive/driver/sqlite_driver,
     common/databases/db_sqlite,
   ],

--- a/tests/waku_archive/test_driver_postgres_query.nim
+++ b/tests/waku_archive/test_driver_postgres_query.nim
@@ -45,6 +45,19 @@ suite "Postgres driver - queries":
 
     (await driver.close()).expect("driver to close")
 
+  asyncTest "check last online":
+    let timestamp = getNowInNanosecondTime()
+
+    let setRes = await driver.setLastOnline(timestamp)
+    assert setRes.isOk(), setRes.error
+
+    let getRes = await driver.getLastOnline()
+    assert getRes.isOk(), getRes.error
+
+    let timeRes = getRes.get()
+
+    assert timestamp == timeRes
+
   asyncTest "no content topic":
     ## Given
     const contentTopic = "test-content-topic"

--- a/tests/waku_archive/test_driver_sqlite_query.nim
+++ b/tests/waku_archive/test_driver_sqlite_query.nim
@@ -4,13 +4,7 @@ import
   std/[options, sequtils, random, algorithm], testutils/unittests, chronos, chronicles
 
 import
-  waku/[
-    common/databases/db_sqlite,
-    waku_archive,
-    waku_archive/driver/sqlite_driver,
-    waku_core,
-    waku_core/message/digest,
-  ],
+  waku/[waku_archive, waku_core, waku_core/message/digest],
   ../testlib/common,
   ../testlib/wakucore,
   ../waku_archive/archive_utils
@@ -20,6 +14,22 @@ logScope:
 
 # Initialize the random number generator
 common.randomize()
+
+suite "SQLite driver - query last online":
+  asyncTest "check last online":
+    let driver = newSqliteArchiveDriver()
+
+    let timestamp = getNowInNanosecondTime()
+
+    let setRes = await driver.setLastOnline(timestamp)
+    assert setRes.isOk(), setRes.error
+
+    let getRes = await driver.getLastOnline()
+    assert getRes.isOk(), getRes.error
+
+    let timeRes = getRes.get()
+
+    assert timestamp == timeRes
 
 suite "SQLite driver - query by content topic":
   asyncTest "no content topic":

--- a/waku/waku_archive/common.nim
+++ b/waku/waku_archive/common.nim
@@ -1,6 +1,6 @@
 {.push raises: [].}
 
-import std/options, results, stew/byteutils, stew/arrayops, nimcrypto/sha2
+import std/options, results
 import ../waku_core, ../common/paging
 
 ## Public API types

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -99,3 +99,13 @@ method existsTable*(
     driver: ArchiveDriver, tableName: string
 ): Future[ArchiveDriverResult[bool]] {.base, async.} =
   discard
+
+method setLastOnline*(
+    driver: ArchiveDriver, time: Timestamp
+): Future[ArchiveDriverResult[void]] {.base, async.} =
+  discard
+
+method getLastOnline*(
+    driver: ArchiveDriver
+): Future[ArchiveDriverResult[Timestamp]] {.base, async.} =
+  discard

--- a/waku/waku_archive/driver/postgres_driver/migrations.nim
+++ b/waku/waku_archive/driver/postgres_driver/migrations.nim
@@ -9,7 +9,7 @@ import
 logScope:
   topics = "waku archive migration"
 
-const SchemaVersion* = 6 # increase this when there is an update in the database schema
+const SchemaVersion* = 7 # increase this when there is an update in the database schema
 
 proc breakIntoStatements*(script: string): seq[string] =
   ## Given a full migration script, that can potentially contain a list

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -355,3 +355,9 @@ method decreaseDatabaseSize*(
 
 method close*(driver: QueueDriver): Future[ArchiveDriverResult[void]] {.async.} =
   return ok()
+
+method setLastOnline*(
+    driver: QueueDriver, time: Timestamp
+): Future[ArchiveDriverResult[void]] {.async.} =
+  ## return ok as it only make sense to save a timestamp to disk
+  return ok()


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This PR adds a way to save a timestamp periodically so that we can know when the node was last online.

This feature will be used for a future store resume functionality.

# Changes

<!-- List of detailed changes -->

- [x] sqlite driver set/get last online timestamp
- [x] postgres driver set/get last online timestamp
- [x] postgres migration
- [x] archive set/get last online timestamp
- [x] archive periodically set last online timestamp

