### PR TITLE
chore: improving get_peer_ids_by_protocol in libwaku

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -81,8 +81,11 @@ proc process*(
     return ok(peerIDs)
   of GET_PEER_IDS_BY_PROTOCOL:
     ## returns a comma-separated string of peerIDs that mount the given protocol
-    let (inPeers, outPeers) = waku.node.peerManager.connectedPeers($self[].protocol)
-    let allPeerIDs = inPeers & outPeers
-    return ok(allPeerIDs.join(","))
+    let connectedPeers = waku.node.peerManager.wakuPeerStore
+      .peers($self[].protocol)
+      .filterIt(it.connectedness == Connected)
+      .mapIt($it.peerId)
+      .join(",")
+    return ok(connectedPeers)
 
   return ok("")


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Currently, libwaku's `GET_PEER_IDS_BY_PROTOCOL` returns the peer ids of peers that have an open libp2p stream associated with a given protocol.

However, what's most interesting for us is the capabilities of our connected peers and not which protocols are we actually using.

For example, for req-res protocols such as Store, most of the time we don't have an open stream associated with the Store protocol - which means that with the current approach `GET_PEER_IDS_BY_PROTOCOL` won't return anything.

Therefore, changing the approach so we return all our connected peers that support a given protocol, even if we don't have open streams for that protocol in specific.

# Changes

<!-- List of detailed changes -->

- [x] improving `GET_PEER_IDS_BY_PROTOCOL` so it returns our connected peers with a given capability


## Issue

#3039 
