### PR TITLE
fix: out connections leak

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	path = vendor/nim-libp2p
 	url = https://github.com/vacp2p/nim-libp2p.git
 	ignore = dirty
-	branch = debug-excess-peer-connections
+	branch = master
 [submodule "vendor/nim-stew"]
 	path = vendor/nim-stew
 	url = https://github.com/status-im/nim-stew.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	path = vendor/nim-libp2p
 	url = https://github.com/vacp2p/nim-libp2p.git
 	ignore = dirty
-	branch = master
+	branch = debug-excess-peer-connections
 [submodule "vendor/nim-stew"]
 	path = vendor/nim-stew
 	url = https://github.com/status-im/nim-stew.git

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -732,6 +732,12 @@ proc connectToRelayPeers*(pm: PeerManager) {.async.} =
   var (inRelayPeers, outRelayPeers) = pm.connectedPeers(WakuRelayCodec)
   let totalRelayPeers = inRelayPeers.len + outRelayPeers.len
 
+  info "connectToRelayPeers",
+    inRelayPeers = inRelayPeers.len,
+    inRelayPeersTarget = pm.inRelayPeersTarget,
+    outRelayPeers = outRelayPeers.len,
+    outRelayPeersTarget = pm.outRelayPeersTarget
+
   if inRelayPeers.len > pm.inRelayPeersTarget:
     await pm.pruneInRelayConns(inRelayPeers.len - pm.inRelayPeersTarget)
 
@@ -749,6 +755,8 @@ proc connectToRelayPeers*(pm: PeerManager) {.async.} =
     min(outsideBackoffPeers.len, pm.outRelayPeersTarget - outRelayPeers.len)
     ## number of outstanding connection requests
 
+  info "connectToRelayPeers connecting to peers",
+    numPendingConnReqs = numPendingConnReqs
   while numPendingConnReqs > 0 and outRelayPeers.len < pm.outRelayPeersTarget:
     let numPeersToConnect = min(numPendingConnReqs, MaxParallelDials)
     await pm.connectToNodes(outsideBackoffPeers[index ..< (index + numPeersToConnect)])
@@ -757,6 +765,12 @@ proc connectToRelayPeers*(pm: PeerManager) {.async.} =
 
     index += numPeersToConnect
     numPendingConnReqs -= numPeersToConnect
