### PR TITLE
chore: deprecating pubsub topic

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -6,7 +6,7 @@ when not (compileOption("threads")):
 
 {.push raises: [].}
 
-import std/[strformat, strutils, times, options, random]
+import std/[strformat, strutils, times, options, random, sequtils]
 import
   confutils,
   chronicles,
@@ -379,7 +379,9 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
     raise newException(ConfigurationError, "rln-relay-cred-path MUST be passed")
 
   if conf.relay:
-    await node.mountRelay(conf.topics.split(" "))
+    let shards =
+      conf.shards.mapIt(RelayShard(clusterId: conf.clusterId, shardId: uint16(it)))
+    await node.mountRelay(shards)
 
   await node.mountLibp2pPing()
 

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -83,11 +83,18 @@ type
       name: "keep-alive"
     .}: bool
 
-    topics* {.
-      desc: "Default topics to subscribe to (space separated list).",
-      defaultValue: "/waku/2/rs/0/0",
-      name: "topics"
-    .}: string
+    clusterId* {.
+      desc:
+        "Cluster id that the node is running in. Node in a different cluster id is disconnected.",
+      defaultValue: 0,
+      name: "cluster-id"
+    .}: uint16
+
+    shards* {.
+      desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
+      defaultValue: @[uint16(0)],
+      name: "shard"
+    .}: seq[uint16]
 
     ## Store config
     store* {.

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -91,7 +91,8 @@ type
     .}: uint16
 
     shards* {.
-      desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
+      desc:
+        "Shards index to subscribe to [0..NUM_SHARDS_IN_NETWORK-1]. Argument may be repeated.",
       defaultValue: @[uint16(0)],
       name: "shard"
     .}: seq[uint16]

--- a/apps/chat2bridge/config_chat2bridge.nim
+++ b/apps/chat2bridge/config_chat2bridge.nim
@@ -67,12 +67,6 @@ type Chat2MatterbridgeConf* = object
     name: "nodekey"
   .}: crypto.PrivateKey
 
-  topics* {.
-    desc: "Default topics to subscribe to (space separated list)",
-    defaultValue: "/waku/2/rs/0/0",
-    name: "topics"
-  .}: string
-
   store* {.
     desc: "Flag whether to start store protocol", defaultValue: true, name: "store"
   .}: bool

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -98,7 +98,7 @@ type LiteProtocolTesterConf* = object
 
   ## TODO: extend lite protocol tester configuration based on testing needs
   # shards* {.
-  #   desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
+  #   desc: "Shards index to subscribe to [0..NUM_SHARDS_IN_NETWORK-1]. Argument may be repeated.",
   #   defaultValue: @[],
   #   name: "shard"
   # .}: seq[uint16]

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -567,10 +567,10 @@ when isMainModule:
     conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
     conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
     conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
-    conf.networkShards = twnClusterConf.networkShards
+    conf.numShardsInNetwork = twnClusterConf.numShardsInNetwork
 
     if conf.shards.len == 0:
-      conf.shards = toSeq(uint16(0) .. uint16(twnClusterConf.networkShards - 1))
+      conf.shards = toSeq(uint16(0) .. uint16(twnClusterConf.numShardsInNetwork - 1))
 
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -441,10 +441,12 @@ proc initAndStartApp(
     ipAddr = some(extIp), tcpPort = some(nodeTcpPort), udpPort = some(nodeUdpPort)
   )
   builder.withWakuCapabilities(flags)
-  let addShardedTopics = builder.withShardedTopics(conf.pubsubTopics)
-  if addShardedTopics.isErr():
-    error "failed to add sharded topics to ENR", error = addShardedTopics.error
-    return err($addShardedTopics.error)
+
+  builder.withWakuRelaySharding(
+    RelayShards(clusterId: conf.clusterId, shardIds: conf.shards)
+  ).isOkOr:
+    error "failed to add sharded topics to ENR", error = error
+    return err("failed to add sharded topics to ENR: " & $error)
 
   let recordRes = builder.build()
   let record =
@@ -561,7 +563,6 @@ when isMainModule:
     let twnClusterConf = ClusterConf.TheWakuNetworkConf()
 
     conf.bootstrapNodes = twnClusterConf.discv5BootstrapNodes
-    conf.pubsubTopics = twnClusterConf.pubsubTopics
     conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
     conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
     conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -43,8 +43,9 @@ type NetworkMonitorConf* = object
     name: "shard"
   .}: seq[uint16]
 
-  networkShards* {.desc: "Number of shards in the network", name: "network-shards".}:
-    uint32
+  numShardsInNetwork* {.
+    desc: "Number of shards in the network", name: "num-shards-in-network"
+  .}: uint32
 
   refreshInterval* {.
     desc: "How often new peers are discovered and connected to (in seconds)",

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -39,7 +39,8 @@ type NetworkMonitorConf* = object
   .}: string
 
   shards* {.
-    desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
+    desc:
+      "Shards index to subscribe to [0..NUM_SHARDS_IN_NETWORK-1]. Argument may be repeated.",
     name: "shard"
   .}: seq[uint16]
 

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -38,10 +38,13 @@ type NetworkMonitorConf* = object
     name: "dns-discovery-url"
   .}: string
 
-  pubsubTopics* {.
-    desc: "Default pubsub topic to subscribe to. Argument may be repeated.",
-    name: "pubsub-topic"
-  .}: seq[string]
+  shards* {.
+    desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
+    name: "shard"
+  .}: seq[uint16]
+
+  networkShards* {.desc: "Number of shards in the network", name: "network-shards".}:
+    uint16
 
   refreshInterval* {.
     desc: "How often new peers are discovered and connected to (in seconds)",
@@ -55,7 +58,7 @@ type NetworkMonitorConf* = object
       "Cluster id that the node is running in. Node in a different cluster id is disconnected.",
     defaultValue: 1,
     name: "cluster-id"
-  .}: uint32
+  .}: uint16
 
   rlnRelay* {.
     desc: "Enable spam protection through rln-relay: true|false",

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -44,7 +44,7 @@ type NetworkMonitorConf* = object
   .}: seq[uint16]
 
   networkShards* {.desc: "Number of shards in the network", name: "network-shards".}:
-    uint16
+    uint32
 
   refreshInterval* {.
     desc: "How often new peers are discovered and connected to (in seconds)",

--- a/apps/wakucanary/wakucanary.nim
+++ b/apps/wakucanary/wakucanary.nim
@@ -81,7 +81,8 @@ type WakuCanaryConf* = object
   .}: bool
 
   shards* {.
-    desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
+    desc:
+      "Shards index to subscribe to [0..NUM_SHARDS_IN_NETWORK-1]. Argument may be repeated.",
     defaultValue: @[],
     name: "shard",
     abbr: "s"

--- a/docs/operators/how-to/run.md
+++ b/docs/operators/how-to/run.md
@@ -18,7 +18,7 @@ By default a nwaku node will:
 See [this tutorial](./configure-key.md) if you want to generate and configure a persistent private key.
 - listen for incoming libp2p connections on the default TCP port (`60000`)
 - enable `relay` protocol
-- subscribe to the default pubsub topic, namely `/waku/2/rs/0/0`
+- subscribe to the default clusterId (0) and shard (0)
 - enable `store` protocol, but only as a client.
 This implies that the nwaku node will not persist any historical messages itself,
 but can query `store` service peers who do so.

--- a/tests/node/peer_manager/test_peer_manager.nim
+++ b/tests/node/peer_manager/test_peer_manager.nim
@@ -20,8 +20,6 @@ suite "Peer Manager":
       serverKey {.threadvar.}: PrivateKey
       clientKey {.threadvar.}: PrivateKey
       clusterId {.threadvar.}: uint64
-      shardTopic0 {.threadvar.}: string
-      shardTopic1 {.threadvar.}: string
 
     asyncSetup:
       listenPort = Port(0)
@@ -29,16 +27,16 @@ suite "Peer Manager":
       serverKey = generateSecp256k1Key()
       clientKey = generateSecp256k1Key()
       clusterId = 1
-      shard0 = RelayShard(clusterId: clusterId, shardId: 0)
-      shard1 = RelayShard(clusterId: clusterId, shardId: 1)
 
     asyncTest "light client is not disconnected":
       # Given two nodes with the same shardId
       let
-        server =
-          newTestWakuNode(serverKey, listenAddress, listenPort, shards = @[shard0])
-        client =
-          newTestWakuNode(clientKey, listenAddress, listenPort, shards = @[shard1])
+        server = newTestWakuNode(
+          serverKey, listenAddress, listenPort, clusterId = clusterId, shards = @[0]
+        )
+        client = newTestWakuNode(
+          clientKey, listenAddress, listenPort, clusterId = clusterId, shards = @[1]
+        )
 
       # And both mount metadata and filter
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic
@@ -68,10 +66,12 @@ suite "Peer Manager":
     asyncTest "relay with same shardId is not disconnected":
       # Given two nodes with the same shardId
       let
-        server =
-          newTestWakuNode(serverKey, listenAddress, listenPort, shards = @[shard0])
-        client =
-          newTestWakuNode(clientKey, listenAddress, listenPort, shards = @[shard1])
+        server = newTestWakuNode(
+          serverKey, listenAddress, listenPort, clusterId = clusterId, shards = @[0]
+        )
+        client = newTestWakuNode(
+          clientKey, listenAddress, listenPort, clusterId = clusterId, shards = @[1]
+        )
 
       # And both mount metadata and relay
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic
@@ -99,10 +99,12 @@ suite "Peer Manager":
     asyncTest "relay with different shardId is disconnected":
       # Given two nodes with different shardIds
       let
-        server =
-          newTestWakuNode(serverKey, listenAddress, listenPort, shards = @[shard0])
-        client =
-          newTestWakuNode(clientKey, listenAddress, listenPort, shards = @[shard1])
+        server = newTestWakuNode(
+          serverKey, listenAddress, listenPort, clusterId = clusterId, shards = @[0]
+        )
+        client = newTestWakuNode(
+          clientKey, listenAddress, listenPort, clusterId = clusterId, shards = @[1]
+        )
 
       # And both mount metadata and relay
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic

--- a/tests/node/peer_manager/test_peer_manager.nim
+++ b/tests/node/peer_manager/test_peer_manager.nim
@@ -29,18 +29,16 @@ suite "Peer Manager":
       serverKey = generateSecp256k1Key()
       clientKey = generateSecp256k1Key()
       clusterId = 1
-      shardTopic0 = "/waku/2/rs/" & $clusterId & "/0"
-      shardTopic1 = "/waku/2/rs/" & $clusterId & "/1"
+      shard0 = RelayShard(clusterId: clusterId, shardId: 0)
+      shard1 = RelayShard(clusterId: clusterId, shardId: 1)
 
     asyncTest "light client is not disconnected":
       # Given two nodes with the same shardId
       let
-        server = newTestWakuNode(
-          serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0]
-        )
-        client = newTestWakuNode(
-          clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic1]
-        )
+        server =
+          newTestWakuNode(serverKey, listenAddress, listenPort, shards = @[shard0])
+        client =
+          newTestWakuNode(clientKey, listenAddress, listenPort, shards = @[shard1])
 
       # And both mount metadata and filter
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic
@@ -70,12 +68,10 @@ suite "Peer Manager":
     asyncTest "relay with same shardId is not disconnected":
       # Given two nodes with the same shardId
       let
