### PR TITLE
chore: lightpush - error metric less variable by only setting a fixed string

### DIFF
--- a/tests/node/test_wakunode_lightpush.nim
+++ b/tests/node/test_wakunode_lightpush.nim
@@ -179,8 +179,5 @@ suite "RLN Proofs as a Lightpush Service":
 
       # Then the message is not relayed but not due to RLN
       assert publishResponse.isErr(), "We expect an error response"
-      assert (
-        publishResponse.error.contains(
-          "Lightpush request has not been published to any peers"
-        )
-      ), "incorrect error response"
+      assert (publishResponse.error == protocol_metrics.notPublishedAnyPeer),
+        "incorrect error response"

--- a/tests/node/test_wakunode_lightpush.nim
+++ b/tests/node/test_wakunode_lightpush.nim
@@ -88,11 +88,9 @@ suite "Waku Lightpush - End To End":
 
       # Then the message is not relayed but not due to RLN
       assert publishResponse.isErr(), "We expect an error response"
-      assert (
-        publishResponse.error.contains(
-          "Lightpush request has not been published to any peers"
-        )
-      ), "incorrect error response"
+
+      assert (publishResponse.error == protocol_metrics.notPublishedAnyPeer),
+        "incorrect error response"
 
   suite "Waku LightPush Validation Tests":
     asyncTest "Validate message size exceeds limit":

--- a/waku/waku_lightpush/callbacks.nim
+++ b/waku/waku_lightpush/callbacks.nim
@@ -5,6 +5,7 @@ import
   ../waku_relay,
   ./common,
   ./protocol,
+  ./protocol_metrics,
   ../waku_rln_relay,
   ../waku_rln_relay/protocol_types
 
@@ -54,8 +55,6 @@ proc getRelayPushHandler*(
       ## Agreed change expected to the lightpush protocol to better handle such case. https://github.com/waku-org/pm/issues/93
       let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
       notice "Lightpush request has not been published to any peers", msg_hash = msgHash
-      return err(
-        "Lightpush request has not been published to any peers. msg_hash: " & msgHash
-      )
+      return err(protocol_metrics.notPublishedAnyPeer)
 
     return ok()

--- a/waku/waku_lightpush/protocol_metrics.nim
+++ b/waku/waku_lightpush/protocol_metrics.nim
@@ -16,3 +16,4 @@ const
   emptyResponseBodyFailure* = "empty_response_body_failure"
   messagePushFailure* = "message_push_failure"
   requestLimitReachedFailure* = "request_limit_reached_failure"
+  notPublishedAnyPeer* = "not_published_to_any_peer"


### PR DESCRIPTION
## Description
Avoid having a too-variable metric by preventing adding the msg_hash on it. In that case, we are just adding a fixed string, _not_published_to_any_peer_, when the condition "_Lightpush request has not been published to any peers_" is met.

Thanks for the detailed description @jakubgs :raised_hands: 

## Issue

bug: absurdly high cardinality of waku_lightpush_errors metrics
closes https://github.com/waku-org/nwaku/issues/3019