+  (inRelayPeers, outRelayPeers) = pm.connectedPeers(WakuRelayCodec)
+  info "finished connectToRelayPeers",
+    inRelayPeers = inRelayPeers.len,
+    inRelayPeersTarget = pm.inRelayPeersTarget,
+    outRelayPeers = outRelayPeers.len,
+    outRelayPeersTarget = pm.outRelayPeersTarget
 
 proc manageRelayPeers*(pm: PeerManager) {.async.} =
   if pm.wakuMetadata.shards.len == 0:

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -190,6 +190,7 @@ proc connectRelay*(
     wireAddr = peer.addrs, peerId = peerId, failedAttempts = failedAttempts
 
   var deadline = sleepAsync(dialTimeout)
+  info "calling connectRelay"
   let workfut = pm.switch.connect(peerId, peer.addrs)
 
   # Can't use catch: with .withTimeout() in this case
@@ -685,6 +686,7 @@ proc reconnectPeers*(
   ## Reconnect to peers registered for this protocol. This will update connectedness.
   ## Especially useful to resume connections from persistent storage after a restart.
 
+  info "calling reconnectPeers"
   debug "Reconnecting peers", proto = proto
 
   # Proto is not persisted, we need to iterate over all peers.

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -253,6 +253,8 @@ proc dialPeer(
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
 
+  info "calling dialPeer"
+
   # Dial Peer
   let dialFut = pm.switch.dial(peerId, addrs, proto)
 
@@ -611,6 +613,7 @@ proc dialPeer*(
 
   # First add dialed peer info to peer store, if it does not exist yet..
   # TODO: nim libp2p peerstore already adds them
+  info "calling peerManager's dialPeer"
   if not pm.wakuPeerStore.hasPeer(remotePeerInfo.peerId, proto):
     trace "Adding newly dialed peer to manager",
       peerId = $remotePeerInfo.peerId, address = $remotePeerInfo.addrs[0], proto = proto

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -367,6 +367,7 @@ proc onConnEvent(pm: PeerManager, peerId: PeerID, event: ConnEvent) {.async.} =
     discard
 
 proc onPeerMetadata(pm: PeerManager, peerId: PeerId) {.async.} =
+  info "calling onPeerMetadata"
   let res = catch:
     await pm.switch.dial(peerId, WakuMetadataCodec)
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -367,7 +367,6 @@ proc onConnEvent(pm: PeerManager, peerId: PeerID, event: ConnEvent) {.async.} =
     discard
 
 proc onPeerMetadata(pm: PeerManager, peerId: PeerId) {.async.} =
-  info "calling onPeerMetadata"
   let res = catch:
     await pm.switch.dial(peerId, WakuMetadataCodec)
 
@@ -743,6 +742,8 @@ proc connectToRelayPeers*(pm: PeerManager) {.async.} =
     inRelayPeersTarget = pm.inRelayPeersTarget,
     outRelayPeers = outRelayPeers.len,
     outRelayPeersTarget = pm.outRelayPeersTarget
+
+  info "connectToRelayPeers outRelayPeers", outRelayPeers = outRelayPeers
 
   if inRelayPeers.len > pm.inRelayPeersTarget:
     await pm.pruneInRelayConns(inRelayPeers.len - pm.inRelayPeersTarget)

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -407,9 +407,11 @@ proc onPeerMetadata(pm: PeerManager, peerId: PeerId) {.async.} =
   asyncSpawn(pm.switch.disconnect(peerId))
   pm.wakuPeerStore.delete(peerId)
 
-proc connectedPeers*(pm: PeerManager, protocol: string): (seq[PeerId], seq[PeerId]) =
-  ## Returns the peerIds of physical connections (in and out)
-  ## containing at least one stream with the given protocol.
+proc connectedPeers*(
+    pm: PeerManager, protocol: string = ""
+): (seq[PeerId], seq[PeerId]) =
+  ## Returns the peerIds of physical connections (in and out)
+  ## If a protocol is specified, only returns peers with at least one stream of that protocol
 
   var inPeers: seq[PeerId]
   var outPeers: seq[PeerId]
@@ -417,7 +419,7 @@ proc connectedPeers*(pm: PeerManager, protocol: string): (seq[PeerId], seq[PeerI
   for peerId, muxers in pm.switch.connManager.getConnections():
     for peerConn in muxers:
       let streams = peerConn.getStreams()
-      if streams.anyIt(it.protocol == protocol):
+      if protocol.len == 0 or streams.anyIt(it.protocol == protocol):
         if peerConn.connection.transportDir == Direction.In:
           inPeers.add(peerId)
         elif peerConn.connection.transportDir == Direction.Out:

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -434,6 +434,7 @@ proc startRelay*(node: WakuNode) {.async.} =
     let backoffPeriod =
       node.wakuRelay.parameters.pruneBackoff + chronos.seconds(BackoffSlackTime)
 
+    info "calling reconnectPeers", backoffPeriod = backoffPeriod
     await node.peerManager.reconnectPeers(WakuRelayCodec, backoffPeriod)
 
   # Start the WakuRelay protocol
@@ -1252,7 +1253,6 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
 
     for peer in peers:
       try:
-        info "calling keepAlive dial"
         let conn = await node.switch.dial(peer.peerId, peer.addrs, PingCodec)
         let pingDelay = await node.libp2pPing.ping(conn)
         await conn.close()

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -196,7 +196,6 @@ proc connectToNodes*(
 ) {.async.} =
   ## `source` indicates source of node addrs (static config, api call, discovery, etc)
   # NOTE Connects to the node without a give protocol, which automatically creates streams for relay
-  info "calling connectToNodes"
   await peer_manager.connectToNodes(node.peerManager, nodes, source = source)
 
 proc disconnectNode*(node: WakuNode, remotePeer: RemotePeerInfo) {.async.} =
@@ -434,7 +433,6 @@ proc startRelay*(node: WakuNode) {.async.} =
     let backoffPeriod =
       node.wakuRelay.parameters.pruneBackoff + chronos.seconds(BackoffSlackTime)
 
-    info "calling reconnectPeers", backoffPeriod = backoffPeriod
     await node.peerManager.reconnectPeers(WakuRelayCodec, backoffPeriod)
 
   # Start the WakuRelay protocol

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1252,6 +1252,7 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
 
     for peer in peers:
       try:
+        info "calling keepAlive dial"
         let conn = await node.switch.dial(peer.peerId, peer.addrs, PingCodec)
         let pingDelay = await node.libp2pPing.ping(conn)
         await conn.close()

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1253,6 +1253,7 @@ proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
 
     for peer in peers:
       try:
+        info "calling keepAlive dial", peerId = peer.peerId
         let conn = await node.switch.dial(peer.peerId, peer.addrs, PingCodec)
         let pingDelay = await node.libp2pPing.ping(conn)
         await conn.close()

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -196,6 +196,7 @@ proc connectToNodes*(
 ) {.async.} =
   ## `source` indicates source of node addrs (static config, api call, discovery, etc)
   # NOTE Connects to the node without a give protocol, which automatically creates streams for relay
+  info "calling connectToNodes"
   await peer_manager.connectToNodes(node.peerManager, nodes, source = source)
 
 proc disconnectNode*(node: WakuNode, remotePeer: RemotePeerInfo) {.async.} =


### PR DESCRIPTION

# Description

Once we started promptly disconnecting from excess `in` connections, we began seeing our nodes significantly exceeding their `out` connections targets.

The root cause was a race condition in our keep alive loop https://github.com/waku-org/nwaku/blob/643ab20fc67f251987d594cfb5aa4abb60ccc5b2/waku/node/waku_node.nim#L1241-L1258

The case is the following:
1. A node receives incoming connections beyond its target, and it takes a small amount of time from the moment `nim-libp2p` accepts the connection until our peer manager notices that it's beyond our `in` target and disconnects
2. In the time while we're connected to this `in` connection, we start running the keep alive loop and have that peer in the list of connected peers that we should ping
3. While we're pinging other peers, we disconnect from the `in` connection as we noticed it's beyond our target
4. Because the list of the nodes to ping was generated before we disconnected from the node, we ping the node. As there's no existing connection, we end up creating a new `out` connection towards the node

The proposed change to avoid this race condition is to delegate the responsibility of the periodic ping to the node that originally initiated the connection. Or in other words, whoever initiated a connection is the one responsible to ping periodically to maintain it open - there's no need to have both nodes pinging each other.

# Changes

- [x] extended `connectedPeers()` to allow to get connected peers from all protocols
- [x] modified `keepaliveLoop` so that we only ping nodes in our `out` connections list 



## Issue

closes #3063 
