### PR TITLE
chore: optimizations for discv5 only nodes

### DIFF
--- a/examples/wakustealthcommitments/node_spec.nim
+++ b/examples/wakustealthcommitments/node_spec.nim
@@ -34,7 +34,6 @@ proc setup*(): Waku =
   # Override configuration
   conf.maxMessageSize = twnClusterConf.maxMessageSize
   conf.clusterId = twnClusterConf.clusterId
-  conf.rlnRelay = twnClusterConf.rlnRelay
   conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
   conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
   conf.rlnRelayBandwidthThreshold = twnClusterConf.rlnRelayBandwidthThreshold
@@ -43,6 +42,10 @@ proc setup*(): Waku =
     conf.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
   conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
   conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
+
+  # Only set rlnRelay to true if relay is configured
+  if conf.relay:
+    conf.rlnRelay = twnClusterConf.rlnRelay
 
   debug "Starting node"
   var waku = Waku.init(conf).valueOr:

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -566,6 +566,12 @@ type WakuNodeConf* = object
       name: "discv5-bits-per-hop"
     .}: int
 
+    discv5Only* {.
+      desc: "Disable all protocols other than discv5",
+      defaultValue: false,
+      name: "discv5-only"
+    .}: bool
+
     ## waku peer exchange config
     peerExchange* {.
       desc: "Enable waku peer exchange protocol (responder side): true|false",

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -120,6 +120,10 @@ proc setupProtocols(
   ## Optionally include persistent message storage.
   ## No protocols are started yet.
 
+  if conf.discv5Only:
+    notice "Running node only with Discv5, not mounting additional protocols"
+    return ok()
+
   node.mountMetadata(conf.clusterId).isOkOr:
     return err("failed to mount waku metadata protocol: " & error)
 


### PR DESCRIPTION
# Description
Adding the `discv5-only` CLI flag for bootstrap/discovery nodes that only run discv5. In those cases, we don't mount the libp2p switch nor additional protocols to avoid unnecessary connections

Notice that I changed the approach from `bootstrap-only` to `discv5-only` because bootstrap nodes can use `waku-peer-exchange`, and that protocol does use the nim-libp2p switch. So this optimization works only in the case that it's running Discv5 and nothing else.

<!--
# Changes


- [x] introducing `discv5-only` CLI flag
- [x] not configuring rlnRelay if relay is not configured
- [x] avoid starting switch and protocols other than Discv5 when `discv5-only` is set to true
 


## How to test

1.
1.
1.

-->


## Issue

closes #2892 
