### PR TITLE
chore: returning seqs in libwaku as comma separated strings

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
@@ -1,5 +1,5 @@
 import std/json
-import chronicles, chronos, results, eth/p2p/discoveryv5/enr
+import chronicles, chronos, results, eth/p2p/discoveryv5/enr, strutils
 import ../../../../waku/factory/waku, ../../../../waku/node/waku_node
 
 type DebugNodeMsgType* = enum
@@ -28,7 +28,8 @@ proc process*(
 
   case self.operation
   of RETRIEVE_LISTENING_ADDRESSES:
-    return ok($(%*waku.node.getMultiaddresses()))
+    ## returns a comma-separated string of the listen addresses
+    return ok(waku.node.getMultiaddresses().join(","))
   of RETRIEVE_MY_ENR:
     return ok(waku.node.enr.toURI())
 

--- a/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
@@ -1,5 +1,5 @@
 import std/json
-import chronos, chronicles, results, libp2p/multiaddress
+import chronos, chronicles, results, strutils, libp2p/multiaddress
 import
   ../../../../waku/factory/waku,
   ../../../../waku/discovery/waku_dnsdisc,
@@ -129,7 +129,8 @@ proc process*(
       error "GET_BOOTSTRAP_NODES failed", error = error
       return err($error)
 
-    return ok($(%*nodes))
+    ## returns a comma-separated string of bootstrap nodes' multiaddresses
+    return ok(nodes.join(","))
   of UPDATE_DISCV5_BOOTSTRAP_NODES:
     updateDiscv5BootstrapNodes($self[].nodes, waku).isOkOr:
       error "UPDATE_DISCV5_BOOTSTRAP_NODES failed", error = error


### PR DESCRIPTION
# Description
In libwaku, when returning sequences as outputs, in some places we are returning the sequence as a comma-separated string such as in https://github.com/waku-org/nwaku/blob/18c375a5deea569e4bbef09d1f9376ad92190bc5/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim#L79-L90
while in others we return a string wrapped with the `[ ]` characters, representing an array

For the sake of simplicity and consistence - and mainly so the parsing client-side can be the same in all cases - I propose to return all sequences as comma-separated strings

# Changes

<!-- List of detailed changes -->

- [x] returning output of `RETRIEVE_LISTENING_ADDRESSES` as comma-separated string
- [x] returning output of `GET_BOOTSTRAP_NODES` as comma-separated string


## Issue
#3115 
