### PR TITLE
fix: px protocol decode - do not treat missing response field as error

### DIFF
--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -20,9 +20,10 @@ declarePublicGauge waku_px_peers_received_total,
   "number of ENRs received via peer exchange"
 declarePublicGauge waku_px_peers_received_unknown,
   "number of previously unknown ENRs received via peer exchange"
-declarePublicGauge waku_px_peers_sent, "number of ENRs sent to peer exchange requesters"
+declarePublicCounter waku_px_peers_sent,
+  "number of ENRs sent to peer exchange requesters"
 declarePublicGauge waku_px_peers_cached, "number of peer exchange peer ENRs cached"
-declarePublicGauge waku_px_errors, "number of peer exchange errors", ["type"]
+declarePublicCounter waku_px_errors, "number of peer exchange errors", ["type"]
 
 logScope:
   topics = "waku peer_exchange"

--- a/waku/waku_peer_exchange/rpc_codec.nim
+++ b/waku/waku_peer_exchange/rpc_codec.nim
@@ -103,8 +103,9 @@ proc decode*(T: type PeerExchangeRpc, buffer: seq[byte]): ProtobufResult[T] =
 
   var responseBuffer: seq[byte]
   if not ?pb.getField(2, responseBuffer):
-    return err(ProtobufError.missingRequiredField("response"))
-
-  rpc.response = ?PeerExchangeResponse.decode(responseBuffer)
+    rpc.response =
+      PeerExchangeResponse(status_code: PeerExchangeResponseStatusCode.UNKNOWN)
+  else:
+    rpc.response = ?PeerExchangeResponse.decode(responseBuffer)
 
   ok(rpc)


### PR DESCRIPTION
# Description
With v0.33.0-rc2 on status.staging it was obvious that client using PeerExchange RPC the old way - on request they completely leave out response field (not even default is added) - cause decode error on nwaku side - that now implements changed protocol.


# Changes
- PeerExchangeRpc will not handle missing response field as error.
- By adding Peer Exchange metrics to grafana dashboard it is better to use counters instead of gauge for better dashboard stats.

<!-- List of detailed changes -->

- [X] rpc_codec of WakePeerExchange
- [X] `waku_px_peers_sent` and `waku_px_errors` have changed to counter from gauge type. 

## Issue
https://github.com/waku-org/nwaku/issues/3054
