### PR TITLE
fix: return on insert error

### DIFF
--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -97,6 +97,7 @@ proc handleMessage*(
       contentTopic = msg.contentTopic,
       timestamp = msg.timestamp,
       error = error
+    return
 
   trace "message archived",
     hash_hash = msgHash.to0xHex(),


### PR DESCRIPTION
# Description
Avoids logging a `message archived` log line when a message failed to be inserted
