### PR TITLE
chore: adapt SubscriptionEvents to allow subscribe to pubsub/content topics

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -532,7 +532,8 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
         chat.printReceivedMessage(msg)
 
     node.subscribe(
-      (kind: PubsubSub, topic: DefaultPubsubTopic), some(WakuRelayHandler(handler))
+      (kind: Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""]),
+      some(WakuRelayHandler(handler)),
     )
 
     if conf.rlnRelay:

--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -230,7 +230,10 @@ proc start*(cmb: Chat2MatterBridge) {.async.} =
     except:
       error "exception in relayHandler: " & getCurrentExceptionMsg()
 
-  cmb.nodev2.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic), some(relayHandler))
+  cmb.nodev2.subscribe(
+    (kind: Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""]),
+    some(relayHandler),
+  )
 
 proc stop*(cmb: Chat2MatterBridge) {.async: (raises: [Exception]).} =
   info "Stopping Chat2MatterBridge"

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -524,7 +524,10 @@ proc subscribeAndHandleMessages(
     else:
       msgPerContentTopic[msg.contentTopic] = 1
 
-  node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(WakuRelayHandler(handler)))
+  node.subscribe(
+    (kind: Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+    some(WakuRelayHandler(handler)),
+  )
 
 when isMainModule:
   # known issue: confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError

--- a/examples/subscriber.nim
+++ b/examples/subscriber.nim
@@ -119,7 +119,10 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
         contentTopic = msg.contentTopic,
         timestamp = msg.timestamp
 
-  node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(WakuRelayHandler(handler)))
+  node.subscribe(
+    (kind: Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+    some(WakuRelayHandler(handler)),
+  )
 
 when isMainModule:
   let rng = crypto.newRng()

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -63,7 +63,10 @@ suite "WakuNode":
         msg.payload == payload
       completionFut.complete(true)
 
-    node2.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node2.subscribe(
+      (kind: Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(2000.millis)
 
     var res = await node1.publish(some(pubSubTopic), message)

--- a/tests/test_wakunode_lightpush.nim
+++ b/tests/test_wakunode_lightpush.nim
@@ -42,7 +42,10 @@ suite "WakuNode - Lightpush":
         msg == message
       completionFutRelay.complete(true)
 
-    destNode.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic), some(relayHandler))
+    destNode.subscribe(
+      (kind: Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
 
     # Wait for subscription to take effect
     await sleepAsync(100.millis)

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -92,7 +92,10 @@ suite "WakuNode - Relay":
         msg.payload == payload
       completionFut.complete(true)
 
-    node3.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node3.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(500.millis)
 
     var res = await node1.publish(some(pubSubTopic), message)
@@ -178,7 +181,10 @@ suite "WakuNode - Relay":
       # relay handler is called
       completionFut.complete(true)
 
-    node3.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node3.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(500.millis)
 
     var res = await node1.publish(some(pubSubTopic), message1)
@@ -220,7 +226,9 @@ suite "WakuNode - Relay":
       connOk == true
 
     # Node 1 subscribes to topic
-    nodes[1].subscribe((kind: PubsubSub, topic: DefaultPubsubTopic))
+    nodes[1].subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
+    )
     await sleepAsync(500.millis)
 
     # Node 0 publishes 5 messages not compliant with WakuMessage (aka random bytes)
@@ -281,7 +289,10 @@ suite "WakuNode - Relay":
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(500.millis)
 
     let res = await node2.publish(some(pubSubTopic), message)
@@ -329,7 +340,10 @@ suite "WakuNode - Relay":
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(500.millis)
 
     let res = await node2.publish(some(pubSubTopic), message)
@@ -381,7 +395,10 @@ suite "WakuNode - Relay":
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(500.millis)
 
     let res = await node2.publish(some(pubSubTopic), message)
@@ -431,7 +448,10 @@ suite "WakuNode - Relay":
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(500.millis)
 
     let res = await node2.publish(some(pubSubTopic), message)
@@ -489,7 +509,10 @@ suite "WakuNode - Relay":
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(500.millis)
 
     let res = await node2.publish(some(pubSubTopic), message)
@@ -587,18 +610,29 @@ suite "WakuNode - Relay":
       "topic must use the same shard"
 
     ## When
-    node.subscribe((kind: ContentSub, topic: contentTopicA), some(handler))
-    node.subscribe((kind: ContentSub, topic: contentTopicB), some(handler))
-    node.subscribe((kind: ContentSub, topic: contentTopicC), some(handler))
+    node.subscribe(
+      (
+        kind: Subscribe,
+        pubsubTopic: "",
+        contentTopics: @[contentTopicA, contentTopicB, contentTopicC],
+      ),
+      some(handler),
+    )
 
     ## Then
-    node.unsubscribe((kind: ContentUnsub, topic: contentTopicB))
+    node.unsubscribe(
+      (kind: topics.Unsubscribe, pubsubTopic: "", contentTopics: @[contentTopicB])
+    )
     check node.wakuRelay.isSubscribed(shard)
 
-    node.unsubscribe((kind: ContentUnsub, topic: contentTopicA))
+    node.unsubscribe(
+      (kind: topics.Unsubscribe, pubsubTopic: "", contentTopics: @[contentTopicA])
+    )
     check node.wakuRelay.isSubscribed(shard)
 
-    node.unsubscribe((kind: ContentUnsub, topic: contentTopicC))
+    node.unsubscribe(
+      (kind: topics.Unsubscribe, pubsubTopic: "", contentTopics: @[contentTopicC])
+    )
     check not node.wakuRelay.isSubscribed(shard)
 
     ## Cleanup

--- a/tests/waku_relay/utils.nim
+++ b/tests/waku_relay/utils.nim
@@ -68,7 +68,10 @@ proc subscribeToContentTopicWithHandler*(
     if topic == topic:
       completionFut.complete(true)
 
-  node.subscribe((kind: ContentSub, topic: contentTopic), some(relayHandler))
+  node.subscribe(
+    (kind: topics.Subscribe, pubsubTopic: "", contentTopics: @[contentTopic]),
+    some(relayHandler),
+  )
   return completionFut
 
 proc subscribeCompletionHandler*(node: WakuNode, pubsubTopic: string): Future[bool] =
@@ -79,7 +82,10 @@ proc subscribeCompletionHandler*(node: WakuNode, pubsubTopic: string): Future[bo
     if topic == pubsubTopic:
       completionFut.complete(true)
 
-  node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+  node.subscribe(
+    (kind: topics.Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]),
+    some(relayHandler),
+  )
   return completionFut
 
 proc sendRlnMessage*(

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -108,7 +108,10 @@ procSuite "WakuNode - RLN relay":
         completionFut.complete(true)
 
     # mount the relay handler
-    node3.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic), some(relayHandler))
+    node3.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(2000.millis)
 
     # prepare the message payload
@@ -183,8 +186,14 @@ procSuite "WakuNode - RLN relay":
         rxMessagesTopic2 = rxMessagesTopic2 + 1
 
     # mount the relay handlers
-    nodes[2].subscribe((kind: PubsubSub, topic: pubsubTopics[0]), some(relayHandler))
-    nodes[2].subscribe((kind: PubsubSub, topic: pubsubTopics[1]), some(relayHandler))
+    nodes[2].subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopics[0], contentTopics: @[""]),
+      some(relayHandler),
+    )
+    nodes[2].subscribe(
+      (kind: topics.Subscribe, pubsubTopic: pubsubTopics[1], contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(1000.millis)
 
     # generate some messages with rln proofs first. generating
@@ -211,11 +220,13 @@ procSuite "WakuNode - RLN relay":
         raiseAssert $error
       messages2.add(message)
 
+    info "AAAAA"
     # publish 3 messages from node[0] (last 2 are spam, window is 10 secs)
     # publish 3 messages from node[1] (last 2 are spam, window is 10 secs)
     for msg in messages1:
       discard await nodes[0].publish(some(pubsubTopics[0]), msg)
     for msg in messages2:
+      info "AAAAA", msg
       discard await nodes[1].publish(some(pubsubTopics[1]), msg)
 
     # wait for gossip to propagate
@@ -303,7 +314,10 @@ procSuite "WakuNode - RLN relay":
         completionFut.complete(true)
 
     # mount the relay handler
-    node3.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic), some(relayHandler))
+    node3.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(2000.millis)
 
     # prepare the message payload
