### PR TITLE
chore: Better timing and requestId detail for slower store db queries 

### DIFF
--- a/tests/waku_store_legacy/test_client.nim
+++ b/tests/waku_store_legacy/test_client.nim
@@ -44,6 +44,7 @@ suite "Store Client":
       pubsubTopic: some(DefaultPubsubTopic),
       contentTopics: @[DefaultContentTopic],
       direction: PagingDirection.FORWARD,
+      requestId: "customRequestId",
     )
 
     serverSwitch = newTestSwitch()
@@ -93,33 +94,39 @@ suite "Store Client":
           pubsubTopic: some(DefaultPubsubTopic),
           contentTopics: @[],
           direction: PagingDirection.FORWARD,
+          requestId: "reqId1",
         )
         invalidQuery2 = HistoryQuery(
           pubsubTopic: PubsubTopic.none(),
           contentTopics: @[DefaultContentTopic],
           direction: PagingDirection.FORWARD,
+          requestId: "reqId2",
         )
         invalidQuery3 = HistoryQuery(
           pubsubTopic: some(DefaultPubsubTopic),
           contentTopics: @[DefaultContentTopic],
           pageSize: 0,
+          requestId: "reqId3",
         )
         invalidQuery4 = HistoryQuery(
           pubsubTopic: some(DefaultPubsubTopic),
           contentTopics: @[DefaultContentTopic],
           pageSize: 0,
+          requestId: "reqId4",
         )
         invalidQuery5 = HistoryQuery(
           pubsubTopic: some(DefaultPubsubTopic),
           contentTopics: @[DefaultContentTopic],
           startTime: some(0.Timestamp),
           endTime: some(0.Timestamp),
+          requestId: "reqId5",
         )
         invalidQuery6 = HistoryQuery(
           pubsubTopic: some(DefaultPubsubTopic),
           contentTopics: @[DefaultContentTopic],
           startTime: some(0.Timestamp),
           endTime: some(-1.Timestamp),
+          requestId: "reqId6",
         )
 
       # When the query is sent to the server

--- a/tests/waku_store_legacy/test_waku_store.nim
+++ b/tests/waku_store_legacy/test_waku_store.nim
@@ -44,7 +44,9 @@ suite "Waku Store - query handler legacy":
       client = newTestWakuStoreClient(clientSwitch)
 
     let req = HistoryQuery(
-      contentTopics: @[DefaultContentTopic], direction: PagingDirection.FORWARD
+      contentTopics: @[DefaultContentTopic],
+      direction: PagingDirection.FORWARD,
+      requestId: "reqId",
     )
 
     ## When
@@ -96,7 +98,9 @@ suite "Waku Store - query handler legacy":
       client = newTestWakuStoreClient(clientSwitch)
 
     let req = HistoryQuery(
-      contentTopics: @[DefaultContentTopic], direction: PagingDirection.FORWARD
+      contentTopics: @[DefaultContentTopic],
+      direction: PagingDirection.FORWARD,
+      requestId: "reqId",
     )
 
     info "check point" # log added to track flaky test

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -769,6 +769,7 @@ proc toArchiveQuery(
     endTime: request.endTime,
     pageSize: request.pageSize.uint,
     direction: request.direction,
+    requestId: request.requestId,
   )
 
 # TODO: Review this mapping logic. Maybe, move it to the appplication code
@@ -910,6 +911,7 @@ proc toArchiveQuery(request: StoreQueryRequest): waku_archive.ArchiveQuery =
   query.hashes = request.messageHashes
   query.cursor = request.paginationCursor
   query.direction = request.paginationForward
+  query.requestId = request.requestId
 
   if request.paginationLimit.isSome():
     query.pageSize = uint(request.paginationLimit.get())

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -145,6 +145,7 @@ proc findMessages*(
       hashes = query.hashes,
       maxPageSize = maxPageSize + 1,
       ascendingOrder = isAscendingOrder,
+      requestId = query.requestId,
     )
   ).valueOr:
     return err(ArchiveError(kind: ArchiveErrorKind.DRIVER_ERROR, cause: error))

--- a/waku/waku_archive/common.nim
+++ b/waku/waku_archive/common.nim
@@ -18,6 +18,7 @@ type
     hashes*: seq[WakuMessageHash]
     pageSize*: uint
     direction*: PagingDirection
+    requestId*: string
 
   ArchiveResponse* = object
     hashes*: seq[WakuMessageHash]

--- a/waku/waku_archive/driver.nim
+++ b/waku/waku_archive/driver.nim
@@ -37,6 +37,7 @@ method getMessages*(
     hashes = newSeq[WakuMessageHash](0),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
+    requestId = "",
 ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async.} =
   discard
 

