### PR TITLE
fix: avoid using the msg key in chronicles

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -397,14 +397,14 @@ proc publish*(
   if node.wakuRelay.isNil():
     let msg =
       "Invalid API call to `publish`. WakuRelay not mounted. Try `lightpush` instead."
-    error "publish error", msg = msg
+    error "publish error", err = msg
     # TODO: Improve error handling
     return err(msg)
 
   let pubsubTopic = pubsubTopicOp.valueOr:
     node.wakuSharding.getShard(message.contentTopic).valueOr:
       let msg = "Autosharding error: " & error
-      error "publish error", msg = msg
+      error "publish error", err = msg
       return err(msg)
 
   #TODO instead of discard return error when 0 peers received the message
@@ -1105,7 +1105,7 @@ proc lightpushPublish*(
     peerOpt = node.peerManager.selectPeer(WakuLightPushCodec)
     if peerOpt.isNone():
       let msg = "no suitable remote peers"
-      error "failed to publish message", msg = msg
+      error "failed to publish message", err = msg
       return err(msg)
   elif not node.wakuLightPush.isNil():
     peerOpt = some(RemotePeerInfo.init($node.switch.peerInfo.peerId))

--- a/waku/node/waku_switch.nim
+++ b/waku/node/waku_switch.nim
@@ -30,7 +30,7 @@ proc getSecureKey(path: string): TLSPrivateKey {.raises: [Defect, IOError].} =
     let key = TLSPrivateKey.init(stringkey)
     return key
   except TLSStreamProtocolError as exc:
-    debug "exception raised from getSecureKey", msg = exc.msg
+    debug "exception raised from getSecureKey", err = exc.msg
 
 proc getSecureCert(path: string): TLSCertificate {.raises: [Defect, IOError].} =
   trace "Certificate path is.", path = path
@@ -39,7 +39,7 @@ proc getSecureCert(path: string): TLSCertificate {.raises: [Defect, IOError].} =
     let cert = TLSCertificate.init(stringCert)
     return cert
   except TLSStreamProtocolError as exc:
-    debug "exception raised from getSecureCert", msg = exc.msg
+    debug "exception raised from getSecureCert", err = exc.msg
 
 proc withWssTransport*(
     b: SwitchBuilder, secureKeyPath: string, secureCertPath: string

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -259,7 +259,7 @@ proc installRelayApiHandlers*(
 
     let pubsubTopic = node.wakuSharding.getShard(message.contentTopic).valueOr:
       let msg = "Autosharding error: " & error
-      error "publish error", msg = msg
+      error "publish error", err = msg
       return RestApiResponse.badRequest("Failed to publish. " & msg)
 
     # if RLN is mounted, append the proof to the message


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
As reported on https://github.com/vacp2p/nim-libp2p/issues/1176, using `msg` as a key in `chronicles` causes duplicate keys when parsing the logs, as the main log message is also saved under the `msg` key.

Fixing the instances of this bug in nwaku
 