@@ -452,7 +466,10 @@ procSuite "WakuNode - RLN relay":
           completionFut4.complete(true)
 
     # mount the relay handler for node3
-    node3.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic), some(relayHandler))
+    node3.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
     await sleepAsync(2000.millis)
 
     ## node1 publishes and relays 4 messages to node2
@@ -541,7 +558,10 @@ procSuite "WakuNode - RLN relay":
         if msg == wm6:
           completionFut6.complete(true)
 
-    node2.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic), some(relayHandler))
+    node2.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""]),
+      some(relayHandler),
+    )
 
     # Given all messages have an rln proof and are published by the node 1
     let publishSleepDuration: Duration = 5000.millis

--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -279,7 +279,9 @@ suite "Waku v2 Rest API - Filter V2":
       subPeerId = restFilterTest.subscriberNode.peerInfo.toRemotePeerInfo().peerId
 
     restFilterTest.messageCache.pubsubSubscribe(DefaultPubsubTopic)
-    restFilterTest.serviceNode.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic))
+    restFilterTest.serviceNode.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
+    )
 
     # When
     var requestBody = FilterSubscribeRequest(
@@ -324,7 +326,9 @@ suite "Waku v2 Rest API - Filter V2":
     # setup filter service and client node
     let restFilterTest = await RestFilterTest.init()
     let subPeerId = restFilterTest.subscriberNode.peerInfo.toRemotePeerInfo().peerId
-    restFilterTest.serviceNode.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic))
+    restFilterTest.serviceNode.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
+    )
 
     let requestBody = FilterSubscribeRequest(
       requestId: "1001",
@@ -395,7 +399,9 @@ suite "Waku v2 Rest API - Filter V2":
     # setup filter service and client node
     let restFilterTest = await RestFilterTest.init()
     let subPeerId = restFilterTest.subscriberNode.peerInfo.toRemotePeerInfo().peerId
-    restFilterTest.serviceNode.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic))
+    restFilterTest.serviceNode.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
+    )
 
     let requestBody = FilterSubscribeRequest(
       requestId: "1001",

--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -101,10 +101,10 @@ suite "Waku v2 Rest API - lightpush":
     let restLightPushTest = await RestLightPushTest.init()
 
     restLightPushTest.consumerNode.subscribe(
-      (kind: PubsubSub, topic: DefaultPubsubTopic)
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
     )
     restLightPushTest.serviceNode.subscribe(
-      (kind: PubsubSub, topic: DefaultPubsubTopic)
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
     )
     require:
       toSeq(restLightPushTest.serviceNode.wakuRelay.subscribedTopics).len == 1
@@ -133,7 +133,7 @@ suite "Waku v2 Rest API - lightpush":
     let restLightPushTest = await RestLightPushTest.init()
 
     restLightPushTest.serviceNode.subscribe(
-      (kind: PubsubSub, topic: DefaultPubsubTopic)
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
     )
     require:
       toSeq(restLightPushTest.serviceNode.wakuRelay.subscribedTopics).len == 1

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -245,7 +245,9 @@ suite "Waku v2 Rest API - Relay":
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
-    node.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic))
+    node.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
+    )
     require:
       toSeq(node.wakuRelay.subscribedTopics).len == 1
 
