### PR TITLE
feat: windows support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The nwaku repository implements Waku, and provides tools related to it.
 
 For more details see the [source code](waku/README.md)
 
-## How to Build & Run
+## How to Build & Run ( Linux, MacOS & WSL )
 
 These instructions are generic. For more detailed instructions, see the Waku source code above.
 
@@ -47,6 +47,17 @@ For more on how to run `wakunode2`, refer to:
 #### Issues
 ##### WSL
 If you encounter difficulties building the project on WSL, consider placing the project within WSL's filesystem, avoiding the `/mnt/` directory.
+
+### How to Build & Run ( Windows )
+
+Note: This is a work in progress. The current setup procedure is as follows:
+Goal: Get rid of windows specific procedures and make the build process the same as linux/macos. 
+
+The current setup procedure is as follows:
+
+1. Clone the repository and checkout master branch
+2. Ensure prerequisites are installed (Make, GCC, MSYS2/MinGW)
+3. Run scripts/windows_setup.sh
 
 ### Developing
 

--- a/config.nims
+++ b/config.nims
@@ -1,9 +1,19 @@
+import os
+
 if defined(release):
   switch("nimcache", "nimcache/release/$projectName")
 else:
   switch("nimcache", "nimcache/debug/$projectName")
 
 if defined(windows):
+  switch("passL", "rln.lib")
+
+  # Automatically add all vendor subdirectories
+  for dir in walkDir("./vendor"):
+    if dir.kind == pcDir:
+      switch("path", dir.path)
+      switch("path", dir.path / "src")
+
   # disable timestamps in Windows PE headers - https://wiki.debian.org/ReproducibleBuilds/TimestampsInPEBinaries
   switch("passL", "-Wl,--no-insert-timestamp")
   # increase stack size

--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -42,10 +42,13 @@ else
     # Build rln instead
     # first, check if submodule version = version in Makefile
     cargo metadata --format-version=1 --no-deps --manifest-path "${build_dir}/rln/Cargo.toml"
-    submodule_version=$(
-      cargo metadata --format-version=1 --no-deps --manifest-path "${build_dir}/rln/Cargo.toml" \
-        | jq -r '.packages[] | select(.name == "rln") | .version'
-    )
+
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+        submodule_version=$(cargo metadata --format-version=1 --no-deps --manifest-path "${build_dir}/rln/Cargo.toml" | sed -n 's/.*"name":"rln","version":"\([^"]*\)".*/\1/p')
+    else
+        submodule_version=$(cargo metadata --format-version=1 --no-deps --manifest-path "${build_dir}/rln/Cargo.toml" | jq -r '.packages[] | select(.name == "rln") | .version')
+    fi
+    
     if [[ "v${submodule_version}" != "${rln_version}" ]]; then
         echo "Submodule version (v${submodule_version}) does not match version in Makefile (${rln_version})"
         echo "Please update the submodule to ${rln_version}"

--- a/scripts/windows_setup.sh
+++ b/scripts/windows_setup.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+echo "Windows Setup Script"
+echo "===================="
+
+# Function to execute a command and check its status
+execute_command() {
+    echo "Executing: $1"
+    if eval "$1"; then
+        echo "✓ Command succeeded"
+    else
+        echo "✗ Command failed"
+        exit 1
+    fi
+}
+
+# Function to change directory safely
+change_directory() {
+    echo "Changing to directory: $1"
+    if cd "$1"; then
+        echo "✓ Changed directory successfully"
+    else
+        echo "✗ Failed to change directory"
+        exit 1
+    fi
+}
+
+# Function to build a component
+build_component() {
+    local dir="$1"
+    local command="$2"
+    local name="$3"
+    
+    echo "Building $name"
+    if [ -d "$dir" ]; then
+        change_directory "$dir"
+        execute_command "$command"
+        change_directory - > /dev/null
+    else
+        echo "✗ $name directory not found: $dir"
+        exit 1
+    fi
+}
+
+echo "1. Updating submodules"
+execute_command "git submodule update --init --recursive"
+
+echo "2. Creating tmp directory"
+execute_command "mkdir -p tmp"
+
+echo "3. Building Nim"
+build_component "vendor/nimbus-build-system/vendor/Nim" "./build_all.bat" "Nim"
+
+echo "4. Building miniupnpc"
+build_component "vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc" "./mingw32make.bat" "miniupnpc"
+
+echo "5. Building libnatpmp"
+build_component "vendor/nim-nat-traversal/vendor/libnatpmp-upstream" "./build.bat" "libnatpmp"
+
+echo "6. Building libunwind"
+build_component "vendor/nim-libbacktrace" "make install/usr/lib/libunwind.a" "libunwind"
+
+echo "7. Building wakunode2"
+execute_command "make wakunode2 V=1 NIMFLAGS="-d:disableMarchNative -d:postgres -d:chronicles_colors:none" "
+
+echo "Windows setup completed successfully!"


### PR DESCRIPTION
# Windows support for nwaku - Initial pull request

## Overview
This pull request (PR) introduces official Windows support for nwaku. Our ultimate goal is to achieve parity with Linux and macOS, allowing Windows users to build and run nwaku using familiar `make` targets, with minimal platform-specific steps.

## Current status and objectives

- [x] Build wakunode2 successfully on Windows [ Done }
- [x] Run unit tests successfully [ Done ]
- [x] Avoid bypassing waku_sync binding [ Done ]
- [ ] Automate installation of prerequisites (gcc, make, cargo, msys, path setup, library linking) [ In Progress ]
- [ ] Build and run cwaku example [ In Progress ]
- [ ] Implement CI/CD integration for Windows [ Not Started ]

## Setup procedure

The current setup procedure is as follows:

1. Clone the repository and checkout the `windows_support` branch
2. Ensure prerequisites are installed (Make, GCC, MSYS2/MinGW)
3. Run `scripts/windows_setup.sh`
4. Execute `make wakunode2` (additional targets coming soon)

Note: This procedure will be updated as we progress towards our goal of making the windows build process similar to linux and mac. Eventually, users will be able to use standard `make` targets without additional setup steps.

### Achievements
- Successfully building wakunode2 on Windows
- Unit tests passing
- waku_sync binding properly integrated