### PR TITLE
chore: libwaku - exposing discv5 store-client and relay connected and mesh peers

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -75,6 +75,12 @@ int waku_relay_publish(void* ctx,
                        WakuCallBack callback,
                        void* userData);
 
+int waku_lightpush_publish(void* ctx,
+                       const char* pubSubTopic,
+                       const char* jsonWakuMessage,
+                       WakuCallBack callback,
+                       void* userData);
+
 int waku_relay_subscribe(void* ctx,
                          const char* pubSubTopic,
                          WakuCallBack callback,
@@ -84,6 +90,23 @@ int waku_relay_unsubscribe(void* ctx,
                            const char* pubSubTopic,
                            WakuCallBack callback,
                            void* userData);
+
+int waku_relay_get_num_connected_peers(void* ctx,
+                           const char* pubSubTopic,
+                           WakuCallBack callback,
+                           void* userData);
+
+int waku_relay_get_num_peers_in_mesh(void* ctx,
+                           const char* pubSubTopic,
+                           WakuCallBack callback,
+                           void* userData);
+
+int waku_store_query(void* ctx,
+                        const char* jsonQuery,
+                        const char* peerAddr,
+                        int timeoutMs,
+                        WakuCallBack callback,
+                        void* userData);
 
 int waku_connect(void* ctx,
                  const char* peerMultiAddr,
@@ -113,6 +136,14 @@ int waku_discv5_update_bootnodes(void* ctx,
                                  char* bootnodes,
                                  WakuCallBack callback,
                                  void* userData);
+
+int waku_start_discv5(void* ctx,
+                      WakuCallBack callback,
+                      void* userData);
+
+int waku_stop_discv5(void* ctx,
+                     WakuCallBack callback,
+                     void* userData);
 
 // Retrieves the ENR information
 int waku_get_my_enr(void* ctx,

--- a/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
@@ -1,12 +1,21 @@
+import std/[json, sugar, options]
 import chronos, results
-import ../../../../../waku/factory/waku, ../../../../alloc, ../../../../callback
+import
+  ../../../../../waku/factory/waku,
+  ../../../../alloc,
+  ../../../../callback,
+  ../../../../../waku/waku_core/peers,
+  ../../../../../waku/waku_core/time,
+  ../../../../../waku/waku_core/message/digest,
+  ../../../../../waku/waku_store/common,
+  ../../../../../waku/waku_store/client,
+  ../../../../../waku/common/paging
 
 type StoreReqType* = enum
   REMOTE_QUERY ## to perform a query to another Store node
-  LOCAL_QUERY ## to retrieve the data from 'self' node
 
-type StoreQueryRequest* = object
-  queryJson: cstring
+type JsonStoreQueryRequest* = object
+  jsonQuery: cstring
   peerAddr: cstring
   timeoutMs: cint
   storeCallback: WakuCallBack
@@ -15,37 +24,118 @@ type StoreRequest* = object
   operation: StoreReqType
   storeReq: pointer
 
-proc createShared*(
-    T: type StoreRequest, operation: StoreReqType, request: pointer
-): ptr type T =
-  var ret = createShared(T)
-  ret[].request = request
-  return ret
+func fromJsonNode(
+    T: type JsonStoreQueryRequest, jsonContent: JsonNode
+): StoreQueryRequest =
+  let contentTopics = collect(newSeq):
+    for cTopic in jsonContent["content_topics"].getElems():
+      cTopic.getStr()
+
+  let msgHashes = collect(newSeq):
+    for hashJsonObj in jsonContent["message_hashes"].getElems():
+      var hash: WakuMessageHash
+      var count: int = 0
+      for byteValue in hashJsonObj.getElems():
+        hash[count] = byteValue.getInt().byte
+        count.inc()
+
+      hash
+
+  let pubsubTopic =
+    if jsonContent.contains("pubsub_topic"):
+      some(jsonContent["pubsub_topic"].getStr())
+    else:
+      none(string)
+
+  let startTime =
+    if jsonContent.contains("time_start"):
+      some(Timestamp(jsonContent["time_start"].getInt()))
+    else:
+      none(Timestamp)
+
+  let endTime =
+    if jsonContent.contains("time_end"):
+      some(Timestamp(jsonContent["time_end"].getInt()))
+    else:
+      none(Timestamp)
+
+  let paginationCursor =
+    if jsonContent.contains("pagination_cursor"):
+      var hash: WakuMessageHash
+      var count: int = 0
+      for byteValue in jsonContent["pagination_cursor"].getElems():
+        hash[count] = byteValue.getInt().byte
+        count.inc()
+
+      some(hash)
+    else:
+      none(WakuMessageHash)
+
+  let paginationForwardBool = jsonContent["pagination_forward"].getBool()
+  let paginationForward =
+    if paginationForwardBool: PagingDirection.FORWARD else: PagingDirection.BACKWARD
+
+  let paginationLimit =
+    if jsonContent.contains("pagination_limit"):
+      some(uint64(jsonContent["pagination_limit"].getInt()))
+    else:
+      none(uint64)
+
+  return StoreQueryRequest(
+    requestId: jsonContent["request_id"].getStr(),
+    includeData: jsonContent["include_data"].getBool(),
+    pubsubTopic: pubsubTopic,
+    contentTopics: contentTopics,
+    startTime: startTime,
+    endTime: endTime,
+    messageHashes: msgHashes,
+    paginationCursor: paginationCursor,
+    paginationForward: paginationForward,
+    paginationLimit: paginationLimit,
+  )
 
 proc createShared*(
-    T: type StoreQueryRequest,
-    queryJson: cstring,
+    T: type JsonStoreQueryRequest,
+    jsonQuery: cstring,
     peerAddr: cstring,
     timeoutMs: cint,
     storeCallback: WakuCallBack = nil,
 ): ptr type T =
   var ret = createShared(T)
   ret[].timeoutMs = timeoutMs
-  ret[].queryJson = queryJson.alloc()
+  ret[].jsonQuery = jsonQuery.alloc()
   ret[].peerAddr = peerAddr.alloc()
   ret[].storeCallback = storeCallback
   return ret
 
-proc destroyShared(self: ptr StoreQueryRequest) =
-  deallocShared(self[].queryJson)
+proc destroyShared(self: ptr JsonStoreQueryRequest) =
+  deallocShared(self[].jsonQuery)
   deallocShared(self[].peerAddr)
   deallocShared(self)
 
 proc process(
-    self: ptr StoreQueryRequest, waku: ptr Waku
+    self: ptr JsonStoreQueryRequest, waku: ptr Waku
 ): Future[Result[string, string]] {.async.} =
   defer:
     destroyShared(self)
+
+  let jsonContentRes = catch:
+    parseJson($self[].jsonQuery)
+
+  if jsonContentRes.isErr():
+    return err(
+      "JsonStoreQueryRequest failed parsing store request: " & jsonContentRes.error.msg
+    )
+
+  let storeQueryRequest = JsonStoreQueryRequest.fromJsonNode(jsonContentRes.get())
+
+  let peer = peers.parsePeerInfo($self[].peerAddr).valueOr:
+    return err("JsonStoreQueryRequest failed to parse peer addr: " & $error)
+
+  let queryResponse = (await waku.node.wakuStoreClient.query(storeQueryRequest, peer)).valueOr:
+    return err("JsonStoreQueryRequest failed store query: " & $error)
+
+  return ok($(%*queryResponse)) ## returning the response in json format
 
 proc process*(
     self: ptr StoreRequest, waku: ptr Waku
@@ -55,9 +145,6 @@ proc process*(
 
   case self.operation
   of REMOTE_QUERY:
-    return await cast[ptr StoreQueryRequest](self[].storeReq).process(waku)
-  of LOCAL_QUERY:
-    discard
-    # cast[ptr StoreQueryRequest](request[].reqContent).process(node)
+    return await cast[ptr JsonStoreQueryRequest](self[].storeReq).process(waku)
 
-  return ok("")
+  return err("store request not handled at all")

--- a/library/waku_thread/inter_thread_communication/waku_thread_request.nim
+++ b/library/waku_thread/inter_thread_communication/waku_thread_request.nim
@@ -10,6 +10,7 @@ import
   ./requests/peer_manager_request,
   ./requests/protocols/relay_request,
   ./requests/protocols/store_request,
+  ./requests/protocols/lightpush_request,
   ./requests/debug_node_request,
   ./requests/discovery_request
 
@@ -20,6 +21,7 @@ type RequestType* {.pure.} = enum
   STORE
   DEBUG
   DISCOVERY
+  LIGHTPUSH
 
 type InterThreadRequest* = object
   reqType: RequestType
@@ -56,6 +58,8 @@ proc process*(
       cast[ptr DebugNodeRequest](request[].reqContent).process(waku[])
     of DISCOVERY:
       cast[ptr DiscoveryRequest](request[].reqContent).process(waku)
+    of LIGHTPUSH:
+      cast[ptr LightpushRequest](request[].reqContent).process(waku)
 
   return await retFut
 

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -441,3 +441,44 @@ proc publish*(
   let relayedPeerCount = await procCall GossipSub(w).publish(pubsubTopic, data)
 
   return relayedPeerCount
+
+proc getNumPeersInMesh*(w: WakuRelay, pubsubTopic: PubsubTopic): Result[int, string] =
+  ## Returns the number of peers in a mesh defined by the passed pubsub topic.
+  ## The 'mesh' atribute is defined in the GossipSub ref object.
+
+  if not w.mesh.hasKey(pubsubTopic):
+    return err(
+      "getNumPeersInMesh - there is no mesh peer for the given pubsub topic: " &
+        pubsubTopic
+    )
+
+  let peersRes = catch:
+    w.mesh[pubsubTopic]
+
+  let peers: HashSet[PubSubPeer] = peersRes.valueOr:
+    return
+      err("getNumPeersInMesh - exception accessing " & pubsubTopic & ": " & error.msg)
+
+  return ok(peers.len)
+
+proc getNumConnectedPeers*(
+    w: WakuRelay, pubsubTopic: PubsubTopic
+): Result[int, string] =
+  ## Returns the number of connected peers and subscribed to the passed pubsub topic.
+  ## The 'gossipsub' atribute is defined in the GossipSub ref object.
+
+  if not w.gossipsub.hasKey(pubsubTopic):
+    return err(
+      "getNumConnectedPeers - there is no gossipsub peer for the given pubsub topic: " &
+        pubsubTopic
+    )
+
+  let peersRes = catch:
+    w.gossipsub[pubsubTopic]
+
+  let peers: HashSet[PubSubPeer] = peersRes.valueOr:
+    return err(
+      "getNumConnectedPeers - exception accessing " & pubsubTopic & ": " & error.msg
+    )
+
+  return ok(peers.len)


### PR DESCRIPTION
# Description
Step further to make nwaku completely accessible from libwaku. Still pending to expose some features such as peer exchange, or filter.

# Changes

- Allow to start or stop discv5
- Expose lightpush request operation
- Expose list of connected and mesh peers
- Expose store client
