### PR TITLE
chore: Circuit relay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,6 @@ jobs:
         run: |
           postgres_enabled=0
           if [ ${{ runner.os }} == "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get install -y libpcre3 libpcre3-dev
-
             sudo docker run --rm -d -e POSTGRES_PASSWORD=test123 -p 5432:5432 postgres:15.4-alpine3.18
             postgres_enabled=1
           fi

--- a/apps/liteprotocoltester/liteprotocoltester.nim
+++ b/apps/liteprotocoltester/liteprotocoltester.nim
@@ -124,7 +124,7 @@ when isMainModule:
     error "Starting esential REST server failed.", error = $error
     quit(QuitFailure)
 
-  var wakuApp = Waku.init(wakuConf).valueOr:
+  var wakuApp = Waku.new(wakuConf).valueOr:
     error "Waku initialization failed", error = error
     quit(QuitFailure)
 

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -42,7 +42,7 @@ when isMainModule:
     error "failure while loading the configuration", error = error
     quit(QuitFailure)
 
-  ## Also called within Waku.init. The call to startRestServerEsentials needs the following line
+  ## Also called within Waku.new. The call to startRestServerEsentials needs the following line
   logging.setupLog(conf.logLevel, conf.logFormat)
 
   case conf.cmd
@@ -66,7 +66,7 @@ when isMainModule:
       error "Starting esential REST server failed.", error = $error
       quit(QuitFailure)
 
-    var waku = Waku.init(confCopy).valueOr:
+    var waku = Waku.new(confCopy).valueOr:
       error "Waku initialization failed", error = error
       quit(QuitFailure)
 

--- a/examples/wakustealthcommitments/node_spec.nim
+++ b/examples/wakustealthcommitments/node_spec.nim
@@ -48,7 +48,7 @@ proc setup*(): Waku =
     conf.rlnRelay = twnClusterConf.rlnRelay
 
   debug "Starting node"
-  var waku = Waku.init(conf).valueOr:
+  var waku = Waku.new(conf).valueOr:
     error "Waku initialization failed", error = error
     quit(QuitFailure)
 

--- a/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
@@ -59,7 +59,7 @@ proc createWaku(configJson: cstring): Future[Result[Waku, string]] {.async.} =
             formattedString & ". expected type: " & $typeof(confValue)
         )
 
-  let wakuRes = Waku.init(conf).valueOr:
+  let wakuRes = Waku.new(conf).valueOr:
     error "waku initialization failed", error = error
     return err("Failed setting up Waku: " & $error)
 

--- a/tests/factory/test_node_factory.nim
+++ b/tests/factory/test_node_factory.nim
@@ -8,7 +8,7 @@ suite "Node Factory":
   test "Set up a node based on default configurations":
     let conf = defaultTestWakuNodeConf()
 
-    let node = setupNode(conf).valueOr:
+    let node = setupNode(conf, relay = Relay.new()).valueOr:
       raiseAssert error
 
     check:
@@ -23,7 +23,7 @@ suite "Node Factory":
     var conf = defaultTestWakuNodeConf()
     conf.store = true
 
-    let node = setupNode(conf).valueOr:
+    let node = setupNode(conf, relay = Relay.new()).valueOr:
       raiseAssert error
 
     check:
@@ -35,7 +35,7 @@ test "Set up a node with Filter enabled":
   var conf = defaultTestWakuNodeConf()
   conf.filter = true
 
-  let node = setupNode(conf).valueOr:
+  let node = setupNode(conf, relay = Relay.new()).valueOr:
     raiseAssert error
 
   check:
@@ -45,7 +45,7 @@ test "Set up a node with Filter enabled":
 test "Start a node based on default configurations":
   let conf = defaultTestWakuNodeConf()
 
-  let node = setupNode(conf).valueOr:
+  let node = setupNode(conf, relay = Relay.new()).valueOr:
     raiseAssert error
 
   assert not node.isNil(), "Node can't be nil"

--- a/tests/factory/test_node_factory.nim
+++ b/tests/factory/test_node_factory.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import testutils/unittests, chronos
+import testutils/unittests, chronos, libp2p/protocols/connectivity/relay/relay
 
 import ../testlib/wakunode, waku/factory/node_factory, waku/waku_node
 

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -269,14 +269,9 @@ procSuite "Peer Manager":
       database = SqliteDatabase.new(":memory:")[]
       storage = WakuPeerStorage.new(database)[]
       node1 = newTestWakuNode(
-        generateSecp256k1Key(),
-        ValidIpAddress.init($getPrimaryIPAddr()),
-        Port(44048),
-        peerStorage = storage,
+        generateSecp256k1Key(), getPrimaryIPAddr(), Port(44048), peerStorage = storage
       )
-      node2 = newTestWakuNode(
-        generateSecp256k1Key(), ValidIpAddress.init($getPrimaryIPAddr()), Port(34023)
-      )
+      node2 = newTestWakuNode(generateSecp256k1Key(), getPrimaryIPAddr(), Port(34023))
 
     node1.mountMetadata(0).expect("Mounted Waku Metadata")
     node2.mountMetadata(0).expect("Mounted Waku Metadata")
@@ -344,14 +339,9 @@ procSuite "Peer Manager":
       database = SqliteDatabase.new(":memory:")[]
       storage = WakuPeerStorage.new(database)[]
       node1 = newTestWakuNode(
-        generateSecp256k1Key(),
-        ValidIpAddress.init($getPrimaryIPAddr()),
-        Port(44048),
-        peerStorage = storage,
+        generateSecp256k1Key(), getPrimaryIPAddr(), Port(44048), peerStorage = storage
       )
-      node2 = newTestWakuNode(
-        generateSecp256k1Key(), ValidIpAddress.init($getPrimaryIPAddr()), Port(34023)
-      )
+      node2 = newTestWakuNode(generateSecp256k1Key(), getPrimaryIPAddr(), Port(34023))
 
     node1.mountMetadata(0).expect("Mounted Waku Metadata")
     node2.mountMetadata(0).expect("Mounted Waku Metadata")

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options, sequtils, times, sugar],
+  std/[options, sequtils, times, sugar, net],
   stew/shims/net as stewNet,
   testutils/unittests,
   chronos,
