### PR TITLE
fix: setting up node with modified config

### DIFF
--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -58,13 +58,15 @@ when isMainModule:
     nodeHealthMonitor = WakuNodeHealthMonitor()
     nodeHealthMonitor.setOverallHealth(HealthStatus.INITIALIZING)
 
+    var confCopy = conf
+
     let restServer = rest_server_builder.startRestServerEsentials(
-      nodeHealthMonitor, conf
+      nodeHealthMonitor, confCopy
     ).valueOr:
       error "Starting esential REST server failed.", error = $error
       quit(QuitFailure)
 
-    var waku = Waku.init(conf).valueOr:
+    var waku = Waku.init(confCopy).valueOr:
       error "Waku initialization failed", error = error
       quit(QuitFailure)
 
@@ -77,12 +79,12 @@ when isMainModule:
       quit(QuitFailure)
 
     rest_server_builder.startRestServerProtocolSupport(
-      restServer, waku.node, waku.wakuDiscv5, conf
+      restServer, waku.node, waku.wakuDiscv5, confCopy
     ).isOkOr:
       error "Starting protocols support REST server failed.", error = $error
       quit(QuitFailure)
 
-    waku.metricsServer = waku_metrics.startMetricsServerAndLogging(conf).valueOr:
+    waku.metricsServer = waku_metrics.startMetricsServerAndLogging(confCopy).valueOr:
       error "Starting monitoring and external interfaces failed", error = error
       quit(QuitFailure)
 

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -17,7 +17,7 @@ include waku/factory/waku
 suite "Wakunode2 - Waku":
   test "compilation version should be reported":
     ## Given
-    let conf = defaultTestWakuNodeConf()
+    var conf = defaultTestWakuNodeConf()
 
     let waku = Waku.init(conf).valueOr:
       raiseAssert error
@@ -43,7 +43,7 @@ suite "Wakunode2 - Waku initialization":
 
   test "node setup is successful with default configuration":
     ## Given
-    let conf = defaultTestWakuNodeConf()
+    var conf = defaultTestWakuNodeConf()
 
     ## When
     var waku = Waku.init(conf).valueOr:


### PR DESCRIPTION
# Description
We currently modify a copy of our configurations when initializing a node in https://github.com/waku-org/nwaku/blob/1713f562353476235a2076941775a1f150d7c615/waku/factory/waku.nim#L104-L106

However, we don't use this modified configuration when setting up the protocols and initializing the node, which causes mismatches between them.

Added a fix to use the same version of the configuration at the`wakunode2` application layer.

# Changes

<!-- List of detailed changes -->

- [x] using modified config copy in `wakunode2`



<!--
## Issue

closes #
-->