### PR TITLE
chore: libwaku retrieve my enr and adapt golang example

### DIFF
--- a/examples/golang/waku.go
+++ b/examples/golang/waku.go
@@ -457,8 +457,8 @@ func (self *WakuNode) WakuGetMyENR() (string, error) {
 	C.cGoWakuGetMyENR(self.ctx, resp)
 
 	if C.getRet(resp) == C.RET_OK {
-		var listenAddresses = C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
-		return listenAddresses, nil
+		var myENR = C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+		return myENR, nil
 	}
 	errMsg := "error WakuGetMyENR: " +
 		C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))

--- a/examples/golang/waku.go
+++ b/examples/golang/waku.go
@@ -1,7 +1,8 @@
 package main
 
 /*
-	#cgo LDFLAGS: -L../../build/ -lwaku -Wl,--allow-multiple-definition
+	#cgo LDFLAGS: -L../../build/ -lwaku -lnegentropy -Wl,--allow-multiple-definition
+	#cgo LDFLAGS: -L../../ -Wl,-rpath,../../
 
 	#include "../../library/libwaku.h"
 	#include <stdio.h>
@@ -169,6 +170,10 @@ package main
 
 	void cGoWakuListenAddresses(void* ctx, void* resp) {
 		WAKU_CALL (waku_listen_addresses(ctx, (WakuCallBack) callback, resp) );
+	}
+
+	void cGoWakuGetMyENR(void* ctx, void* resp) {
+		WAKU_CALL (waku_get_my_enr(ctx, (WakuCallBack) callback, resp) );
 	}
 
 */
@@ -446,6 +451,20 @@ func (self *WakuNode) WakuListenAddresses() (string, error) {
 	return "", errors.New(errMsg)
 }
 
+func (self *WakuNode) WakuGetMyENR() (string, error) {
+	var resp = C.allocResp()
+	defer C.freeResp(resp)
+	C.cGoWakuGetMyENR(self.ctx, resp)
+
+	if C.getRet(resp) == C.RET_OK {
+		var listenAddresses = C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+		return listenAddresses, nil
+	}
+	errMsg := "error WakuGetMyENR: " +
+		C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+	return "", errors.New(errMsg)
+}
+
 func main() {
 	WakuSetup()
 
@@ -516,11 +535,18 @@ func main() {
 		return
 	}
 
+	myENR, err := node.WakuGetMyENR()
+	if err != nil {
+		fmt.Println("Error happened:", err.Error())
+		return
+	}
+
 	fmt.Println("Version:", version)
 	fmt.Println("Custom content topic:", formattedContentTopic)
 	fmt.Println("Custom pubsub topic:", formattedPubsubTopic)
 	fmt.Println("Default pubsub topic:", defaultPubsubTopic)
 	fmt.Println("Listen addresses:", listenAddresses)
+	fmt.Println("My ENR:", myENR)
 
 	// Wait for a SIGINT or SIGTERM signal
 	ch := make(chan os.Signal, 1)

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -114,6 +114,11 @@ int waku_discv5_update_bootnodes(void* ctx,
                                  WakuCallBack callback,
                                  void* userData);
 
+// Retrieves the ENR information
+int waku_get_my_enr(void* ctx,
+                    WakuCallBack callback,
+                    void* userData);
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -491,5 +491,24 @@ proc waku_discv5_update_bootnodes(
   callback(RET_OK, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
   return RET_OK
 
+proc waku_get_my_enr(
+    ctx: ptr Context, callback: WakuCallBack, userData: pointer
+): cint {.dynlib, exportc.} =
+  ctx[].userData = userData
+
+  let connRes = waku_thread.sendRequestToWakuThread(
+    ctx,
+    RequestType.DEBUG,
+    DebugNodeRequest.createShared(DebugNodeMsgType.RETRIEVE_MY_ENR),
+  )
+  if connRes.isErr():
+    let msg = $connRes.error
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return RET_ERR
+  else:
+    let msg = $connRes.value
+    callback(RET_OK, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return RET_OK
+
 ### End of exported procs
 ################################################################################

--- a/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
@@ -1,9 +1,10 @@
 import std/json
-import chronicles, chronos, results
+import chronicles, chronos, results, eth/p2p/discoveryv5/enr
 import ../../../../waku/factory/waku, ../../../../waku/node/waku_node
 
 type DebugNodeMsgType* = enum
   RETRIEVE_LISTENING_ADDRESSES
+  RETRIEVE_MY_ENR
 
 type DebugNodeRequest* = object
   operation: DebugNodeMsgType
@@ -28,5 +29,7 @@ proc process*(
   case self.operation
   of RETRIEVE_LISTENING_ADDRESSES:
     return ok($(%*waku.node.getMultiaddresses()))
+  of RETRIEVE_MY_ENR:
+    return ok($(%*waku.node.enr.toURI()))
 
   return err("unsupported operation in DebugNodeRequest")


### PR DESCRIPTION
## Description
Add new "get ENR" method available in libwaku

## Changes


- new `waku_get_my_enr` available in `libwaku`
- adapt Golang example to use the new `waku_get_my_enr` function

