### PR TITLE
chore: rate limit peer exchange protocol, enhanced response status in RPC

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
@@ -104,7 +104,8 @@ proc updateDiscv5BootstrapNodes(nodes: string, waku: ptr Waku): Result[void, str
 proc performPeerExchangeRequestTo(
     numPeers: uint64, waku: ptr Waku
 ): Future[Result[int, string]] {.async.} =
-  return await waku.node.fetchPeerExchangePeers(numPeers)
+  return (await waku.node.fetchPeerExchangePeers(numPeers)).isOkOr:
+    return err($error)
 
 proc process*(
     self: ptr DiscoveryRequest, waku: ptr Waku

--- a/tests/common/test_all.nim
+++ b/tests/common/test_all.nim
@@ -8,4 +8,5 @@ import
   ./test_parse_size,
   ./test_tokenbucket,
   ./test_requestratelimiter,
+  ./test_ratelimit_setting,
   ./test_timed_map

--- a/tests/common/test_ratelimit_setting.nim
+++ b/tests/common/test_ratelimit_setting.nim
@@ -1,0 +1,150 @@
+#                Chronos Test Suite
+#            (c) Copyright 2022-Present
+#         Status Research & Development GmbH
+#
+#              Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#              MIT license (LICENSE-MIT)
+
+{.used.}
+
+import testutils/unittests
+import chronos, libp2p/stream/connection
+import std/[sequtils, options, tables]
+
+import ../../waku/common/rate_limit/request_limiter
+import ../../waku/common/rate_limit/timed_map
+
+let proto = "ProtocolDescriptor"
+
+let conn1 = Connection(peerId: PeerId.random().tryGet())
+let conn2 = Connection(peerId: PeerId.random().tryGet())
+let conn3 = Connection(peerId: PeerId.random().tryGet())
+
+suite "RateLimitSetting":
+  test "Parse rate limit setting - ok":
+    let test1 = "10/2m"
+    let test2 = "  store : 10  /1h"
+    let test2a = "storev2 : 10  /1h"
+    let test2b = "storeV3:        12  /1s"
+    let test3 = "LIGHTPUSH: 10/ 1m"
+    let test4 = "px:10/2 s "
+    let test5 = "filter:42/66ms"
+
+    let expU = UnlimitedRateLimit
+    let exp1: RateLimitSetting = (10, 2.minutes)
+    let exp2: RateLimitSetting = (10, 1.hours)
+    let exp2a: RateLimitSetting = (10, 1.hours)
+    let exp2b: RateLimitSetting = (12, 1.seconds)
+    let exp3: RateLimitSetting = (10, 1.minutes)
+    let exp4: RateLimitSetting = (10, 2.seconds)
+    let exp5: RateLimitSetting = (42, 66.milliseconds)
+
+    let res1 = ProtocolRateLimitSettings.parse(@[test1])
+    let res2 = ProtocolRateLimitSettings.parse(@[test2])
+    let res2a = ProtocolRateLimitSettings.parse(@[test2a])
+    let res2b = ProtocolRateLimitSettings.parse(@[test2b])
+    let res3 = ProtocolRateLimitSettings.parse(@[test3])
+    let res4 = ProtocolRateLimitSettings.parse(@[test4])
+    let res5 = ProtocolRateLimitSettings.parse(@[test5])
+
+    check:
+      res1.isOk()
+      res1.get() == {GLOBAL: exp1}.toTable()
+      res2.isOk()
+      res2.get() == {GLOBAL: expU, STOREV2: exp2, STOREV3: exp2}.toTable()
+      res2a.isOk()
+      res2a.get() == {GLOBAL: expU, STOREV2: exp2a}.toTable()
+      res2b.isOk()
+      res2b.get() == {GLOBAL: expU, STOREV3: exp2b}.toTable()
+      res3.isOk()
+      res3.get() == {GLOBAL: expU, LIGHTPUSH: exp3}.toTable()
+      res4.isOk()
+      res4.get() == {GLOBAL: expU, PEEREXCHG: exp4}.toTable()
+      res5.isOk()
+      res5.get() == {GLOBAL: expU, FILTER: exp5}.toTable()
+
+  test "Parse rate limit setting - err":
+    let test1 = "10/2d"
+    let test2 = "  stre : 10  /1h"
+    let test2a = "storev2 10  /1h"
+    let test2b = "storev3:        12 1s"
+    let test3 = "somethingelse: 10/ 1m"
+    let test4 = ":px:10/2 s "
+    let test5 = "filter:p42/66ms"
+
+    let res1 = ProtocolRateLimitSettings.parse(@[test1])
+    let res2 = ProtocolRateLimitSettings.parse(@[test2])
+    let res2a = ProtocolRateLimitSettings.parse(@[test2a])
+    let res2b = ProtocolRateLimitSettings.parse(@[test2b])
+    let res3 = ProtocolRateLimitSettings.parse(@[test3])
+    let res4 = ProtocolRateLimitSettings.parse(@[test4])
+    let res5 = ProtocolRateLimitSettings.parse(@[test5])
+
+    check:
+      res1.isErr()
+      res2.isErr()
+      res2a.isErr()
+      res2b.isErr()
+      res3.isErr()
+      res4.isErr()
+      res5.isErr()
+
+  test "Parse rate limit setting - complex":
+    let expU = UnlimitedRateLimit
+
+    let test1 = @["lightpush:2/2ms", "10/2m", " store: 3/3s", " storev2:12/12s"]
+    let exp1 = {
+      GLOBAL: (10, 2.minutes),
+      LIGHTPUSH: (2, 2.milliseconds),
+      STOREV3: (3, 3.seconds),
+      STOREV2: (12, 12.seconds),
+    }.toTable()
+
+    let res1 = ProtocolRateLimitSettings.parse(test1)
+
+    check:
+      res1.isOk()
+      res1.get() == exp1
+      res1.get().getSetting(PEEREXCHG) == (10, 2.minutes)
+      res1.get().getSetting(STOREV2) == (12, 12.seconds)
+      res1.get().getSetting(STOREV3) == (3, 3.seconds)
+      res1.get().getSetting(LIGHTPUSH) == (2, 2.milliseconds)
+
+    let test2 = @["lightpush:2/2ms", " store: 3/3s", "px:10/10h", "filter:4/42ms"]
+    let exp2 = {
+      GLOBAL: expU,
+      LIGHTPUSH: (2, 2.milliseconds),
+      STOREV3: (3, 3.seconds),
+      STOREV2: (3, 3.seconds),
+      FILTER: (4, 42.milliseconds),
+      PEEREXCHG: (10, 10.hours),
+    }.toTable()
+
+    let res2 = ProtocolRateLimitSettings.parse(test2)
+
+    check:
+      res2.isOk()
+      res2.get() == exp2
+
+    let test3 =
+      @["storev2:1/1s", "store:3/3s", "storev3:4/42ms", "storev3:5/5s", "storev3:6/6s"]
+    let exp3 =
+      {GLOBAL: expU, STOREV3: (6, 6.seconds), STOREV2: (1, 1.seconds)}.toTable()
+
+    let res3 = ProtocolRateLimitSettings.parse(test3)
+
+    check:
+      res3.isOk()
+      res3.get() == exp3
+      res3.get().getSetting(LIGHTPUSH) == expU
+
+    let test4 = newSeq[string](0)
+    let exp4 = {GLOBAL: expU}.toTable()
+
+    let res4 = ProtocolRateLimitSettings.parse(test4)
+
+    check:
+      res4.isOk()
+      res4.get() == exp4
+      res3.get().getSetting(LIGHTPUSH) == expU

--- a/tests/common/test_ratelimit_setting.nim
+++ b/tests/common/test_ratelimit_setting.nim
@@ -50,17 +50,27 @@ suite "RateLimitSetting":
 
     check:
       res1.isOk()
-      res1.get() == {GLOBAL: exp1}.toTable()
+      res1.get() == {GLOBAL: exp1, FILTER: FilterDefaultPerPeerRateLimit}.toTable()
       res2.isOk()
-      res2.get() == {GLOBAL: expU, STOREV2: exp2, STOREV3: exp2}.toTable()
+      res2.get() ==
+        {
+          GLOBAL: expU,
+          FILTER: FilterDefaultPerPeerRateLimit,
+          STOREV2: exp2,
+          STOREV3: exp2,
+        }.toTable()
       res2a.isOk()
-      res2a.get() == {GLOBAL: expU, STOREV2: exp2a}.toTable()
+      res2a.get() ==
+        {GLOBAL: expU, FILTER: FilterDefaultPerPeerRateLimit, STOREV2: exp2a}.toTable()
       res2b.isOk()
-      res2b.get() == {GLOBAL: expU, STOREV3: exp2b}.toTable()
+      res2b.get() ==
+        {GLOBAL: expU, FILTER: FilterDefaultPerPeerRateLimit, STOREV3: exp2b}.toTable()
       res3.isOk()
-      res3.get() == {GLOBAL: expU, LIGHTPUSH: exp3}.toTable()
+      res3.get() ==
+        {GLOBAL: expU, FILTER: FilterDefaultPerPeerRateLimit, LIGHTPUSH: exp3}.toTable()
       res4.isOk()
-      res4.get() == {GLOBAL: expU, PEEREXCHG: exp4}.toTable()
+      res4.get() ==
+        {GLOBAL: expU, FILTER: FilterDefaultPerPeerRateLimit, PEEREXCHG: exp4}.toTable()
       res5.isOk()
       res5.get() == {GLOBAL: expU, FILTER: exp5}.toTable()
 
@@ -96,6 +106,7 @@ suite "RateLimitSetting":
     let test1 = @["lightpush:2/2ms", "10/2m", " store: 3/3s", " storev2:12/12s"]
     let exp1 = {
       GLOBAL: (10, 2.minutes),
+      FILTER: FilterDefaultPerPeerRateLimit,
       LIGHTPUSH: (2, 2.milliseconds),
       STOREV3: (3, 3.seconds),
       STOREV2: (12, 12.seconds),
@@ -129,8 +140,12 @@ suite "RateLimitSetting":
 
     let test3 =
       @["storev2:1/1s", "store:3/3s", "storev3:4/42ms", "storev3:5/5s", "storev3:6/6s"]
-    let exp3 =
-      {GLOBAL: expU, STOREV3: (6, 6.seconds), STOREV2: (1, 1.seconds)}.toTable()
+    let exp3 = {
+      GLOBAL: expU,
+      FILTER: FilterDefaultPerPeerRateLimit,
+      STOREV3: (6, 6.seconds),
+      STOREV2: (1, 1.seconds),
+    }.toTable()
 
     let res3 = ProtocolRateLimitSettings.parse(test3)
 
@@ -140,7 +155,7 @@ suite "RateLimitSetting":
       res3.get().getSetting(LIGHTPUSH) == expU
 
     let test4 = newSeq[string](0)
-    let exp4 = {GLOBAL: expU}.toTable()
+    let exp4 = {GLOBAL: expU, FILTER: FilterDefaultPerPeerRateLimit}.toTable()
 
     let res4 = ProtocolRateLimitSettings.parse(test4)
 

--- a/tests/node/test_wakunode_peer_exchange.nim
+++ b/tests/node/test_wakunode_peer_exchange.nim
@@ -84,7 +84,8 @@ suite "Waku Peer Exchange":
       # Then no peers are fetched
       check:
         node.peerManager.peerStore.peers.len == 0
-        res.error == "PeerExchange is not mounted"
+        res.error.status == SERVICE_UNAVAILABLE
+        res.error.desc == some("PeerExchange is not mounted")
 
     asyncTest "Node fetches with mounted peer exchange, but no peers":
       # Given a node with peer exchange mounted
@@ -92,7 +93,9 @@ suite "Waku Peer Exchange":
 
       # When a node fetches peers
       let res = await node.fetchPeerExchangePeers(1)
-      check res.error == "Peer exchange failure: peer_not_found_failure"
+      check:
+        res.error.status == SERVICE_UNAVAILABLE
+        res.error.desc == some("peer_not_found_failure")
 
       # Then no peers are fetched
       check node.peerManager.peerStore.peers.len == 0

--- a/tests/node/test_wakunode_peer_exchange.nim
+++ b/tests/node/test_wakunode_peer_exchange.nim
@@ -84,8 +84,8 @@ suite "Waku Peer Exchange":
       # Then no peers are fetched
       check:
         node.peerManager.peerStore.peers.len == 0
-        res.error.status == SERVICE_UNAVAILABLE
-        res.error.desc == some("PeerExchange is not mounted")
+        res.error.status_code == SERVICE_UNAVAILABLE
+        res.error.status_desc == some("PeerExchange is not mounted")
 
     asyncTest "Node fetches with mounted peer exchange, but no peers":
       # Given a node with peer exchange mounted
@@ -94,8 +94,8 @@ suite "Waku Peer Exchange":
       # When a node fetches peers
       let res = await node.fetchPeerExchangePeers(1)
       check:
-        res.error.status == SERVICE_UNAVAILABLE
-        res.error.desc == some("peer_not_found_failure")
+        res.error.status_code == SERVICE_UNAVAILABLE
+        res.error.status_desc == some("peer_not_found_failure")
 
       # Then no peers are fetched
       check node.peerManager.peerStore.peers.len == 0

--- a/tests/waku_filter_v2/test_waku_filter_dos_protection.nim
+++ b/tests/waku_filter_v2/test_waku_filter_dos_protection.nim
@@ -146,7 +146,7 @@ suite "Waku Filter - DOS protection":
       some(FilterSubscribeErrorKind.TOO_MANY_REQUESTS)
 
     # ensure period of time has passed and clients can again use the service
-    await sleepAsync(700.milliseconds)
+    await sleepAsync(1000.milliseconds)
     check client1.subscribe(serverRemotePeerInfo, pubsubTopic, contentTopicSeq) ==
       none(FilterSubscribeErrorKind)
     check client2.subscribe(serverRemotePeerInfo, pubsubTopic, contentTopicSeq) ==

--- a/tests/waku_peer_exchange/test_protocol.nim
+++ b/tests/waku_peer_exchange/test_protocol.nim
@@ -222,7 +222,7 @@ suite "Waku Peer Exchange":
       # Check that it failed gracefully
       check:
         response.isErr
-        response.error.status == PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE
+        response.error.status_code == PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE
 
     asyncTest "Request 0 peers, with 0 peers in PeerExchange":
       # Given a disconnected PeerExchange
@@ -237,7 +237,7 @@ suite "Waku Peer Exchange":
       # Then the response should be an error
       check:
         response.isErr
-        response.error.status == PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE
+        response.error.status_code == PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE
 
     asyncTest "Pool filtering":
       let
@@ -331,7 +331,7 @@ suite "Waku Peer Exchange":
       # Then the response should be an error
       check:
         response.isErr
-        response.error.status == PeerExchangeResponseStatusCode.DIAL_FAILURE
+        response.error.status_code == PeerExchangeResponseStatusCode.DIAL_FAILURE
 
     asyncTest "Connections are closed after response is sent":
       # Create 3 nodes
@@ -397,12 +397,9 @@ suite "Waku Peer Exchange":
 
       # Check we got back the enr we mocked
       check:
-        decodedBuff.get().responseStatus.isSome()
-        decodedBuff.get().responseStatus.get().status ==
-          PeerExchangeResponseStatusCode.SUCCESS
-        decodedBuff.get().response.isSome()
-        decodedBuff.get().response.get().peerInfos.len == 1
-        decodedBuff.get().response.get().peerInfos[0].enr == enr1.raw
+        decodedBuff.get().response.status_code == PeerExchangeResponseStatusCode.SUCCESS
+        decodedBuff.get().response.peerInfos.len == 1
+        decodedBuff.get().response.peerInfos[0].enr == enr1.raw
 
     asyncTest "RateLimit as expected":
       let
@@ -452,7 +449,7 @@ suite "Waku Peer Exchange":
         await node2.wakuPeerExchange.request(1, node1.peerInfo.toRemotePeerInfo())
       check:
         response2.isErr
-        response2.error().status == PeerExchangeResponseStatusCode.TOO_MANY_REQUESTS
+        response2.error().status_code == PeerExchangeResponseStatusCode.TOO_MANY_REQUESTS
 
       await sleepAsync(150.milliseconds)
       let response3 = await node2.wakuPeerExchange.request(1, connOpt.get())

--- a/tests/waku_peer_exchange/test_protocol.nim
+++ b/tests/waku_peer_exchange/test_protocol.nim
@@ -385,7 +385,7 @@ suite "Waku Peer Exchange":
       let conn = connOpt.get()
 
       # Send bytes so that they directly hit the handler
-      let rpc = PeerExchangeRpc(request: PeerExchangeRequest(numPeers: 1))
+      let rpc = PeerExchangeRpc.makeRequest(1)
 
       var buffer: seq[byte]
       await conn.writeLP(rpc.encode().buffer)
@@ -397,5 +397,9 @@ suite "Waku Peer Exchange":
 
       # Check we got back the enr we mocked
       check:
-        decodedBuff.get().response.peerInfos.len == 1
-        decodedBuff.get().response.peerInfos[0].enr == enr1.raw
+        decodedBuff.get().responseStatus.isSome()
+        decodedBuff.get().responseStatus.get().status ==
+          PeerExchangeResponseStatusCode.SUCCESS
+        decodedBuff.get().response.isSome()
+        decodedBuff.get().response.get().peerInfos.len == 1
+        decodedBuff.get().response.get().peerInfos[0].enr == enr1.raw

--- a/tests/waku_peer_exchange/test_protocol.nim
+++ b/tests/waku_peer_exchange/test_protocol.nim
@@ -1,11 +1,10 @@
 {.used.}
 
 import
-  std/[options, sequtils, tables],
+  std/[options, sequtils, tables, net],
   testutils/unittests,
   chronos,
   chronicles,
-  stew/shims/net,
   libp2p/[switch, peerId, crypto/crypto, multistream, muxers/muxer],
   eth/[keys, p2p/discoveryv5/enr]
 
@@ -223,6 +222,7 @@ suite "Waku Peer Exchange":
       # Check that it failed gracefully
       check:
         response.isErr
+        response.error.status == PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE
 
     asyncTest "Request 0 peers, with 0 peers in PeerExchange":
       # Given a disconnected PeerExchange
@@ -237,7 +237,7 @@ suite "Waku Peer Exchange":
       # Then the response should be an error
       check:
         response.isErr
-        response.error == "peer_not_found_failure"
+        response.error.status == PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE
 
     asyncTest "Pool filtering":
       let
@@ -331,7 +331,7 @@ suite "Waku Peer Exchange":
       # Then the response should be an error
       check:
         response.isErr
-        response.error == "dial_failure"
+        response.error.status == PeerExchangeResponseStatusCode.DIAL_FAILURE
 
     asyncTest "Connections are closed after response is sent":
       # Create 3 nodes

--- a/tests/waku_peer_exchange/test_rpc_codec.nim
+++ b/tests/waku_peer_exchange/test_rpc_codec.nim
@@ -1,10 +1,9 @@
 {.used.}
 
 import
-  std/[options],
+  std/[options, net],
   testutils/unittests,
   chronos,
-  stew/shims/net,
   libp2p/switch,
   libp2p/peerId,
   libp2p/crypto/crypto,

--- a/tests/waku_peer_exchange/test_rpc_codec.nim
+++ b/tests/waku_peer_exchange/test_rpc_codec.nim
@@ -23,6 +23,17 @@ import
 suite "Peer Exchange RPC":
   asyncTest "Encode - Decode":
     # Setup
+    let rpcReq = PeerExchangeRpc.makeRequest(2)
+    let rpcReqBuffer: seq[byte] = rpcReq.encode().buffer
+    let resReq = PeerExchangeRpc.decode(rpcReqBuffer)
+
+    check:
+      resReq.isOk
+      resReq.get().response.isNone()
+      resReq.get().responseStatus.isNone()
+      resReq.get().request.isSome()
+      resReq.get().request.get().numPeers == 2
+
     var
       enr1 = enr.Record(seqNum: 0, raw: @[])
       enr2 = enr.Record(seqNum: 0, raw: @[])
@@ -35,28 +46,35 @@ suite "Peer Exchange RPC":
         "enr:-Iu4QK_T7kzAmewG92u1pr7o6St3sBqXaiIaWIsFNW53_maJEaOtGLSN2FUbm6LmVxSfb1WfC7Eyk-nFYI7Gs3SlchwBgmlkgnY0gmlwhI5d6VKJc2VjcDI1NmsxoQLPYQDvrrFdCrhqw3JuFaGD71I8PtPfk6e7TJ3pg_vFQYN0Y3CC6mKDdWRwgiMq"
       )
 
-    let
-      peerInfos =
-        @[PeerExchangePeerInfo(enr: enr1.raw), PeerExchangePeerInfo(enr: enr2.raw)]
-      rpc = PeerExchangeRpc(response: PeerExchangeResponse(peerInfos: peerInfos))
+    let peerInfos =
+      @[PeerExchangePeerInfo(enr: enr1.raw), PeerExchangePeerInfo(enr: enr2.raw)]
+    let rpc = PeerExchangeRpc.makeResponse(peerInfos)
 
     # When encoding and decoding
-    let
-      rpcBuffer: seq[byte] = rpc.encode().buffer
-      res = PeerExchangeRpc.decode(rpcBuffer)
+    let rpcBuffer: seq[byte] = rpc.encode().buffer
+    let res = PeerExchangeRpc.decode(rpcBuffer)
 
     # Then the peerInfos match the originals
     check:
       res.isOk
-      res.get().response.peerInfos == peerInfos
+      res.get().request.isNone()
+      res.get().response.isSome()
+      res.get().responseStatus.isSome()
+      res.get().responseStatus.get().status == PeerExchangeResponseStatusCode.SUCCESS
+      res.get().response.get().peerInfos == peerInfos
 
     # When using the decoded responses to create new enrs
     var
       resEnr1 = enr.Record(seqNum: 0, raw: @[])
       resEnr2 = enr.Record(seqNum: 0, raw: @[])
 
-    discard resEnr1.fromBytes(res.get().response.peerInfos[0].enr)
-    discard resEnr2.fromBytes(res.get().response.peerInfos[1].enr)
+    check:
+      res.get().response.isSome()
+      res.get().responseStatus.isSome()
+      res.get().responseStatus.get().status == PeerExchangeResponseStatusCode.SUCCESS
+
+    discard resEnr1.fromBytes(res.get().response.get().peerInfos[0].enr)
+    discard resEnr2.fromBytes(res.get().response.get().peerInfos[1].enr)
 
     # Then they match the original enrs
     check:

--- a/tests/waku_peer_exchange/test_rpc_codec.nim
+++ b/tests/waku_peer_exchange/test_rpc_codec.nim
@@ -28,10 +28,7 @@ suite "Peer Exchange RPC":
 
     check:
       resReq.isOk
-      resReq.get().response.isNone()
-      resReq.get().responseStatus.isNone()
-      resReq.get().request.isSome()
-      resReq.get().request.get().numPeers == 2
+      resReq.get().request.numPeers == 2
 
     var
       enr1 = enr.Record(seqNum: 0, raw: @[])
@@ -56,11 +53,8 @@ suite "Peer Exchange RPC":
     # Then the peerInfos match the originals
     check:
       res.isOk
-      res.get().request.isNone()
-      res.get().response.isSome()
-      res.get().responseStatus.isSome()
-      res.get().responseStatus.get().status == PeerExchangeResponseStatusCode.SUCCESS
-      res.get().response.get().peerInfos == peerInfos
+      res.get().response.status_code == PeerExchangeResponseStatusCode.SUCCESS
+      res.get().response.peerInfos == peerInfos
 
     # When using the decoded responses to create new enrs
     var
@@ -68,12 +62,10 @@ suite "Peer Exchange RPC":
       resEnr2 = enr.Record(seqNum: 0, raw: @[])
 
     check:
-      res.get().response.isSome()
-      res.get().responseStatus.isSome()
-      res.get().responseStatus.get().status == PeerExchangeResponseStatusCode.SUCCESS
+      res.get().response.status_code == PeerExchangeResponseStatusCode.SUCCESS
 
-    discard resEnr1.fromBytes(res.get().response.get().peerInfos[0].enr)
-    discard resEnr2.fromBytes(res.get().response.get().peerInfos[1].enr)
+    discard resEnr1.fromBytes(res.get().response.peerInfos[0].enr)
+    discard resEnr2.fromBytes(res.get().response.peerInfos[1].enr)
 
     # Then they match the original enrs
     check:

--- a/waku/common/rate_limit/service_metrics.nim
+++ b/waku/common/rate_limit/service_metrics.nim
@@ -1,9 +1,19 @@
 {.push raises: [].}
 
-import metrics
+import std/options
+import metrics, setting
+
+declarePublicGauge waku_service_requests_limit,
+  "Applied rate limit of non-relay service", ["service"]
 
 declarePublicCounter waku_service_requests,
   "number of non-relay service requests received", ["service", "state"]
 
 declarePublicCounter waku_service_network_bytes,
   "total incoming traffic of specific waku services", labels = ["service", "direction"]
+
+proc setServiceLimitMetric*(service: string, limit: Option[RateLimitSetting]) =
+  if limit.isSome() and not limit.get().isUnlimited():
+    waku_service_requests_limit.set(
+      limit.get().calculateLimitPerSecond(), labelValues = [service]
+    )

--- a/waku/common/rate_limit/setting.nim
+++ b/waku/common/rate_limit/setting.nim
@@ -133,3 +133,8 @@ proc getSetting*(
 ): RateLimitSetting =
   let default = t.getOrDefault(GLOBAL, UnlimitedRateLimit)
   return t.getOrDefault(protocol, default)
+
+proc calculateLimitPerSecond*(setting: RateLimitSetting): float64 =
+  if setting.isUnlimited():
+    return 0.float64
+  return (setting.volume.float64 / setting.period.milliseconds.float64) * 1000.float64

--- a/waku/common/rate_limit/setting.nim
+++ b/waku/common/rate_limit/setting.nim
@@ -63,13 +63,12 @@ proc translate(sProtocol: string): RateLimitedProtocol {.raises: [ValueError].} 
 proc fillSettingTable(
     t: var ProtocolRateLimitSettings, sProtocol: var string, setting: RateLimitSetting
 ) {.raises: [ValueError].} =
-  let protocol = translate(sProtocol)
-
   if sProtocol == "store":
     # generic store will only applies to version which is not listed directly
     discard t.hasKeyOrPut(STOREV2, setting)
     discard t.hasKeyOrPut(STOREV3, setting)
   else:
+    let protocol = translate(sProtocol)
     # always overrides, last one wins if same protocol duplicated
     t[protocol] = setting
 

--- a/waku/common/rate_limit/setting.nim
+++ b/waku/common/rate_limit/setting.nim
@@ -1,12 +1,35 @@
 {.push raises: [].}
 
-import chronos/timer
+import chronos/timer, std/[tables, strutils, options], regex, results
 
 # Setting for TokenBucket defined as volume over period of time
 type RateLimitSetting* = tuple[volume: int, period: Duration]
 
+type RateLimitedProtocol* = enum
+  GLOBAL
+  STOREV2
+  STOREV3
+  LIGHTPUSH
+  PEEREXCHG
+  FILTER
+
+type ProtocolRateLimitSettings* = Table[RateLimitedProtocol, RateLimitSetting]
+type ProtocolRateLimit = tuple[protocol: RateLimitedProtocol, setting: RateLimitSetting]
+
 # Set the default to switch off rate limiting for now
 let DefaultGlobalNonRelayRateLimit*: RateLimitSetting = (0, 0.minutes)
+let UnlimitedRateLimit*: RateLimitSetting = (0, 0.seconds)
+
+# Acceptable call frequence from one peer using filter service
+# Assumption is having to set up a subscription with max 30 calls than using ping in every min
+# While subscribe/unsubscribe events are distributed in time among clients, pings will happen regularly from
+# all subscribed peers
+let FilterDefaultPerPeerRateLimit*: RateLimitSetting = (30, 1.minutes)
+
+# For being used under GC-safe condition must use threadvar
+var DefaultProtocolRateLimit* {.threadvar.}: ProtocolRateLimitSettings
+DefaultProtocolRateLimit =
+  {GLOBAL: UnlimitedRateLimit, FILTER: FilterDefaultPerPeerRateLimit}.toTable()
 
 proc isUnlimited*(t: RateLimitSetting): bool {.inline.} =
   return t.volume <= 0 or t.period <= 0.seconds
@@ -17,3 +40,96 @@ func `$`*(t: RateLimitSetting): string {.inline.} =
       "no-limit"
     else:
       $t.volume & "/" & $t.period
+
+proc translate(sProtocol: string): RateLimitedProtocol =
+  if sProtocol.len == 0:
+    return GLOBAL
+
+  case sProtocol
+  of "global":
+    return GLOBAL
+  of "storev2":
+    return STOREV2
+  of "storev3":
+    return STOREV3
+  of "lightpush":
+    return LIGHTPUSH
+  of "px":
+    return PEEREXCHG
+  of "filter":
+    return FILTER
+
+proc fillSettingTable(
+    t: var ProtocolRateLimitSettings, sProtocol: var string, setting: RateLimitSetting
+) =
+  let protocol = translate(sProtocol)
+
+  if sProtocol == "store":
+    # generic store will only applies to version which is not listed directly
+    discard t.hasKeyOrPut(STOREV2, setting)
+    discard t.hasKeyOrPut(STOREV3, setting)
+  else:
+    # always overrides, last one wins if same protocol duplicated
+    t[protocol] = setting
+
+proc parse*(
+    T: type ProtocolRateLimitSettings, settings: seq[string]
+): Result[ProtocolRateLimitSettings, string] =
+  var settingsTable: ProtocolRateLimitSettings =
+    initTable[RateLimitedProtocol, RateLimitSetting]()
+
+  ## Following regex can match the exact syntax of how rate limit can be set for different protocol or global.
+  ## It uses capture groups
+  ## group0: Will be check if protocol name is followed by a colon but only if protocol name is set.
+  ## group1: Protocol name, if empty we take it as "global" setting
+  ## group2: Volume of tokens - only integer
+  ## group3: Duration of period - only integer
+  ## group4: Unit of period - only h:hour, m:minute, s:second, ms:millisecond allowed
+  ## whitespaces are allowed lazily
+  const parseRegex =
+    """^\s*((store|storev2|storev3|lightpush|px|filter)\s*:)?\s*(\d+)\s*\/\s*(\d+)\s*(s|h|m|ms)\s*$"""
+  const regexParseSize = re2(parseRegex)
+  for settingStr in settings:
+    let aSetting = settingStr.toLower()
+    try:
+      var m: RegexMatch2
+      if aSetting.match(regexParseSize, m) == false:
+        return err("Invalid rate-limit setting: " & settingStr)
+
+      var sProtocol = aSetting[m.captures[1]]
+      let volume = aSetting[m.captures[2]].parseInt()
+      let duration = aSetting[m.captures[3]].parseInt()
+      let periodUnit = aSetting[m.captures[4]]
+
+      var period = 0.seconds
+      case periodUnit
+      of "ms":
+        period = duration.milliseconds
+      of "s":
+        period = duration.seconds
+      of "m":
+        period = duration.minutes
+      of "h":
+        period = duration.hours
+
+      fillSettingTable(settingsTable, sProtocol, (volume, period))
+    except ValueError:
+      return err("Invalid rate-limit setting: " & settingStr)
+
+  # If there were no global setting predefined, we set unlimited
+  # due it is taken for protocols not defined in the list - thus those will not apply accidentally wrong settings.
+  discard settingsTable.hasKeyOrPut(GLOBAL, UnlimitedRateLimit)
+  discard settingsTable.hasKeyOrPut(FILTER, FilterDefaultPerPeerRateLimit)
+
+  return ok(settingsTable)
+
+proc parse*(
+    T: type ProtocolRateLimitSettings, settings: string
+): Result[ProtocolRateLimitSettings, string] =
+  return ok(settingsTable)
+
+proc getSetting*(
+    t: ProtocolRateLimitSettings, protocol: RateLimitedProtocol
+): RateLimitSetting =
+  let default = t.getOrDefault(GLOBAL, UnlimitedRateLimit)
+  return t.getOrDefault(protocol, default)

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -670,21 +670,18 @@ with the drawback of consuming some more bandwitdh.""",
       name: "websocket-secure-cert-path"
     .}: string
 
-    ## Rate limitation config
-    ## Currently default to switch of rate limit until become official
-    requestRateLimit* {.
+    ## Rate limitation config, if not set, rate limit checks will not be performed
+    rateLimits* {.
       desc:
-        "Number of requests to serve by each service in the specified period. Set it to 0 for unlimited",
-      defaultValue: 0,
-      name: "request-rate-limit"
-    .}: int
-
-    ## Currently default to switch of rate limit until become official
-    requestRatePeriod* {.
-      desc: "Period of request rate limitation in seconds. Set it to 0 for unlimited",
-      defaultValue: 0,
-      name: "request-rate-period"
-    .}: int64
+        "Rate limit settings for different protocols." &
+        "Format: protocol:volume/period<unit>" &
+        " Where 'protocol' can be one of: <store|storev2|storev3|lightpush|px|filter> if not defined it means a global setting" &
+        " 'volume' and period must be an integer value. " &
+        " 'unit' must be one of <h|m|s|ms> - hours, minutes, seconds, milliseconds respectively. " &
+        "Argument may be repeated.",
+      defaultValue: newSeq[string](0),
+      name: "rate-limit"
+    .}: seq[string]
 
 ## Parsing
 
@@ -850,6 +847,7 @@ proc load*(T: type WakuNodeConf, version = ""): ConfResult[T] =
           sources.addConfigFile(Toml, conf.configFile.get())
       ,
     )
+
     ok(conf)
   except CatchableError:
     err(getCurrentExceptionMsg())

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -368,7 +368,10 @@ proc setupProtocols(
   # waku peer exchange setup
   if conf.peerExchange:
     try:
-      await mountPeerExchange(node, some(conf.clusterId))
+      let rateLimitSetting: RateLimitSetting =
+        (conf.requestRateLimit, chronos.seconds(conf.requestRatePeriod))
+
+      await mountPeerExchange(node, some(conf.clusterId), rateLimitSetting)
     except CatchableError:
       return
         err("failed to mount waku peer-exchange protocol: " & getCurrentExceptionMsg())

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -114,6 +114,7 @@ type
     started*: bool # Indicates that node has started listening
     topicSubscriptionQueue*: AsyncEventQueue[SubscriptionEvent]
     contentTopicHandlers: Table[ContentTopic, TopicHandler]
+    rateLimitSettings*: ProtocolRateLimitSettings
 
 proc getAutonatService*(rng: ref HmacDrbgContext): AutonatService =
   ## AutonatService request other peers to dial us back
@@ -164,6 +165,7 @@ proc new*(
     enr: enr,
     announcedAddresses: netConfig.announcedAddresses,
     topicSubscriptionQueue: queue,
+    rateLimitSettings: DefaultProtocolRateLimit,
   )
 
   return node
@@ -481,7 +483,7 @@ proc mountFilter*(
     maxFilterPeers: uint32 = filter_subscriptions.MaxFilterPeers,
     maxFilterCriteriaPerPeer: uint32 = filter_subscriptions.MaxFilterCriteriaPerPeer,
     messageCacheTTL: Duration = filter_subscriptions.MessageCacheTTL,
-    rateLimitSetting: RateLimitSetting = FilterPerPeerRateLimit,
+    rateLimitSetting: RateLimitSetting = FilterDefaultPerPeerRateLimit,
 ) {.async: (raises: []).} =
   ## Mounting filter v2 protocol
 
@@ -1166,10 +1168,15 @@ proc mountPeerExchange*(
 
 proc fetchPeerExchangePeers*(
     node: Wakunode, amount: uint64
-): Future[Result[int, string]] {.async: (raises: []).} =
+): Future[Result[int, PeerExchangeResponseStatus]] {.async: (raises: []).} =
   if node.wakuPeerExchange.isNil():
     error "could not get peers from px, waku peer-exchange is nil"
-    return err("PeerExchange is not mounted")
+    return err(
+      PeerExchangeResponseStatus(
+        status: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+        desc: some("PeerExchange is not mounted"),
+      )
+    )
 
   info "Retrieving peer info via peer exchange protocol"
   let pxPeersRes = await node.wakuPeerExchange.request(amount)
@@ -1187,7 +1194,7 @@ proc fetchPeerExchangePeers*(
   else:
     warn "failed to retrieve peer info via peer exchange protocol",
       error = pxPeersRes.error
-    return err("Peer exchange failure: " & $pxPeersRes.error)
+    return err(pxPeersRes.error)
 
 # TODO: Move to application module (e.g., wakunode2.nim)
 proc setPeerExchangePeer*(
@@ -1376,3 +1383,10 @@ proc isReady*(node: WakuNode): Future[bool] {.async: (raises: [Exception]).} =
     return true
   return await node.wakuRlnRelay.isReady()
   ## TODO: add other protocol `isReady` checks
+
+proc setRateLimits*(node: WakuNode, limits: seq[string]): Result[void, string] =
+  let rateLimitConfig = ProtocolRateLimitSettings.parse(limits)
+  if rateLimitConfig.isErr():
+    return err("invalid rate limit settings:" & rateLimitConfig.error)
+  node.rateLimitSettings = rateLimitConfig.get()
+  ok()

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1144,11 +1144,14 @@ proc mountRlnRelay*(
 ## Waku peer-exchange
 
 proc mountPeerExchange*(
-    node: WakuNode, cluster: Option[uint16] = none(uint16)
+    node: WakuNode,
+    cluster: Option[uint16] = none(uint16),
+    rateLimit: RateLimitSetting = DefaultGlobalNonRelayRateLimit,
 ) {.async: (raises: []).} =
   info "mounting waku peer exchange"
 
-  node.wakuPeerExchange = WakuPeerExchange.new(node.peerManager, cluster)
+  node.wakuPeerExchange =
+    WakuPeerExchange.new(node.peerManager, cluster, some(rateLimit))
 
   if node.started:
     try:

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1172,9 +1172,9 @@ proc fetchPeerExchangePeers*(
   if node.wakuPeerExchange.isNil():
     error "could not get peers from px, waku peer-exchange is nil"
     return err(
-      PeerExchangeResponseStatus(
-        status: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
-        desc: some("PeerExchange is not mounted"),
+      (
+        status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+        status_desc: some("PeerExchange is not mounted"),
       )
     )
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1389,4 +1389,4 @@ proc setRateLimits*(node: WakuNode, limits: seq[string]): Result[void, string] =
   if rateLimitConfig.isErr():
     return err("invalid rate limit settings:" & rateLimitConfig.error)
   node.rateLimitSettings = rateLimitConfig.get()
-  ok()
+  return ok()

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -328,6 +328,7 @@ proc new*(
   )
 
   wf.initProtocolHandler()
+  setServiceLimitMetric(WakuFilterSubscribeCodec, rateLimitSetting)
   return wf
 
 const MaintainSubscriptionsInterval* = 1.minutes

--- a/waku/waku_filter_v2/subscriptions.nim
+++ b/waku/waku_filter_v2/subscriptions.nim
@@ -12,12 +12,6 @@ const
   DefaultSubscriptionTimeToLiveSec* = 5.minutes
   MessageCacheTTL* = 2.minutes
 
-  # Acceptable call frequence from one peer using filter service
-  # Assumption is having to set up a subscription with max 30 calls than using ping in every min
-  # While subscribe/unsubscribe events are distributed in time among clients, pings will happen regularly from
-  # all subscribed peers
-  FilterPerPeerRateLimit*: RateLimitSetting = (30, 1.minutes)
-
 type
   # a single filter criterion is fully defined by a pubsub topic and content topic
   FilterCriterion* = tuple[pubsubTopic: PubsubTopic, contentTopic: ContentTopic]

--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -110,4 +110,5 @@ proc new*(
     requestRateLimiter: newRequestRateLimiter(rateLimitSetting),
   )
   wl.initProtocolHandler()
+  setServiceLimitMetric(WakuLightpushCodec, rateLimitSetting)
   return wl

--- a/waku/waku_peer_exchange.nim
+++ b/waku/waku_peer_exchange.nim
@@ -1,5 +1,5 @@
 {.push raises: [].}
 
-import ./waku_peer_exchange/protocol
+import ./waku_peer_exchange/[protocol, rpc]
 
-export protocol
+export protocol, rpc

--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -264,5 +264,6 @@ proc new*(
     requestRateLimiter: newRequestRateLimiter(rateLimitSetting),
   )
   wpx.initProtocolHandler()
+  setServiceLimitMetric(WakuPeerExchangeCodec, rateLimitSetting)
   asyncSpawn wpx.updatePxEnrCache()
   return wpx

--- a/waku/waku_peer_exchange/rpc.nim
+++ b/waku/waku_peer_exchange/rpc.nim
@@ -29,7 +29,7 @@ type
     responseStatus*: Option[PeerExchangeResponseStatus]
 
 proc makeRequest*(T: type PeerExchangeRpc, numPeers: uint64): T =
-  return T(request: some(PeerExchangeRequest(numPeers: numpeers)))
+  return T(request: some(PeerExchangeRequest(numPeers: numPeers)))
 
 proc makeResponse*(T: type PeerExchangeRpc, peerInfos: seq[PeerExchangePeerInfo]): T =
   return T(

--- a/waku/waku_peer_exchange/rpc.nim
+++ b/waku/waku_peer_exchange/rpc.nim
@@ -1,3 +1,5 @@
+import std/options
+
 type
   PeerExchangePeerInfo* = object
     enr*: seq[byte] # RLP encoded ENR: https://eips.ethereum.org/EIPS/eip-778
@@ -8,6 +10,35 @@ type
   PeerExchangeResponse* = object
     peerInfos*: seq[PeerExchangePeerInfo]
 
+  PeerExchangeResponseStatusCode* {.pure.} = enum
+    UNKNOWN = uint32(000)
+    SUCCESS = uint32(200)
+    BAD_REQUEST = uint32(400)
+    TOO_MANY_REQUESTS = uint32(429)
+    SERVICE_UNAVAILABLE = uint32(503)
+
+  PeerExchangeResponseStatus* = object
+    status*: PeerExchangeResponseStatusCode
+    desc*: Option[string]
+
   PeerExchangeRpc* = object
-    request*: PeerExchangeRequest
-    response*: PeerExchangeResponse
+    request*: Option[PeerExchangeRequest]
+    response*: Option[PeerExchangeResponse]
+    responseStatus*: Option[PeerExchangeResponseStatus]
+
+proc makeRequest*(T: type PeerExchangeRpc, numPeers: uint64): T =
+  return T(request: some(PeerExchangeRequest(numPeers: numpeers)))
+
+proc makeResponse*(T: type PeerExchangeRpc, peerInfos: seq[PeerExchangePeerInfo]): T =
+  return T(
+    response: some(PeerExchangeResponse(peerInfos: peerInfos)),
+    responseStatus:
+      some(PeerExchangeResponseStatus(status: PeerExchangeResponseStatusCode.SUCCESS)),
+  )
+
+proc makeErrorResponse*(
+    T: type PeerExchangeRpc,
+    status: PeerExchangeResponseStatusCode,
+    desc: Option[string] = none(string),
+): T =
+  return T(responseStatus: some(PeerExchangeResponseStatus(status: status, desc: desc)))

--- a/waku/waku_peer_exchange/rpc.nim
+++ b/waku/waku_peer_exchange/rpc.nim
@@ -14,8 +14,10 @@ type
     UNKNOWN = uint32(000)
     SUCCESS = uint32(200)
     BAD_REQUEST = uint32(400)
+    BAD_RESPONSE = uint32(401)
     TOO_MANY_REQUESTS = uint32(429)
     SERVICE_UNAVAILABLE = uint32(503)
+    DIAL_FAILURE = uint32(599)
 
   PeerExchangeResponseStatus* = object
     status*: PeerExchangeResponseStatusCode
@@ -42,3 +44,16 @@ proc makeErrorResponse*(
     desc: Option[string] = none(string),
 ): T =
   return T(responseStatus: some(PeerExchangeResponseStatus(status: status, desc: desc)))
+
+proc `$`*(statusCode: PeerExchangeResponseStatusCode): string =
+  case statusCode
+  of PeerExchangeResponseStatusCode.UNKNOWN: "UNKNOWN"
+  of PeerExchangeResponseStatusCode.SUCCESS: "SUCCESS"
+  of PeerExchangeResponseStatusCode.BAD_REQUEST: "BAD_REQUEST"
+  of PeerExchangeResponseStatusCode.BAD_RESPONSE: "BAD_RESPONSE"
+  of PeerExchangeResponseStatusCode.TOO_MANY_REQUESTS: "TOO_MANY_REQUESTS"
+  of PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE: "SERVICE_UNAVAILABLE"
+  of PeerExchangeResponseStatusCode.DIAL_FAILURE: "DIAL_FAILURE"
+
+proc `$`*(pxResponseStatus: PeerExchangeResponseStatus): string =
+  return $pxResponseStatus.status & " - " & pxResponseStatus.desc.get("")

--- a/waku/waku_peer_exchange/rpc_codec.nim
+++ b/waku/waku_peer_exchange/rpc_codec.nim
@@ -1,5 +1,6 @@
 {.push raises: [].}
 
+import std/options
 import ../common/protobuf, ./rpc
 
 proc encode*(rpc: PeerExchangeRequest): ProtoBuffer =
@@ -59,26 +60,81 @@ proc decode*(T: type PeerExchangeResponse, buffer: seq[byte]): ProtoResult[T] =
 
   ok(rpc)
 
-proc encode*(rpc: PeerExchangeRpc): ProtoBuffer =
+proc parse*(T: type PeerExchangeResponseStatusCode, status: uint32): T =
+  case status
+  of 200, 400, 429, 503:
+    PeerExchangeResponseStatusCode(status)
+  else:
+    PeerExchangeResponseStatusCode.UNKNOWN
+
+proc encode*(rpc: PeerExchangeResponseStatus): ProtoBuffer =
   var pb = initProtoBuffer()
 
-  pb.write3(1, rpc.request.encode())
-  pb.write3(2, rpc.response.encode())
+  pb.write3(1, rpc.status.uint32)
+  pb.write3(2, rpc.desc)
+
   pb.finish3()
 
   pb
 
-proc decode*(T: type PeerExchangeRpc, buffer: seq[byte]): ProtoResult[T] =
+proc decode*(T: type PeerExchangeResponseStatus, buffer: seq[byte]): ProtobufResult[T] =
+  var pb = initProtoBuffer(buffer)
+  var rpc = PeerExchangeResponseStatus(status: PeerExchangeResponseStatusCode.UNKNOWN)
+
+  var status: uint32
+  if ?pb.getField(1, status):
+    rpc.status = PeerExchangeResponseStatusCode.parse(status)
+  else:
+    return err(ProtobufError.missingRequiredField("status"))
+
+  var desc: string
+  if ?pb.getField(2, desc):
+    rpc.desc = some(desc)
+  else:
+    rpc.desc = none(string)
+
+  ok(rpc)
+
+proc encode*(rpc: PeerExchangeRpc): ProtoBuffer =
+  var pb = initProtoBuffer()
+
+  if rpc.request.isSome():
+    pb.write3(1, rpc.request.get().encode())
+  if rpc.response.isSome():
+    pb.write3(2, rpc.response.get().encode())
+  if rpc.responseStatus.isSome():
+    pb.write3(10, rpc.responseStatus.get().encode())
+
+  pb.finish3()
+
+  pb
+
+proc decode*(T: type PeerExchangeRpc, buffer: seq[byte]): ProtobufResult[T] =
   let pb = initProtoBuffer(buffer)
   var rpc = PeerExchangeRpc()
 
   var requestBuffer: seq[byte]
-  if not ?pb.getField(1, requestBuffer):
-    return err(ProtoError.RequiredFieldMissing)
-  rpc.request = ?PeerExchangeRequest.decode(requestBuffer)
+  let isRequest = ?pb.getField(1, requestBuffer)
 
   var responseBuffer: seq[byte]
-  discard ?pb.getField(2, responseBuffer)
-  rpc.response = ?PeerExchangeResponse.decode(responseBuffer)
+  let isResponse = ?pb.getField(2, responseBuffer)
+
+  if isRequest and isResponse:
+    return err(ProtobufError.missingRequiredField("request and response are exclusive"))
+
+  if not isRequest and not isResponse:
+    return err(ProtobufError.missingRequiredField("request"))
+
+  if isRequest:
+    rpc.request = some(?PeerExchangeRequest.decode(requestBuffer))
+
+  if isResponse:
+    rpc.response = some(?PeerExchangeResponse.decode(responseBuffer))
+
+  var status: seq[byte]
+  if ?pb.getField(10, status):
+    rpc.responseStatus = some(?PeerExchangeResponseStatus.decode(status))
+  elif not isRequest:
+    return err(ProtobufError.missingRequiredField("responseStatus"))
 
   ok(rpc)

--- a/waku/waku_peer_exchange/rpc_codec.nim
+++ b/waku/waku_peer_exchange/rpc_codec.nim
@@ -122,9 +122,6 @@ proc decode*(T: type PeerExchangeRpc, buffer: seq[byte]): ProtobufResult[T] =
   if isRequest and isResponse:
     return err(ProtobufError.missingRequiredField("request and response are exclusive"))
 
-  if not isRequest and not isResponse:
-    return err(ProtobufError.missingRequiredField("request"))
-
   if isRequest:
     rpc.request = some(?PeerExchangeRequest.decode(requestBuffer))
 
@@ -134,6 +131,9 @@ proc decode*(T: type PeerExchangeRpc, buffer: seq[byte]): ProtobufResult[T] =
   var status: seq[byte]
   if ?pb.getField(10, status):
     rpc.responseStatus = some(?PeerExchangeResponseStatus.decode(status))
+    if rpc.responseStatus.get().status == PeerExchangeResponseStatusCode.SUCCESS and
+        not isResponse:
+      return err(ProtobufError.missingRequiredField("response"))
   elif not isRequest:
     return err(ProtobufError.missingRequiredField("responseStatus"))
 

--- a/waku/waku_store/protocol.nim
+++ b/waku/waku_store/protocol.nim
@@ -154,5 +154,5 @@ proc new*(
   )
 
   store.initProtocolHandler()
-
+  setServiceLimitMetric(WakuStoreCodec, rateLimitSetting)
   return store

--- a/waku/waku_store_legacy/protocol.nim
+++ b/waku/waku_store_legacy/protocol.nim
@@ -153,4 +153,5 @@ proc new*(
     requestRateLimiter: newRequestRateLimiter(rateLimitSetting),
   )
   ws.initProtocolHandler()
+  setServiceLimitMetric(WakuLegacyStoreCodec, rateLimitSetting)
   ws


### PR DESCRIPTION
# Description
As part of [DOS protection for req-res protocols and metrics](https://github.com/waku-org/pm/issues/66)  Waku PeerExchange protocol must be protected just as Lightpush/Store and Filter.

# Changes

- [x] Ratlimit config and check was added to WakuPeerExchange
- [x] Due to the protocol RPC structure limiter status response capabilities, new fields had been added (status and optional descritpion)
- [x] Better error handling and reporting in WakuPeerExchange request/response side.
- [x] Test adjustments.
- [x] Enhance Waku CLI Rate Limit configuration (allow multiple configuration added, separately for each protocol)
- [x] Added new gauge to help dashboard show effective applied rate limit of protocols 

#### Warning

The last bullet point introduces a refactored rate limit configuration over CLI/TOML file.
This was necessary as identified different needs for different protocols (out of dogfooding and dashboard data)
This change will break former CLI as removed two former rate-limit option and replaced them by one - formatted string - that can be repeated. 
> As rate-limit configuration is not yet used this breaking change shall not cause trouble, just we need to handle upgrades with care.

New CLI option is `--rate-limit` which has to be set as string in a proper format.
Examples:
- `--rate-limit="lightpush:13/10s"` 
- `--rate-limit="storev3:15/1500ms"` 
- `--rate-limit="px:1/1m"` 
- `--rate-limit="100/10m"`
  - this last one is taken as global and will be used as default for protocols not set otherwise  

As this option can be repeated rate limit configuration can be fine-grained for every needs.

## How to test

Tests are adjusted and extended. Every peer exchange test must run without error.

## Issue
https://github.com/waku-org/nwaku/issues/3028

## Further actions:

- [x] https://github.com/waku-org/specs/blob/master/standards/core/peer-exchange.md must be adjusted
- [x] Configuration documentation must be pulled after.
- [ ] Add dashboard panel for PeerExchange metrics