### PR TITLE
feat: waku rendezvous wrapper

### DIFF
--- a/tests/factory/test_node_factory.nim
+++ b/tests/factory/test_node_factory.nim
@@ -17,7 +17,7 @@ suite "Node Factory":
       node.wakuStore.isNil()
       node.wakuFilter.isNil()
       not node.wakuStoreClient.isNil()
-      not node.rendezvous.isNil()
+      not node.wakuRendezvous.isNil()
 
   test "Set up a node with Store enabled":
     var conf = defaultTestWakuNodeConf()

--- a/tests/test_waku_rendezvous.nim
+++ b/tests/test_waku_rendezvous.nim
@@ -33,11 +33,7 @@ procSuite "Waku Rendezvous":
       )
 
     await allFutures(
-      [
-        node1.mountWakuRendezvous(),
-        node2.mountWakuRendezvous(),
-        node3.mountWakuRendezvous(),
-      ]
+      [node1.mountRendezvous(), node2.mountRendezvous(), node3.mountRendezvous()]
     )
     await allFutures([node1.start(), node2.start(), node3.start()])
 

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -40,6 +40,7 @@ proc defaultTestWakuNodeConf*(): WakuNodeConf =
     clusterId: DefaultClusterId,
     shards: @[DefaultShardId],
     relay: true,
+    rendezvous: true,
     storeMessageDbUrl: "sqlite://store.sqlite3",
   )
 

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -62,7 +62,7 @@ suite "Wakunode2 - Waku initialization":
       node.wakuArchive.isNil()
       node.wakuStore.isNil()
       not node.wakuStoreClient.isNil()
-      not node.rendezvous.isNil()
+      not node.wakuRendezvous.isNil()
 
     ## Cleanup
     waitFor waku.stop()
@@ -92,7 +92,7 @@ suite "Wakunode2 - Waku initialization":
       node.wakuArchive.isNil()
       node.wakuStore.isNil()
       not node.wakuStoreClient.isNil()
