### PR TITLE
fix: rejecting excess relay connections

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -440,7 +440,7 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
     if inRelayPeers.len > pm.inRelayPeersTarget and
         pm.peerStore.hasPeer(peerId, WakuRelayCodec):
       debug "disconnecting relay peer because reached max num in-relay peers",
-        peerId,
+        peerId = peerId,
         inRelayPeers = inRelayPeers.len,
         inRelayPeersTarget = pm.inRelayPeersTarget
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -66,7 +66,7 @@ const
   PrunePeerStoreInterval = chronos.minutes(10)
 
   # How often metrics and logs are shown/updated
-  LogAndMetricsInterval = chronos.seconds(15)
+  LogAndMetricsInterval = chronos.minutes(3)
 
   # Max peers that we allow from the same IP
   DefaultColocationLimit* = 5
@@ -539,9 +539,9 @@ proc new*(
     storage: storage,
     initialBackoffInSec: initialBackoffInSec,
     backoffFactor: backoffFactor,
-    outRelayPeersTarget: 7,
-    inRelayPeersTarget: 3,
-    maxRelayPeers: 10,
+    outRelayPeersTarget: outRelayPeersTarget,
+    inRelayPeersTarget: maxRelayPeersValue - outRelayPeersTarget,
+    maxRelayPeers: maxRelayPeersValue,
     maxFailedAttempts: maxFailedAttempts,
     colocationLimit: colocationLimit,
     shardedPeerManagement: shardedPeerManagement,
@@ -735,8 +735,6 @@ proc connectToRelayPeers*(pm: PeerManager) {.async.} =
   let totalRelayPeers = inRelayPeers.len + outRelayPeers.len
 
   if inRelayPeers.len > pm.inRelayPeersTarget:
-    notice "------------ connectToRelayPeers inRelayPeers.len > pm.inRelayPeersTarget",
-      inRelayPeers = inRelayPeers, inRelayPeersTarget = pm.inRelayPeersTarget
     await pm.pruneInRelayConns(inRelayPeers.len - pm.inRelayPeersTarget)
 
   if outRelayPeers.len >= pm.outRelayPeersTarget:

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -66,7 +66,7 @@ const
   PrunePeerStoreInterval = chronos.minutes(10)
 
   # How often metrics and logs are shown/updated
-  LogAndMetricsInterval = chronos.minutes(3)
+  LogAndMetricsInterval = chronos.seconds(15)
 
   # Max peers that we allow from the same IP
   DefaultColocationLimit* = 5
@@ -499,7 +499,7 @@ proc new*(
     error "Max backoff time can't be over 1 week", maxBackoff = backoff
     raise newException(Defect, "Max backoff time can't be over 1 week")
 
-  let outRelayPeersTarget = max(maxRelayPeersValue div 3, 10)
+  let outRelayPeersTarget = maxRelayPeersValue div 3
 
   let pm = PeerManager(
     switch: switch,
@@ -719,11 +719,11 @@ proc pruneInRelayConns(pm: PeerManager, amount: int) {.async.} =
 
 proc connectToRelayPeers*(pm: PeerManager) {.async.} =
   var (inRelayPeers, outRelayPeers) = pm.connectedPeers(WakuRelayCodec)
-  let maxConnections = pm.switch.connManager.inSema.size
   let totalRelayPeers = inRelayPeers.len + outRelayPeers.len
-  let inPeersTarget = maxConnections - pm.outRelayPeersTarget
 
   if inRelayPeers.len > pm.inRelayPeersTarget:
+    notice "------------ connectToRelayPeers inRelayPeers.len > pm.inRelayPeersTarget",
+      inRelayPeers = inRelayPeers, inRelayPeersTarget = pm.inRelayPeersTarget
     await pm.pruneInRelayConns(inRelayPeers.len - pm.inRelayPeersTarget)
 
   if outRelayPeers.len >= pm.outRelayPeersTarget:

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -404,6 +404,24 @@ proc onPeerMetadata(pm: PeerManager, peerId: PeerId) {.async.} =
   asyncSpawn(pm.switch.disconnect(peerId))
   pm.wakuPeerStore.delete(peerId)
 
+proc connectedPeers*(pm: PeerManager, protocol: string): (seq[PeerId], seq[PeerId]) =
+  ## Returns the peerIds of physical connections (in and out)
+  ## containing at least one stream with the given protocol.
+
+  var inPeers: seq[PeerId]
+  var outPeers: seq[PeerId]
+
+  for peerId, muxers in pm.switch.connManager.getConnections():
+    for peerConn in muxers:
+      let streams = peerConn.getStreams()
+      if streams.anyIt(it.protocol == protocol):
+        if peerConn.connection.transportDir == Direction.In:
+          inPeers.add(peerId)
+        elif peerConn.connection.transportDir == Direction.Out:
+          outPeers.add(peerId)
+
+  return (inPeers, outPeers)
+
 # called when a peer i) first connects to us ii) disconnects all connections from us
 proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
   if not pm.wakuMetadata.isNil() and event.kind == PeerEventKind.Joined:
@@ -417,6 +435,19 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
     direction = if event.initiator: Outbound else: Inbound
     connectedness = Connected
 
+    ## Check max allowed in-relay peers
+    let inRelayPeers = pm.connectedPeers(WakuRelayCodec)[0]
+    if inRelayPeers.len > pm.inRelayPeersTarget and
+        pm.peerStore.hasPeer(peerId, WakuRelayCodec):
+      debug "disconnecting relay peer because reached max num in-relay peers",
+        peerId,
+        inRelayPeers = inRelayPeers.len,
+        inRelayPeersTarget = pm.inRelayPeersTarget
+
+      await pm.switch.disconnect(peerId)
+      pm.peerStore.delete(peerId)
+
+    ## Apply max ip colocation limit
     if (let ip = pm.getPeerIp(peerId); ip.isSome()):
       pm.ipTable.mgetOrPut(ip.get, newSeq[PeerId]()).add(peerId)
 
@@ -499,7 +530,7 @@ proc new*(
     error "Max backoff time can't be over 1 week", maxBackoff = backoff
     raise newException(Defect, "Max backoff time can't be over 1 week")
 
-  # let outRelayPeersTarget = 2 * maxRelayPeersValue div 3
+  let outRelayPeersTarget = maxRelayPeersValue div 3
 
   let pm = PeerManager(
     switch: switch,
@@ -673,24 +704,6 @@ proc reconnectPeers*(
       await sleepAsync(backoffTime)
 
     await pm.connectToNodes(@[peerInfo])
-
-proc connectedPeers*(pm: PeerManager, protocol: string): (seq[PeerId], seq[PeerId]) =
-  ## Returns the peerIds of physical connections (in and out)
-  ## containing at least one stream with the given protocol.
-
-  var inPeers: seq[PeerId]
-  var outPeers: seq[PeerId]
-
-  for peerId, muxers in pm.switch.connManager.getConnections():
-    for peerConn in muxers:
-      let streams = peerConn.getStreams()
-      if streams.anyIt(it.protocol == protocol):
-        if peerConn.connection.transportDir == Direction.In:
-          inPeers.add(peerId)
-        elif peerConn.connection.transportDir == Direction.Out:
-          outPeers.add(peerId)
-
-  return (inPeers, outPeers)
 
 proc getNumStreams*(pm: PeerManager, protocol: string): (int, int) =
   var

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -445,7 +445,6 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
         inRelayPeersTarget = pm.inRelayPeersTarget
 
       await pm.switch.disconnect(peerId)
-      pm.wakuPeerStore.delete(peerId)
 
     ## Apply max ip colocation limit
     if (let ip = pm.getPeerIp(peerId); ip.isSome()):

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -443,7 +443,6 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
         peerId = peerId,
         inRelayPeers = inRelayPeers.len,
         inRelayPeersTarget = pm.inRelayPeersTarget
-
       await pm.switch.disconnect(peerId)
 
     ## Apply max ip colocation limit

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -438,14 +438,14 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
     ## Check max allowed in-relay peers
     let inRelayPeers = pm.connectedPeers(WakuRelayCodec)[0]
     if inRelayPeers.len > pm.inRelayPeersTarget and
-        pm.peerStore.hasPeer(peerId, WakuRelayCodec):
+        pm.wakuPeerStore.hasPeer(peerId, WakuRelayCodec):
       debug "disconnecting relay peer because reached max num in-relay peers",
         peerId = peerId,
         inRelayPeers = inRelayPeers.len,
         inRelayPeersTarget = pm.inRelayPeersTarget
 
       await pm.switch.disconnect(peerId)
-      pm.peerStore.delete(peerId)
+      pm.wakuPeerStore.delete(peerId)
 
     ## Apply max ip colocation limit
     if (let ip = pm.getPeerIp(peerId); ip.isSome()):

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -499,7 +499,7 @@ proc new*(
     error "Max backoff time can't be over 1 week", maxBackoff = backoff
     raise newException(Defect, "Max backoff time can't be over 1 week")
 
-  let outRelayPeersTarget = maxRelayPeersValue div 3
+  # let outRelayPeersTarget = 2 * maxRelayPeersValue div 3
 
   let pm = PeerManager(
     switch: switch,
@@ -508,9 +508,9 @@ proc new*(
     storage: storage,
     initialBackoffInSec: initialBackoffInSec,
     backoffFactor: backoffFactor,
-    outRelayPeersTarget: outRelayPeersTarget,
-    inRelayPeersTarget: maxRelayPeersValue - outRelayPeersTarget,
-    maxRelayPeers: maxRelayPeersValue,
+    outRelayPeersTarget: 7,
+    inRelayPeersTarget: 3,
+    maxRelayPeers: 10,
     maxFailedAttempts: maxFailedAttempts,
     colocationLimit: colocationLimit,
     shardedPeerManagement: shardedPeerManagement,


### PR DESCRIPTION
# Description
Rejecting incoming Relay connections whenever we reached our `in` connections target.

Currently, we accept connections and prune the excess connections periodically. However, this approach is not working out properly, as nodes can reconnect to us right after we disconnect to them, making no difference.

This makes the node vulnerable to attacks, as other nodes can fill all our connections without leaving libp2p connections to serve non-Relay nodes.

This PR addresses the issue, disconnecting from a Relay node right after receiving their request, in case we already reached our target.

The content of this PR was actually proposed by @Ivansete-status some weeks ago :) Thanks so much!

# Changes

<!-- List of detailed changes -->

- [x] disconnecting from incoming connections after reaching `inRelayPeersTarget`
- [x] don't set an arbitrary minimum of `outRelayPeersTarget`
- [x] remove unused variables 


## Issue

closes #3063 