--- a/waku/waku_archive/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive/driver/queue_driver/queue_driver.nim
@@ -256,6 +256,7 @@ method getMessages*(
     hashes: seq[WakuMessageHash] = @[],
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
+    requestId = "",
 ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   var index = none(Index)
 

--- a/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive/driver/sqlite_driver/sqlite_driver.nim
@@ -83,6 +83,7 @@ method getMessages*(
     hashes = newSeq[WakuMessageHash](0),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
+    requestId = "",
 ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   if not includeData:
     return s.db.selectMessageHashesByStoreQueryWithLimit(

--- a/waku/waku_archive_legacy/archive.nim
+++ b/waku/waku_archive_legacy/archive.nim
@@ -151,6 +151,7 @@ proc findMessages*(
       hashes = query.hashes,
       maxPageSize = maxPageSize + 1,
       ascendingOrder = isAscendingOrder,
+      requestId = query.requestId,
     )
   ).valueOr:
     return err(ArchiveError(kind: ArchiveErrorKind.DRIVER_ERROR, cause: error))
@@ -230,6 +231,7 @@ proc findMessagesV2*(
       endTime = query.endTime,
       maxPageSize = maxPageSize + 1,
       ascendingOrder = isAscendingOrder,
+      requestId = query.requestId,
     )
   ).valueOr:
     return err(ArchiveError(kind: ArchiveErrorKind.DRIVER_ERROR, cause: error))

--- a/waku/waku_archive_legacy/common.nim
+++ b/waku/waku_archive_legacy/common.nim
@@ -52,6 +52,7 @@ type
     hashes*: seq[WakuMessageHash]
     pageSize*: uint
     direction*: PagingDirection
+    requestId*: string
 
   ArchiveResponse* = object
     hashes*: seq[WakuMessageHash]

--- a/waku/waku_archive_legacy/driver.nim
+++ b/waku/waku_archive_legacy/driver.nim
@@ -41,6 +41,7 @@ method getMessagesV2*(
     endTime = none(Timestamp),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
+    requestId: string,
 ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, deprecated, async.} =
   discard
 
@@ -55,6 +56,7 @@ method getMessages*(
     hashes = newSeq[WakuMessageHash](0),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
+    requestId = "",
 ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.base, async.} =
   discard
 

--- a/waku/waku_archive_legacy/driver/queue_driver/queue_driver.nim
+++ b/waku/waku_archive_legacy/driver/queue_driver/queue_driver.nim
@@ -268,6 +268,7 @@ method getMessages*(
     hashes: seq[WakuMessageHash] = @[],
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
+    requestId = "",
 ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   let cursor = cursor.map(toIndex)
 

--- a/waku/waku_archive_legacy/driver/sqlite_driver/sqlite_driver.nim
+++ b/waku/waku_archive_legacy/driver/sqlite_driver/sqlite_driver.nim
@@ -93,9 +93,8 @@ method getMessagesV2*(
     endTime = none(Timestamp),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
+    requestId: string,
 ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async, deprecated.} =
-  echo "here"
-
   let cursor = cursor.map(toDbCursor)
 
   let rowsRes = s.db.selectMessagesByHistoryQueryWithLimit(
@@ -121,6 +120,7 @@ method getMessages*(
     hashes = newSeq[WakuMessageHash](0),
     maxPageSize = DefaultPageSize,
     ascendingOrder = true,
+    requestId = "",
 ): Future[ArchiveDriverResult[seq[ArchiveRow]]] {.async.} =
   let cursor =
     if cursor.isSome():

--- a/waku/waku_store/client.nim
+++ b/waku/waku_store/client.nim
@@ -24,7 +24,8 @@ proc sendStoreRequest(
 ): Future[StoreQueryResult] {.async, gcsafe.} =
   var req = request
 
-  req.requestId = generateRequestId(self.rng)
+  if req.requestId == "":
+    req.requestId = generateRequestId(self.rng)
 
   let writeRes = catch:
     await connection.writeLP(req.encode().buffer)

--- a/waku/waku_store_legacy/client.nim
+++ b/waku/waku_store_legacy/client.nim
@@ -43,7 +43,13 @@ proc sendHistoryQueryRPC(
 
   let connection = connOpt.get()
 
-  let reqRpc = HistoryRPC(requestId: generateRequestId(w.rng), query: some(req.toRPC()))
+  let requestId =
+    if req.requestId != "":
+      req.requestId
+    else:
+      generateRequestId(w.rng)
+
+  let reqRpc = HistoryRPC(requestId: requestId, query: some(req.toRPC()))
   await connection.writeLP(reqRpc.encode().buffer)
 
   #TODO: I see a challenge here, if storeNode uses a different MaxRPCSize this read will fail.

--- a/waku/waku_store_legacy/common.nim
+++ b/waku/waku_store_legacy/common.nim
@@ -45,6 +45,7 @@ type
     endTime*: Option[Timestamp]
     pageSize*: uint64
     direction*: PagingDirection
+    requestId*: string
 
   HistoryResponse* = object
     messages*: seq[WakuMessage]

--- a/waku/waku_store_legacy/protocol.nim
+++ b/waku/waku_store_legacy/protocol.nim
@@ -58,9 +58,9 @@ proc handleLegacyQueryRequest(
     # TODO: Return (BAD_REQUEST, cause: "empty query")
     return
 
-  let
-    requestId = reqRpc.requestId
-    request = reqRpc.query.get().toAPI()
+  let requestId = reqRpc.requestId
+  var request = reqRpc.query.get().toAPI()
+  request.requestId = requestId
 
   info "received history query",
     peerId = requestor, requestId = requestId, query = request


### PR DESCRIPTION
## Description
Better track the `requestId` that comes from `store` requests to lower layers (archive/database) so that we can link requests with slow queries

## Changes
- Pass down the `requestId` value from store layer to the database layer.
- `pgasyncpool.nim`: Print information for queries slower than 2 seconds.
- `client.nim`: allow sending custom `requestId`.
- Adapt tests a little because now some tests checks the returned `requested` vs the sent `requestId` and they failed because we are adding the `requestId` field in the `ArchiveQuery` object.
