### PR TITLE
chore: updating upload and download artifact actions to v4

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -123,7 +123,7 @@ jobs:
           ref: master
 
       - name: download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
 
       - name: prep variables
         id: vars

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -58,7 +58,7 @@ jobs:
           tar -cvzf ${{steps.vars.outputs.nwaku}} ./build/
 
       - name: Upload asset
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: ${{steps.vars.outputs.nwaku}}
           path: ${{steps.vars.outputs.nwaku}}


### PR DESCRIPTION
# Description
Updating upload and download artifact actions to v4 as versions used by us fail because they're deprecated