-        server = newTestWakuNode(
-          serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0]
-        )
-        client = newTestWakuNode(
-          clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0]
-        )
+        server =
+          newTestWakuNode(serverKey, listenAddress, listenPort, shards = @[shard0])
+        client =
+          newTestWakuNode(clientKey, listenAddress, listenPort, shards = @[shard1])
 
       # And both mount metadata and relay
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic
@@ -103,12 +99,10 @@ suite "Peer Manager":
     asyncTest "relay with different shardId is disconnected":
       # Given two nodes with different shardIds
       let
-        server = newTestWakuNode(
-          serverKey, listenAddress, listenPort, pubsubTopics = @[shardTopic0]
-        )
-        client = newTestWakuNode(
-          clientKey, listenAddress, listenPort, pubsubTopics = @[shardTopic1]
-        )
+        server =
+          newTestWakuNode(serverKey, listenAddress, listenPort, shards = @[shard0])
+        client =
+          newTestWakuNode(clientKey, listenAddress, listenPort, shards = @[shard1])
 
       # And both mount metadata and relay
       discard client.mountMetadata(0) # clusterId irrelevant, overridden by topic

--- a/tests/node/test_wakunode_relay_rln.nim
+++ b/tests/node/test_wakunode_relay_rln.nim
@@ -96,9 +96,9 @@ proc getWakuRlnConfigOnChain*(
   )
 
 proc setupRelayWithOnChainRln*(
-    node: WakuNode, pubsubTopics: seq[string], wakuRlnConfig: WakuRlnConfig
+    node: WakuNode, shards: seq[RelayShard], wakuRlnConfig: WakuRlnConfig
 ) {.async.} =
-  await node.mountRelay(pubsubTopics)
+  await node.mountRelay(shards)
   await node.mountRlnRelay(wakuRlnConfig)
 
 suite "Waku RlnRelay - End to End - Static":
@@ -223,7 +223,7 @@ suite "Waku RlnRelay - End to End - Static":
         nodekey = generateSecp256k1Key()
         node = newTestWakuNode(nodekey, parseIpAddress("0.0.0.0"), Port(0))
 
-      await node.mountRelay(@[DefaultPubsubTopic])
+      await node.mountRelay(@[DefaultRelayShard])
 
       let contractAddress = await uploadRLNContract(EthClient)
       let wakuRlnConfig = WakuRlnConfig(

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -418,7 +418,7 @@ procSuite "Peer Manager":
         generateSecp256k1Key(),
         ValidIpAddress.init("0.0.0.0"),
         port,
-        pubsubTopics = @["/waku/2/rs/3/0"],
+        shards = @[RelayShard(clusterId: 3, shardId: 0)],
       )
 
       # same network
@@ -426,13 +426,13 @@ procSuite "Peer Manager":
         generateSecp256k1Key(),
         ValidIpAddress.init("0.0.0.0"),
         port,
-        pubsubTopics = @["/waku/2/rs/4/0"],
+        shards = @[RelayShard(clusterId: 4, shardId: 0)],
       )
       node3 = newTestWakuNode(
         generateSecp256k1Key(),
         ValidIpAddress.init("0.0.0.0"),
         port,
-        pubsubTopics = @["/waku/2/rs/4/0"],
+        shards = @[RelayShard(clusterId: 4, shardId: 0)],
       )
 
     node1.mountMetadata(3).expect("Mounted Waku Metadata")

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -418,7 +418,8 @@ procSuite "Peer Manager":
         generateSecp256k1Key(),
         ValidIpAddress.init("0.0.0.0"),
         port,
-        shards = @[RelayShard(clusterId: 3, shardId: 0)],
+        clusterId = 3,
+        shards = @[0],
       )
 
       # same network
@@ -426,13 +427,15 @@ procSuite "Peer Manager":
         generateSecp256k1Key(),
         ValidIpAddress.init("0.0.0.0"),
         port,
-        shards = @[RelayShard(clusterId: 4, shardId: 0)],
+        clusterId = 4,
+        shards = @[0],
       )
       node3 = newTestWakuNode(
         generateSecp256k1Key(),
         ValidIpAddress.init("0.0.0.0"),
         port,
-        shards = @[RelayShard(clusterId: 4, shardId: 0)],
+        clusterId = 4,
+        shards = @[0],
       )
 
     node1.mountMetadata(3).expect("Mounted Waku Metadata")

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -419,7 +419,7 @@ procSuite "Peer Manager":
         ValidIpAddress.init("0.0.0.0"),
         port,
         clusterId = 3,
-        shards = @[0],
+        shards = @[uint16(0)],
       )
 
       # same network
@@ -428,14 +428,14 @@ procSuite "Peer Manager":
         ValidIpAddress.init("0.0.0.0"),
         port,
         clusterId = 4,
-        shards = @[0],
+        shards = @[uint16(0)],
       )
       node3 = newTestWakuNode(
         generateSecp256k1Key(),
         ValidIpAddress.init("0.0.0.0"),
         port,
         clusterId = 4,
-        shards = @[0],
+        shards = @[uint16(0)],
       )
 
     node1.mountMetadata(3).expect("Mounted Waku Metadata")

--- a/tests/test_relay_peer_exchange.nim
+++ b/tests/test_relay_peer_exchange.nim
@@ -25,8 +25,8 @@ procSuite "Relay (GossipSub) Peer Exchange":
         newTestWakuNode(node2Key, listenAddress, port, sendSignedPeerRecord = true)
 
     # When both client and server mount relay without a handler
-    await node1.mountRelay(@[DefaultPubsubTopic])
-    await node2.mountRelay(@[DefaultPubsubTopic], none(RoutingRecordsHandler))
+    await node1.mountRelay(@[DefaultRelayShard])
+    await node2.mountRelay(@[DefaultRelayShard], none(RoutingRecordsHandler))
 
     # Then the relays are mounted without a handler
     check:
@@ -75,9 +75,9 @@ procSuite "Relay (GossipSub) Peer Exchange":
       peerExchangeHandle: RoutingRecordsHandler = peerExchangeHandler
 
     # Givem the nodes mount relay with a peer exchange handler
-    await node1.mountRelay(@[DefaultPubsubTopic], some(emptyPeerExchangeHandle))
-    await node2.mountRelay(@[DefaultPubsubTopic], some(emptyPeerExchangeHandle))
-    await node3.mountRelay(@[DefaultPubsubTopic], some(peerExchangeHandle))
+    await node1.mountRelay(@[DefaultRelayShard], some(emptyPeerExchangeHandle))
+    await node2.mountRelay(@[DefaultRelayShard], some(emptyPeerExchangeHandle))
+    await node3.mountRelay(@[DefaultRelayShard], some(peerExchangeHandle))
 
     # Ensure that node1 prunes all peers after the first connection
     node1.wakuRelay.parameters.dHigh = 1

--- a/tests/test_waku_enr.nim
+++ b/tests/test_waku_enr.nim
@@ -280,7 +280,7 @@ suite "Waku ENR - Relay static sharding":
       clusterId: uint16 = 22
       shardId: uint16 = 1
 
