### PR TITLE
chore: adding missing error handling in libwaku

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -309,24 +309,27 @@ proc waku_start(
     ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
 ): cint {.dynlib, exportc.} =
   checkLibwakuParams(ctx, callback, userData)
-  ## TODO: handle the error
-  discard waku_thread.sendRequestToWakuThread(
+
+  waku_thread
+  .sendRequestToWakuThread(
     ctx,
     RequestType.LIFECYCLE,
     NodeLifecycleRequest.createShared(NodeLifecycleMsgType.START_NODE),
   )
+  .handleRes(callback, userData)
 
 proc waku_stop(
     ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
 ): cint {.dynlib, exportc.} =
   checkLibwakuParams(ctx, callback, userData)
 
-  ## TODO: handle the error
-  discard waku_thread.sendRequestToWakuThread(
+  waku_thread
+  .sendRequestToWakuThread(
     ctx,
     RequestType.LIFECYCLE,
     NodeLifecycleRequest.createShared(NodeLifecycleMsgType.STOP_NODE),
   )
+  .handleRes(callback, userData)
 
 proc waku_relay_subscribe(
     ctx: ptr WakuContext,


### PR DESCRIPTION
# Description
In `libwaku`, we are not properly handling errors and returning responses for `waku_start` and `waku_stop` requests

# Changes

<!-- List of detailed changes -->

- [x] handling response for `waku_start` requests
- [x] handling response for `waku_stop` requests

## Issue
#3039 

