### PR TITLE
fix: avoid segfault by setting a default num peers requested in PX

### DIFF
--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -414,7 +414,11 @@ proc startNode*(
 
   # retrieve px peers and add the to the peer store
   if conf.peerExchangeNode != "":
-    let desiredOutDegree = node.wakuRelay.parameters.d.uint64()
+    let desiredOutDegree =
+      if not node.wakuRelay.isNil():
+        node.wakuRelay.parameters.d.uint64()
+      else:
+        DefaultPXNumPeersReq
     (await node.fetchPeerExchangePeers(desiredOutDegree)).isOkOr:
       error "error while fetching peers from peer exchange", error = error
       quit(QuitFailure)

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -414,11 +414,9 @@ proc startNode*(
 
   # retrieve px peers and add the to the peer store
   if conf.peerExchangeNode != "":
-    let desiredOutDegree =
-      if not node.wakuRelay.isNil():
-        node.wakuRelay.parameters.d.uint64()
-      else:
-        DefaultPXNumPeersReq
+    var desiredOutDegree = DefaultPXNumPeersReq
+    if not node.wakuRelay.isNil() and node.wakuRelay.parameters.d.uint64() > 0:
+      desiredOutDegree = node.wakuRelay.parameters.d.uint64()
     (await node.fetchPeerExchangePeers(desiredOutDegree)).isOkOr:
       error "error while fetching peers from peer exchange", error = error
       quit(QuitFailure)

--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -37,6 +37,7 @@ const
   CacheRefreshInterval = 10.minutes
 
   WakuPeerExchangeCodec* = "/vac/waku/peer-exchange/2.0.0-alpha1"
+  DefaultPXNumPeersReq* = 5.uint64()
 
 # Error types (metric label values)
 const
@@ -57,7 +58,7 @@ type
     requestRateLimiter*: RequestRateLimiter
 
 proc request*(
-    wpx: WakuPeerExchange, numPeers: uint64, conn: Connection
+    wpx: WakuPeerExchange, numPeers = DefaultPXNumPeersReq, conn: Connection
 ): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
   let rpc = PeerExchangeRpc.makeRequest(numPeers)
 
@@ -99,7 +100,7 @@ proc request*(
   return ok(decodedBuff.get().response)
 
 proc request*(
-    wpx: WakuPeerExchange, numPeers: uint64, peer: RemotePeerInfo
+    wpx: WakuPeerExchange, numPeers = DefaultPXNumPeersReq, peer: RemotePeerInfo
 ): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
   try:
     let connOpt = await wpx.peerManager.dialPeer(peer, WakuPeerExchangeCodec)
@@ -120,7 +121,7 @@ proc request*(
     )
 
 proc request*(
-    wpx: WakuPeerExchange, numPeers: uint64
+    wpx: WakuPeerExchange, numPeers = DefaultPXNumPeersReq
 ): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
   let peerOpt = wpx.peerManager.selectPeer(WakuPeerExchangeCodec)
   if peerOpt.isNone():

--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -35,9 +35,9 @@ const
     # TODO what is the expected size of a PX message? As currently specified, it can contain an arbitary number of ENRs...
   MaxPeersCacheSize = 60
   CacheRefreshInterval = 10.minutes
+  DefaultPXNumPeersReq* = 5.uint64()
 
   WakuPeerExchangeCodec* = "/vac/waku/peer-exchange/2.0.0-alpha1"
-  DefaultPXNumPeersReq* = 5.uint64()
 
 # Error types (metric label values)
 const


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
When using Peer Exchange in nwaku, we are setting the number of peers requested by using a Relay-specific parameter, which isn't set if we use nwaku as a light client and produces a segfault.

Therefore, defined a `DefaultPXNumPeersReq` constant with a value of 5 to use whenever no argument is provided or whenever Relay is not mounted 

# Changes

<!-- List of detailed changes -->

- [x] defined and integrated `DefaultPXNumPeersReq` constant
- [x] fixed segfault by not reading Relay's parameters if Relay is not mounted


## Issue
#3115 
