### PR TITLE
chore: sharding - reduce log level for a too spammy message

### DIFF
--- a/waku/waku_enr/sharding.nim
+++ b/waku/waku_enr/sharding.nim
@@ -227,7 +227,7 @@ proc containsShard*(r: Record, clusterId, shardId: uint16): bool =
     return false
 
   let record = r.toTyped().valueOr:
-    debug "invalid ENR record", error = error
+    trace "invalid ENR record", error = error
     return false
 
   let rs = record.relaySharding().valueOr:


### PR DESCRIPTION
# Description
@jakubgs reported a large amount of logs:

![image](https://github.com/user-attachments/assets/c4a048b4-ee11-414e-8e4e-aa3471a6e3f5)

We want to avoid that
