### PR TITLE
chore: ANALYZE messages query should be performed regularly

### DIFF
--- a/waku/waku_archive/driver/builder.nim
+++ b/waku/waku_archive/driver/builder.nim
@@ -102,6 +102,8 @@ proc new*(
       ## Hence, this should be run after the migration is completed.
       asyncSpawn driver.startPartitionFactory(onFatalErrorAction)
 
+      driver.startAnalyzeTableLoop()
+
       info "waiting for a partition to be created"
       for i in 0 ..< 100:
         if driver.containsAnyPartition():

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1527,22 +1527,22 @@ proc analyzeTableLoop(self: PostgresDriver) {.async.} =
   ## The database stats should be calculated regularly so that the planner
   ## picks up the proper indexes and we have better query performance.
   while true:
-    debug "analyzeTable lock db"
+    debug "analyzeTableLoop lock db"
     (await self.acquireDatabaseLock(AnalyzeTableLockId)).isOkOr:
       if error != EXPECTED_LOCK_ERROR:
-        error "failed to acquire lock in analyzeTable", error = error
+        error "failed to acquire lock in analyzeTableLoop", error = error
       await sleepAsync(RunAnalyzeInterval)
       continue
 
-    debug "analyzeTable start"
+    debug "analyzeTableLoop start analysis"
     (await self.performWriteQuery(AnalyzeQuery)).isOkOr:
       error "failed to run ANALYZE messages", error = error
 
-    debug "analyzeTable unlock db"
+    debug "analyzeTableLoop unlock db"
     (await self.releaseDatabaseLock(AnalyzeTableLockId)).isOkOr:
-      error "failed to release lock analyzeTable", error = error
+      error "failed to release lock analyzeTableLoop", error = error
 
-    debug "analyzeTable completed"
+    debug "analyzeTableLoop analysis completed"
 
     await sleepAsync(RunAnalyzeInterval)
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -25,6 +25,8 @@ type PostgresDriver* = ref object of ArchiveDriver
   partitionMngr: PartitionManager
   futLoopPartitionFactory: Future[void]
 
+  futLoopAnalyzeTable: Future[void]
+
 const InsertRowStmtName = "InsertRow"
 const InsertRowStmtDefinition =
   """INSERT INTO messages (id, messageHash, pubsubTopic, contentTopic, payload,
@@ -997,6 +999,10 @@ method close*(s: PostgresDriver): Future[ArchiveDriverResult[void]] {.async.} =
   ## Cancel the partition factory loop
   s.futLoopPartitionFactory.cancelSoon()
 
+  ## Cancel analyze table loop
+  if not s.futLoopAnalyzeTable.isNil():
+    s.futLoopAnalyzeTable.cancelSoon()
+
   ## Close the database connection
   let writeCloseRes = await s.writeConnPool.close()
   let readCloseRes = await s.readConnPool.close()
@@ -1030,6 +1036,7 @@ proc sleep*(
 
   return ok()
 
+const EXPECTED_LOCK_ERROR* = "another waku instance is currently executing a migration"
 proc acquireDatabaseLock*(
     s: PostgresDriver, lockId: int = 841886
 ): Future[ArchiveDriverResult[void]] {.async.} =
@@ -1052,7 +1059,7 @@ proc acquireDatabaseLock*(
     return err("error acquiring a lock: " & error)
 
   if locked == "f":
-    return err("another waku instance is currently executing a migration")
+    return err(EXPECTED_LOCK_ERROR)
 
   return ok()
 
@@ -1508,3 +1515,36 @@ method deleteMessagesOlderThanTimestamp*(
     return err("error in deleteMessagesOlderThanTimestamp: " & $error)
 
   return ok()
+
+############################################
+## TODO: start splitting code better
+
+const AnalyzeQuery = "ANALYZE messages"
+const AnalyzeTableLockId = 111111 ## An arbitrary and different lock id
+const RunAnalyzeInterval = timer.days(1)
+
+proc analyzeTableLoop(self: PostgresDriver) {.async.} =
+  ## The database stats should be calculated regularly so that the planner
+  ## picks up the proper indexes and we have better query performance.
+  while true:
+    debug "analyzeTable lock db"
+    (await self.acquireDatabaseLock(AnalyzeTableLockId)).isOkOr:
+      if error != EXPECTED_LOCK_ERROR:
+        error "failed to acquire lock in analyzeTable", error = error
+      await sleepAsync(RunAnalyzeInterval)
+      continue
+
+    debug "analyzeTable start"
+    (await self.performWriteQuery(AnalyzeQuery)).isOkOr:
+      error "failed to run ANALYZE messages", error = error
+
+    debug "analyzeTable unlock db"
+    (await self.releaseDatabaseLock(AnalyzeTableLockId)).isOkOr:
+      error "failed to release lock analyzeTable", error = error
+
+    debug "analyzeTable completed"
+
+    await sleepAsync(RunAnalyzeInterval)
+
+proc startAnalyzeTableLoop*(self: PostgresDriver) =
+  self.futLoopAnalyzeTable = self.analyzeTableLoop


### PR DESCRIPTION
## Description
In a pair session with @richard-ramos, thanks for it :partying_face: :raised_hands: !, we've discovered that the database wasn't using the proper indexes for certain query scenarios.

After applying `ANALYZE messages` to a database we've noticed that the query execution time went from ~1second to ~100ms.

Therefore, we considered that it is interesting to `ANALYZE messages` regularly in the database so that the stats are properly updated and the planner can pick up the optimum indexes for each case.

## Changes

- Run `ANALYZE messages` once a day.

## More context
That was the query under analysis:
```code
SELECT contentTopic, payload, pubsubTopic, version, timestamp, id, messageHash, meta FROM messages WHERE contentTopic IN ('/waku/1/0x9a3fcc34/rfc26','/waku/1/0xc9b649fe/rfc26','/waku/1/0x678be1ba/rfc26','/waku/1/0x87c713d2/rfc26','/waku/1/0x267ad6e5/rfc26','/waku/1/0xb50f4cd5/rfc26','/waku/1/0xe2509252/rfc26','/waku/1/0x8de76c97/rfc26') AND pubsubTopic = '/waku/2/rs/16/32' AND (timestamp, id) < ('1724046108468541771','ed019e15afef1273dabd74e9cc4091fad4a5f0fa054230a8e121f81fcec278c7') AND timestamp >= '1723971035000000000' AND timestamp <= '1724057435000000000' ORDER BY timestamp DESC, id DESC LIMIT '21';
```
