### PR TITLE
chore: remove warnings

### DIFF
--- a/library/events/json_message_event.nim
+++ b/library/events/json_message_event.nim
@@ -1,5 +1,5 @@
-import system, std/[json, sequtils]
-import stew/[byteutils, results]
+import system, results, std/json
+import stew/byteutils
 import
   ../../waku/common/base64,
   ../../waku/waku_core/message,

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -5,7 +5,7 @@
 when defined(linux):
   {.passl: "-Wl,-soname,libwaku.so".}
 
-import std/[json, sequtils, atomics, strformat, options, atomics]
+import std/[json, atomics, strformat, options, atomics]
 import chronicles, chronos
 import
   waku/common/base64,

--- a/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
@@ -1,10 +1,9 @@
-import std/[json, sequtils]
+import std/json
 import chronos, chronicles, results, libp2p/multiaddress
 import
   ../../../../waku/factory/waku,
   ../../../../waku/discovery/waku_dnsdisc,
   ../../../../waku/discovery/waku_discv5,
-  ../../../../waku/waku_peer_exchange,
   ../../../../waku/waku_core/peers,
   ../../../../waku/node/waku_node,
   ../../../alloc

--- a/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
@@ -1,4 +1,4 @@
-import std/[options, sequtils, json, strutils, net]
+import std/[options, json, strutils, net]
 import chronos, chronicles, results, confutils, confutils/std/net
 
 import

--- a/library/waku_thread/inter_thread_communication/requests/protocols/lightpush_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/lightpush_request.nim
@@ -1,5 +1,5 @@
-import std/net, options
-import chronicles, chronos, stew/byteutils, results
+import options
+import chronicles, chronos, results
 import
   ../../../../../waku/waku_core/message/message,
   ../../../../../waku/factory/waku,

--- a/waku.nimble
+++ b/waku.nimble
@@ -161,14 +161,14 @@ task libwakuStatic, "Build the cbindings waku node library":
   let name = "libwaku"
   buildLibrary name,
     "library/",
-    """-d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client" """,
+    """-d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client" --warning:Deprecated:off --warning:UnusedImport:on """,
     "static"
 
 task libwakuDynamic, "Build the cbindings waku node library":
   let name = "libwaku"
   buildLibrary name,
     "library/",
-    """-d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client" """,
+    """-d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client" --warning:Deprecated:off --warning:UnusedImport:on """,
     "dynamic"
 
 ### Mobile Android

--- a/waku/common/rate_limit/per_peer_limiter.nim
+++ b/waku/common/rate_limit/per_peer_limiter.nim
@@ -6,7 +6,7 @@
 
 {.push raises: [].}
 
-import std/[options, tables], chronos/timer, libp2p/stream/connection, libp2p/utility
+import std/[options, tables], libp2p/stream/connection
 
 import ./[single_token_limiter, service_metrics], ../../utils/tableutils
 

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -1,7 +1,7 @@
 {.push raises: [].}
 
 import
-  std/[options, sequtils],
+  std/options,
   results,
   chronicles,
   chronos,

--- a/waku/node/delivery_monitor/recv_monitor.nim
+++ b/waku/node/delivery_monitor/recv_monitor.nim
@@ -2,7 +2,7 @@
 ## receive and is backed by store-v3 requests to get an additional degree of certainty
 ##
 
-import std/[tables, sequtils, sets, options]
+import std/[tables, sequtils, options]
 import chronos, chronicles, libp2p/utility
 import
   ../../waku_core,

--- a/waku/node/delivery_monitor/send_monitor.nim
+++ b/waku/node/delivery_monitor/send_monitor.nim
@@ -1,7 +1,7 @@
 ## This module reinforces the publish operation with regular store-v3 requests.
 ##
 
-import std/[sets, sequtils]
+import std/sequtils
 import chronos, chronicles, libp2p/utility
 import
   ./delivery_callback,
@@ -206,7 +206,7 @@ proc startSendMonitor*(self: SendMonitor) =
   self.msgStoredCheckerHandle = self.checkIfMessagesStored()
 
 proc stopSendMonitor*(self: SendMonitor) =
