### PR TITLE
chore: improving and temporarily skipping flaky rln test

### DIFF
--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -558,7 +558,7 @@ procSuite "WakuNode - RLN relay":
       node2.wakuRlnRelay.nullifierLog.len() == 1
 
     # Epoch 2
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm3, startTime + 5).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm3, startTime + float(1 * epochSizeSec)).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm3)
     await sleepAsync(publishSleepDuration)
@@ -567,7 +567,7 @@ procSuite "WakuNode - RLN relay":
       node2.wakuRlnRelay.nullifierLog.len() == 2
 
     # Epoch 3
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm4, startTime + 10).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm4, startTime + float(2 * epochSizeSec)).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm4)
     await sleepAsync(publishSleepDuration)
@@ -576,7 +576,7 @@ procSuite "WakuNode - RLN relay":
       node2.wakuRlnRelay.nullifierLog.len() == 3
 
     # Epoch 4
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm5, startTime + 15).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm5, startTime + float(3 * epochSizeSec)).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm5)
     await sleepAsync(publishSleepDuration)
@@ -585,7 +585,7 @@ procSuite "WakuNode - RLN relay":
       node2.wakuRlnRelay.nullifierLog.len() == 4
 
     # Epoch 5
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm6, startTime + 20).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm6, startTime + float(4 * epochSizeSec)).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm6)
     await sleepAsync(publishSleepDuration)

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -542,13 +542,13 @@ procSuite "WakuNode - RLN relay":
 
     # Given all messages have an rln proof and are published by the node 1
     let publishSleepDuration: Duration = 5000.millis
-    let time = epochTime()
+    let startTime = epochTime()
 
     # Epoch 1
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm1, time).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm1, startTime).isOkOr:
       raiseAssert $error
     # Message wm2 is published in the same epoch as wm1, so it'll be considered spam
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm2, time).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm2, startTime).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm1)
     discard await node1.publish(some(DefaultPubsubTopic), wm2)
@@ -558,7 +558,7 @@ procSuite "WakuNode - RLN relay":
       node2.wakuRlnRelay.nullifierLog.len() == 1
 
     # Epoch 2
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm3, epochTime()).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm3, startTime + 5).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm3)
     await sleepAsync(publishSleepDuration)
@@ -567,7 +567,7 @@ procSuite "WakuNode - RLN relay":
       node2.wakuRlnRelay.nullifierLog.len() == 2
 
     # Epoch 3
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm4, epochTime()).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm4, startTime + 10).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm4)
     await sleepAsync(publishSleepDuration)
@@ -576,7 +576,7 @@ procSuite "WakuNode - RLN relay":
       node2.wakuRlnRelay.nullifierLog.len() == 3
 
     # Epoch 4
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm5, epochTime()).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm5, startTime + 15).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm5)
     await sleepAsync(publishSleepDuration)
@@ -585,7 +585,7 @@ procSuite "WakuNode - RLN relay":
       node2.wakuRlnRelay.nullifierLog.len() == 4
 
     # Epoch 5
-    node1.wakuRlnRelay.unsafeAppendRLNProof(wm6, epochTime()).isOkOr:
+    node1.wakuRlnRelay.unsafeAppendRLNProof(wm6, startTime + 20).isOkOr:
       raiseAssert $error
     discard await node1.publish(some(DefaultPubsubTopic), wm6)
     await sleepAsync(publishSleepDuration)

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -11,7 +11,7 @@ import
   libp2p/protocols/pubsub/pubsub
 import
   waku/[waku_core, waku_node, waku_rln_relay],
-  ../testlib/[wakucore, futures, wakunode],
+  ../testlib/[wakucore, futures, wakunode, testutils],
   ./rln/waku_rln_relay_utils
 
 from std/times import epochTime

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -478,7 +478,7 @@ procSuite "WakuNode - RLN relay":
     await node2.stop()
     await node3.stop()
 
-  asyncTest "clearNullifierLog: should clear epochs > MaxEpochGap":
+  xasyncTest "clearNullifierLog: should clear epochs > MaxEpochGap":
     # Given two nodes
     let
       contentTopic = ContentTopic("/waku/2/default-content/proto")


### PR DESCRIPTION
# Description
For quite a while, the test `WakuNode - RLN relay::clearNullifierLog: should clear epochs > MaxEpochGap` has been extremely flaky in the CI.

I added in this PR a small fix to make the test more deterministic, however I still see that it's a bit flaky anyways.

So I propose to skip this test in the meantime until we get to work on it, and opened the following issue to track it https://github.com/waku-org/nwaku/issues/3095

# Changes


- [x] hardcoding message timestamps relative to `startTime`
- [x] skipping test

