### PR TITLE
chore: disabling metrics for libwaku

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -63,12 +63,12 @@ proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
     extra_params &= " " & paramStr(i)
   if `type` == "static":
     exec "nim c" & " --out:build/" & name &
-      ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header " &
+      ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header --undef:metrics " &
       extra_params & " " & srcDir & name & ".nim"
   else:
     exec "nim c" & " --out:build/" & name &
-      ".so --threads:on --app:lib --opt:size --noMain --mm:refc --header " & extra_params &
-      " " & srcDir & name & ".nim"
+      ".so --threads:on --app:lib --opt:size --noMain --mm:refc --header --undef:metrics " &
+      extra_params & " " & srcDir & name & ".nim"
 
 proc buildMobileAndroid(srcDir = ".", params = "") =
   let cpu = getEnv("CPU")

--- a/waku/waku_core/time.nim
+++ b/waku/waku_core/time.nim
@@ -18,7 +18,9 @@ proc nowInUnixFloat(): float =
 proc getNowInNanosecondTime*(): Timestamp =
   return getNanosecondTime(nowInUnixFloat())
 
-template nanosecondTime*(collector: Summary | Histogram, body: untyped) =
+template nanosecondTime*(
+    collector: Summary | Histogram | typedesc[IgnoredCollector], body: untyped
+) =
   when defined(metrics):
     let start = nowInUnixFloat()
     body

--- a/waku/waku_rln_relay/protocol_metrics.nim
+++ b/waku/waku_rln_relay/protocol_metrics.nim
@@ -80,24 +80,26 @@ proc getRlnMetricsLogger*(): RLNMetricsLogger =
   var cumulativeValidMessages = 0.float64
   var cumulativeProofs = 0.float64
 
-  logMetrics = proc() =
-    {.gcsafe.}:
-      let freshErrorCount = parseAndAccumulate(waku_rln_errors_total, cumulativeErrors)
-      let freshMsgCount =
-        parseAndAccumulate(waku_rln_messages_total, cumulativeMessages)
-      let freshSpamCount =
-        parseAndAccumulate(waku_rln_spam_messages_total, cumulativeSpamMessages)
-      let freshInvalidMsgCount =
-        parseAndAccumulate(waku_rln_invalid_messages_total, cumulativeInvalidMessages)
-      let freshValidMsgCount =
-        parseAndAccumulate(waku_rln_valid_messages_total, cumulativeValidMessages)
-      let freshProofCount =
-        parseAndAccumulate(waku_rln_proof_verification_total, cumulativeProofs)
+  when defined(metrics):
+    logMetrics = proc() =
+      {.gcsafe.}:
+        let freshErrorCount =
+          parseAndAccumulate(waku_rln_errors_total, cumulativeErrors)
+        let freshMsgCount =
+          parseAndAccumulate(waku_rln_messages_total, cumulativeMessages)
+        let freshSpamCount =
+          parseAndAccumulate(waku_rln_spam_messages_total, cumulativeSpamMessages)
+        let freshInvalidMsgCount =
+          parseAndAccumulate(waku_rln_invalid_messages_total, cumulativeInvalidMessages)
+        let freshValidMsgCount =
+          parseAndAccumulate(waku_rln_valid_messages_total, cumulativeValidMessages)
+        let freshProofCount =
+          parseAndAccumulate(waku_rln_proof_verification_total, cumulativeProofs)
 
-      info "Total messages", count = freshMsgCount
-      info "Total spam messages", count = freshSpamCount
-      info "Total invalid messages", count = freshInvalidMsgCount
-      info "Total valid messages", count = freshValidMsgCount
-      info "Total errors", count = freshErrorCount
-      info "Total proofs verified", count = freshProofCount
+        info "Total messages", count = freshMsgCount
+        info "Total spam messages", count = freshSpamCount
+        info "Total invalid messages", count = freshInvalidMsgCount
+        info "Total valid messages", count = freshValidMsgCount
+        info "Total errors", count = freshErrorCount
+        info "Total proofs verified", count = freshProofCount
   return logMetrics


### PR DESCRIPTION
# Description
When running a node using libwaku, we repeatedly get the following error

```
metrics error: New label values must be added from same thread as the metric was created from - observation dropped: libp2p_gossipsub_peers_per_topic_gossipsub collector
metrics error: New label values must be added from same thread as the metric was created from - observation dropped: libp2p_gossipsub_peers_per_topic_fanout collector.
metrics error: New label values must be added from same thread as the metric was created from - observation dropped: libp2p_gossipsub_peers_per_topic_mesh collector.
```

Disabling by default the metrics for libwaku until the root cause is taken care of


# Changes

<!-- List of detailed changes -->

- [x] undefining the metrics compilation flag
- [x] modified `nanosecondTime` to accept the type passed when metrics are disabled
- [x] assigning a proc to `logMetrics` only when metrics are defined 

<!--
## How to test

1.
1.
1.

-->


## Issue
#3039 
