### PR TITLE
fix: remove quotes from libwaku's returned enr string

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
@@ -30,7 +30,7 @@ proc process*(
   of RETRIEVE_LISTENING_ADDRESSES:
     return ok($(%*waku.node.getMultiaddresses()))
   of RETRIEVE_MY_ENR:
-    return ok($(%*waku.node.enr.toURI()))
+    return ok(waku.node.enr.toURI())
 
   error "unsupported operation in DebugNodeRequest"
   return err("unsupported operation in DebugNodeRequest")


### PR DESCRIPTION
# Description
In libwaku, when processing a `RETRIEVE_MY_ENR` request we are adding an extra `"` in the beginning and in the end of the string.

This is necessary for `RETRIEVE_LISTENING_ADDRESSES` because we have to convert a sequence to a string, but for`RETRIEVE_MY_ENR` which already has a return type of type string, this ends up adding extra quotes.
# Changes

<!-- List of detailed changes -->

- [x] returning string in `RETRIEVE_MY_ENR` as is



## Issue
#3039 