### PR TITLE
fix: static linking negentropy in ARM based mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,12 @@ clean: | clean-librln
 .PHONY: negentropy
 
 LIBNEGENTROPY_BUILDDIR := $(CURDIR)/vendor/negentropy/cpp
+ifeq ($(detected_OS),Linux)
 LIBNEGENTROPY_FILE := libnegentropy.a
+else
+LIBNEGENTROPY_FILE := libnegentropy.so
+endif
+
 
 deps: | negentropy
 
@@ -185,7 +190,10 @@ $(LIBNEGENTROPY_FILE):
 negentropy: | $(LIBNEGENTROPY_FILE)
     ## Pass libnegentropy and it's deps to linker.
     $(eval LIBNEGENTROPY_PATH := $(shell if [ -f "$(LIBNEGENTROPY_FILE)" ]; then echo "$(LIBNEGENTROPY_FILE)"; else echo "./$(LIBNEGENTROPY_FILE)"; fi))
-    $(eval NIM_PARAMS += --passL:$(LIBNEGENTROPY_PATH) --passL:-lcrypto --passL:-lssl --passL:-lstdc++)
+    $(eval NIM_PARAMS += --passL:$(LIBNEGENTROPY_PATH))
+	ifeq ($(detected_OS),Linux)
+        $(eval NIM_PARAMS += --passL:-lcrypto --passL:-lssl --passL:-lstdc++)
+    endif
 
 negentropy-clean:
 	$(MAKE) -C $(LIBNEGENTROPY_BUILDDIR) clean && \

--- a/Makefile
+++ b/Makefile
@@ -172,12 +172,7 @@ clean: | clean-librln
 .PHONY: negentropy
 
 LIBNEGENTROPY_BUILDDIR := $(CURDIR)/vendor/negentropy/cpp
-ifeq ($(detected_OS),Linux)
 LIBNEGENTROPY_FILE := libnegentropy.a
-else
-LIBNEGENTROPY_FILE := libnegentropy.so
-endif
-
 
 deps: | negentropy
 
@@ -190,10 +185,7 @@ $(LIBNEGENTROPY_FILE):
 negentropy: | $(LIBNEGENTROPY_FILE)
     ## Pass libnegentropy and it's deps to linker.
     $(eval LIBNEGENTROPY_PATH := $(shell if [ -f "$(LIBNEGENTROPY_FILE)" ]; then echo "$(LIBNEGENTROPY_FILE)"; else echo "./$(LIBNEGENTROPY_FILE)"; fi))
-    $(eval NIM_PARAMS += --passL:$(LIBNEGENTROPY_PATH))
-	ifeq ($(detected_OS),Linux)
-        $(eval NIM_PARAMS += --passL:-lcrypto --passL:-lssl --passL:-lstdc++)
-    endif
+    $(eval NIM_PARAMS += --passL:$(LIBNEGENTROPY_PATH) --passL:-lcrypto --passL:-lssl --passL:-lstdc++)
 
 negentropy-clean:
 	$(MAKE) -C $(LIBNEGENTROPY_BUILDDIR) clean && \

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ $(LIBNEGENTROPY_FILE):
 negentropy: | $(LIBNEGENTROPY_FILE)
     ## Pass libnegentropy and it's deps to linker.
     $(eval LIBNEGENTROPY_PATH := $(shell if [ -f "$(LIBNEGENTROPY_FILE)" ]; then echo "$(LIBNEGENTROPY_FILE)"; else echo "./$(LIBNEGENTROPY_FILE)"; fi))
-    $(eval NIM_PARAMS += --passL:$(LIBNEGENTROPY_PATH) --passL:-lcrypto --passL:-lssl --passL:-lstdc++)
+    $(eval NIM_PARAMS += --passL:$(LIBNEGENTROPY_PATH) --passL:-lcrypto --passL:-lssl --passL:-lstdc++ --passL:-L/opt/homebrew/lib/)
 
 negentropy-clean:
 	$(MAKE) -C $(LIBNEGENTROPY_BUILDDIR) clean && \


### PR DESCRIPTION
# Description

Adding `--passL:-L/opt/homebrew/lib/` when linking negentropy to fix error of missing crypto library in ARM based mac