### PR TITLE
chore: upgrade peer exchange mounting 

### DIFF
--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -579,6 +579,13 @@ type WakuNodeConf* = object
       name: "peer-exchange"
     .}: bool
 
+    peerExchangeNode* {.
+      desc:
+        "Peer multiaddr to send peer exchange requests to. (enables peer exchange protocol requester side)",
+      defaultValue: "",
+      name: "peer-exchange-node"
+    .}: string
+
     ## websocket config
     websocketSupport* {.
       desc: "Enable websocket:  true|false",

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -579,13 +579,6 @@ type WakuNodeConf* = object
       name: "peer-exchange"
     .}: bool
 
-    peerExchangeNode* {.
-      desc:
-        "Peer multiaddr to send peer exchange requests to. (enables peer exchange protocol requester side)",
-      defaultValue: "",
-      name: "peer-exchange-node"
-    .}: string
-
     ## websocket config
     websocketSupport* {.
       desc: "Enable websocket:  true|false",

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -345,6 +345,14 @@ proc setupProtocols(
       return
         err("failed to mount waku peer-exchange protocol: " & getCurrentExceptionMsg())
 
+  if conf.peerExchangeNode != "":
+    let peerExchangeNode = parsePeerInfo(conf.peerExchangeNode)
+    if peerExchangeNode.isOk():
+      node.peerManager.addServicePeer(peerExchangeNode.value, WakuPeerExchangeCodec)
+    else:
+      return
+        err("failed to set node waku peer-exchange peer: " & peerExchangeNode.error)
+
   return ok()
 
 ## Start node

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -338,20 +338,12 @@ proc setupProtocols(
       return err("failed to set node waku filter peer: " & filterNode.error)
 
   # waku peer exchange setup
-  if conf.peerExchangeNode != "" or conf.peerExchange:
+  if conf.peerExchange:
     try:
       await mountPeerExchange(node, some(conf.clusterId))
     except CatchableError:
       return
         err("failed to mount waku peer-exchange protocol: " & getCurrentExceptionMsg())
-
-    if conf.peerExchangeNode != "":
-      let peerExchangeNode = parsePeerInfo(conf.peerExchangeNode)
-      if peerExchangeNode.isOk():
-        node.peerManager.addServicePeer(peerExchangeNode.value, WakuPeerExchangeCodec)
-      else:
-        return
-          err("failed to set node waku peer-exchange peer: " & peerExchangeNode.error)
 
   return ok()
 


### PR DESCRIPTION
This PR upgrades the mounting scheme for peer_exchange. With this update, a specific node address is no longer required when mounting peer_exchange from the node side.