-  self.msgStoredCheckerHandle.cancel()
+  discard self.msgStoredCheckerHandle.cancelAndWait()
 
 proc setDeliveryCallback*(self: SendMonitor, deliveryCb: DeliveryFeedbackCallback) =
   self.deliveryCb = deliveryCb

--- a/waku/node/delivery_monitor/subscriptions_observer.nim
+++ b/waku/node/delivery_monitor/subscriptions_observer.nim
@@ -9,5 +9,5 @@ method onSubscribe*(
 
 method onUnsubscribe*(
     self: SubscriptionObserver, pubsubTopic: string, contentTopics: seq[string]
-) {.gcsafe, raises: [].} =
+) {.base, gcsafe, raises: [].} =
   error "onUnsubscribe not implemented"

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -2,9 +2,10 @@
 
 import
   std/[times, options, sequtils, algorithm],
-  stew/[results, byteutils],
+  stew/[byteutils],
   chronicles,
   chronos,
+  results,
   metrics
 import
   ../common/paging,

--- a/waku/waku_archive/common.nim
+++ b/waku/waku_archive/common.nim
@@ -1,6 +1,6 @@
 {.push raises: [].}
 
-import std/options, results, stew/byteutils, stew/arrayops, nimcrypto/sha2
+import std/options, results
 import ../waku_core, ../common/paging
 
 ## Public API types

--- a/waku/waku_archive_legacy/archive.nim
+++ b/waku/waku_archive_legacy/archive.nim
@@ -4,11 +4,12 @@ else:
   {.push raises: [].}
 
 import
-  std/[times, options, sequtils, strutils, algorithm],
-  stew/[results, byteutils],
+  std/[times, options, sequtils, algorithm],
+  stew/byteutils,
   chronicles,
   chronos,
-  metrics
+  metrics,
+  results
 import
   ../common/paging,
   ./driver,

--- a/waku/waku_archive_legacy/driver/queue_driver/index.nim
+++ b/waku/waku_archive_legacy/driver/queue_driver/index.nim
@@ -3,7 +3,7 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import stew/byteutils, nimcrypto/sha2
+import nimcrypto/sha2
 import ../../../waku_core, ../../common
 
 type Index* = object

