### PR TITLE
test: avoid too verbose rln test

### DIFF
--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -539,9 +539,9 @@ suite "Waku rln relay":
 
     let root = rawRoot.inHex()
 
-    debug "groupIdCredentials", groupIdCredentials
-    debug "groupIDCommitments",
-      groupIDCommitments = groupIDCommitments.mapIt(it.inHex())
+    debug "groupIdCredentials", num_group_id_credentials = groupIdCredentials.len
+    # debug "groupIDCommitments", leaving commented in case needed to debug in the future
+    #   groupIDCommitments = groupIDCommitments.mapIt(it.inHex())
     debug "root", root
 
     check:

--- a/tests/waku_rln_relay/test_waku_rln_relay.nim
+++ b/tests/waku_rln_relay/test_waku_rln_relay.nim
@@ -502,8 +502,8 @@ suite "Waku rln relay":
 
     let (list, root) = memListRes.get()
 
-    debug "created membership key list", list
-    debug "the Merkle tree root", root
+    debug "created membership key list", number_of_keys = list.len
+    debug "Merkle tree root", size_calculated_tree_root = root.len
 
     check:
       list.len == groupSize # check the number of keys


### PR DESCRIPTION
This is to avoid too long test logs such as:

![image](https://github.com/user-attachments/assets/8a1e9509-dc48-4fed-9eeb-de288cb9c517)
