### PR TITLE
fix: networkmonitor compilation issue

### DIFF
--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -318,7 +318,7 @@ proc crawlNetwork(
     let discoveredNodes = await wakuDiscv5.findRandomPeers()
 
     # nodes are nested into bucket, flat it
-    #let flatNodes = wakuDiscv5.protocol.routingTable.buckets.mapIt(it.nodes).flatten()
+    let flatNodes = wakuDiscv5.protocol.routingTable.buckets.mapIt(it.nodes).flatten()
 
     # populate metrics related to capabilities as advertised by the ENR (see waku field)
     setDiscoveredPeersCapabilities(discoveredNodes)


### PR DESCRIPTION
I other PRs we have the following error:
![image](https://github.com/user-attachments/assets/d6cffcd1-b634-4363-b74b-815a6043ed3b)
