### PR TITLE
fix: returning peerIds in base 64 in GET_ALL_PEER_IDS

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -83,6 +83,6 @@ proc process*(
     ## returns a comma-separated string of peerIDs that mount the given protocol
     let (inPeers, outPeers) = waku.node.peerManager.connectedPeers($self[].protocol)
     let allPeerIDs = inPeers & outPeers
-    return ok(allPeerIDs.mapIt(it.hex()).join(","))
+    return ok(allPeerIDs.join(","))
 
   return ok("")


### PR DESCRIPTION
# Description
In libwaku's `GET_ALL_PEER_IDS` requests, stop converting the peerId's to hex and returning them in their original base 64 form
# Changes

<!-- List of detailed changes -->

- [x] return peerIds in base 64

## Issue

#3039 