@@ -270,12 +270,12 @@ procSuite "Peer Manager":
       storage = WakuPeerStorage.new(database)[]
       node1 = newTestWakuNode(
         generateSecp256k1Key(),
-        ValidIpAddress.init("127.0.0.1"),
+        ValidIpAddress.init($getPrimaryIPAddr()),
         Port(44048),
         peerStorage = storage,
       )
       node2 = newTestWakuNode(
-        generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(34023)
+        generateSecp256k1Key(), ValidIpAddress.init($getPrimaryIPAddr()), Port(34023)
       )
 
     node1.mountMetadata(0).expect("Mounted Waku Metadata")
@@ -345,12 +345,12 @@ procSuite "Peer Manager":
       storage = WakuPeerStorage.new(database)[]
       node1 = newTestWakuNode(
         generateSecp256k1Key(),
-        ValidIpAddress.init("127.0.0.1"),
+        ValidIpAddress.init($getPrimaryIPAddr()),
         Port(44048),
         peerStorage = storage,
       )
       node2 = newTestWakuNode(
-        generateSecp256k1Key(), ValidIpAddress.init("127.0.0.1"), Port(34023)
+        generateSecp256k1Key(), ValidIpAddress.init($getPrimaryIPAddr()), Port(34023)
       )
 
     node1.mountMetadata(0).expect("Mounted Waku Metadata")

--- a/tests/test_waku_switch.nim
+++ b/tests/test_waku_switch.nim
@@ -26,7 +26,7 @@ suite "Waku Switch":
     ## Given
     let
       sourceSwitch = newTestSwitch()
-      wakuSwitch = newWakuSwitch(rng = rng(), relay = Relay.new())
+      wakuSwitch = newWakuSwitch(rng = rng(), circuitRelay = Relay.new())
     await sourceSwitch.start()
     await wakuSwitch.start()
 
@@ -46,7 +46,7 @@ suite "Waku Switch":
   asyncTest "Waku Switch acts as circuit relayer":
     ## Setup
     let
-      wakuSwitch = newWakuSwitch(rng = rng(), relay = Relay.new())
+      wakuSwitch = newWakuSwitch(rng = rng(), circuitRelay = Relay.new())
       sourceClient = RelayClient.new()
       destClient = RelayClient.new()
       sourceSwitch = newCircuitRelayClientSwitch(sourceClient)

--- a/tests/test_waku_switch.nim
+++ b/tests/test_waku_switch.nim
@@ -26,7 +26,7 @@ suite "Waku Switch":
     ## Given
     let
       sourceSwitch = newTestSwitch()
-      wakuSwitch = newWakuSwitch(rng = rng())
+      wakuSwitch = newWakuSwitch(rng = rng(), relay = Relay.new())
     await sourceSwitch.start()
     await wakuSwitch.start()
 
@@ -46,7 +46,7 @@ suite "Waku Switch":
   asyncTest "Waku Switch acts as circuit relayer":
     ## Setup
     let
-      wakuSwitch = newWakuSwitch(rng = rng())
+      wakuSwitch = newWakuSwitch(rng = rng(), relay = Relay.new())
       sourceClient = RelayClient.new()
       destClient = RelayClient.new()
       sourceSwitch = newCircuitRelayClientSwitch(sourceClient)

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[sequtils, strutils],
+  std/[sequtils, strutils, net],
   stew/byteutils,
   stew/shims/net as stewNet,
   testutils/unittests,
@@ -169,7 +169,7 @@ suite "WakuNode":
       nodeKey = generateSecp256k1Key()
       bindIp = parseIpAddress("0.0.0.0")
       bindPort = Port(61006)
-      extIp = some(parseIpAddress("127.0.0.1"))
+      extIp = some(parseIpAddress($getPrimaryIPAddr()))
       extPort = some(Port(61008))
       node = newTestWakuNode(nodeKey, bindIp, bindPort, extIp, extPort)
 
@@ -205,7 +205,7 @@ suite "WakuNode":
       nodeKey = generateSecp256k1Key()
       bindIp = parseIpAddress("0.0.0.0")
       bindPort = Port(61010)
-      extIp = some(parseIpAddress("127.0.0.1"))
+      extIp = some(parseIpAddress($getPrimaryIPAddr()))
       extPort = some(Port(61012))
       domainName = "example.com"
       expectedDns4Addr =

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -169,7 +169,7 @@ suite "WakuNode":
       nodeKey = generateSecp256k1Key()
       bindIp = parseIpAddress("0.0.0.0")
       bindPort = Port(61006)
-      extIp = some(parseIpAddress($getPrimaryIPAddr()))
+      extIp = some(getPrimaryIPAddr())
       extPort = some(Port(61008))
       node = newTestWakuNode(nodeKey, bindIp, bindPort, extIp, extPort)
 
@@ -205,7 +205,7 @@ suite "WakuNode":
       nodeKey = generateSecp256k1Key()
       bindIp = parseIpAddress("0.0.0.0")
       bindPort = Port(61010)
-      extIp = some(parseIpAddress($getPrimaryIPAddr()))
+      extIp = some(getPrimaryIPAddr())
       extPort = some(Port(61012))
       domainName = "example.com"
       expectedDns4Addr =

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -19,7 +19,7 @@ suite "Wakunode2 - Waku":
     ## Given
     var conf = defaultTestWakuNodeConf()
 
-    let waku = Waku.init(conf).valueOr:
+    let waku = Waku.new(conf).valueOr:
       raiseAssert error
 
     ## When
@@ -35,7 +35,7 @@ suite "Wakunode2 - Waku initialization":
     var conf = defaultTestWakuNodeConf()
     conf.peerPersistence = true
 
