### PR TITLE
chore: lightpush better feedback if lightpush service node without peers

### DIFF
--- a/tests/node/test_wakunode_lightpush.nim
+++ b/tests/node/test_wakunode_lightpush.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options, tables, sequtils, tempfiles],
+  std/[options, tables, sequtils, tempfiles, strutils],
   stew/shims/net as stewNet,
   testutils/unittests,
   chronos,
@@ -86,8 +86,13 @@ suite "Waku Lightpush - End To End":
       if not publishResponse.isOk():
         echo "Publish failed: ", publishResponse.error()
 
-      # Then the message is relayed to the server
-      assertResultOk publishResponse
+      # Then the message is not relayed but not due to RLN
+      assert publishResponse.isErr(), "We expect an error response"
+      assert (
+        publishResponse.error.contains(
+          "Lightpush request has not been published to any peers"
+        )
+      ), "incorrect error response"
 
   suite "Waku LightPush Validation Tests":
     asyncTest "Validate message size exceeds limit":
@@ -174,5 +179,10 @@ suite "RLN Proofs as a Lightpush Service":
       if not publishResponse.isOk():
         echo "Publish failed: ", publishResponse.error()
 
-      # Then the message is relayed to the server
-      assertResultOk publishResponse
+      # Then the message is not relayed but not due to RLN
+      assert publishResponse.isErr(), "We expect an error response"
+      assert (
+        publishResponse.error.contains(
+          "Lightpush request has not been published to any peers"
+        )
+      ), "incorrect error response"

--- a/waku/waku_lightpush/callbacks.nim
+++ b/waku/waku_lightpush/callbacks.nim
@@ -54,5 +54,8 @@ proc getRelayPushHandler*(
       ## Agreed change expected to the lightpush protocol to better handle such case. https://github.com/waku-org/pm/issues/93
       let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
       notice "Lightpush request has not been published to any peers", msg_hash = msgHash
+      return err(
+        "Lightpush request has not been published to any peers. msg_hash: " & msgHash
+      )
 
     return ok()

--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -42,8 +42,10 @@ proc handleRequest*(
 
       pubSubTopic = request.get().pubSubTopic
       message = request.get().message
+
     waku_lightpush_messages.inc(labelValues = ["PushRequest"])
-    notice "lightpush request",
+
+    notice "handling lightpush request",
       peer_id = peerId,
       requestId = requestId,
       pubsubTopic = pubsubTopic,


### PR DESCRIPTION
## Description
Give better feedback in case the lightpush server node cannot relay messages to other peers

## Issue

closes https://github.com/waku-org/nwaku/issues/2950
