### PR TITLE
chore: Optimize store

### DIFF
--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -34,16 +34,15 @@ suite "Postgres driver":
     var futures = newSeq[Future[ArchiveDriverResult[void]]](0)
 
     let beforeSleep = now()
-    for _ in 1 .. 100:
+
+    for _ in 1 .. 25:
       futures.add(driver.sleep(1))
 
     await allFutures(futures)
 
     let diff = now() - beforeSleep
-    # Actually, the diff randomly goes between 1 and 2 seconds.
-    # although in theory it should spend 1s because we establish 100
-    # connections and we spawn 100 tasks that spend ~1s each.
-    assert diff < 20_000_000_000
+
+    assert diff < 2_000_000_000 ## nanoseconds
 
   asyncTest "Insert a message":
     const contentTopic = "test-content-topic"

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -76,7 +76,7 @@ proc openDbConn(connString: string): Result[DbConn, string] =
 
 proc new*(T: type DbConnWrapper, connString: string): Result[T, string] =
   let dbConn = openDbConn(connString).valueOr:
-    return err("failed to stablish a new connection: " & $error)
+    return err("failed to establish a new connection: " & $error)
 
   return ok(DbConnWrapper(dbConn: dbConn, open: true))
 

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -160,7 +160,11 @@ proc waitQueryToFinish(
     pqclear(pqResult)
 
 proc dbConnQuery*(
-    db: DbConn, query: SqlQuery, args: seq[string], rowCallback: DataProc
+    db: DbConn,
+    query: SqlQuery,
+    args: seq[string],
+    rowCallback: DataProc,
+    requestId: string,
 ): Future[Result[void, string]] {.async, gcsafe.} =
   let cleanedQuery = ($query).replace(" ", "").replace("\n", "")
   ## remove everything between ' or " all possible sequence of numbers. e.g. rm partition partition
@@ -188,6 +192,7 @@ proc dbConnQuery*(
 
   if "insert" notin ($query).toLower():
     debug "dbConnQuery",
+      requestId,
       query = $query,
       querySummary,
       waitDurationSecs = waitDuration,
@@ -202,6 +207,7 @@ proc dbConnQueryPrepared*(
     paramLengths: seq[int32],
     paramFormats: seq[int32],
     rowCallback: DataProc,
+    requestId: string,
 ): Future[Result[void, string]] {.async, gcsafe.} =
   var queryStartTime = getTime().toUnixFloat()
   db.sendQueryPrepared(stmtName, paramValues, paramLengths, paramFormats).isOkOr:
@@ -222,6 +228,9 @@ proc dbConnQueryPrepared*(
 
   if "insert" notin stmtName.toLower():
     debug "dbConnQueryPrepared",
-      stmtName, waitDurationSecs = waitDuration, sendDurationSecs = sendDuration
+      requestId,
+      stmtName,
+      waitDurationSecs = waitDuration,
+      sendDurationSecs = sendDuration
 
   return ok()

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -132,7 +132,7 @@ proc waitQueryToFinish(
   ## The 'rowCallback' param is != nil when the underlying query wants to retrieve results (SELECT.)
   ## For other queries, like "INSERT", 'rowCallback' should be nil.
 
-  debug "waitQueryToFinish", requestId
+  debug "waitQueryToFinish", requestId, db = db.repr
   var dataAvailable = false
   proc onDataAvailable(udata: pointer) {.gcsafe, raises: [].} =
     dataAvailable = true
@@ -142,10 +142,10 @@ proc waitQueryToFinish(
   asyncengine.addReader2(asyncFd, onDataAvailable).isOkOr:
     return err("failed to add event reader in waitQueryToFinish: " & $error)
 
-  debug "waitQueryToFinish", requestId
+  debug "waitQueryToFinish", requestId, db = db.repr
   while not dataAvailable:
     await sleepAsync(timer.milliseconds(1))
-  debug "waitQueryToFinish", requestId
+  debug "waitQueryToFinish", requestId, db = db.repr
 
   ## Now retrieve the result
   while true:
@@ -155,7 +155,7 @@ proc waitQueryToFinish(
       db.check().isOkOr:
         return err("error in query: " & $error)
 
-      debug "waitQueryToFinish", requestId
+      debug "waitQueryToFinish", requestId, db = db.repr
 
       return ok() # reached the end of the results
 

--- a/waku/common/databases/db_postgres/pgasyncpool.nim
+++ b/waku/common/databases/db_postgres/pgasyncpool.nim
@@ -106,7 +106,7 @@ proc resetConnPool*(pool: PgAsyncPool): Future[DatabaseResult[void]] {.async.} =
 
   return ok()
 
-const SlowQueryThresholdInNanoSeconds = 1_000_000_000
+const SlowQueryThreshold = 1.seconds
 
 proc pgQuery*(
     pool: PgAsyncPool,
@@ -122,7 +122,7 @@ proc pgQuery*(
   let dbConnWrapper = pool.conns[connIndex]
   defer:
     let queryDuration = getNowInNanosecondTime() - queryStartTime
-    if queryDuration > SlowQueryThresholdInNanoSeconds:
+    if queryDuration > SlowQueryThreshold.nanos:
       debug "pgQuery slow query",
         query_duration_secs = (queryDuration / 1_000_000_000), query, requestId
 

--- a/waku/common/databases/db_postgres/pgasyncpool.nim
+++ b/waku/common/databases/db_postgres/pgasyncpool.nim
@@ -156,7 +156,7 @@ proc runStmt*(
 
   defer:
     let queryDuration = getNowInNanosecondTime() - queryStartTime
-    if queryDuration > SlowQueryThresholdInNanoSeconds:
+    if queryDuration > SlowQueryThreshold.nanos:
       debug "runStmt slow query",
         query_duration = queryDuration / 1_000_000_000,
         query = stmtDefinition,

--- a/waku/common/databases/db_postgres/pgasyncpool.nim
+++ b/waku/common/databases/db_postgres/pgasyncpool.nim
@@ -146,7 +146,7 @@ proc releaseConn(pool: PgAsyncPool, conn: DbConn) =
     if pool.conns[i].dbConn == conn:
       pool.conns[i].busy = false
 
-const SlowQueryThresholdInNanoSeconds = 2_000_000_000
+const SlowQueryThresholdInNanoSeconds = 1_000_000_000
 
 proc pgQuery*(
     pool: PgAsyncPool,
@@ -167,7 +167,7 @@ proc pgQuery*(
       debug "pgQuery slow query",
         query_duration_secs = (queryDuration / 1_000_000_000), query, requestId
 
-  (await conn.dbConnQuery(sql(query), args, rowCallback)).isOkOr:
+  (await conn.dbConnQuery(sql(query), args, rowCallback, requestId)).isOkOr:
     return err("error in asyncpool query: " & $error)
 
   return ok()
@@ -218,7 +218,7 @@ proc runStmt*(
 
   (
     await conn.dbConnQueryPrepared(
-      stmtName, paramValues, paramLengths, paramFormats, rowCallback
+      stmtName, paramValues, paramLengths, paramFormats, rowCallback, requestId
     )
   ).isOkOr:
     return err("error in runStmt: " & $error)

--- a/waku/common/databases/db_postgres/pgasyncpool.nim
+++ b/waku/common/databases/db_postgres/pgasyncpool.nim
@@ -2,37 +2,22 @@
 # Inspired by: https://github.com/treeform/pg/
 {.push raises: [].}
 
-import std/[sequtils, nre, strformat, sets], results, chronos, chronicles
-  std/[sequtils, nre, strformat, sets],
+import
+  std/[sequtils, nre, strformat],
   results,
   chronos,
   chronos/threadsync,
   chronicles,
-  strutils,
-  random
+  strutils
 import ./dbconn, ../common, ../../../waku_core/time
-
-type PgAsyncPoolState {.pure.} = enum
-  Closed
-  Live
-  Closing
-
-type PgDbConn = ref object
-  dbConn: DbConn
-  open: bool
-  busy: bool
-  preparedStmts: HashSet[string] ## [stmtName's]
-  busySignal: ThreadSignalPtr ## signal to wait while the pool is busy
 
 type
   # Database connection pool
   PgAsyncPool* = ref object
     connString: string
     maxConnections: int
-
-    state: PgAsyncPoolState
-    conns: seq[PgDbConn]
-    busySignal: ThreadSignalPtr
+    conns: seq[DbConnWrapper]
+    busySignal: ThreadSignalPtr ## signal to wait while the pool is busy
 
 proc new*(T: type PgAsyncPool, dbUrl: string, maxConnections: int): DatabaseResult[T] =
   var connString: string
@@ -51,93 +36,64 @@ proc new*(T: type PgAsyncPool, dbUrl: string, maxConnections: int): DatabaseResu
       SyntaxError:
     return err("could not parse postgres string: " & getCurrentExceptionMsg())
 
-  let busySignal = ThreadSignalPtr.new().valueOr:
-    return err("error creating busySignal ThreadSignalPtr in PgAsyncPool: " & $error)
-
   let pool = PgAsyncPool(
     connString: connString,
     maxConnections: maxConnections,
-    state: PgAsyncPoolState.Live,
-    conns: newSeq[PgDbConn](0),
-    busySignal: busySignal,
+    conns: newSeq[DbConnWrapper](0),
   )
 
   return ok(pool)
 
-func isLive(pool: PgAsyncPool): bool =
-  pool.state == PgAsyncPoolState.Live
-
 func isBusy(pool: PgAsyncPool): bool =
-  pool.conns.mapIt(it.busy).allIt(it)
+  return pool.conns.mapIt(it.isPgDbConnBusy()).allIt(it)
 
 proc close*(pool: PgAsyncPool): Future[Result[void, string]] {.async.} =
   ## Gracefully wait and close all openned connections
-
-  if pool.state == PgAsyncPoolState.Closing:
-    while pool.state == PgAsyncPoolState.Closing:
-      await sleepAsync(0.milliseconds) # Do not block the async runtime
-    return ok()
-
-  pool.state = PgAsyncPoolState.Closing
-
   # wait for the connections to be released and close them, without
   # blocking the async runtime
-  while pool.conns.anyIt(it.busy):
-    debug "closing waiting while connections are busy"
-    await pool.busySignal.wait()
 
-    for i in 0 ..< pool.conns.len:
-      if pool.conns[i].busy:
-        continue
+  debug "close PgAsyncPool"
+  await allFutures(pool.conns.mapIt(it.futBecomeFree))
+  debug "closing all connection PgAsyncPool"
 
   for i in 0 ..< pool.conns.len:
-    if pool.conns[i].open:
-      pool.conns[i].dbConn.closeDbConn()
-      pool.conns[i].busy = false
-      pool.conns[i].open = false
+    if pool.conns[i].isPgDbConnOpen():
+      pool.conns[i].closeDbConn().isOkOr:
+        return err("error in close PgAsyncPool: " & $error)
+      pool.conns[i].setPgDbConnOpen(false)
 
   pool.conns.setLen(0)
-  pool.state = PgAsyncPoolState.Closed
 
   return ok()
 
 proc getFirstFreeConnIndex(pool: PgAsyncPool): DatabaseResult[int] =
   for index in 0 ..< pool.conns.len:
-    if pool.conns[index].busy:
+    if pool.conns[index].isPgDbConnBusy():
       continue
 
     ## Pick up the first free connection and set it busy
-    pool.conns[index].busy = true
     return ok(index)
 
 proc getConnIndex(pool: PgAsyncPool): Future[DatabaseResult[int]] {.async.} =
   ## Waits for a free connection or create if max connections limits have not been reached.
   ## Returns the index of the free connection
 
-  if not pool.isLive():
-    return err("pool is not live")
-
   if not pool.isBusy():
     return pool.getFirstFreeConnIndex()
 
   ## Pool is busy then
-
   if pool.conns.len == pool.maxConnections:
     ## Can't create more connections. Wait for a free connection without blocking the async runtime.
-    if pool.isBusy():
-      await pool.busySignal.wait()
+    let busyFuts = pool.conns.mapIt(it.futBecomeFree)
+    discard await one(busyFuts)
 
     return pool.getFirstFreeConnIndex()
   elif pool.conns.len < pool.maxConnections:
     ## stablish a new connection
-    let conn = dbconn.open(pool.connString).valueOr:
-      return err("failed to stablish a new connection: " & $error)
+    let dbConn = DbConnWrapper.new(pool.connString).valueOr:
+      return err("error creating DbConnWrapper: " & $error)
 
-    pool.conns.add(
-      PgDbConn(
-        dbConn: conn, open: true, busy: true, preparedStmts: initHashSet[string]()
-      )
-    )
+    pool.conns.add(dbConn)
     return ok(pool.conns.len - 1)
 
 proc resetConnPool*(pool: PgAsyncPool): Future[DatabaseResult[void]] {.async.} =
@@ -145,24 +101,10 @@ proc resetConnPool*(pool: PgAsyncPool): Future[DatabaseResult[void]] {.async.} =
   ## This proc is intended to be called when the connection with the database
   ## got interrupted from the database side or a connectivity problem happened.
 
-  for i in 0 ..< pool.conns.len:
-    pool.conns[i].busy = false
-
   (await pool.close()).isOkOr:
     return err("error in resetConnPool: " & error)
 
-  pool.state = PgAsyncPoolState.Live
   return ok()
-
-proc releaseConn(pool: PgAsyncPool, conn: DbConn) =
-  ## Marks the connection as released.
-  for i in 0 ..< pool.conns.len:
-    if pool.conns[i].dbConn == conn:
-      pool.conns[i].busy = false
-
-  pool.busySignal.fireSync().isOkOr:
-    error "error triggering busySignal in releaseConn", error = $error
-
 
 const SlowQueryThresholdInNanoSeconds = 1_000_000_000
 
@@ -177,15 +119,14 @@ proc pgQuery*(
     return err("connRes.isErr in query: " & $error)
 
   let queryStartTime = getNowInNanosecondTime()
-  let conn = pool.conns[connIndex].dbConn
+  let dbConnWrapper = pool.conns[connIndex]
   defer:
-    pool.releaseConn(conn)
     let queryDuration = getNowInNanosecondTime() - queryStartTime
     if queryDuration > SlowQueryThresholdInNanoSeconds:
       debug "pgQuery slow query",
         query_duration_secs = (queryDuration / 1_000_000_000), query, requestId
 
-  (await conn.dbConnQuery(sql(query), args, rowCallback, requestId)).isOkOr:
+  (await dbConnWrapper.dbConnQuery(sql(query), args, rowCallback, requestId)).isOkOr:
     return err("error in asyncpool query: " & $error)
 
   return ok()
@@ -210,11 +151,10 @@ proc runStmt*(
   let connIndex = (await pool.getConnIndex()).valueOr:
     return err("Error in runStmt: " & $error)
 
-  let conn = pool.conns[connIndex].dbConn
+  let dbConnWrapper = pool.conns[connIndex]
   let queryStartTime = getNowInNanosecondTime()
 
   defer:
-    pool.releaseConn(conn)
     let queryDuration = getNowInNanosecondTime() - queryStartTime
     if queryDuration > SlowQueryThresholdInNanoSeconds:
       debug "runStmt slow query",
@@ -222,20 +162,20 @@ proc runStmt*(
         query = stmtDefinition,
         requestId
 
-  if not pool.conns[connIndex].preparedStmts.contains(stmtName):
+  if not pool.conns[connIndex].containsPreparedStmt(stmtName):
     # The connection doesn't have that statement yet. Let's create it.
     # Each session/connection has its own prepared statements.
     let res = catch:
       let len = paramValues.len
-      discard conn.prepare(stmtName, sql(stmtDefinition), len)
+      discard dbConnWrapper.getDbConn().prepare(stmtName, sql(stmtDefinition), len)
 
     if res.isErr():
       return err("failed prepare in runStmt: " & res.error.msg)
 
-    pool.conns[connIndex].preparedStmts.incl(stmtName)
+    pool.conns[connIndex].inclPreparedStmt(stmtName)
 
   (
-    await conn.dbConnQueryPrepared(
+    await dbConnWrapper.dbConnQueryPrepared(
       stmtName, paramValues, paramLengths, paramFormats, rowCallback, requestId
     )
   ).isOkOr:

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -336,8 +336,6 @@ proc subscribe*(
     error "Invalid API call to `subscribe`. Was already subscribed"
     return
 
-  debug "subscribe", pubsubTopic = pubsubTopic
-
   node.topicSubscriptionQueue.emit((kind: PubsubSub, topic: pubsubTopic))
   node.registerRelayDefaultHandler(pubsubTopic)
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -123,9 +123,9 @@ const SelectWithCursorNoDataAscStmtDef =
           timestamp <= $7
     ORDER BY timestamp ASC, messageHash ASC LIMIT $8;"""
 
-const SelectCursorByHashName = "SelectMessageByHash"
+const SelectCursorByHashName = "SelectMessageByHashInMessagesLookup"
 const SelectCursorByHashDef =
-  """SELECT timestamp FROM messages
+  """SELECT timestamp FROM messages_lookup
     WHERE messageHash = $1"""
 
 const


### PR DESCRIPTION
## Description
We have three big-time consumption components in `store`:
1. database
2. communicate with database
3. return a response to store-client

This PR enhances the point 2, because we've been applying an incorrect `async` approach, which was to wait for a certain state with the following technique:

```
while pool.isBusy():
      await sleepAsync(0.milliseconds)
```
or
```
while not dataAvailable:
  await sleepAsync(timer.milliseconds(1))
```

Doing that has a very big impact on performance because we were adding a massive amount of future objects to the async queue. @arnetheduck - correct me if that statement is not accurate.

Therefore, in this PR we are starting to apply a better `async` approach to properly coordinate tasks.

----

Aside from that, we are simplifying `pgasyncpool.nim` and suggesting a better wrapper for the `DbConn` object. 
  
-----

We are also optimizing the following query so that we use the `messages_lookup` table instead:
```SELECT timestamp FROM messages WHERE messageHash = $1```