### PR TITLE
chore: using mplex instead of yamux

### DIFF
--- a/waku/node/waku_switch.nim
+++ b/waku/node/waku_switch.nim
@@ -86,7 +86,6 @@ proc newWakuSwitch*(
     .withMaxIn(maxIn)
     .withMaxOut(maxOut)
     .withMaxConnsPerPeer(maxConnsPerPeer)
-    .withYamux()
     .withMplex(inTimeout, outTimeout)
     .withNoise()
     .withTcpTransport(transportFlags)


### PR DESCRIPTION
# Description
Switching our multiplexer from `yamux` to `mplex` after finding the Futures leak in `yamux` reported in https://github.com/vacp2p/nim-libp2p/issues/1165

Once it's taken care of we can switch back to `yamux`