### PR TITLE
chore: append current version in agentString which is used by the identify protocol

### DIFF
--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -26,6 +26,9 @@ include ../waku_core/message/default_values
 
 export confTomlDefs, confTomlNet, confEnvvarDefs, confEnvvarNet
 
+# Git version in git describe format (defined at compile time)
+const git_version* {.strdefine.} = "n/a"
+
 type ConfResult*[T] = Result[T, string]
 
 type EthRpcUrl* = distinct string
@@ -157,7 +160,7 @@ type WakuNodeConf* = object
     .}: uint16
 
     agentString* {.
-      defaultValue: "nwaku",
+      defaultValue: "nwaku-" & git_version,
       desc: "Node agent string which is used as identifier in network",
       name: "agent-string"
     .}: string


### PR DESCRIPTION
As suggested by @weboko , it is interesting to add the current nwaku version within the `identify` protocol response.

This PR achieves that. f.e.:

![image](https://github.com/user-attachments/assets/c314d59a-0e5e-4a49-a6f3-831f05c56b03)