-    let waku = Waku.init(conf).valueOr:
+    let waku = Waku.new(conf).valueOr:
       raiseAssert error
 
     check:
@@ -46,7 +46,7 @@ suite "Wakunode2 - Waku initialization":
     var conf = defaultTestWakuNodeConf()
 
     ## When
-    var waku = Waku.init(conf).valueOr:
+    var waku = Waku.new(conf).valueOr:
       raiseAssert error
 
     (waitFor startWaku(addr waku)).isOkOr:
@@ -73,7 +73,7 @@ suite "Wakunode2 - Waku initialization":
     conf.tcpPort = Port(0)
 
     ## When
-    var waku = Waku.init(conf).valueOr:
+    var waku = Waku.new(conf).valueOr:
       raiseAssert error
 
     (waitFor startWaku(addr waku)).isOkOr:

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -38,15 +38,9 @@ suite "Waku v2 Rest API - Admin":
   var client {.threadvar.}: RestClientRef
 
   asyncSetup:
-    node1 = newTestWakuNode(
-      generateSecp256k1Key(), getPrimaryIPAddr(), Port(60600)
-    )
-    node2 = newTestWakuNode(
-      generateSecp256k1Key(), getPrimaryIPAddr(), Port(60602)
-    )
-    node3 = newTestWakuNode(
-      generateSecp256k1Key(), getPrimaryIPAddr(), Port(60604)
-    )
+    node1 = newTestWakuNode(generateSecp256k1Key(), getPrimaryIPAddr(), Port(60600))
+    node2 = newTestWakuNode(generateSecp256k1Key(), getPrimaryIPAddr(), Port(60602))
+    node3 = newTestWakuNode(generateSecp256k1Key(), getPrimaryIPAddr(), Port(60604))
 
     await allFutures(node1.start(), node2.start(), node3.start())
     await allFutures(

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -39,13 +39,13 @@ suite "Waku v2 Rest API - Admin":
 
   asyncSetup:
     node1 = newTestWakuNode(
-      generateSecp256k1Key(), parseIpAddress($getPrimaryIPAddr()), Port(60600)
+      generateSecp256k1Key(), getPrimaryIPAddr(), Port(60600)
     )
     node2 = newTestWakuNode(
-      generateSecp256k1Key(), parseIpAddress($getPrimaryIPAddr()), Port(60602)
+      generateSecp256k1Key(), getPrimaryIPAddr(), Port(60602)
     )
     node3 = newTestWakuNode(
-      generateSecp256k1Key(), parseIpAddress($getPrimaryIPAddr()), Port(60604)
+      generateSecp256k1Key(), getPrimaryIPAddr(), Port(60604)
     )
 
     await allFutures(node1.start(), node2.start(), node3.start())

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[sequtils, strformat],
+  std/[sequtils, strformat, net],
   stew/shims/net,
   testutils/unittests,
   presto,
@@ -38,12 +38,15 @@ suite "Waku v2 Rest API - Admin":
   var client {.threadvar.}: RestClientRef
 
   asyncSetup:
-    node1 =
-      newTestWakuNode(generateSecp256k1Key(), parseIpAddress("127.0.0.1"), Port(60600))
-    node2 =
-      newTestWakuNode(generateSecp256k1Key(), parseIpAddress("127.0.0.1"), Port(60602))
-    node3 =
-      newTestWakuNode(generateSecp256k1Key(), parseIpAddress("127.0.0.1"), Port(60604))
+    node1 = newTestWakuNode(
+      generateSecp256k1Key(), parseIpAddress($getPrimaryIPAddr()), Port(60600)
+    )
+    node2 = newTestWakuNode(
+      generateSecp256k1Key(), parseIpAddress($getPrimaryIPAddr()), Port(60602)
+    )
+    node3 = newTestWakuNode(
+      generateSecp256k1Key(), parseIpAddress($getPrimaryIPAddr()), Port(60604)
+    )
 
     await allFutures(node1.start(), node2.start(), node3.start())
     await allFutures(

--- a/waku/common/utils/nat.nim
+++ b/waku/common/utils/nat.nim
@@ -39,7 +39,12 @@ proc setupNat*(
       warn "NAT already initialized, skipping as cannot be done multiple times"
     else:
       singletonNat = true
-      let extIp = getExternalIP(strategy)
+      var extIp = none(IpAddress)
+      try:
+        extIp = getExternalIP(strategy)
+      except Exception:
+        warn "exception in setupNat", error = getCurrentExceptionMsg()
+
       if extIP.isSome():
         endpoint.ip = some(extIp.get())
         # RedirectPorts in considered a gcsafety violation

--- a/waku/discovery/autonat_service.nim
+++ b/waku/discovery/autonat_service.nim
@@ -6,6 +6,8 @@ import
   libp2p/protocols/connectivity/autonat/service,
   libp2p/protocols/connectivity/autonat/core
 
+const AutonatCheckInterval = Opt.some(chronos.seconds(30))
+
 proc getAutonatService*(rng: ref HmacDrbgContext): AutonatService =
   ## AutonatService request other peers to dial us back
   ## flagging us as Reachable or NotReachable.
@@ -15,7 +17,7 @@ proc getAutonatService*(rng: ref HmacDrbgContext): AutonatService =
   let autonatService = AutonatService.new(
     autonatClient = AutonatClient.new(),
     rng = rng,
-    scheduleInterval = Opt.some(chronos.seconds(120)),
+    scheduleInterval = AutonatCheckInterval,
     askNewConnectedPeers = false,
     numPeersToAsk = 3,
     maxQueueSize = 3,

--- a/waku/discovery/autonat_service.nim
+++ b/waku/discovery/autonat_service.nim
@@ -1,0 +1,34 @@
+import
+  chronos,
+  chronicles,
+  bearssl/rand,
+  libp2p/protocols/connectivity/autonat/client,
+  libp2p/protocols/connectivity/autonat/service,
+  libp2p/protocols/connectivity/autonat/core
+
+proc getAutonatService*(rng: ref HmacDrbgContext): AutonatService =
+  ## AutonatService request other peers to dial us back
+  ## flagging us as Reachable or NotReachable.
+  ## minConfidence is used as threshold to determine the state.
+  ## If maxQueueSize > numPeersToAsk past samples are considered
+  ## in the calculation.
+  let autonatService = AutonatService.new(
+    autonatClient = AutonatClient.new(),
+    rng = rng,
+    scheduleInterval = Opt.some(chronos.seconds(120)),
+    askNewConnectedPeers = false,
+    numPeersToAsk = 3,
+    maxQueueSize = 3,
+    minConfidence = 0.7,
+  )
+
+  proc statusAndConfidenceHandler(
+      networkReachability: NetworkReachability, confidence: Opt[float]
+  ): Future[void] {.async.} =
+    if confidence.isSome():
+      info "Peer reachability status",
+        networkReachability = networkReachability, confidence = confidence.get()
+
+  autonatService.statusAndConfidenceHandler(statusAndConfidenceHandler)
+
+  return autonatService

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -117,7 +117,7 @@ proc updateAnnouncedMultiAddress*(
     return err("failed to update multiaddress in ENR: " & $error)
 
   debug "ENR updated successfully with new multiaddress",
-    enr = wd.protocol.localNode.record.toUri(), record = $(wd.protocol.localNode.record)
+    enrUri = wd.protocol.localNode.record.toUri(), enr = $(wd.protocol.localNode.record)
 
   return ok()
 

--- a/waku/factory/builder.nim
+++ b/waku/factory/builder.nim
@@ -40,7 +40,6 @@ type
     switchSslSecureKey: Option[string]
     switchSslSecureCert: Option[string]
     switchSendSignedPeerRecord: Option[bool]
-    services: seq[Service]
     circuitRelay: Relay
 
     #Rate limit configs for non-relay req-resp protocols

--- a/waku/factory/builder.nim
+++ b/waku/factory/builder.nim
@@ -7,13 +7,18 @@ import
   libp2p/crypto/crypto,
   libp2p/builders,
   libp2p/nameresolving/nameresolver,
-  libp2p/transports/wstransport
+  libp2p/transports/wstransport,
+  libp2p/protocols/connectivity/relay/client,
+  libp2p/protocols/connectivity/relay/relay,
+  libp2p/services/autorelayservice,
+  libp2p/services/hpservice
 import
   ../waku_enr,
   ../discovery/waku_discv5,
   ../waku_node,
   ../node/peer_manager,
-  ../common/rate_limit/setting
+  ../common/rate_limit/setting,
+  ../discovery/autonat_service
 
 type
   WakuNodeBuilder* = object # General
@@ -38,6 +43,7 @@ type
     switchSslSecureKey: Option[string]
     switchSslSecureCert: Option[string]
     switchSendSignedPeerRecord: Option[bool]
+    switchIsRelayClient: bool ## circuit-relay related
 
     #Rate limit configs for non-relay req-resp protocols
     rateLimitSettings: Option[seq[string]]
@@ -126,12 +132,14 @@ proc withSwitchConfiguration*(
     secureKey = none(string),
     secureCert = none(string),
     agentString = none(string),
+    isRelayClient = false,
 ) =
   builder.switchMaxConnections = maxConnections
   builder.switchSendSignedPeerRecord = some(sendSignedPeerRecord)
   builder.switchSslSecureKey = secureKey
   builder.switchSslSecureCert = secureCert
   builder.switchAgentString = agentString
+  builder.switchIsRelayClient = isRelayClient
 
   if not nameResolver.isNil():
     builder.switchNameResolver = some(nameResolver)
@@ -154,6 +162,22 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
   if builder.record.isNone():
     return err("node record is required")
 
+  let autonatService = autonat_service.getAutonatService(rng)
+  var services: seq[Service]
+
+  var relay = Relay.new()
+    ## by default, the node is configured as a server relay-circuit node
+
+  if builder.switchIsRelayClient:
+    ## The node is considered to be behind a NAT or firewall and then it
+    ## should struggle to be reachable and establish connections to other nodes
+    relay = RelayClient.new()
+    let autoRelayService = AutoRelayService.new(1, RelayClient(relay), nil, rng)
+    let holePunchService = HPService.new(autonatService, autoRelayService)
+    services = @[Service(holePunchService)]
+  else:
+    services = @[Service(autonatService)]
+
   var switch: Switch
   try:
     switch = newWakuSwitch(
@@ -170,7 +194,8 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
       sendSignedPeerRecord = builder.switchSendSignedPeerRecord.get(false),
       agentString = builder.switchAgentString,
       peerStoreCapacity = builder.peerStorageCapacity,
-      services = @[Service(getAutonatService(rng))],
+      services = services,
+      relay = relay,
     )
   except CatchableError:
     return err("failed to create switch: " & getCurrentExceptionMsg())

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -245,6 +245,16 @@ type WakuNodeConf* = object
       name: "dns4-domain-name"
     .}: string
 
+    ## Circuit-relay config
+    isRelayClient* {.
+      desc:
+        """Set the node as a relay-client.
+Set it to true for nodes that might run behind a NAT or firewall and
+hence would have reachability issues.""",
+      defaultValue: false
+      name: "relay-client"
+    .}: bool
+
     ## Relay config
     relay* {.
       desc: "Enable relay protocol: true|false", defaultValue: true, name: "relay"

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -249,9 +249,9 @@ type WakuNodeConf* = object
     isRelayClient* {.
       desc:
         """Set the node as a relay-client.
-Set it to true for nodes that might run behind a NAT or firewall and
+Set it to true for nodes that run behind a NAT or firewall and
 hence would have reachability issues.""",
-      defaultValue: false
+      defaultValue: false,
       name: "relay-client"
     .}: bool
 

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -97,6 +97,7 @@ proc initNode(
     sendSignedPeerRecord = conf.relayPeerExchange,
       # We send our own signed peer record when peer exchange enabled
     agentString = some(conf.agentString),
+    isRelayClient = conf.isRelayClient,
   )
   builder.withColocationLimit(conf.colocationLimit)
   builder.withPeerManagerConfig(

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -435,9 +435,7 @@ proc startNode*(
   return ok()
 
 proc setupNode*(
-    conf: WakuNodeConf,
-    rng: ref HmacDrbgContext = crypto.newRng(),
-    relay: Relay = Relay.new(),
+    conf: WakuNodeConf, rng: ref HmacDrbgContext = crypto.newRng(), relay: Relay
 ): Result[WakuNode, string] =
   # Use provided key only if corresponding rng is also provided
   let key =

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -105,7 +105,7 @@ proc initNode(
     maxRelayPeers = conf.maxRelayPeers, shardAware = conf.relayShardedPeerManagement
   )
   builder.withRateLimit(conf.rateLimits)
-  builder.withRelay(relay)
+  builder.withCircuitRelay(relay)
 
   node =
     ?builder.build().mapErr(

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -139,6 +139,11 @@ proc setupSwitchServices(
 
 ## Initialisation
 
+proc newCircuitRelay(isRelayClient: bool): Relay =
+  if isRelayClient:
+    return RelayClient.new()
+  return Relay.new()
+
 proc new*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
   let rng = crypto.newRng()
 
@@ -220,9 +225,7 @@ proc new*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
       "Retrieving dynamic bootstrap nodes failed: " & dynamicBootstrapNodesRes.error
     )
 
-  var relay = Relay.new()
-  if confCopy.isRelayClient:
-    relay = RelayClient.new()
+  var relay = newCircuitRelay(confCopy.isRelayClient)
 
   let nodeRes = setupNode(confCopy, rng, relay)
   if nodeRes.isErr():

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -137,9 +137,6 @@ proc setupSwitchServices(
   else:
     waku.node.switch.services = @[Service(autonatService)]
 
-    if conf.isRelayClient:
-      let relay = RelayClient.new()
-
 ## Initialisation
 
 proc new*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -275,7 +275,7 @@ proc updateWaku(waku: ptr Waku): Result[void, string] =
 
     waku[].node.announcedAddresses = netConf.announcedAddresses
 
-    printNodeNetworkInfo(waku[].node)
+    ?updateAnnouncedAddrWithPrimaryIpAddr(waku[].node)
 
   return ok()
 

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -121,8 +121,9 @@ proc setupSwitchServices(
     debug "waku node announced addresses updated",
       announcedAddresses = waku.node.announcedAddresses
 
-    waku.wakuDiscv5.updateAnnouncedMultiAddress(addresses).isOkOr:
-      error "failed to update announced multiaddress", error = $error
+    if not isNil(waku.wakuDiscv5):
+      waku.wakuDiscv5.updateAnnouncedMultiAddress(addresses).isOkOr:
+        error "failed to update announced multiaddress", error = $error
 
   let autonatService = getAutonatService(rng)
   if conf.isRelayClient:

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -1,18 +1,22 @@
 {.push raises: [].}
 
 import
-  std/options,
+  std/[options, sequtils],
   results,
   chronicles,
   chronos,
+  libp2p/protocols/connectivity/relay/relay,
+  libp2p/protocols/connectivity/relay/client,
   libp2p/wire,
-  libp2p/multicodec,
   libp2p/crypto/crypto,
   libp2p/protocols/pubsub/gossipsub,
+  libp2p/services/autorelayservice,
+  libp2p/services/hpservice,
   libp2p/peerid,
   libp2p/discovery/discoverymngr,
   libp2p/discovery/rendezvousinterface,
   eth/keys,
+  eth/p2p/discoveryv5/enr,
   presto,
   metrics,
   metrics/chronos_httpserver
@@ -29,6 +33,7 @@ import
   ../waku_relay/protocol,
   ../discovery/waku_dnsdisc,
   ../discovery/waku_discv5,
+  ../discovery/autonat_service,
   ../waku_enr/sharding,
   ../waku_rln_relay,
   ../waku_store,
@@ -36,7 +41,8 @@ import
   ../factory/networks_config,
   ../factory/node_factory,
   ../factory/internal_config,
-  ../factory/external_config
+  ../factory/external_config,
+  ../waku_enr/multiaddr
 
 logScope:
   topics = "wakunode waku"
@@ -44,7 +50,7 @@ logScope:
 # Git version in git describe format (defined at compile time)
 const git_version* {.strdefine.} = "n/a"
 
-type Waku* = object
+type Waku* = ref object
   version: string
   conf: WakuNodeConf
   rng: ref HmacDrbgContext
@@ -103,9 +109,40 @@ proc validateShards(conf: WakuNodeConf): Result[void, string] =
 
   return ok()
 
+proc setupSwitchServices(
+    waku: Waku, conf: WakuNodeConf, circuitRelay: Relay, rng: ref HmacDrbgContext
+) =
+  proc onReservation(addresses: seq[MultiAddress]) {.gcsafe, raises: [].} =
+    debug "circuit relay handler new reserve event",
+      addrs_before = $(waku.node.announcedAddresses), addrs = $addresses
+
+    waku.node.announcedAddresses.setLen(0) ## remove previous addresses
+    waku.node.announcedAddresses.add(addresses)
+    debug "waku node announced addresses updated",
+      announcedAddresses = waku.node.announcedAddresses
+
+    waku.wakuDiscv5.updateAnnouncedMultiAddress(addresses).isOkOr:
+      error "failed to update announced multiaddress", error = $error
+
+  let autonatService = getAutonatService(rng)
+  if conf.isRelayClient:
+    ## The node is considered to be behind a NAT or firewall and then it
+    ## should struggle to be reachable and establish connections to other nodes
+    const MaxNumRelayServers = 2
+    let autoRelayService = AutoRelayService.new(
+      MaxNumRelayServers, RelayClient(circuitRelay), onReservation, rng
+    )
+    let holePunchService = HPService.new(autonatService, autoRelayService)
+    waku.node.switch.services = @[Service(holePunchService)]
+  else:
+    waku.node.switch.services = @[Service(autonatService)]
+
+    if conf.isRelayClient:
+      let relay = RelayClient.new()
+
 ## Initialisation
 
-proc init*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
+proc new*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
   let rng = crypto.newRng()
 
   logging.setupLog(confCopy.logLevel, confCopy.logFormat)
@@ -186,7 +223,11 @@ proc init*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
       "Retrieving dynamic bootstrap nodes failed: " & dynamicBootstrapNodesRes.error
     )
 
-  let nodeRes = setupNode(confCopy, some(rng))
+  var relay = Relay.new()
+  if confCopy.isRelayClient:
+    relay = RelayClient.new()
+
+  let nodeRes = setupNode(confCopy, rng, relay)
   if nodeRes.isErr():
     error "Failed setting up node", error = nodeRes.error
     return err("Failed setting up node: " & nodeRes.error)
@@ -216,6 +257,8 @@ proc init*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
     dynamicBootstrapNodes: dynamicBootstrapNodesRes.get(),
     deliveryMonitor: deliveryMonitor,
   )
+
+  waku.setupSwitchServices(confCopy, relay, rng)
 
   ok(waku)
 
@@ -254,7 +297,10 @@ proc getRunningNetConfig(waku: ptr Waku): Result[NetConfig, string] =
 
   return ok(netConf)
 
-proc updateEnr(waku: ptr Waku, netConf: NetConfig): Result[void, string] =
+proc updateEnr(waku: ptr Waku): Result[void, string] =
+  let netConf: NetConfig = getRunningNetConfig(waku).valueOr:
+    return err("error calling updateNetConfig: " & $error)
+
   let record = enrConfiguration(waku[].conf, netConf, waku[].key).valueOr:
     return err("ENR setup failed: " & error)
 
@@ -265,17 +311,42 @@ proc updateEnr(waku: ptr Waku, netConf: NetConfig): Result[void, string] =
 
   return ok()
 
+proc updateAddressInENR(waku: ptr Waku): Result[void, string] =
+  let addresses: seq[MultiAddress] = waku[].node.announcedAddresses
+  let encodedAddrs = multiaddr.encodeMultiaddrs(addresses)
+
+  ## First update the enr info contained in WakuNode
+  let keyBytes = waku[].key.getRawBytes().valueOr:
+    return err("failed to retrieve raw bytes from waku key: " & $error)
+
+  let parsedPk = keys.PrivateKey.fromHex(keyBytes.toHex()).valueOr:
+    return err("failed to parse the private key: " & $error)
+
+  let enrFields = @[toFieldPair(MultiaddrEnrField, encodedAddrs)]
+  waku[].node.enr.update(parsedPk, enrFields).isOkOr:
+    return err("failed to update multiaddress in ENR updateAddressInENR: " & $error)
+
+  debug "Waku node ENR updated successfully with new multiaddress",
+    enr = waku[].node.enr.toUri(), record = $(waku[].node.enr)
+
+  ## Now update the ENR infor in discv5
+  if not waku[].wakuDiscv5.isNil():
+    waku[].wakuDiscv5.protocol.localNode.record = waku[].node.enr
+    let enr = waku[].wakuDiscv5.protocol.localNode.record
+
+    debug "Waku discv5 ENR updated successfully with new multiaddress",
+      enr = enr.toUri(), record = $(enr)
+
+  return ok()
+
 proc updateWaku(waku: ptr Waku): Result[void, string] =
   if waku[].conf.tcpPort == Port(0) or waku[].conf.websocketPort == Port(0):
-    let netConf = getRunningNetConfig(waku).valueOr:
-      return err("error calling updateNetConfig: " & $error)
-
-    updateEnr(waku, netConf).isOkOr:
+    updateEnr(waku).isOkOr:
       return err("error calling updateEnr: " & $error)
 
-    waku[].node.announcedAddresses = netConf.announcedAddresses
+  ?updateAnnouncedAddrWithPrimaryIpAddr(waku[].node)
 
-    ?updateAnnouncedAddrWithPrimaryIpAddr(waku[].node)
+  ?updateAddressInENR(waku)
 
   return ok()
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -51,7 +51,7 @@ import
   ./config,
   ./peer_manager,
   ../common/rate_limit/setting,
-  waku/discovery/autonat_service
+  ../discovery/autonat_service
 
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]
 declarePublicHistogram waku_histogram_message_size,

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -407,6 +407,9 @@ proc startRelay*(node: WakuNode) {.async.} =
 
     await node.peerManager.reconnectPeers(WakuRelayCodec, backoffPeriod)
 
+  # Start the WakuRelay protocol
+  await node.wakuRelay.start()
+
   info "relay started successfully"
 
 proc mountRelay*(

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -17,8 +17,6 @@ import
   libp2p/protocols/pubsub/rpc/messages,
   libp2p/protocols/connectivity/autonat/client,
   libp2p/protocols/connectivity/autonat/service,
-  libp2p/protocols/connectivity/relay/relay,
-  libp2p/protocols/connectivity/relay/client,
   libp2p/protocols/rendezvous,
   libp2p/builders,
   libp2p/transports/transport,
@@ -1275,6 +1273,7 @@ proc updateAnnouncedAddrWithPrimaryIpAddr*(node: WakuNode): Result[void, string]
 
   info "PeerInfo", peerId = peerInfo.peerId, addrs = peerInfo.addrs
 
+  ## Update the WakuNode addresses
   var newAnnouncedAddresses = newSeq[MultiAddress](0)
   for address in node.announcedAddresses:
     ## Replace "0.0.0.0" or "127.0.0.1" with the localIp
@@ -1287,12 +1286,16 @@ proc updateAnnouncedAddrWithPrimaryIpAddr*(node: WakuNode): Result[void, string]
 
   node.announcedAddresses = newAnnouncedAddresses
 
+  ## Update the Switch addresses
+  node.switch.peerInfo.addrs = newAnnouncedAddresses
+
   for transport in node.switch.transports:
     for address in transport.addrs:
       let fulladdr = "[" & $address & "/p2p/" & $peerInfo.peerId & "]"
       listenStr &= fulladdr
 
-  info "Listening on", full = listenStr, localIp = localIp
+  info "Listening on",
+    full = listenStr, localIp = localIp, switchAddress = $(node.switch.peerInfo.addrs)
   info "Announcing addresses", full = announcedStr
   info "DNS: discoverable ENR ", enr = node.enr.toUri()
 

--- a/waku/node/waku_switch.nim
+++ b/waku/node/waku_switch.nim
@@ -77,9 +77,7 @@ proc newWakuSwitch*(
     secureCertPath: string = "",
     agentString = none(string), # defaults to nim-libp2p version
     peerStoreCapacity = none(int), # defaults to 1.25 maxConnections
-    services: seq[switch.Service] = @[],
     rendezvous: RendezVous = nil,
-    isRelayClient: bool = false,
     relay: Relay,
 ): Switch {.raises: [Defect, IOError, LPError].} =
   var b = SwitchBuilder
@@ -116,9 +114,6 @@ proc newWakuSwitch*(
       b = b.withWsTransport()
   else:
     b = b.withAddress(address)
-
-  if services.len > 0:
-    b = b.withServices(services)
 
   if not rendezvous.isNil():
     b = b.withRendezVous(rendezvous)

--- a/waku/node/waku_switch.nim
+++ b/waku/node/waku_switch.nim
@@ -9,6 +9,7 @@ import
   libp2p/crypto/crypto,
   libp2p/protocols/pubsub/gossipsub,
   libp2p/protocols/rendezvous,
+  libp2p/protocols/connectivity/relay/relay,
   libp2p/nameresolving/nameresolver,
   libp2p/builders,
   libp2p/switch,
@@ -78,6 +79,8 @@ proc newWakuSwitch*(
     peerStoreCapacity = none(int), # defaults to 1.25 maxConnections
     services: seq[switch.Service] = @[],
     rendezvous: RendezVous = nil,
+    isRelayClient: bool = false,
+    relay: Relay,
 ): Switch {.raises: [Defect, IOError, LPError].} =
   var b = SwitchBuilder
     .new()
@@ -92,7 +95,7 @@ proc newWakuSwitch*(
     .withTcpTransport(transportFlags)
     .withNameResolver(nameResolver)
     .withSignedPeerRecord(sendSignedPeerRecord)
-    .withCircuitRelay()
+    .withCircuitRelay(relay)
     .withAutonat()
 
   if peerStoreCapacity.isSome():

--- a/waku/node/waku_switch.nim
+++ b/waku/node/waku_switch.nim
@@ -78,7 +78,7 @@ proc newWakuSwitch*(
     agentString = none(string), # defaults to nim-libp2p version
     peerStoreCapacity = none(int), # defaults to 1.25 maxConnections
     rendezvous: RendezVous = nil,
-    relay: Relay,
+    circuitRelay: Relay,
 ): Switch {.raises: [Defect, IOError, LPError].} =
   var b = SwitchBuilder
     .new()
@@ -93,7 +93,7 @@ proc newWakuSwitch*(
     .withTcpTransport(transportFlags)
     .withNameResolver(nameResolver)
     .withSignedPeerRecord(sendSignedPeerRecord)
-    .withCircuitRelay(relay)
+    .withCircuitRelay(circuitRelay)
     .withAutonat()
 
   if peerStoreCapacity.isSome():

--- a/waku/waku_core/peers.nim
+++ b/waku/waku_core/peers.nim
@@ -4,6 +4,7 @@ import
   std/[options, sequtils, strutils, uri, net],
   results,
   chronos,
+  chronicles,
   eth/keys,
   eth/p2p/discoveryv5/enr,
   eth/net/utils,
@@ -15,6 +16,7 @@ import
   libp2p/peerid,
   libp2p/peerinfo,
   libp2p/routing_record,
+  regex,
   json_serialization
 
 type
@@ -108,7 +110,7 @@ proc init*(
 
 ## Parse
 
-proc validWireAddr*(ma: MultiAddress): bool =
+proc validWireAddr(ma: MultiAddress): bool =
   ## Check if wire Address is supported
   const ValidTransports = mapOr(TCP, WebSockets)
   return ValidTransports.match(ma)
@@ -118,9 +120,44 @@ proc parsePeerInfo*(peer: RemotePeerInfo): Result[RemotePeerInfo, string] =
   ## format `(ip4|ip6)/tcp/p2p`, into dialable PeerInfo
   ok(peer)
 
-proc parsePeerInfo*(peer: MultiAddress): Result[RemotePeerInfo, string] =
-  ## Parses a fully qualified peer multiaddr, in the
-  ## format `(ip4|ip6)/tcp/p2p`, into dialable PeerInfo
+proc parsePeerInfoFromCircuitRelayAddr(
+    address: string
+): Result[RemotePeerInfo, string] =
+  var match: RegexMatch2
+  # Parse like: /ip4/162.19.247.156/tcp/60010/p2p/16Uiu2HAmCzWcYBCw3xKW8De16X9wtcbQrqD8x7CRRv4xpsFJ4oN8/p2p-circuit/p2p/16Uiu2HAm2eqzqp6xn32fzgGi8K4BuF88W4Xy6yxsmDcW8h1gj6ie
+  let maPattern =
+    re2"\/(ip4|ip6|dns|dnsaddr|dns4|dns6)\/[0-9a-fA-F:.]+\/(tcp|ws|wss)\/\d+\/p2p\/(.+)\/p2p-circuit\/p2p\/(.+)"
+  if not regex.match(address, maPattern, match):
+    return err("failed to parse ma: " & address)
+
+  if match.captures.len != 4:
+    return err(
+      "failed parsing p2p-circuit addr, expected 4 regex capture groups: " & address &
+        " found: " & $(match.namedGroups.len)
+    )
+
+  let relayPeerId = address[match.group(2)]
+  let targetPeerIdStr = address[match.group(3)]
+
+  discard PeerID.init(relayPeerId).valueOr:
+    return err("invalid relay peer id from p2p-circuit address: " & address)
+  let targetPeerId = PeerID.init(targetPeerIdStr).valueOr:
+    return err("invalid targetPeerId peer id from p2p-circuit address: " & address)
+
+  let pattern = "/p2p-circuit"
+  let idx = address.find(pattern)
+  let wireAddr: MultiAddress =
+    if idx != -1:
+      # Extract everything from the start up to and including "/p2p-circuit"
+      let adr = address[0 .. (idx + pattern.len - 1)]
+      MultiAddress.init(adr).valueOr:
+        return err("could not create multiaddress from: " & adr)
+    else:
+      return err("could not find /p2p-circuit pattern in: " & address)
+
+  return ok(RemotePeerInfo.init(targetPeerId, @[wireAddr]))
+
+proc parsePeerInfoFromRegularAddr(peer: MultiAddress): Result[RemotePeerInfo, string] =
   var p2pPart: MultiAddress
   var wireAddr = MultiAddress()
   for addrPart in peer.items():
@@ -160,6 +197,16 @@ proc parsePeerInfo*(peer: MultiAddress): Result[RemotePeerInfo, string] =
     return err("invalid multiaddress: no supported transport found")
 
   return ok(RemotePeerInfo.init(peerId, @[wireAddr]))
+
+proc parsePeerInfo*(peer: MultiAddress): Result[RemotePeerInfo, string] =
+  ## Parses a fully qualified peer multiaddr into dialable RemotePeerInfo
+
+  let peerAddrStr = $peer
+
+  if "p2p-circuit" in peerAddrStr:
+    return parsePeerInfoFromCircuitRelayAddr(peerAddrStr)
+
+  return parsePeerInfoFromRegularAddr(peer)
 
 proc parsePeerInfo*(peer: string): Result[RemotePeerInfo, string] =
   ## Parses a fully qualified peer multiaddr, in the
@@ -256,7 +303,7 @@ converter toRemotePeerInfo*(peerInfo: PeerInfo): RemotePeerInfo =
   RemotePeerInfo(
     peerId: peerInfo.peerId,
     addrs: peerInfo.listenAddrs,
-    enr: none(Record),
+    enr: none(enr.Record),
     protocols: peerInfo.protocols,
     agent: peerInfo.agentVersion,
     protoVersion: peerInfo.protoVersion,

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -501,3 +501,10 @@ proc getNumConnectedPeers*(
     )
 
   return ok(peers.len)
+
+proc getSubscribedTopics*(w: WakuRelay): seq[PubsubTopic] =
+  ## Returns a seq containing the current list of subscribed topics
+  var topics: seq[PubsubTopic]
+  for t in w.validatorInserted.keys():
+    topics.add(t)
+  return topics


### PR DESCRIPTION
## Description
Allow a node to act as a circuit-relay client/server. Also, start the _Hole Punch_ server.
This is useful for nodes that are behind a NAT or firewall and hence are not reachable.

Special kudos to @richard-ramos , @lchenut and @diegomrsantos. This PR is yours and also inspired by this PR: https://github.com/waku-org/nwaku/pull/1766


## Changes

- Undo installation of libpcre because we forced ubuntu 22.04 (unrelated change.)
- Make `Waku` a `ref object` so that it's always passed as by ref.
- Move autonat service code into a separate module, `autonate_service` and check self-reachability every 30 sec instead of every 2 min.
- New external parameter, `relay-client`, which allows setting the node as a circuit-relay client. (we will need to document that.)
- Update ENR when a circuit-relay-client reserves a slot in a circuit-relay-server.
- Update announced IP address to avoid announcing `0.0.0.0` or `127.0.0.1`.
- Spawn nim-libp2p `DiscoveryManager` with rendezvous to advertise rendezvous namespaces based on the subscribed pubsub topics.
- nat: add exception protection when calling `getExternalIP`.

## How to test
Three nodes need to run. Two configured as `relay-client` and a third one configured as a `relay server` (default.)

1. Start service node with the following in a VPS so that it is reachable:
```nim
ports-shift = 10
cluster-id = 2
log-level = "DEBUG"
nodekey = "1264d111d729a6eb6d2e6113e163f017b5ef03a6f94c9b5b7bb1bb36fa5cb07a9"

relay = false
```

2. Start node A with the following configuration and behind a NAT. This will connect to the service node.
```nim
ports-shift = 1
cluster-id = 2
staticnode = [ "/ip4/162.19.247.156/tcp/60010/p2p/16Uiu2HAmCzWcYBCw3xKW8De16X9wtcbQrqD8x7CRRv4xpsFJ4oN8" ]

log-level = "DEBUG"
nodekey = "364d111d729a6eb6d2e6113e163f017b5ef03a6f94c9b5b7bb1bb36fa5cb07a9"

relay-client = true
```

Wait for two minutes until the node A determines that it is not reachable. When that happens, the node A reserves a circuit-relay slot in the relay service node.

3. Start node B that will establish a relay connection with node A, through the relay sever:

```nim
ports-shift = 3
cluster-id = 2
staticnode = [ "/ip4/162.19.247.156/tcp/60010/p2p/16Uiu2HAmCzWcYBCw3xKW8De16X9wtcbQrqD8x7CRRv4xpsFJ4oN8/p2p-circuit/p2p/16Uiu2HAm2eqzqp6xn32fzgGi8K4BuF88W4Xy6yxsmDcW8h1gj6ie" ]
log-level = "DEBUG"
nodekey = "764d111d729a6eb6d2e6113e163f017b5ef03a6f94c9b5b7bb1bb36fa5cb07a9"

relay-client = true

```
4. Stop the service node. In that case, node A and node B will still be connected even though they are not reachable due to the NAT condition.

## Issue

closes https://github.com/waku-org/nwaku/issues/2514