### PR TITLE
chore: print WakuMessageHash as hex strings

### DIFF
--- a/waku/waku_core/message/digest.nim
+++ b/waku/waku_core/message/digest.nim
@@ -8,6 +8,9 @@ import ../topics, ./message
 
 type WakuMessageHash* = array[32, byte]
 
+func `$`*(hash: WakuMessageHash): string =
+  return hash.to0xHex()
+
 const EmptyWakuMessageHash*: WakuMessageHash = [
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0,

--- a/waku/waku_core/message/digest.nim
+++ b/waku/waku_core/message/digest.nim
@@ -8,8 +8,16 @@ import ../topics, ./message
 
 type WakuMessageHash* = array[32, byte]
 
+func shortLog*(hash: WakuMessageHash): string =
+  ## Returns compact string representation of ``WakuMessageHash``.
+  var hexhash = newStringOfCap(13)
+  hexhash &= hash.toOpenArray(0, 1).to0xHex()
+  hexhash &= "..."
+  hexhash &= hash.toOpenArray(hash.len - 2, hash.high).toHex()
+  hexhash
+
 func `$`*(hash: WakuMessageHash): string =
-  return hash.to0xHex()
+  shortLog(hash)
 
 const EmptyWakuMessageHash*: WakuMessageHash = [
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
# Description
Currently message hashes are printed like this:
```
 topics="waku store" tid=1 file=protocol.nim:58 peerId=16U*BGaw4B requestId=75cbe84cac46075074bcb95cc1920703a7b4bc2aba306959c11085b5379ffef8 request="(requestId: \"75cbe84cac46075074bcb95cc1920703a7b4bc2aba306959c11085b5379ffef8\", includeData: false, pubsubTopic: none(string), contentTopics: @[], startTime: none(CompiledIntTypes), endTime: none(CompiledIntTypes), messageHashes: @[[129, 203, 114, 194, 222, 123, 86, 228, 156, 248, 29, 51, 153, 77, 232, 234, 124, 205, 98, 87, 59, 33, 178, 231, 153, 98, 190, 112, 172, 251, 129, 170], [171, 5, 26, 138, 98, 133, 28, 211, 242, 130, 235, 135, 150, 206, 79, 16, 204, 114, 139, 103, 124, 102, 40, 96, 73, 103, 59, 102, 210, 152, 66, 229], [105, 227, 97, 110, 122, 72, 36, 150, 98, 112, 239, 37, 220, 175, 171, 55, 249, 239, 136, 108, 228, 76, 54, 47, 186, 59, 244, 128, 60, 95, 13, 250], [145, 128, 146, 47, 111, 163, 239, 21, 128, 137, 27, 226, 185, 28, 9, 133, 130, 213, 138, 225, 10, 169, 112, 48, 183, 116, 177, 189, 228, 189, 64, 222], [122, 56, 93, 236, 124, 13, 204, 143, 71, 58, 69, 112, 80, 15, 77, 126, .....
```
With this change, they would look like this instead:
```
 topics="waku store" tid=1 file=protocol.nim:58 peerId=16U*BGaw4B requestId=75cbe84cac46075074bcb95cc1920703a7b4bc2aba306959c11085b5379ffef8 request="(requestId: \"75cbe84cac46075074bcb95cc1920703a7b4bc2aba306959c11085b5379ffef8\", includeData: false, pubsubTopic: none(string), contentTopics: @[], startTime: none(CompiledIntTypes), endTime: none(CompiledIntTypes), messageHashes: @[0x0102030405060708090001020304050607080900010203040506070809000102, 0x0202030405060708090001020304050607080900010203040506070809000102, 0x0302030405060708090001020304050607080900010203040506070809000102....
```
Which makes them easier to read and search in kibana, as well as reduces the  length of the log lines
