### PR TITLE
fix: faster retention policy when error and use of detach finalize when needed

### DIFF
--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -24,6 +24,7 @@ const
 
   # Retention policy
   WakuArchiveDefaultRetentionPolicyInterval* = chronos.minutes(30)
+  WakuArchiveDefaultRetentionPolicyIntervalWhenError* = chronos.minutes(1)
 
   # Metrics reporting
   WakuArchiveDefaultMetricsReportInterval* = chronos.minutes(30)
@@ -193,6 +194,9 @@ proc periodicRetentionPolicy(self: WakuArchive) {.async.} =
     (await policy.execute(self.driver)).isOkOr:
       waku_archive_errors.inc(labelValues = [retPolicyFailure])
       error "failed execution of retention policy", error = error
+      await sleepAsync(WakuArchiveDefaultRetentionPolicyIntervalWhenError)
+      ## in case of error, let's try again faster
+      continue
 
     await sleepAsync(WakuArchiveDefaultRetentionPolicyInterval)
 


### PR DESCRIPTION
## Description
There are occasions where the concurrently-detach partition query didn't complete successfully. In those cases, the database shows an error hint recommending to perform a "finalize" detach partition. This PR aims at applying this approach when that error happens

## Changes

- [x] Apply detach FINALIZE when recommended by the database 
- [x] Speed up the retention policy application to once every minute, in case of error, so that we try again faster instead of waiting for 30 minutes each time. 

## Issue

closes https://github.com/waku-org/nwaku/issues/2890