-    let shard = RelayShard(clusterId, shardId)
+    let shard = RelayShard(clusterId: clusterId, shardId: shardId)
 
     ## When
     let shardsTopics = RelayShards.init(clusterId, shardId).expect("Valid Shards")

--- a/tests/test_waku_enr.nim
+++ b/tests/test_waku_enr.nim
@@ -280,7 +280,7 @@ suite "Waku ENR - Relay static sharding":
       clusterId: uint16 = 22
       shardId: uint16 = 1
 
-    let shard = RelayShard.staticSharding(clusterId, shardId)
+    let shard = RelayShard(clusterId, shardId)
 
     ## When
     let shardsTopics = RelayShards.init(clusterId, shardId).expect("Valid Shards")

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -58,15 +58,15 @@ suite "WakuNode":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       check:
-        topic == pubSubTopic
+        topic == $shard
         msg.contentTopic == contentTopic
         msg.payload == payload
       completionFut.complete(true)
 
-    node2.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node2.subscribe((kind: PubsubSub, topic: $shard), some(relayHandler))
     await sleepAsync(2000.millis)
 
-    var res = await node1.publish(some(pubSubTopic), message)
+    var res = await node1.publish(some($shard), message)
     assert res.isOk(), $res.error
 
     await sleepAsync(2000.millis)

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -28,7 +28,7 @@ suite "WakuNode":
       node1 = newTestWakuNode(nodeKey1, parseIpAddress("0.0.0.0"), Port(61000))
       nodeKey2 = generateSecp256k1Key()
       node2 = newTestWakuNode(nodeKey2, parseIpAddress("0.0.0.0"), Port(61002))
-      pubSubTopic = "/waku/2/rs/0/0"
+      shard = DefaultRelayShard
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)
@@ -36,13 +36,13 @@ suite "WakuNode":
     # Setup node 1 with stable codec "/vac/waku/relay/2.0.0"
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[shard])
     node1.wakuRelay.codec = "/vac/waku/relay/2.0.0"
 
     # Setup node 2 with beta codec "/vac/waku/relay/2.0.0-beta2"
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[shard])
     node2.wakuRelay.codec = "/vac/waku/relay/2.0.0-beta2"
 
     check:

--- a/tests/test_wakunode_lightpush.nim
+++ b/tests/test_wakunode_lightpush.nim
@@ -19,8 +19,8 @@ suite "WakuNode - Lightpush":
 
     await allFutures(destNode.start(), bridgeNode.start(), lightNode.start())
 
-    await destNode.mountRelay(@[DefaultPubsubTopic])
-    await bridgeNode.mountRelay(@[DefaultPubsubTopic])
+    await destNode.mountRelay(@[DefaultRelayShard])
+    await bridgeNode.mountRelay(@[DefaultRelayShard])
     await bridgeNode.mountLightPush()
     lightNode.mountLightPushClient()
 

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -37,8 +37,8 @@ proc defaultTestWakuNodeConf*(): WakuNodeConf =
     nat: "any",
     maxConnections: 50,
     maxMessageSize: "1024 KiB",
-    clusterId: 0,
-    shards: @[uint16(0)],
+    clusterId: DefaultClusterId,
+    shards: @[DefaultShardId],
     relay: true,
     storeMessageDbUrl: "sqlite://store.sqlite3",
   )

--- a/tests/waku_core/test_namespaced_topics.nim
+++ b/tests/waku_core/test_namespaced_topics.nim
@@ -136,7 +136,7 @@ suite "Waku Message - Content topics namespacing":
 suite "Waku Message - Pub-sub topics namespacing":
   test "Stringify static sharding pub-sub topic":
     ## Given
-    var shard = RelayShard(clusterId = 0, shardId = 2)
+    var shard = RelayShard(clusterId: 0, shardId: 2)
 
     ## When
     let topic = $shard

--- a/tests/waku_core/test_namespaced_topics.nim
+++ b/tests/waku_core/test_namespaced_topics.nim
@@ -136,7 +136,7 @@ suite "Waku Message - Content topics namespacing":
 suite "Waku Message - Pub-sub topics namespacing":
   test "Stringify static sharding pub-sub topic":
     ## Given
-    var shard = RelayShard.staticSharding(clusterId = 0, shardId = 2)
+    var shard = RelayShard(clusterId = 0, shardId = 2)
 
     ## When
     let topic = $shard

--- a/tests/waku_core/topics/test_pubsub_topic.nim
+++ b/tests/waku_core/topics/test_pubsub_topic.nim
@@ -10,10 +10,10 @@ suite "Static Sharding Functionality":
     check:
       shard.clusterId == 0
       shard.shardId == 1
-      shard == RelayShard(0, 1)
+      shard == RelayShard(clusterId: 0, shardId: 1)
 
   test "Pubsub Topic Naming Compliance":
-    let shard = RelayShard(0, 1)
+    let shard = RelayShard(clusterId: 0, shardId: 1)
     check:
       shard.clusterId == 0
       shard.shardId == 1

--- a/tests/waku_core/topics/test_pubsub_topic.nim
+++ b/tests/waku_core/topics/test_pubsub_topic.nim
@@ -10,10 +10,10 @@ suite "Static Sharding Functionality":
     check:
       shard.clusterId == 0
       shard.shardId == 1
-      shard == RelayShard.staticSharding(0, 1)
+      shard == RelayShard(0, 1)
 
   test "Pubsub Topic Naming Compliance":
-    let shard = RelayShard.staticSharding(0, 1)
+    let shard = RelayShard(0, 1)
     check:
       shard.clusterId == 0
       shard.shardId == 1

--- a/tests/waku_core/topics/test_sharding.nim
+++ b/tests/waku_core/topics/test_sharding.nim
@@ -54,16 +54,16 @@ suite "Autosharding":
 
       # Then the generated shards are valid
       check:
-        shard1 == RelayShard(ClusterId, 3)
-        shard2 == RelayShard(ClusterId, 3)
-        shard3 == RelayShard(ClusterId, 6)
-        shard4 == RelayShard(ClusterId, 6)
-        shard5 == RelayShard(ClusterId, 3)
-        shard6 == RelayShard(ClusterId, 3)
-        shard7 == RelayShard(ClusterId, 3)
-        shard8 == RelayShard(ClusterId, 3)
-        shard9 == RelayShard(ClusterId, 7)
-        shard10 == RelayShard(ClusterId, 3)
+        shard1 == RelayShard(clusterId: ClusterId, shardId: 3)
+        shard2 == RelayShard(clusterId: ClusterId, shardId: 3)
+        shard3 == RelayShard(clusterId: ClusterId, shardId: 6)
+        shard4 == RelayShard(clusterId: ClusterId, shardId: 6)
+        shard5 == RelayShard(clusterId: ClusterId, shardId: 3)
+        shard6 == RelayShard(clusterId: ClusterId, shardId: 3)
+        shard7 == RelayShard(clusterId: ClusterId, shardId: 3)
+        shard8 == RelayShard(clusterId: ClusterId, shardId: 3)
+        shard9 == RelayShard(clusterId: ClusterId, shardId: 7)
+        shard10 == RelayShard(clusterId: ClusterId, shardId: 3)
 
   suite "getShard from NsContentTopic":
     test "Generate Gen0 Shard with topic.generation==none":
@@ -75,7 +75,7 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.value() == RelayShard(ClusterId, 3)
+        shard.value() == RelayShard(clusterId: ClusterId, shardId: 3)
 
     test "Generate Gen0 Shard with topic.generation==0":
       let sharding =
@@ -85,7 +85,7 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.value() == RelayShard(ClusterId, 3)
+        shard.value() == RelayShard(clusterId: ClusterId, shardId: 3)
 
     test "Generate Gen0 Shard with topic.generation==other":
       let sharding =
@@ -106,7 +106,7 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.value() == RelayShard(ClusterId, 3)
+        shard.value() == RelayShard(clusterId: ClusterId, shardId: 3)
 
     test "Generate Gen0 Shard with topic.generation==0":
       let sharding =
@@ -116,7 +116,7 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.value() == RelayShard(ClusterId, 3)
+        shard.value() == RelayShard(clusterId: ClusterId, shardId: 3)
 
     test "Generate Gen0 Shard with topic.generation==other":
       let sharding =

--- a/tests/waku_core/topics/test_sharding.nim
+++ b/tests/waku_core/topics/test_sharding.nim
@@ -54,16 +54,16 @@ suite "Autosharding":
 
       # Then the generated shards are valid
       check:
