### PR TITLE
fix: PeerExchange rpc decode in order not to take response's status_code mandatory - for support old protocol implementation

### DIFF
--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -217,7 +217,9 @@ proc populateEnrCache(wpx: WakuPeerExchange) =
 
 proc updatePxEnrCache(wpx: WakuPeerExchange) {.async.} =
   # try more aggressively to fill the cache at startup
-  while wpx.enrCache.len < MaxPeersCacheSize:
+  var attempts = 10
+  while wpx.enrCache.len < MaxPeersCacheSize and attempts > 0:
+    attempts -= 1
     wpx.populateEnrCache()
     await sleepAsync(5.seconds)
 

--- a/waku/waku_peer_exchange/rpc_codec.nim
+++ b/waku/waku_peer_exchange/rpc_codec.nim
@@ -71,7 +71,11 @@ proc decode*(T: type PeerExchangeResponse, buffer: seq[byte]): ProtobufResult[T]
   if ?pb.getField(10, status_code):
     rpc.status_code = PeerExchangeResponseStatusCode.parse(status_code)
   else:
-    return err(ProtobufError.missingRequiredField("status_code"))
+    # older peers may not support status_code field yet
+    if rpc.peerInfos.len() > 0:
+      rpc.status_code = PeerExchangeResponseStatusCode.SUCCESS
+    else:
+      rpc.status_code = PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE
 
   var status_desc: string
   if ?pb.getField(11, status_desc):


### PR DESCRIPTION
# Description
lite-protocol-tester implementation started using PX from the receiver side and found that node that implements old style PeerExchange protocol does not containing status_code and status_desc can cause decode failure.
To handle this false assumption of making status_code for response mandatory, if not included the value is derived from the response enr list length.

+1
I found that PeerExchange tries to aggressively fill the ENR cache at startup. It takes a minimum 60 Peers to fill in the cache. But if there is not many this loop will run - async - till end of program at every 5.secs, instead of running at every 10 minutes as designed.
So to break the loop I added a max 10 times trial of aggressive filling.

# Changes

- [x] PeerExchange rpc_codec - to derive status_code value if not included in the protobuf payload
- [x] PeerExchange protocol initial ENR cache fill limited to 10 trials.
