### PR TITLE
fix: add a limit of max 10 content topics per query

### DIFF
--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -22,6 +22,7 @@ logScope:
 const
   DefaultPageSize*: uint = 20
   MaxPageSize*: uint = 100
+  MaxContentTopicsPerQuery*: int = 10
 
   # Retention policy
   WakuArchiveDefaultRetentionPolicyInterval* = chronos.minutes(30)
@@ -124,6 +125,9 @@ proc findMessages*(
 
     if cursor == EmptyWakuMessageHash:
       return err(ArchiveError.invalidQuery("all zeroes cursor hash"))
+
+    if query.contentTopics.len > MaxContentTopicsPerQuery:
+      return err(ArchiveError.invalidQuery("too many content topics"))
 
   let maxPageSize =
     if query.pageSize <= 0:


### PR DESCRIPTION
Adds the same restriction we had on waku archive legacy of a maximum of 10 content topics per query as it currently was limitless. We have seen that the store query performance drops the more content topics we add so adding a limit of 10 will help avoid this situation as well as comply with the current assumptions of status-go