--- a/waku/waku_filter_v2/common.nim
+++ b/waku/waku_filter_v2/common.nim
@@ -63,7 +63,7 @@ proc serviceUnavailable*(
 proc parse*(T: type FilterSubscribeErrorKind, kind: uint32): T =
   case kind
   of 000, 200, 300, 400, 404, 429, 503:
-    FilterSubscribeErrorKind(kind)
+    cast[FilterSubscribeErrorKind](kind)
   else:
     FilterSubscribeErrorKind.UNKNOWN
 

--- a/waku/waku_filter_v2/subscriptions.nim
+++ b/waku/waku_filter_v2/subscriptions.nim
@@ -1,7 +1,7 @@
 {.push raises: [].}
 
 import std/[sets, tables], chronicles, chronos, libp2p/peerid, stew/shims/sets
-import ../waku_core, ../utils/tableutils, ../common/rate_limit/setting
+import ../waku_core, ../utils/tableutils
 
 logScope:
   topics = "waku filter subscriptions"

--- a/waku/waku_lightpush/callbacks.nim
+++ b/waku/waku_lightpush/callbacks.nim
@@ -4,7 +4,6 @@ import
   ../waku_core,
   ../waku_relay,
   ./common,
-  ./protocol,
   ./protocol_metrics,
   ../waku_rln_relay,
   ../waku_rln_relay/protocol_types

--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -1,5 +1,5 @@
 import
-  std/[options, sequtils, random, sugar],
+  std/[options, sequtils, random],
   results,
   chronicles,
   chronos,

--- a/waku/waku_peer_exchange/rpc_codec.nim
+++ b/waku/waku_peer_exchange/rpc_codec.nim
@@ -42,7 +42,7 @@ proc decode*(T: type PeerExchangePeerInfo, buffer: seq[byte]): ProtoResult[T] =
 proc parse*(T: type PeerExchangeResponseStatusCode, status: uint32): T =
   case status
   of 200, 400, 429, 503:
-    PeerExchangeResponseStatusCode(status)
+    cast[PeerExchangeResponseStatusCode](status)
   else:
     PeerExchangeResponseStatusCode.UNKNOWN
 

--- a/waku/waku_rln_relay/protocol_metrics.nim
+++ b/waku/waku_rln_relay/protocol_metrics.nim
@@ -1,12 +1,6 @@
 {.push raises: [].}
 
-import
-  chronicles,
-  chronos,
-  metrics,
-  metrics/chronos_httpserver,
-  ./constants,
-  ../utils/collector
+import chronicles, metrics, metrics/chronos_httpserver, ./constants, ../utils/collector
 
 export metrics
 

--- a/waku/waku_store/common.nim
+++ b/waku/waku_store/common.nim
@@ -76,7 +76,7 @@ type
   StoreQueryResult* = Result[StoreQueryResponse, StoreError]
 
 proc into*(errCode: ErrorCode): StatusCode =
-  StatusCode(uint32(errCode))
+  cast[StatusCode](uint32(errCode))
 
 proc new*(T: type StoreError, code: uint32, desc: string): T =
   let kind = ErrorCode.parse(code)
@@ -98,7 +98,7 @@ proc new*(T: type StoreError, code: uint32, desc: string): T =
 proc parse*(T: type ErrorCode, kind: uint32): T =
   case kind
   of 000, 300, 400, 429, 503, 504:
-    ErrorCode(kind)
+    cast[ErrorCode](kind)
   else:
     ErrorCode.UNKNOWN
 

--- a/waku/waku_store_legacy/rpc.nim
+++ b/waku/waku_store_legacy/rpc.nim
@@ -75,7 +75,7 @@ type
 proc parse*(T: type HistoryResponseErrorRPC, kind: uint32): T =
   case kind
   of 0, 1, 429, 503:
-    HistoryResponseErrorRPC(kind)
+    cast[HistoryResponseErrorRPC](kind)
   else:
     # TODO: Improve error variants/move to satus codes
     HistoryResponseErrorRPC.INVALID_CURSOR


### PR DESCRIPTION
While attempting to compile libwaku from within status-desktop, even tho I'm using the same nim version, it failed to compile with some warnings like: 
```
/home/richard/status/status-desktop/vendor/status-go/third_party/nwaku/waku/waku_archive_legacy/archive.nim(227, 23) Error: getMessagesV2 is deprecated [Deprecated]
stack trace: (most recent call last)
/home/richard/status/status-desktop/vendor/status-go/third_party/nwaku/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(421, 18)
/home/richard/status/status-desktop/vendor/status-go/third_party/nwaku/waku.nimble(169, 3) libwakuDynamicTask
/home/richard/status/status-desktop/vendor/status-go/third_party/nwaku/waku.nimble(69, 5) buildLibrary
/home/richard/status/status-desktop/vendor/status-go/third_party/nwaku/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(265, 7) exec
/home/richard/status/status-desktop/vendor/status-go/third_party/nwaku/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(265, 7) Error: unhandled exception: FAILED: nim c --out:build/libwaku.so --threads:on --app:lib --opt:size --noMain --mm:refc --header --undef:metrics -d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client"  --verbosity:0 --hints:off -d:chronicles_log_level=TRACE -d:git_version="v0.33.0-26-gab7618" -d:release --passL:libnegentropy.a --passL:-lcrypto --passL:-lssl --passL:-lstdc++ --passL:librln_v0.5.1.a --passL:-lm library/libwaku.nim [OSError]
```

for both using deprecated functions, as well as unused imports.

Another error I saw was:
```
 Error: conversion to enum with holes is unsafe` is triggered
```

I could not figure out the reason why in status-desktop this happens, so I decided to fix the code instead which was faster:

- Removes deprecation and unused import warnings for libwaku. The other targets remain unmodified
- Removes unused imports.
- Adds `.base.` pragma to `SubscriptionObserver.onSubscribe`
- Uses casting for uint to enums conversions.. This casting should be safe as we are already limiting the values we accept on the `case` that precedes the cast
- Update nim-chronicles version so we have access to `RfcUtcTime` compile option