@@ -461,7 +463,9 @@ suite "Waku v2 Rest API - Relay":
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
-    node.subscribe((kind: ContentSub, topic: DefaultContentTopic))
+    node.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultContentTopic, contentTopics: @[""])
+    )
     require:
       toSeq(node.wakuRelay.subscribedTopics).len == 1
 
@@ -564,7 +568,9 @@ suite "Waku v2 Rest API - Relay":
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
-    node.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic))
+    node.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
+    )
     require:
       toSeq(node.wakuRelay.subscribedTopics).len == 1
 
@@ -619,7 +625,9 @@ suite "Waku v2 Rest API - Relay":
 
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
 
-    node.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic))
+    node.subscribe(
+      (kind: topics.Subscribe, pubsubTopic: DefaultPubsubTopic, contentTopics: @[""])
+    )
     require:
       toSeq(node.wakuRelay.subscribedTopics).len == 1
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -268,8 +268,8 @@ proc subscriptionsListener(wd: WakuDiscoveryV5) {.async.} =
 
     # Since we don't know the events we will receive we have to anticipate.
 
-    let subs = events.filterIt(it.kind == PubsubSub).mapIt(it.topic)
-    let unsubs = events.filterIt(it.kind == PubsubUnsub).mapIt(it.topic)
+    let subs = events.filterIt(it.kind == Subscribe).mapIt(it.pubsubTopic)
+    let unsubs = events.filterIt(it.kind == Unsubscribe).mapIt(it.pubsubTopic)
 
     if subs.len == 0 and unsubs.len == 0:
       continue