-        shard1 == RelayShard.staticSharding(ClusterId, 3)
-        shard2 == RelayShard.staticSharding(ClusterId, 3)
-        shard3 == RelayShard.staticSharding(ClusterId, 6)
-        shard4 == RelayShard.staticSharding(ClusterId, 6)
-        shard5 == RelayShard.staticSharding(ClusterId, 3)
-        shard6 == RelayShard.staticSharding(ClusterId, 3)
-        shard7 == RelayShard.staticSharding(ClusterId, 3)
-        shard8 == RelayShard.staticSharding(ClusterId, 3)
-        shard9 == RelayShard.staticSharding(ClusterId, 7)
-        shard10 == RelayShard.staticSharding(ClusterId, 3)
+        shard1 == RelayShard(ClusterId, 3)
+        shard2 == RelayShard(ClusterId, 3)
+        shard3 == RelayShard(ClusterId, 6)
+        shard4 == RelayShard(ClusterId, 6)
+        shard5 == RelayShard(ClusterId, 3)
+        shard6 == RelayShard(ClusterId, 3)
+        shard7 == RelayShard(ClusterId, 3)
+        shard8 == RelayShard(ClusterId, 3)
+        shard9 == RelayShard(ClusterId, 7)
+        shard10 == RelayShard(ClusterId, 3)
 
   suite "getShard from NsContentTopic":
     test "Generate Gen0 Shard with topic.generation==none":
@@ -75,7 +75,7 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.value() == RelayShard.staticSharding(ClusterId, 3)
+        shard.value() == RelayShard(ClusterId, 3)
 
     test "Generate Gen0 Shard with topic.generation==0":
       let sharding =
@@ -85,7 +85,7 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.value() == RelayShard.staticSharding(ClusterId, 3)
+        shard.value() == RelayShard(ClusterId, 3)
 
     test "Generate Gen0 Shard with topic.generation==other":
       let sharding =
@@ -106,7 +106,7 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.value() == RelayShard.staticSharding(ClusterId, 3)
+        shard.value() == RelayShard(ClusterId, 3)
 
     test "Generate Gen0 Shard with topic.generation==0":
       let sharding =
@@ -116,7 +116,7 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.value() == RelayShard.staticSharding(ClusterId, 3)
+        shard.value() == RelayShard(ClusterId, 3)
 
     test "Generate Gen0 Shard with topic.generation==other":
       let sharding =

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -63,19 +63,19 @@ suite "WakuNode - Relay":
       node2 = newTestWakuNode(nodeKey2, parseIpAddress("0.0.0.0"), Port(0))
       nodeKey3 = generateSecp256k1Key()
       node3 = newTestWakuNode(nodeKey3, parseIpAddress("0.0.0.0"), Port(0))
-      pubSubTopic = "test"
+      shard = DefaultRelayShard
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[shard])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[shard])
 
     await node3.start()
-    await node3.mountRelay(@[pubSubTopic])
+    await node3.mountRelay(@[shard])
 
     await allFutures(
       node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()]),
@@ -87,15 +87,15 @@ suite "WakuNode - Relay":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       check:
-        topic == pubSubTopic
+        topic == $shard
         msg.contentTopic == contentTopic
         msg.payload == payload
       completionFut.complete(true)
 
-    node3.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node3.subscribe((kind: PubsubSub, topic: $shard), some(relayHandler))
     await sleepAsync(500.millis)
 
-    var res = await node1.publish(some(pubSubTopic), message)
+    var res = await node1.publish(some($shard), message)
     assert res.isOk(), $res.error
 
     ## Then
@@ -124,7 +124,7 @@ suite "WakuNode - Relay":
       nodeKey3 = generateSecp256k1Key()
       node3 = newTestWakuNode(nodeKey3, parseIpAddress("0.0.0.0"), Port(0))
 
-      pubSubTopic = "test"
+      shard = DefaultRelayShard
       contentTopic1 = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message1 = WakuMessage(payload: payload, contentTopic: contentTopic1)
@@ -135,13 +135,13 @@ suite "WakuNode - Relay":
 
     # start all the nodes
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[shard])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[shard])
 
     await node3.start()
-    await node3.mountRelay(@[pubSubTopic])
+    await node3.mountRelay(@[shard])
 
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
     await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
@@ -155,7 +155,7 @@ suite "WakuNode - Relay":
     ): Future[ValidationResult] {.async.} =
       ## the validator that only allows messages with contentTopic1 to be relayed
       check:
-        topic == pubSubTopic
+        topic == $shard
 
       # only relay messages with contentTopic1
       if msg.contentTopic != contentTopic1:
@@ -172,22 +172,22 @@ suite "WakuNode - Relay":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       check:
-        topic == pubSubTopic
+        topic == $shard
         # check that only messages with contentTopic1 is relayed (but not contentTopic2)
         msg.contentTopic == contentTopic1
       # relay handler is called
       completionFut.complete(true)
 
-    node3.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node3.subscribe((kind: PubsubSub, topic: $shard), some(relayHandler))
     await sleepAsync(500.millis)
 
-    var res = await node1.publish(some(pubSubTopic), message1)
+    var res = await node1.publish(some($shard), message1)
     assert res.isOk(), $res.error
 
     await sleepAsync(500.millis)
 
     # message2 never gets relayed because of the validator
-    res = await node1.publish(some(pubSubTopic), message2)
+    res = await node1.publish(some($shard), message2)
     assert res.isOk(), $res.error
 
     await sleepAsync(500.millis)
@@ -258,16 +258,16 @@ suite "WakuNode - Relay":
         wsBindPort = Port(0),
         wsEnabled = true,
       )
-      pubSubTopic = "test"
+      pubSubTopic = DefaultRelayShard
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[shard])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[shard])
 
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
@@ -276,15 +276,15 @@ suite "WakuNode - Relay":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       check:
-        topic == pubSubTopic
+        topic == $shard
         msg.contentTopic == contentTopic
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe((kind: PubsubSub, topic: $shard), some(relayHandler))
     await sleepAsync(500.millis)
 
-    let res = await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some($shard), message)
     assert res.isOk(), $res.error
 
     await sleepAsync(500.millis)
@@ -306,16 +306,16 @@ suite "WakuNode - Relay":
       )
       nodeKey2 = generateSecp256k1Key()
       node2 = newTestWakuNode(nodeKey2, parseIpAddress("0.0.0.0"), bindPort = Port(0))
-      pubSubTopic = "test"
+      shard = DefaultRelayShard
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[shard])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[shard])
 
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
@@ -324,15 +324,15 @@ suite "WakuNode - Relay":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       check:
-        topic == pubSubTopic
+        topic == $shard
         msg.contentTopic == contentTopic
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe((kind: PubsubSub, topic: $shard), some(relayHandler))
     await sleepAsync(500.millis)
 
-    let res = await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some($shard), message)
     assert res.isOk(), $res.error
 
     await sleepAsync(500.millis)
@@ -354,16 +354,16 @@ suite "WakuNode - Relay":
         wsBindPort = Port(0),
         wsEnabled = true,
       )
-      pubSubTopic = "test"
+      shard = DefaultRelayShard
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[shard])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[shard])
 
     #delete websocket peer address
     # TODO: a better way to find the index - this is too brittle
@@ -376,15 +376,15 @@ suite "WakuNode - Relay":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       check:
-        topic == pubSubTopic
+        topic == $shard
         msg.contentTopic == contentTopic
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe((kind: PubsubSub, topic: $shard), some(relayHandler))
     await sleepAsync(500.millis)
 
-    let res = await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some($shard), message)
     assert res.isOk(), $res.error
 
     await sleepAsync(500.millis)
@@ -408,16 +408,16 @@ suite "WakuNode - Relay":
       )
       nodeKey2 = generateSecp256k1Key()
       node2 = newTestWakuNode(nodeKey2, parseIpAddress("0.0.0.0"), bindPort = Port(0))
-      pubSubTopic = "test"
+      shard = DefaultRelayShard
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[shard])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[shard])
 
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
@@ -426,15 +426,15 @@ suite "WakuNode - Relay":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       check:
-        topic == pubSubTopic
+        topic == $shard
         msg.contentTopic == contentTopic
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe((kind: PubsubSub, topic: $shard), some(relayHandler))
     await sleepAsync(500.millis)
 
-    let res = await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some($shard), message)
     assert res.isOk(), $res.error
 
     await sleepAsync(500.millis)
@@ -466,16 +466,16 @@ suite "WakuNode - Relay":
       )
 
     let
-      pubSubTopic = "test"
+      shard = DefaultRelayShard
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)
 
     await node1.start()
-    await node1.mountRelay(@[pubSubTopic])
+    await node1.mountRelay(@[shard])
 
     await node2.start()
-    await node2.mountRelay(@[pubSubTopic])
+    await node2.mountRelay(@[shard])
 
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
@@ -484,15 +484,15 @@ suite "WakuNode - Relay":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       check:
-        topic == pubSubTopic
+        topic == $shard
         msg.contentTopic == contentTopic
         msg.payload == payload
       completionFut.complete(true)
 
-    node1.subscribe((kind: PubsubSub, topic: pubsubTopic), some(relayHandler))
+    node1.subscribe((kind: PubsubSub, topic: $shard), some(relayHandler))
     await sleepAsync(500.millis)
 
-    let res = await node2.publish(some(pubSubTopic), message)
+    let res = await node2.publish(some($shard), message)
     assert res.isOk(), $res.error
 
     await sleepAsync(500.millis)

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -258,7 +258,7 @@ suite "WakuNode - Relay":
         wsBindPort = Port(0),
         wsEnabled = true,
       )
-      pubSubTopic = DefaultRelayShard
+      shard = DefaultRelayShard
       contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)