-      not node.rendezvous.isNil()
+      not node.wakuRendezvous.isNil()
 
       # DS structures are updated with dynamic ports
       typedNodeEnr.get().tcp.get() != 0

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -647,6 +647,13 @@ with the drawback of consuming some more bandwitdh.""",
       name: "peer-exchange-node"
     .}: string
 
+    ## Rendez vous
+    rendezvous* {.
+      desc: "Enable waku rendezvous discovery server",
+      defaultValue: false,
+      name: "rendezvous"
+    .}: bool
+
     ## websocket config
     websocketSupport* {.
       desc: "Enable websocket:  true|false",

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -650,7 +650,7 @@ with the drawback of consuming some more bandwitdh.""",
     ## Rendez vous
     rendezvous* {.
       desc: "Enable waku rendezvous discovery server",
-      defaultValue: false,
+      defaultValue: true,
       name: "rendezvous"
     .}: bool
 

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -207,6 +207,14 @@ proc setupProtocols(
         protectedShard = shardKey.shard, publicKey = shardKey.key
     node.wakuRelay.addSignedShardsValidator(subscribedProtectedShards, conf.clusterId)
 
+    # Only relay nodes can be rendezvous points.
+    if conf.rendezvous:
+      try:
+        await mountRendezvous(node)
+      except CatchableError:
+        return
+          err("failed to mount waku rendezvous protocol: " & getCurrentExceptionMsg())
+
   # Keepalive mounted on all nodes
   try:
     await mountLibp2pPing(node)
@@ -364,12 +372,6 @@ proc setupProtocols(
     else:
       return
         err("failed to set node waku peer-exchange peer: " & peerExchangeNode.error)
-
-  # Enable Rendezvous Discovery protocol
-  try:
-    await mountRendezvous(node, conf.rendezvous)
-  except CatchableError:
-    return err("failed to mount waku rendezvous protocol: " & getCurrentExceptionMsg())
 
   return ok()
 

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -207,13 +207,6 @@ proc setupProtocols(
         protectedShard = shardKey.shard, publicKey = shardKey.key
     node.wakuRelay.addSignedShardsValidator(subscribedProtectedShards, conf.clusterId)
 
-    # Enable Rendezvous Discovery protocol when Relay is enabled
-    try:
-      await mountRendezvous(node)
-    except CatchableError:
-      return
-        err("failed to mount waku rendezvous protocol: " & getCurrentExceptionMsg())
-
   # Keepalive mounted on all nodes
   try:
     await mountLibp2pPing(node)
@@ -371,6 +364,12 @@ proc setupProtocols(
     else:
       return
         err("failed to set node waku peer-exchange peer: " & peerExchangeNode.error)
+
+  # Enable Rendezvous Discovery protocol
+  try:
+    await mountRendezvous(node, conf.rendezvous)
+  except CatchableError:
+    return err("failed to mount waku rendezvous protocol: " & getCurrentExceptionMsg())
 
   return ok()
 

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -209,7 +209,7 @@ proc setupProtocols(
 
     # Only relay nodes should be rendezvous points.
     if conf.rendezvous:
-      await mountWakuRendezvous(node)
+      await mountRendezvous(node)
 
   # Keepalive mounted on all nodes
   try:

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -209,7 +209,7 @@ proc setupProtocols(
 
     # Only relay nodes should be rendezvous points.
     if conf.rendezvous:
-      await mountRendezvous(node)
+      await node.mountRendezvous()
 
   # Keepalive mounted on all nodes
   try:

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -207,13 +207,9 @@ proc setupProtocols(
         protectedShard = shardKey.shard, publicKey = shardKey.key
     node.wakuRelay.addSignedShardsValidator(subscribedProtectedShards, conf.clusterId)
 
-    # Only relay nodes can be rendezvous points.
+    # Only relay nodes should be rendezvous points.
     if conf.rendezvous:
-      try:
-        await mountRendezvous(node)
-      except CatchableError:
-        return
-          err("failed to mount waku rendezvous protocol: " & getCurrentExceptionMsg())
+      await mountRendezvous(node)
 
   # Keepalive mounted on all nodes
   try:

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -209,7 +209,7 @@ proc setupProtocols(
 
     # Only relay nodes should be rendezvous points.
     if conf.rendezvous:
-      await mountRendezvous(node)
+      await mountWakuRendezvous(node)
 
   # Keepalive mounted on all nodes
   try:

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -374,16 +374,6 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: 
   if not waku[].deliveryMonitor.isNil():
     waku[].deliveryMonitor.startDeliveryMonitor()
 
-  ## libp2p DiscoveryManager
-  waku[].discoveryMngr = DiscoveryManager()
-  waku[].discoveryMngr.add(
-    RendezVousInterface.new(rdv = waku[].node.wakuRendezvous, tta = 1.minutes)
-  )
-  if not isNil(waku[].node.wakuRelay):
-    for topic in waku[].node.wakuRelay.getSubscribedTopics():
-      debug "advertise rendezvous namespace", topic
-      waku[].discoveryMngr.advertise(RdvNamespace(topic))
-
   return ok()
 
 # Waku shutdown

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -377,7 +377,7 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: 
   ## libp2p DiscoveryManager
   waku[].discoveryMngr = DiscoveryManager()
   waku[].discoveryMngr.add(
-    RendezVousInterface.new(rdv = waku[].node.rendezvous, tta = 1.minutes)
+    RendezVousInterface.new(rdv = waku[].node.wakuRendezvous, tta = 1.minutes)
   )
   if not isNil(waku[].node.wakuRelay):
     for topic in waku[].node.wakuRelay.getSubscribedTopics():

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1214,12 +1214,11 @@ proc startKeepalive*(node: WakuNode, keepalive = 2.minutes) =
 
   asyncSpawn node.keepaliveLoop(keepalive)
 
-proc mountRendezvous*(node: WakuNode, enabled: bool) {.async: (raises: []).} =
+proc mountRendezvous*(node: WakuNode) {.async: (raises: []).} =
   info "mounting rendezvous discovery protocol"
 
   try:
-    node.wakuRendezvous =
-      WakuRendezVous.new(node.switch, node.peerManager, node.enr, enabled)
+    node.wakuRendezvous = WakuRendezVous.new(node.switch, node.peerManager, node.enr)
   except Exception as e:
     error "failed to create rendezvous", error = getCurrentExceptionMsg()
     return
@@ -1234,6 +1233,9 @@ proc mountRendezvous*(node: WakuNode, enabled: bool) {.async: (raises: []).} =
     node.switch.mount(node.wakuRendezvous)
   except LPError:
     error "failed to mount rendezvous", error = getCurrentExceptionMsg()
+
+  # Always start discovering peers at startup
+  await node.wakuRendezvous.initialRequestAll()
 
 proc isBindIpWithZeroPort(inputMultiAdd: MultiAddress): bool =
   let inputStr = $inputMultiAdd

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1214,11 +1214,11 @@ proc startKeepalive*(node: WakuNode, keepalive = 2.minutes) =
 
   asyncSpawn node.keepaliveLoop(keepalive)
 
-proc mountRendezvous*(node: WakuNode) {.async: (raises: []).} =
+proc mountWakuRendezvous*(node: WakuNode) {.async: (raises: []).} =
   info "mounting rendezvous discovery protocol"
 
   node.wakuRendezvous = WakuRendezVous.new(node.switch, node.peerManager, node.enr).valueOr:
-    error "rendezvous new failed", error = error
+    error "initializing waku rendezvous failed", error = error
     return
 
   # Always start discovering peers at startup
@@ -1227,11 +1227,6 @@ proc mountRendezvous*(node: WakuNode) {.async: (raises: []).} =
 
   if node.started:
     await node.wakuRendezvous.start()
-
-  try:
-    node.switch.mount(node.wakuRendezvous)
-  except LPError:
-    error "failed to mount rendezvous", error = getCurrentExceptionMsg()
 
 proc isBindIpWithZeroPort(inputMultiAdd: MultiAddress): bool =
   let inputStr = $inputMultiAdd

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1302,10 +1302,7 @@ proc start*(node: WakuNode) {.async.} =
     await node.wakuStoreResume.start()
 
   if not node.wakuRendezvous.isNil():
-    try:
-      await node.wakuRendezvous.start()
-    except CatchableError:
-      error "failed to start rendezvous", error = getCurrentExceptionMsg()
+    await node.wakuRendezvous.start()
 
   ## The switch uses this mapper to update peer info addrs
   ## with announced addrs after start

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1214,7 +1214,7 @@ proc startKeepalive*(node: WakuNode, keepalive = 2.minutes) =
 
   asyncSpawn node.keepaliveLoop(keepalive)
 
-proc mountWakuRendezvous*(node: WakuNode) {.async: (raises: []).} =
+proc mountRendezvous*(node: WakuNode) {.async: (raises: []).} =
   info "mounting rendezvous discovery protocol"
 
   node.wakuRendezvous = WakuRendezVous.new(node.switch, node.peerManager, node.enr).valueOr:

--- a/waku/waku_rendezvous.nim
+++ b/waku/waku_rendezvous.nim
@@ -1,0 +1,3 @@
+import ./waku_rendezvous/protocol
+
+export protocol

--- a/waku/waku_rendezvous/common.nim
+++ b/waku/waku_rendezvous/common.nim
@@ -5,7 +5,8 @@ import chronos
 import ../waku_enr/capabilities
 
 const DiscoverLimit* = 1000
-const DefaultRegistrationInterval* = 1.minutes
+const DefaultRegistrationTTL* = 60.seconds
+const DefaultRegistrationInterval* = 10.seconds
 
 proc computeNamespace*(clusterId: uint16, shard: uint16): string =
   var namespace = "rs/"

--- a/waku/waku_rendezvous/common.nim
+++ b/waku/waku_rendezvous/common.nim
@@ -7,6 +7,7 @@ import ../waku_enr/capabilities
 const DiscoverLimit* = 1000
 const DefaultRegistrationTTL* = 60.seconds
 const DefaultRegistrationInterval* = 10.seconds
+const PeersRequestedCount* = 12
 
 proc computeNamespace*(clusterId: uint16, shard: uint16): string =
   var namespace = "rs/"

--- a/waku/waku_rendezvous/common.nim
+++ b/waku/waku_rendezvous/common.nim
@@ -1,0 +1,28 @@
+{.push raises: [].}
+
+import chronos
+
+import ../waku_enr/capabilities
+
+const DiscoverLimit* = 1000
+const DefaultRegistrationInterval* = 2.hours
+
+proc computeNamespace*(clusterId: uint16, shard: uint16): string =
+  var namespace = "rs/"
+
+  namespace &= $clusterId
+  namespace &= '/'
+  namespace &= $shard
+
+  return namespace
+
+proc computeNamespace*(clusterId: uint16, shard: uint16, cap: Capabilities): string =
+  var namespace = "rs/"
+
+  namespace &= $clusterId
+  namespace &= '/'
+  namespace &= $shard
+  namespace &= '/'
+  namespace &= $cap
+
+  return namespace

--- a/waku/waku_rendezvous/common.nim
+++ b/waku/waku_rendezvous/common.nim
@@ -5,7 +5,7 @@ import chronos
 import ../waku_enr/capabilities
 
 const DiscoverLimit* = 1000
-const DefaultRegistrationInterval* = 2.hours
+const DefaultRegistrationInterval* = 1.minutes
 
 proc computeNamespace*(clusterId: uint16, shard: uint16): string =
   var namespace = "rs/"

--- a/waku/waku_rendezvous/common.nim
+++ b/waku/waku_rendezvous/common.nim
@@ -1,8 +1,8 @@
 {.push raises: [].}
 
-import chronos
+import std/options, chronos
 
-import ../waku_enr/capabilities
+import ../common/enr, ../waku_enr/capabilities, ../waku_enr/sharding
 
 const DiscoverLimit* = 1000
 const DefaultRegistrationTTL* = 60.seconds
@@ -28,3 +28,9 @@ proc computeNamespace*(clusterId: uint16, shard: uint16, cap: Capabilities): str
   namespace &= $cap
 
   return namespace
+
+proc getRelayShards*(enr: enr.Record): Option[RelayShards] =
+  let typedRecord = enr.toTyped().valueOr:
+    return none(RelayShards)
+
+  return typedRecord.relaySharding()

--- a/waku/waku_rendezvous/protocol.nim
+++ b/waku/waku_rendezvous/protocol.nim
@@ -30,7 +30,7 @@ type WakuRendezVous* = ref object of RendezVous
 
   periodicRegistrationFut: Future[void]
 
-  clientOnly: bool
+  enabled: bool
 
 proc advertise(
     self: WakuRendezVous, namespace: string, ttl: Duration = MinimumDuration
@@ -100,7 +100,7 @@ proc new*(
     peerManager: peerManager,
     relayshard: relayshard,
     capabilities: capabilities,
-    clientOnly: clientOnly,
+    enabled: enabled,
   )
 
   RendezVous(wrv).setup(switch)
@@ -140,7 +140,7 @@ proc advertiseAll*(self: WakuRendezVous) {.async.} =
 
   let futs = collect(newSeq):
     for namespace in namespaces:
-      self.advertise(namespace)
+      self.advertise(namespace, 1.minutes)
 
   let handles = await allFinished(futs)
 
@@ -219,8 +219,6 @@ proc stopWait*(self: WakuRendezVous) {.async.} =
     return
 
   debug "stopping waku rendezvous discovery"
-
-  await self.unsubcribeAll()
 
   if not self.periodicRegistrationFut.isNil():
     await self.periodicRegistrationFut.cancelAndWait()

--- a/waku/waku_rendezvous/protocol.nim
+++ b/waku/waku_rendezvous/protocol.nim
@@ -1,0 +1,226 @@
+{.push raises: [].}
+
+import
+  std/[sugar, options],
+  results,
+  chronos,
+  chronicles,
+  metrics,
+  libp2p/protocols/rendezvous,
+  libp2p/switch,
+  libp2p/utility
+
+import
+  ../node/peer_manager,
+  ../common/enr,
+  ../waku_enr/capabilities,
+  ../waku_enr/sharding,
+  ../waku_core/peers as peers,
+  ./common
+
+logScope:
+  topics = "waku rendez vous"
+
+declarePublicCounter peerFound, "number of peers found via rendezvous"
+
+type WakuRendezVous* = ref object of RendezVous
+  peerManager: PeerManager
+  relayShard: RelayShards
+  capabilities: seq[Capabilities]
+
+  periodicRegistrationFut: Future[void]
+
+  clientOnly: bool
+
+proc advertise(
+    self: WakuRendezVous, namespace: string, ttl: Duration = MinimumDuration
+): Future[Result[void, string]] {.async.} =
+  ## Register with all rendez vous peers under a namespace
+
+  let catchable = catch:
+    await procCall RendezVous(self).advertise(namespace, ttl)
+
+  if catchable.isErr():
+    return err(catchable.error.msg)
+
+  return ok()
+
+proc request(
+    self: WakuRendezVous, namespace: string, count: int = DiscoverLimit
+): Future[Result[seq[PeerRecord], string]] {.async.} =
+  ## Request all records from all rendez vous peers with matching a namespace
+
+  let catchable = catch:
+    await RendezVous(self).request(namespace, count)
+
+  if catchable.isErr():
+    return err(catchable.error.msg)
+
+  return ok(catchable.get())
+
+proc requestLocally(self: WakuRendezVous, namespace: string): seq[PeerRecord] =
+  RendezVous(self).requestLocally(namespace)
+
+proc unsubscribeLocally(self: WakuRendezVous, namespace: string) =
+  RendezVous(self).unsubscribeLocally(namespace)
+
+proc unsubscribe(
+    self: WakuRendezVous, namespace: string
+): Future[Result[void, string]] {.async.} =
+  ## Unsubscribe from all rendez vous peers including locally
+
+  let catchable = catch:
+    await RendezVous(self).unsubscribe(namespace)
+
+  if catchable.isErr():
+    return err(catchable.error.msg)
+
+  return ok()
+
+proc getRelayShards(enr: enr.Record): Option[RelayShards] =
+  let typedRecord = enr.toTyped().valueOr:
+    return none(RelayShards)
+
+  return typedRecord.relaySharding()
+
+proc new*(
+    T: type WakuRendezVous,
+    switch: Switch,
+    peerManager: PeerManager,
+    enr: Record,
+    enabled: bool,
+): T =
+  let relayshard = getRelayShards(enr).valueOr:
+    warn "Using default cluster id 0"
+    RelayShards(clusterID: 0, shardIds: @[])
+
+  let capabilities = enr.getCapabilities()
+
+  let wrv = WakuRendezVous(
+    peerManager: peerManager,
+    relayshard: relayshard,
+    capabilities: capabilities,
+    clientOnly: clientOnly,
+  )
+
+  RendezVous(wrv).setup(switch)
+
+  debug "waku rendezvous initialized",
+    cluster = relayshard.clusterId,
+    shards = relayshard.shardIds,
+    capabilities = capabilities
+
+  return wrv
+
+proc advertisementNamespaces(self: WakuRendezVous): seq[string] =
+  let namespaces = collect(newSeq):
+    for shard in self.relayShard.shardIds:
+      for cap in self.capabilities:
+        computeNamespace(self.relayShard.clusterId, shard, cap)
+
+  return namespaces
+
+proc requestNamespaces(self: WakuRendezVous): seq[string] =
+  let namespaces = collect(newSeq):
+    for shard in self.relayShard.shardIds:
+      for cap in Capabilities:
+        computeNamespace(self.relayShard.clusterId, shard, cap)
+
+  return namespaces
+
+proc shardOnlyNamespaces(self: WakuRendezVous): seq[string] =
+  let namespaces = collect(newSeq):
+    for shard in self.relayShard.shardIds:
+      computeNamespace(self.relayShard.clusterId, shard)
+
+  return namespaces
+
+proc advertiseAll*(self: WakuRendezVous) {.async.} =
+  let namespaces = self.shardOnlyNamespaces()
+
+  let futs = collect(newSeq):
+    for namespace in namespaces:
+      self.advertise(namespace)
+
+  let handles = await allFinished(futs)
+
+  for fut in handles:
+    let res = fut.read
+
+    if res.isErr():
+      warn "failed to advertise", error = res.error
+
+  debug "waku rendezvous advertisements finished", adverCount = handles.len
+
+proc requestAll*(self: WakuRendezVous) {.async.} =
+  let namespaces = self.shardOnlyNamespaces()
+
+  let futs = collect(newSeq):
+    for namespace in namespaces:
+      self.request(namespace)
+
+  let handles = await allFinished(futs)
+
+  for fut in handles:
+    let res = fut.read
+
+    if res.isErr():
+      warn "failed to request", error = res.error
+    else:
+      for peer in res.get():
+        peerFound.inc()
+        self.peerManager.addPeer(peer)
+
+  debug "waku rendezvous requests finished", requestCount = handles.len
+
+proc unsubcribeAll*(self: WakuRendezVous) {.async.} =
+  let namespaces = self.shardOnlyNamespaces()
+
+  let futs = collect(newSeq):
+    for namespace in namespaces:
+      self.unsubscribe(namespace)
+
+  let handles = await allFinished(futs)
+
+  for fut in handles:
+    let res = fut.read
+
+    if res.isErr():
+      warn "failed to unsubcribe", error = res.error
+
+  debug "waku rendezvous unsubscriptions finished", unsubCount = handles.len
+
+  return
+
+proc periodicRegistration(self: WakuRendezVous) {.async.} =
+  debug "waku rendezvous periodic registration started",
+    interval = DefaultRegistrationInterval
+
+  # infinite loop
+  while true:
+    # default ttl of registration is the same as default interval
+    await self.advertiseAll()
+
+    await sleepAsync(DefaultRegistrationInterval)
+
+proc start*(self: WakuRendezVous) {.async.} =
+  await self.requestAll()
+
+  if not self.enabled:
+    return
+
+  debug "starting waku rendezvous discovery"
+
+  # start registering forever
+  self.periodicRegistrationFut = self.periodicRegistration()
+
+proc stopWait*(self: WakuRendezVous) {.async.} =
+  if not self.enabled:
+    return
+
+  debug "stopping waku rendezvous discovery"
+
+  await self.unsubcribeAll()
+
+  if not self.periodicRegistrationFut.isNil():
+    await self.periodicRegistrationFut.cancelAndWait()

--- a/waku/waku_rendezvous/protocol.nim
+++ b/waku/waku_rendezvous/protocol.nim
@@ -40,7 +40,7 @@ proc batchAdvertise*(
   ## Register with all rendez vous peers under a namespace
 
   let catchable = catch:
-    await procCall RendezVous(self).batchAdvertise(namespace, ttl, peers)
+    await procCall RendezVous(self).advertise(namespace, ttl, peers)
 
   if catchable.isErr():
     return err(catchable.error.msg)
@@ -56,7 +56,7 @@ proc batchRequest*(
   ## Request all records from all rendez vous peers with matching a namespace
 
   let catchable = catch:
-    await RendezVous(self).batchRequest(namespace, count, peers)
+    await RendezVous(self).request(namespace, count, peers)
 
   if catchable.isErr():
     return err(catchable.error.msg)
@@ -103,7 +103,7 @@ proc advertiseAll(self: WakuRendezVous) {.async.} =
         continue
 
       # Advertise yourself on that peer
-      self.batchAdvertise(namespace, DefaultRegistrationTTL, @[rpi.peerId])
+      self.advertise(namespace, DefaultRegistrationTTL, @[rpi.peerId])
 
   let handles = await allFinished(futs)
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
I've wrapped libp2p rendezvous protocol so that at the waku layer we can register at rdv points and also request peer records.

spec -> https://github.com/waku-org/specs/blob/master/standards/core/rendezvous.md

# Changes

<!-- List of detailed changes -->

- [x] rendezvous wrapper
- [x] server periodic registration
- [x] config