--- a/waku/waku_api/rest/builder.nim
+++ b/waku/waku_api/rest/builder.nim
@@ -134,11 +134,17 @@ proc startRestServerProtocolSupport*(
 
     for pubsubTopic in conf.pubsubTopics:
       cache.pubsubSubscribe(pubsubTopic)
-      node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(handler))
+      node.subscribe(
+        (kind: Subscribe, pubsubTopic: pubsubTopic, contentTopics: @[""]), some(handler)
+      )
 
     for contentTopic in conf.contentTopics:
       cache.contentSubscribe(contentTopic)
-      node.subscribe((kind: ContentSub, topic: contentTopic), some(handler))
+
+    node.subscribe(
+      (kind: Subscribe, pubsubTopic: "", contentTopics: conf.contentTopics),
+      some(handler),
+    )
 
     installRelayApiHandlers(router, node, cache)
   else:

--- a/waku/waku_core/topics.nim
+++ b/waku/waku_core/topics.nim
@@ -4,9 +4,8 @@ export content_topic, pubsub_topic, sharding
 
 type
   SubscriptionKind* = enum
-    ContentSub
-    ContentUnsub
-    PubsubSub
-    PubsubUnsub
+    Subscribe
+    Unsubscribe
 
-  SubscriptionEvent* = tuple[kind: SubscriptionKind, topic: string]
+  SubscriptionEvent* =
+    tuple[kind: SubscriptionKind, pubsubTopic: string, contentTopics: seq[string]]

--- a/waku/waku_filter_v2/rpc.nim
+++ b/waku/waku_filter_v2/rpc.nim
@@ -39,7 +39,7 @@ proc subscribe*(
 ): T =
   FilterSubscribeRequest(
     requestId: requestId,
-    filterSubscribeType: SUBSCRIBE,
+    filterSubscribeType: FilterSubscribeType.SUBSCRIBE,
     pubsubTopic: some(pubsubTopic),
     contentTopics: contentTopics,
   )
@@ -52,7 +52,7 @@ proc unsubscribe*(
 ): T =
   FilterSubscribeRequest(
     requestId: requestId,
-    filterSubscribeType: UNSUBSCRIBE,
+    filterSubscribeType: FilterSubscribeType.UNSUBSCRIBE,
     pubsubTopic: some(pubsubTopic),
     contentTopics: contentTopics,
   )

--- a/waku/waku_metadata/protocol.nim
+++ b/waku/waku_metadata/protocol.nim
@@ -128,16 +128,16 @@ proc subscriptionsListener(wm: WakuMetadata) {.async.} =
     let events = await wm.topicSubscriptionQueue.waitEvents(key)
 
     for event in events:
-      let parsedTopic = NsPubsubTopic.parse(event.topic).valueOr:
+      let parsedTopic = NsPubsubTopic.parse(event.pubsubTopic).valueOr:
         continue
 
       if parsedTopic.clusterId != wm.clusterId:
         continue
 
       case event.kind
-      of PubsubSub:
+      of Subscribe:
         wm.shards.incl(parsedTopic.shardId)
-      of PubsubUnsub:
+      of Unsubscribe:
         wm.shards.excl(parsedTopic.shardId)
       else:
         continue


### PR DESCRIPTION

This is needed from the PoV of filter so that the delivery monitor can be aware of the pubsub/content topics the node is interested in