--- a/tests/waku_relay/utils.nim
+++ b/tests/waku_relay/utils.nim
@@ -53,9 +53,9 @@ proc setupRln*(node: WakuNode, identifier: uint) {.async.} =
   )
 
 proc setupRelayWithRln*(
-    node: WakuNode, identifier: uint, pubsubTopics: seq[string]
+    node: WakuNode, identifier: uint, shards: seq[RelayShards]
 ) {.async.} =
-  await node.mountRelay(pubsubTopics)
+  await node.mountRelay(shards)
   await setupRln(node, identifier)
 
 proc subscribeToContentTopicWithHandler*(

--- a/tests/waku_relay/utils.nim
+++ b/tests/waku_relay/utils.nim
@@ -53,7 +53,7 @@ proc setupRln*(node: WakuNode, identifier: uint) {.async.} =
   )
 
 proc setupRelayWithRln*(
-    node: WakuNode, identifier: uint, shards: seq[RelayShards]
+    node: WakuNode, identifier: uint, shards: seq[RelayShard]
 ) {.async.} =
   await node.mountRelay(shards)
   await setupRln(node, identifier)

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -139,7 +139,7 @@ procSuite "WakuNode - RLN relay":
     await allFutures(nodes.mapIt(it.start()))
 
     let shards =
