### PR TITLE
chore: test peer connection management

### DIFF
--- a/tests/node/peer_manager/peer_store/utils.nim
+++ b/tests/node/peer_manager/peer_store/utils.nim
@@ -1,7 +1,7 @@
 import std/options, stew/results, libp2p/peerstore
 
 import
-  ../../../../waku/node/peer_manager/[waku_peer_store, peer_store/waku_peer_storage],
+  waku/node/peer_manager/[waku_peer_store, peer_store/waku_peer_storage],
   ../../../waku_archive/archive_utils
 
 proc newTestWakuPeerStorage*(path: Option[string] = string.none()): WakuPeerStorage =

--- a/tests/node/peer_manager/peer_store/utils.nim
+++ b/tests/node/peer_manager/peer_store/utils.nim
@@ -1,9 +1,12 @@
-import stew/results
+import std/options, stew/results, libp2p/peerstore
 
 import
-  ../../../../waku/node/peer_manager/peer_store/waku_peer_storage,
+  ../../../../waku/node/peer_manager/[waku_peer_store, peer_store/waku_peer_storage],
   ../../../waku_archive/archive_utils
 
-proc newTestWakuPeerStorage*(): WakuPeerStorage =
-  let db = newSqliteDatabase()
+proc newTestWakuPeerStorage*(path: Option[string] = string.none()): WakuPeerStorage =
+  let db = newSqliteDatabase(path)
   WakuPeerStorage.new(db).value()
+
+proc peerExists*(peerStore: PeerStore, peerId: PeerId): bool =
+  return peerStore[AddressBook].contains(peerId)

--- a/tests/node/peer_manager/peer_store/utils.nim
+++ b/tests/node/peer_manager/peer_store/utils.nim
@@ -1,12 +1,9 @@
-import std/options, stew/results, libp2p/peerstore
+import stew/results
 
 import
-  waku/node/peer_manager/[waku_peer_store, peer_store/waku_peer_storage],
+  ../../../../waku/node/peer_manager/peer_store/waku_peer_storage,
   ../../../waku_archive/archive_utils
 
-proc newTestWakuPeerStorage*(path: Option[string] = string.none()): WakuPeerStorage =
-  let db = newSqliteDatabase(path)
+proc newTestWakuPeerStorage*(): WakuPeerStorage =
+  let db = newSqliteDatabase()
   WakuPeerStorage.new(db).value()
-
-proc peerExists*(peerStore: PeerStore, peerId: PeerId): bool =
-  return peerStore[AddressBook].contains(peerId)

--- a/tests/node/test_wakunode_peer_manager.nim
+++ b/tests/node/test_wakunode_peer_manager.nim
@@ -595,9 +595,7 @@ suite "Peer Manager":
               serverPeerStore.get(clientPeerId).connectedness == Connectedness.CanConnect
 
           # When triggering the reconnection
-          var beforeReconnect = getTime().toUnixFloat()
           await client.peerManager.reconnectPeers(WakuRelayCodec)
-          let reconnectDuration = getTime().toUnixFloat() - beforeReconnect
 
           # Then both peers should be marked as Connected
           waitActive:
@@ -622,8 +620,7 @@ suite "Peer Manager":
           check:
             clientPeerStore.get(serverPeerId).connectedness == Connectedness.Connected
             serverPeerStore.get(clientPeerId).connectedness == Connectedness.Connected
-            reconnectDurationWithBackoffPeriod >
-              (reconnectDuration + backoffPeriod.seconds.float)
+            reconnectDurationWithBackoffPeriod > backoffPeriod.seconds.float
 
 suite "Handling Connections on Different Networks":
   # TODO: Implement after discv5 and peer manager's interaction is understood

--- a/tests/node/test_wakunode_peer_manager.nim
+++ b/tests/node/test_wakunode_peer_manager.nim
@@ -611,7 +611,7 @@ suite "Peer Manager":
 
           # When triggering a reconnection with a backoff period
           let backoffPeriod = chronos.seconds(1)
-          beforeReconnect = getTime().toUnixFloat()
+          let beforeReconnect = getTime().toUnixFloat()
           await client.peerManager.reconnectPeers(WakuRelayCodec, backoffPeriod)
           let reconnectDurationWithBackoffPeriod =
             getTime().toUnixFloat() - beforeReconnect

--- a/tests/testlib/testutils.nim
+++ b/tests/testlib/testutils.nim
@@ -1,4 +1,4 @@
-import testutils/unittests
+import testutils/unittests, chronos
 
 template xsuite*(name: string, body: untyped) =
   discard
@@ -27,3 +27,11 @@ template xasyncTest*(name: string, body: untyped) =
 template asyncTestx*(name: string, body: untyped) =
   test name:
     skip()
+
+template waitActive*(condition: bool) =
+  for i in 0 ..< 200:
+    if condition:
+      break
+    await sleepAsync(10)
+
+  assert condition

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -198,6 +198,9 @@ proc connectToNodes*(
   # NOTE Connects to the node without a give protocol, which automatically creates streams for relay
   await peer_manager.connectToNodes(node.peerManager, nodes, source = source)
 
+proc disconnectNode*(node: WakuNode, remotePeer: RemotePeerInfo) {.async.} =
+  await peer_manager.disconnectNode(node.peerManager, remotePeer)
+
 ## Waku Sync
 
 proc mountWakuSync*(


### PR DESCRIPTION
# Description
Enhance reconnect logic and fix reconnect tests.
The important point is that it is necessary to set a port different than zero in tests.

# Changes

## Issue
closes
- https://github.com/waku-org/nwaku/issues/2592
