### PR TITLE
chore: Switch libnegentropy library build from shared to static linkage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,6 @@ RUN apk add --no-cache libgcc pcre-dev libpq-dev bind-tools
 # Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
 RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
-# Fix for 'Error loading shared library libnegentropy.so: No such file or directory'
-COPY --from=nim-build /app/libnegentropy.so /usr/lib/
-
 # Copy to separate location to accomodate different MAKE_TARGET values
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ clean: | clean-librln
 .PHONY: negentropy
 
 LIBNEGENTROPY_BUILDDIR := $(CURDIR)/vendor/negentropy/cpp
-LIBNEGENTROPY_FILE := libnegentropy.so
+LIBNEGENTROPY_FILE := libnegentropy.a
 
 deps: | negentropy
 
@@ -183,9 +183,9 @@ $(LIBNEGENTROPY_FILE):
 		cp $(LIBNEGENTROPY_BUILDDIR)/${LIBNEGENTROPY_FILE} ${LIBNEGENTROPY_FILE}
 
 negentropy: | $(LIBNEGENTROPY_FILE)
-    ## Pass libnegentropy to linker.
+    ## Pass libnegentropy and it's deps to linker.
     $(eval LIBNEGENTROPY_PATH := $(shell if [ -f "$(LIBNEGENTROPY_FILE)" ]; then echo "$(LIBNEGENTROPY_FILE)"; else echo "./$(LIBNEGENTROPY_FILE)"; fi))
-    $(eval NIM_PARAMS += --passL:$(LIBNEGENTROPY_PATH))
+    $(eval NIM_PARAMS += --passL:$(LIBNEGENTROPY_PATH) --passL:-lcrypto --passL:-lssl --passL:-lstdc++)
 
 negentropy-clean:
 	$(MAKE) -C $(LIBNEGENTROPY_BUILDDIR) clean && \

--- a/apps/liteprotocoltester/Dockerfile.liteprotocoltester
+++ b/apps/liteprotocoltester/Dockerfile.liteprotocoltester
@@ -29,8 +29,6 @@
 
   COPY build/liteprotocoltester /usr/bin/
   COPY apps/liteprotocoltester/run_tester_node.sh /usr/bin/
-  COPY ./libnegentropy.so /usr/lib/
-
 
   ENTRYPOINT ["/usr/bin/run_tester_node.sh", "/usr/bin/liteprotocoltester"]
 

--- a/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
+++ b/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
@@ -51,7 +51,6 @@
 
   # Copy migration scripts for DB upgrades
   COPY --from=nim-build /app/migrations/ /app/migrations/
-  COPY --from=nim-build /app/libnegentropy.so /usr/lib/
 
   ENTRYPOINT ["/usr/bin/liteprotocoltester"]
 

--- a/docker/binaries/Dockerfile.bn.amd64
+++ b/docker/binaries/Dockerfile.bn.amd64
@@ -19,9 +19,6 @@ RUN apt-get update &&\
 # Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
 RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
-# Fix for 'Error loading shared library libnegentropy.so: No such file or directory'
-ADD ./libnegentropy.so ./
-
 # Copy to separate location to accomodate different MAKE_TARGET values
 ADD ./build/$MAKE_TARGET /usr/local/bin/
 

--- a/waku/waku_sync/raw_bindings.nim
+++ b/waku/waku_sync/raw_bindings.nim
@@ -9,8 +9,6 @@ const negentropyPath =
   currentSourcePath.rsplit(DirSep, 1)[0] & DirSep & ".." & DirSep & ".." & DirSep &
   "vendor" & DirSep & "negentropy" & DirSep & "cpp" & DirSep
 
-{.link: negentropyPath & "libnegentropy.so".}
-
 const NEGENTROPY_HEADER = negentropyPath & "negentropy_wrapper.h"
 
 logScope:
@@ -193,7 +191,7 @@ proc new*(T: type NegentropyStorage): Result[T, string] =
   #TODO db name and path
   let storage = storage_init("", "")
 
-  #[ TODO: Uncomment once we move to lmdb   
+  #[ TODO: Uncomment once we move to lmdb
   if storage == nil:
     return err("storage initialization failed") ]#
   return ok(storage)
@@ -244,7 +242,7 @@ proc new*(
 ): Result[T, string] =
   let subrange = subrange_init(storage, startTime, endTime)
 
-  #[ TODO: Uncomment once we move to lmdb   
+  #[ TODO: Uncomment once we move to lmdb
   if storage == nil:
     return err("storage initialization failed") ]#
   return ok(subrange)
@@ -314,7 +312,7 @@ method delete*(self: NegentropyWithSubRange) =
   self.inner.free()
 
 method initiate*(self: NegentropyWithSubRange): Result[NegentropyPayload, string] =
-  ## Client inititate a sync session with a server by sending a payload 
+  ## Client inititate a sync session with a server by sending a payload
   var myResult {.noinit.}: BindingResult = BindingResult()
   var myResultPtr = addr myResult
 
@@ -409,7 +407,7 @@ method delete*(self: NegentropyWithStorage) =
   self.inner.free()
 
 method initiate*(self: NegentropyWithStorage): Result[NegentropyPayload, string] =
-  ## Client inititate a sync session with a server by sending a payload 
+  ## Client inititate a sync session with a server by sending a payload
   var myResult {.noinit.}: BindingResult = BindingResult()
   var myResultPtr = addr myResult
 


### PR DESCRIPTION
# Description
Due to various link issues with libnegentropy build as shared object, this PR is an experimental/proposal to switch to static linkage. 

# Changes

- [X] negentropy repo contains its own part in a separate branch: draft PR: https://github.com/waku-org/negentropy/pull/10
- [X] change waku target dependencies to libnegentropy.a and added negentropy dependencies to link.
- [X] Removed libnegentropy.so copy from Dockerfiles.

<!--
## How to test

1. All tests, must work same

## Issue
https://github.com/waku-org/nwaku/issues/3040