-      @[RelayShard(clusterId: 0, shard: 0), RelayShard(clusterId: 0, shard: 1)]
+      @[RelayShard(clusterId: 0, shardId: 0), RelayShard(clusterId: 0, shardId: 1)]
     let contentTopics =
       @[
         ContentTopic("/waku/2/content-topic-a/proto"),

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -50,7 +50,7 @@ procSuite "WakuNode - RLN relay":
 
     # set up three nodes
     # node1
-    await node1.mountRelay(@[DefaultPubsubTopic])
+    await node1.mountRelay(@[DefaultRelayShard])
 
     # mount rlnrelay in off-chain mode
     let wakuRlnConfig1 = WakuRlnConfig(
@@ -66,7 +66,7 @@ procSuite "WakuNode - RLN relay":
     await node1.start()
 
     # node 2
-    await node2.mountRelay(@[DefaultPubsubTopic])
+    await node2.mountRelay(@[DefaultRelayShard])
     # mount rlnrelay in off-chain mode
     let wakuRlnConfig2 = WakuRlnConfig(
       rlnRelayDynamic: false,
@@ -81,7 +81,7 @@ procSuite "WakuNode - RLN relay":
     await node2.start()
 
     # node 3
-    await node3.mountRelay(@[DefaultPubsubTopic])
+    await node3.mountRelay(@[DefaultRelayShard])
 
     let wakuRlnConfig3 = WakuRlnConfig(
       rlnRelayDynamic: false,
@@ -131,18 +131,15 @@ procSuite "WakuNode - RLN relay":
     await node2.stop()
     await node3.stop()
 
-  asyncTest "testing rln-relay is applied in all rln pubsub/content topics":
+  asyncTest "testing rln-relay is applied in all rln shards/content topics":
     # create 3 nodes
     let nodes = toSeq(0 ..< 3).mapIt(
         newTestWakuNode(generateSecp256k1Key(), parseIpAddress("0.0.0.0"), Port(0))
       )
     await allFutures(nodes.mapIt(it.start()))
 
-    let pubsubTopics =
-      @[
-        PubsubTopic("/waku/2/pubsubtopic-a/proto"),
-        PubsubTopic("/waku/2/pubsubtopic-b/proto"),
-      ]
+    let shards =
+      @[RelayShard(clusterId: 0, shard: 0), RelayShard(clusterId: 0, shard: 1)]
     let contentTopics =
       @[
         ContentTopic("/waku/2/content-topic-a/proto"),
@@ -150,7 +147,7 @@ procSuite "WakuNode - RLN relay":
       ]
 
     # set up three nodes
-    await allFutures(nodes.mapIt(it.mountRelay(pubsubTopics)))
+    await allFutures(nodes.mapIt(it.mountRelay(shards)))
 
     # mount rlnrelay in off-chain mode
     for index, node in nodes:
@@ -245,7 +242,7 @@ procSuite "WakuNode - RLN relay":
 
     # set up three nodes
     # node1
-    await node1.mountRelay(@[DefaultPubsubTopic])
+    await node1.mountRelay(@[DefaultRelayShard])
 
     # mount rlnrelay in off-chain mode
     let wakuRlnConfig1 = WakuRlnConfig(
@@ -261,7 +258,7 @@ procSuite "WakuNode - RLN relay":
     await node1.start()
 
     # node 2
-    await node2.mountRelay(@[DefaultPubsubTopic])
+    await node2.mountRelay(@[DefaultRelayShard])
     # mount rlnrelay in off-chain mode
     let wakuRlnConfig2 = WakuRlnConfig(
       rlnRelayDynamic: false,
@@ -276,7 +273,7 @@ procSuite "WakuNode - RLN relay":
     await node2.start()
 
     # node 3
-    await node3.mountRelay(@[DefaultPubsubTopic])
+    await node3.mountRelay(@[DefaultRelayShard])
 
     let wakuRlnConfig3 = WakuRlnConfig(
       rlnRelayDynamic: false,
@@ -361,7 +358,7 @@ procSuite "WakuNode - RLN relay":
 
     # set up three nodes
     # node1
-    await node1.mountRelay(@[DefaultPubsubTopic])
+    await node1.mountRelay(@[DefaultRelayShard])
 
     # mount rlnrelay in off-chain mode
     let wakuRlnConfig1 = WakuRlnConfig(
@@ -377,7 +374,7 @@ procSuite "WakuNode - RLN relay":
     await node1.start()
 
     # node 2
-    await node2.mountRelay(@[DefaultPubsubTopic])
+    await node2.mountRelay(@[DefaultRelayShard])
 
     # mount rlnrelay in off-chain mode
     let wakuRlnConfig2 = WakuRlnConfig(
@@ -392,7 +389,7 @@ procSuite "WakuNode - RLN relay":
     await node2.start()
 
     # node 3
-    await node3.mountRelay(@[DefaultPubsubTopic])
+    await node3.mountRelay(@[DefaultRelayShard])
 
     # mount rlnrelay in off-chain mode
     let wakuRlnConfig3 = WakuRlnConfig(
@@ -485,7 +482,7 @@ procSuite "WakuNode - RLN relay":
     # Given two nodes
     let
       contentTopic = ContentTopic("/waku/2/default-content/proto")
-      pubsubTopicSeq = @[DefaultPubsubTopic]
+      shardSeq = @[DefaultRelayShard]
       nodeKey1 = generateSecp256k1Key()
       node1 = newTestWakuNode(nodeKey1, parseIpAddress("0.0.0.0"), Port(0))
       nodeKey2 = generateSecp256k1Key()
@@ -493,12 +490,12 @@ procSuite "WakuNode - RLN relay":
       epochSizeSec: uint64 = 5 # This means rlnMaxEpochGap = 4
 
     # Given both nodes mount relay and rlnrelay
-    await node1.mountRelay(pubsubTopicSeq)
+    await node1.mountRelay(shardSeq)
     let wakuRlnConfig1 = buildWakuRlnConfig(1, epochSizeSec, "wakunode_10")
     await node1.mountRlnRelay(wakuRlnConfig1)
 
     # Mount rlnrelay in node2 in off-chain mode
-    await node2.mountRelay(@[DefaultPubsubTopic])
+    await node2.mountRelay(@[DefaultRelayShard])
     let wakuRlnConfig2 = buildWakuRlnConfig(2, epochSizeSec, "wakunode_11")
     await node2.mountRlnRelay(wakuRlnConfig2)
 
@@ -613,7 +610,7 @@ procSuite "WakuNode - RLN relay":
     # Given two nodes
     let
       contentTopic = ContentTopic("/waku/2/default-content/proto")
-      pubsubTopicSeq = @[DefaultPubsubTopic]
+      shardSeq = @[DefaultRelayShard]
       nodeKey1 = generateSecp256k1Key()
       node1 = newTestWakuNode(nodeKey1, parseIpAddress("0.0.0.0"), Port(0))
       nodeKey2 = generateSecp256k1Key()
@@ -622,12 +619,12 @@ procSuite "WakuNode - RLN relay":
 
     # Given both nodes mount relay and rlnrelay
     # Mount rlnrelay in node1 in off-chain mode
-    await node1.mountRelay(pubsubTopicSeq)
+    await node1.mountRelay(shardSeq)
     let wakuRlnConfig1 = buildWakuRlnConfig(1, epochSizeSec, "wakunode_10")
     await node1.mountRlnRelay(wakuRlnConfig1)
 
     # Mount rlnrelay in node2 in off-chain mode
-    await node2.mountRelay(@[DefaultPubsubTopic])
+    await node2.mountRelay(@[DefaultRelayShard])
     let wakuRlnConfig2 = buildWakuRlnConfig(2, epochSizeSec, "wakunode_11")
     await node2.mountRlnRelay(wakuRlnConfig2)
 

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -174,14 +174,14 @@ procSuite "WakuNode - RLN relay":
         topic: PubsubTopic, msg: WakuMessage
     ): Future[void] {.async, gcsafe.} =
       info "relayHandler. The received topic:", topic
-      if topic == pubsubTopics[0]:
+      if topic == $shards[0]:
         rxMessagesTopic1 = rxMessagesTopic1 + 1
-      elif topic == pubsubTopics[1]:
+      elif topic == $shards[1]:
         rxMessagesTopic2 = rxMessagesTopic2 + 1
 
     # mount the relay handlers
-    nodes[2].subscribe((kind: PubsubSub, topic: pubsubTopics[0]), some(relayHandler))
-    nodes[2].subscribe((kind: PubsubSub, topic: pubsubTopics[1]), some(relayHandler))
+    nodes[2].subscribe((kind: PubsubSub, topic: $shards[0]), some(relayHandler))
+    nodes[2].subscribe((kind: PubsubSub, topic: $shards[1]), some(relayHandler))
     await sleepAsync(1000.millis)
 
     # generate some messages with rln proofs first. generating
@@ -211,9 +211,9 @@ procSuite "WakuNode - RLN relay":
     # publish 3 messages from node[0] (last 2 are spam, window is 10 secs)
     # publish 3 messages from node[1] (last 2 are spam, window is 10 secs)
     for msg in messages1:
-      discard await nodes[0].publish(some(pubsubTopics[0]), msg)
+      discard await nodes[0].publish(some($shards[0]), msg)
     for msg in messages2:
-      discard await nodes[1].publish(some(pubsubTopics[1]), msg)
+      discard await nodes[1].publish(some($shards[1]), msg)
 
     # wait for gossip to propagate
     await sleepAsync(5000.millis)

--- a/tests/waku_rln_relay/utils_static.nim
+++ b/tests/waku_rln_relay/utils_static.nim
@@ -32,9 +32,9 @@ proc setupStaticRln*(
   )
 
 proc setupRelayWithStaticRln*(
-    node: WakuNode, identifier: uint, pubsubTopics: seq[string]
+    node: WakuNode, identifier: uint, shards: seq[RelayShard]
 ) {.async.} =
-  await node.mountRelay(pubsubTopics)
+  await node.mountRelay(shards)
   await setupStaticRln(node, identifier)
 
 proc subscribeCompletionHandler*(node: WakuNode, pubsubTopic: string): Future[bool] =

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -95,7 +95,7 @@ suite "Waku v2 Rest API - Relay":
       shard3 = RelayShard(clusterId: DefaultClusterId, shardId: 3)
       shard4 = RelayShard(clusterId: DefaultClusterId, shardId: 4)
 
-    await node.mountRelay(@[$shard0, $shard1, $shard2, $shard3])
+    await node.mountRelay(@[shard0, shard1, shard2, shard3])
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -312,8 +312,11 @@ type WakuNodeConf* = object
       name: "keep-alive"
     .}: bool
 
-    networkShards* {.
-      desc: "Number of shards in the network", defaultValue: 0, name: "network-shards"
+    # If numShardsInNetwork is not set, we use the number of shards configured as numShardsInNetwork
+    numShardsInNetwork* {.
+      desc: "Number of shards in the network",
+      defaultValue: 0,
+      name: "num-shards-in-network"
     .}: uint32
 
     pubsubTopics* {.

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -312,8 +312,9 @@ type WakuNodeConf* = object
       name: "keep-alive"
     .}: bool
 
-    networkShards* {.desc: "Number of shards in the network", name: "network-shards".}:
-      uint32
+    networkShards* {.
+      desc: "Number of shards in the network", defaultValue: 0, name: "network-shards"
+    .}: uint32
 
     pubsubTopics* {.
       desc:

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -315,6 +315,13 @@ type WakuNodeConf* = object
     networkShards* {.desc: "Number of shards in the network", name: "network-shards".}:
       uint32
 
+    pubsubTopics* {.
+      desc:
+        "Deprecated. Default pubsub topic to subscribe to. Argument may be repeated.",
+      defaultValue: @[],
+      name: "pubsub-topic"
+    .}: seq[string]
+
     shards* {.
       desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
       defaultValue:

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -312,11 +312,8 @@ type WakuNodeConf* = object
       name: "keep-alive"
     .}: bool
 
-    pubsubTopics* {.
-      desc: "Default pubsub topic to subscribe to. Argument may be repeated.",
-      defaultValue: @[],
-      name: "pubsub-topic"
-    .}: seq[string]
+    networkShards* {.desc: "Number of shards in the network", name: "network-shards".}:
+      uint32
 
     shards* {.
       desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -327,7 +327,8 @@ type WakuNodeConf* = object
     .}: seq[string]
 
     shards* {.
-      desc: "Shards index to subscribe to [0..MAX_SHARDS-1]. Argument may be repeated.",
+      desc:
+        "Shards index to subscribe to [0..NUM_SHARDS_IN_NETWORK-1]. Argument may be repeated.",
       defaultValue:
         @[
           uint16(0),

--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -30,10 +30,16 @@ proc enrConfiguration*(
 
   var shards = newSeq[uint16]()
 
-  let shardsOpt = topicsToRelayShards(conf.pubsubTopics).valueOr:
+  # Only for dev purposes. After everything compiles, remove this block and uncomment the one below
+  let shardsOpt = topicsToRelayShards(@["/waku/2/rs/0/0"]).valueOr:
     error "failed to parse pubsub topic, please format according to static shard specification",
       error = $error
     return err("failed to parse pubsub topic: " & $error)
+
+  #[ let shardsOpt = topicsToRelayShards(conf.pubsubTopics).valueOr:
+    error "failed to parse pubsub topic, please format according to static shard specification",
+      error = $error
+    return err("failed to parse pubsub topic: " & $error) ]#
 
   if shardsOpt.isSome():
     let relayShards = shardsOpt.get()

--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -28,35 +28,8 @@ proc enrConfiguration*(
 
   enrBuilder.withMultiaddrs(netConfig.enrMultiaddrs)
 
-  var shards = newSeq[uint16]()
-
-  # Only for dev purposes. After everything compiles, remove this block and uncomment the one below
-  let shardsOpt = topicsToRelayShards(@["/waku/2/rs/0/0"]).valueOr:
-    error "failed to parse pubsub topic, please format according to static shard specification",
-      error = $error
-    return err("failed to parse pubsub topic: " & $error)
-
-  #[ let shardsOpt = topicsToRelayShards(conf.pubsubTopics).valueOr:
-    error "failed to parse pubsub topic, please format according to static shard specification",
-      error = $error
-    return err("failed to parse pubsub topic: " & $error) ]#
-
-  if shardsOpt.isSome():
-    let relayShards = shardsOpt.get()
-
-    if relayShards.clusterid != conf.clusterId:
-      error "pubsub topic corresponds to different shard than configured",
-        nodeCluster = conf.clusterId, pubsubCluster = relayShards.clusterid
-      return err("pubsub topic corresponds to different shard than configured")
-
-    shards = relayShards.shardIds
-  elif conf.shards.len > 0:
-    shards = toSeq(conf.shards.mapIt(uint16(it)))
-  else:
-    info "no pubsub topics specified"
-
   enrBuilder.withWakuRelaySharding(
-    RelayShards(clusterId: conf.clusterId, shardIds: shards)
+    RelayShards(clusterId: conf.clusterId, shardIds: conf.shards)
   ).isOkOr:
     return err("could not initialize ENR with shards")
 

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -10,7 +10,7 @@ type ClusterConf* = object
   rlnRelayBandwidthThreshold*: int
   rlnEpochSizeSec*: uint64
   rlnRelayUserMessageLimit*: uint64
-  networkShards*: uint32
+  numShardsInNetwork*: uint32
   discv5Discovery*: bool
   discv5BootstrapNodes*: seq[string]
 
@@ -28,7 +28,7 @@ proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
     rlnRelayBandwidthThreshold: 0,
     rlnEpochSizeSec: 600,
     rlnRelayUserMessageLimit: 100,
-    networkShards: 8,
+    numShardsInNetwork: 8,
     discv5Discovery: true,
     discv5BootstrapNodes:
       @[

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -10,7 +10,7 @@ type ClusterConf* = object
   rlnRelayBandwidthThreshold*: int
   rlnEpochSizeSec*: uint64
   rlnRelayUserMessageLimit*: uint64
-  pubsubTopics*: seq[string]
+  networkShards*: uint32
   discv5Discovery*: bool
   discv5BootstrapNodes*: seq[string]
 
@@ -28,11 +28,7 @@ proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
     rlnRelayBandwidthThreshold: 0,
     rlnEpochSizeSec: 600,
     rlnRelayUserMessageLimit: 100,
-    pubsubTopics:
-      @[
-        "/waku/2/rs/1/0", "/waku/2/rs/1/1", "/waku/2/rs/1/2", "/waku/2/rs/1/3",
-        "/waku/2/rs/1/4", "/waku/2/rs/1/5", "/waku/2/rs/1/6", "/waku/2/rs/1/7",
-      ],
+    networkShards: 8,
     discv5Discovery: true,
     discv5BootstrapNodes:
       @[

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -136,6 +136,10 @@ proc setupProtocols(
     # If conf.numShardsInNetwork is not set, use the number of shards configured as numShardsInNetwork
   let numShardsInNetwork = getNumShardsInNetwork(conf)
 
+  if conf.numShardsInNetwork == 0:
+    warn "Number of shards in network not configured, setting it to",
+      numShardsInNetwork = $numShardsInNetwork
+
   node.mountSharding(conf.clusterId, numShardsInNetwork).isOkOr:
     return err("failed to mount waku sharding: " & error)
 

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -117,7 +117,7 @@ proc getNetworkShards*(conf: WakuNodeConf): uint32 =
   if conf.networkShards != 0:
     return conf.networkShards
   # If conf.networkShards is not set, use the number of shards configured as networkShards
-  return uint32(conf.shards.len)
+  return uint32(max(conf.shards) + 1)
 
 proc setupProtocols(
     node: WakuNode, conf: WakuNodeConf, nodeKey: crypto.PrivateKey

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -116,8 +116,9 @@ proc initNode(
 proc getNumShardsInNetwork*(conf: WakuNodeConf): uint32 =
   if conf.numShardsInNetwork != 0:
     return conf.numShardsInNetwork
-  # If conf.numShardsInNetwork is not set, use the number of shards configured as numShardsInNetwork
-  return uint32(max(conf.shards) + 1)
+  # If conf.numShardsInNetwork is not set, use 1024 - the maximum possible as per the static sharding spec
+  # https://github.com/waku-org/specs/blob/master/standards/core/relay-sharding.md#static-sharding
+  return uint32(MaxShardIndex + 1)
 
 proc setupProtocols(
     node: WakuNode, conf: WakuNodeConf, nodeKey: crypto.PrivateKey

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -113,10 +113,10 @@ proc initNode(
 
 ## Mount protocols
 
-proc getNetworkShards*(conf: WakuNodeConf): uint32 =
-  if conf.networkShards != 0:
-    return conf.networkShards
-  # If conf.networkShards is not set, use the number of shards configured as networkShards
+proc getNumShardsInNetwork*(conf: WakuNodeConf): uint32 =
+  if conf.numShardsInNetwork != 0:
+    return conf.numShardsInNetwork
+  # If conf.numShardsInNetwork is not set, use the number of shards configured as numShardsInNetwork
   return uint32(max(conf.shards) + 1)
 
 proc setupProtocols(
@@ -133,10 +133,10 @@ proc setupProtocols(
   node.mountMetadata(conf.clusterId).isOkOr:
     return err("failed to mount waku metadata protocol: " & error)
 
-    # If conf.networkShards is not set, use the number of shards configured as networkShards
-  let networkShards = getNetworkShards(conf)
+    # If conf.numShardsInNetwork is not set, use the number of shards configured as numShardsInNetwork
+  let numShardsInNetwork = getNumShardsInNetwork(conf)
 
-  node.mountSharding(conf.clusterId, networkShards).isOkOr:
+  node.mountSharding(conf.clusterId, numShardsInNetwork).isOkOr:
     return err("failed to mount waku sharding: " & error)
 
   # Mount relay on all nodes

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -160,7 +160,7 @@ proc setupProtocols(
 
     peerExchangeHandler = some(handlePeerExchange)
 
-  var autoShards: seq[RelayShard] = @[]
+  var autoShards: seq[RelayShard]
   for contentTopic in conf.contentTopics:
     let shard = node.wakuSharding.getShard(contentTopic).valueOr:
       return err("Could not parse content topic: " & error)

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -111,11 +111,6 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
   # cluster-id=1 (aka The Waku Network)
   of 1:
     let twnClusterConf = ClusterConf.TheWakuNetworkConf()
-    if len(confCopy.shards) != 0:
-      confCopy.pubsubTopics =
-        confCopy.shards.mapIt(twnClusterConf.pubsubTopics[it.uint16])
-    else:
-      confCopy.pubsubTopics = twnClusterConf.pubsubTopics
 
     # Override configuration
     confCopy.maxMessageSize = twnClusterConf.maxMessageSize

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -87,13 +87,13 @@ func version*(waku: Waku): string =
   waku.version
 
 proc validateShards(conf: WakuNodeConf): Result[void, string] =
-  let networkShards = getNetworkShards(conf)
+  let numShardsInNetwork = getNumShardsInNetwork(conf)
 
   for shard in conf.shards:
-    if shard >= networkShards:
+    if shard >= numShardsInNetwork:
       let msg =
-        "validateShards invalid shard: " & $shard & " when networkShards: " &
-        $networkShards # fmt doesn't work
+        "validateShards invalid shard: " & $shard & " when numShardsInNetwork: " &
+        $numShardsInNetwork # fmt doesn't work
       error "validateShards failed", error = msg
       return err(msg)
 
@@ -149,7 +149,7 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
       confCopy.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
     confCopy.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
     confCopy.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
-    confCopy.networkShards = twnClusterConf.networkShards
+    confCopy.numShardsInNetwork = twnClusterConf.numShardsInNetwork
 
     # Only set rlnRelay to true if relay is configured
     if confCopy.relay:

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -106,6 +106,20 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
 
   logging.setupLog(conf.logLevel, conf.logFormat)
 
+  # TODO: remove after pubsubtopic config gets removed
+  #[ let shards = newSeq[uint16]()
+  if conf.pubsubTopics.length > 0:
+    let shardsOpt = topicsToRelayShards(conf.pubsubTopics).valueOr:
+      error "failed to parse pubsub topic, please format according to static shard specification",
+        error = $error
+      return err("failed to parse pubsub topic: " & $error)
+
+    if shardsOpt.isSome():
+      let relayShards = shardsOpt.get()
+      for shard in relayShards:
+        shards.add(shard.shardId)
+      confCopy.shards = shards ]#
+
   case confCopy.clusterId
 
   # cluster-id=1 (aka The Waku Network)

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -119,6 +119,11 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
 
     if shardsOpt.isSome():
       let relayShards = shardsOpt.get()
+      if relayShards.clusterId != conf.clusterId:
+        error "clusterId of the pubsub topic should match the node's cluster",
+          nodeCluster = conf.clusterId, pubsubCluster = relayShards.clusterId
+        return err("clusterId of the pubsub topic should match the node's cluster")
+
       for shard in relayShards.shardIds:
         shards.add(shard)
       confCopy.shards = shards
@@ -152,7 +157,7 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
   info "Running nwaku node", version = git_version
   logConfig(confCopy)
 
-  let validateShardsRes = validateShards(conf)
+  let validateShardsRes = validateShards(confCopy)
   if validateShardsRes.isErr():
     error "Failed validating shards", error = $validateShardsRes.error
     return err("Failed validating shards: " & $validateShardsRes.error)

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -91,8 +91,9 @@ proc validateShards(conf: WakuNodeConf): Result[void, string] =
 
   for shard in conf.shards:
     if shard >= networkShards:
-      let msg = "Invalid shard: " & $shard & " when networkShards: " & $networkShards
-        # fmt doesn't work
+      let msg =
+        "validateShards invalid shard: " & $shard & " when networkShards: " &
+        $networkShards # fmt doesn't work
       error "validateShards failed", error = msg
       return err(msg)
 
@@ -120,9 +121,11 @@ proc init*(T: type Waku, conf: WakuNodeConf): Result[Waku, string] =
     if shardsOpt.isSome():
       let relayShards = shardsOpt.get()
       if relayShards.clusterId != conf.clusterId:
-        error "clusterId of the pubsub topic should match the node's cluster",
+        error "clusterId of the pubsub topic should match the node's cluster. e.g. --pubsub-topic=/waku/2/rs/22/1 and --cluster-id=22",
           nodeCluster = conf.clusterId, pubsubCluster = relayShards.clusterId
-        return err("clusterId of the pubsub topic should match the node's cluster")
+        return err(
+          "clusterId of the pubsub topic should match the node's cluster. e.g. --pubsub-topic=/waku/2/rs/22/1 and --cluster-id=22"
+        )
 
       for shard in relayShards.shardIds:
         shards.add(shard)

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -321,7 +321,7 @@ proc subscribe*(
         error "Autosharding error", error = error
         return
 
-      (shard, some(subscription.topic))
+      ($shard, some(subscription.topic))
     of PubsubSub:
       (subscription.topic, none(ContentTopic))
     else:
@@ -356,7 +356,7 @@ proc unsubscribe*(node: WakuNode, subscription: SubscriptionEvent) =
         error "Autosharding error", error = error
         return
 
-      (shard, some(subscription.topic))
+      ($shard, some(subscription.topic))
     of PubsubUnsub:
       (subscription.topic, none(ContentTopic))
     else:
@@ -437,7 +437,7 @@ proc startRelay*(node: WakuNode) {.async.} =
 
 proc mountRelay*(
     node: WakuNode,
-    pubsubTopics: seq[string] = @[],
+    shards: seq[RelayShard] = @[],
     peerExchangeHandler = none(RoutingRecordsHandler),
     maxMessageSize = int(DefaultMaxWakuMessageSize),
 ) {.async, gcsafe.} =
@@ -466,11 +466,11 @@ proc mountRelay*(
 
   node.switch.mount(node.wakuRelay, protocolMatcher(WakuRelayCodec))
 
-  info "relay mounted successfully", pubsubTopics = pubsubTopics
+  info "relay mounted successfully", shards = shards
 
-  # Subscribe to topics
-  for pubsubTopic in pubsubTopics:
-    node.subscribe((kind: PubsubSub, topic: pubsubTopic))
+  # Subscribe to shards
+  for shard in shards:
+    node.subscribe((kind: PubsubSub, topic: $shard))
 
 ## Waku filter
 

--- a/waku/waku_api/rest/builder.nim
+++ b/waku/waku_api/rest/builder.nim
@@ -132,7 +132,8 @@ proc startRestServerProtocolSupport*(
 
     let handler = messageCacheHandler(cache)
 
-    for pubsubTopic in conf.pubsubTopics:
+    for shard in conf.shards:
+      let pubsubTopic = $RelayShard(clusterId: conf.clusterId, shardId: shard)
       cache.pubsubSubscribe(pubsubTopic)
       node.subscribe((kind: PubsubSub, topic: pubsubTopic), some(handler))
 

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -282,7 +282,7 @@ proc installRelayApiHandlers*(
     debug "Publishing message",
       contentTopic = message.contentTopic, rln = not node.wakuRlnRelay.isNil()
 
-    var publishFut = node.publish(some(pubsubTopic), message)
+    var publishFut = node.publish(some($pubsubTopic), message)
     if not await publishFut.withTimeout(futTimeout):
       return RestApiResponse.internalServerError("Failed to publish: timedout")
 

--- a/waku/waku_core/topics/pubsub_topic.nim
+++ b/waku/waku_core/topics/pubsub_topic.nim
@@ -13,7 +13,8 @@ export parsing
 
 type PubsubTopic* = string
 
-const DefaultPubsubTopic* = PubsubTopic("/waku/2/rs/0/0")
+const DefaultShardId* = uint16(0)
+const DefaultClusterId* = uint16(0)
 
 ## Namespaced pub-sub topic
 

--- a/waku/waku_core/topics/pubsub_topic.nim
+++ b/waku/waku_core/topics/pubsub_topic.nim
@@ -13,17 +13,16 @@ export parsing
 
 type PubsubTopic* = string
 
-const DefaultShardId* = uint16(0)
-const DefaultClusterId* = uint16(0)
-
-## Namespaced pub-sub topic
+## Relay Shard
 
 type RelayShard* = object
   clusterId*: uint16
   shardId*: uint16
 
-proc staticSharding*(T: type RelayShard, clusterId, shardId: uint16): T =
-  return RelayShard(clusterId: clusterId, shardId: shardId)
+const DefaultShardId* = uint16(0)
+const DefaultClusterId* = uint16(0)
+const DefaultRelayShard* =
+  RelayShard(clusterId: DefaultClusterId, shardId: DefaultShardId)
 
 # Serialization
 
@@ -68,7 +67,7 @@ proc parseStaticSharding*(
         ParsingError.invalidFormat($err)
     )
 
-  ok(RelayShard.staticSharding(clusterId, shardId))
+  ok(RelayShard(clusterId, shardId))
 
 proc parse*(T: type RelayShard, topic: PubsubTopic): ParsingResult[RelayShard] =
   ## Splits a namespaced topic string into its constituent parts.

--- a/waku/waku_core/topics/pubsub_topic.nim
+++ b/waku/waku_core/topics/pubsub_topic.nim
@@ -31,6 +31,8 @@ proc `$`*(topic: RelayShard): string =
   ## in the format `/waku/2/rs/<cluster-id>/<shard-id>
   return "/waku/2/rs/" & $topic.clusterId & "/" & $topic.shardId
 
+const DefaultPubsubTopic* = $DefaultRelayShard
+
 # Deserialization
 
 const

--- a/waku/waku_core/topics/pubsub_topic.nim
+++ b/waku/waku_core/topics/pubsub_topic.nim
@@ -67,7 +67,7 @@ proc parseStaticSharding*(
         ParsingError.invalidFormat($err)
     )
 
-  ok(RelayShard(clusterId, shardId))
+  ok(RelayShard(clusterId: clusterId, shardId: shardId))
 
 proc parse*(T: type RelayShard, topic: PubsubTopic): ParsingResult[RelayShard] =
   ## Splits a namespaced topic string into its constituent parts.

--- a/waku/waku_core/topics/sharding.nim
+++ b/waku/waku_core/topics/sharding.nim
@@ -42,13 +42,13 @@ proc getShard*(s: Sharding, topic: NsContentTopic): Result[RelayShard, string] =
   else:
     return err("Generation > 0 are not supported yet")
 
-proc getShard*(s: Sharding, topic: ContentTopic): Result[PubsubTopic, string] =
+proc getShard*(s: Sharding, topic: ContentTopic): Result[RelayShard, string] =
   let parsedTopic = NsContentTopic.parse(topic).valueOr:
     return err($error)
 
   let shard = ?s.getShard(parsedTopic)
 
-  ok($shard)
+  ok(shard)
 
 proc parseSharding*(
     s: Sharding,

--- a/waku/waku_core/topics/sharding.nim
+++ b/waku/waku_core/topics/sharding.nim
@@ -27,7 +27,7 @@ proc getGenZeroShard*(s: Sharding, topic: NsContentTopic, count: int): RelayShar
   # This is equilavent to modulo shard count but faster
   let shard = hashValue and uint64((count - 1))
 
-  RelayShard.staticSharding(s.clusterId, uint16(shard))
+  RelayShard(s.clusterId, uint16(shard))
 
 proc getShard*(s: Sharding, topic: NsContentTopic): Result[RelayShard, string] =
   ## Compute the (pubsub topic) shard to use for this content topic.
@@ -130,7 +130,7 @@ proc parseSharding*(
   var list = newSeq[(RelayShard, float64)](shardCount)
 
   for (shard, weight) in shardsNWeights:
-    let pubsub = RelayShard.staticSharding(ClusterId, uint16(shard))
+    let pubsub = RelayShard(ClusterId, uint16(shard))
 
     let clusterBytes = toBytesBE(uint16(ClusterId))
     let shardBytes = toBytesBE(uint16(shard))

--- a/waku/waku_core/topics/sharding.nim
+++ b/waku/waku_core/topics/sharding.nim
@@ -27,7 +27,7 @@ proc getGenZeroShard*(s: Sharding, topic: NsContentTopic, count: int): RelayShar
   # This is equilavent to modulo shard count but faster
   let shard = hashValue and uint64((count - 1))
 
-  RelayShard(s.clusterId, uint16(shard))
+  RelayShard(clusterId: s.clusterId, shardId: uint16(shard))
 
 proc getShard*(s: Sharding, topic: NsContentTopic): Result[RelayShard, string] =
   ## Compute the (pubsub topic) shard to use for this content topic.
@@ -130,7 +130,7 @@ proc parseSharding*(
   var list = newSeq[(RelayShard, float64)](shardCount)
 
   for (shard, weight) in shardsNWeights:
-    let pubsub = RelayShard(ClusterId, uint16(shard))
+    let pubsub = RelayShard(clusterId: ClusterId, shardId: uint16(shard))
 
     let clusterBytes = toBytesBE(uint16(ClusterId))
     let shardBytes = toBytesBE(uint16(shard))

--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -13,7 +13,7 @@ import ../common/enr, ../waku_core
 logScope:
   topics = "waku enr sharding"
 
-const MaxShardIndex: uint16 = 1023
+const MaxShardIndex*: uint16 = 1023
 
 const
   ShardingIndicesListEnrField* = "rs"

--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -25,7 +25,7 @@ type RelayShards* = object
   shardIds*: seq[uint16]
 
 func topics*(rs: RelayShards): seq[RelayShard] =
-  rs.shardIds.mapIt(RelayShard.staticSharding(rs.clusterId, it))
+  rs.shardIds.mapIt(RelayShard(rs.clusterId, it))
 
 func init*(T: type RelayShards, clusterId, shardId: uint16): Result[T, string] =
   if shardId > MaxShardIndex:

--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -25,7 +25,7 @@ type RelayShards* = object
   shardIds*: seq[uint16]
 
 func topics*(rs: RelayShards): seq[RelayShard] =
-  rs.shardIds.mapIt(RelayShard(rs.clusterId, it))
+  rs.shardIds.mapIt(RelayShard(clusterId: rs.clusterId, shardId: it))
 
 func init*(T: type RelayShards, clusterId, shardId: uint16): Result[T, string] =
   if shardId > MaxShardIndex:


### PR DESCRIPTION
# Description
Deprecating the `pubsub-topic` CLI config in favor of `cluster-id`, `shards` and a new config item `network-shards` stating the amount of shards in the given `cluster-id` for autosharding purposes

The word `pubsubTopic` in our codebase will refer solely to the string representation of `clusterId`+`shard` that we use in the `libp2p` layer.

# Changes


- [x] marking pubsub topic configuration as deprecated
- [x] converting pubsub topics to shards for compatibility during the deprecation period
- [x] using `RelayShard` type instead of pubsub topic strings in Waku's higher layers
- [x] Introducing `network-shards` configuration item for autosharding
- [x] Using the max shard number + 1 as `network-shards` if not configured

<!--
## How to test

1.
1.
1.

-->


## Issue

closes #2806 
