### PR TITLE
fix: copy libnegentropy.so from nim-build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG NIM_COMMIT
 ARG LOG_LEVEL=TRACE
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq
+RUN apk add --no-cache bash git build-base openssl-dev pcre-dev linux-headers curl jq
 
 WORKDIR /app
 COPY . .
@@ -47,7 +47,7 @@ RUN apk add --no-cache libgcc pcre-dev libpq-dev bind-tools
 RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
 # Fix for 'Error loading shared library libnegentropy.so: No such file or directory'
-ADD ./libnegentropy.so ./
+COPY --from=nim-build /app/libnegentropy.so ./
 
 # Copy to separate location to accomodate different MAKE_TARGET values
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/


### PR DESCRIPTION
We shouldn't assume it exists on the host.

Introduced by:
- https://github.com/waku-org/nwaku/pull/2403