### PR TITLE
chore: add to libwaku peer id retrieval proc

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -172,6 +172,10 @@ int waku_get_my_enr(void* ctx,
                     WakuCallBack callback,
                     void* userData);
 
+int waku_get_my_peerid(void* ctx,
+                    WakuCallBack callback,
+                    void* userData);
+
 int waku_peer_exchange_request(void* ctx,
                                int numPeers,
                                WakuCallBack callback,

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -626,6 +626,19 @@ proc waku_get_my_enr(
   )
   .handleRes(callback, userData)
 
+proc waku_get_my_peerid(
+    ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
+): cint {.dynlib, exportc.} =
+  checkLibwakuParams(ctx, callback, userData)
+
+  waku_thread
+  .sendRequestToWakuThread(
+    ctx,
+    RequestType.DEBUG,
+    DebugNodeRequest.createShared(DebugNodeMsgType.RETRIEVE_MY_PEER_ID),
+  )
+  .handleRes(callback, userData)
+
 proc waku_start_discv5(
     ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
 ): cint {.dynlib, exportc.} =

--- a/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
@@ -5,6 +5,7 @@ import ../../../../waku/factory/waku, ../../../../waku/node/waku_node
 type DebugNodeMsgType* = enum
   RETRIEVE_LISTENING_ADDRESSES
   RETRIEVE_MY_ENR
+  RETRIEVE_MY_PEER_ID
 
 type DebugNodeRequest* = object
   operation: DebugNodeMsgType
@@ -32,6 +33,8 @@ proc process*(
     return ok(waku.node.getMultiaddresses().join(","))
   of RETRIEVE_MY_ENR:
     return ok(waku.node.enr.toURI())
+  of RETRIEVE_MY_PEER_ID:
+    return ok($waku.node.peerId())
 
   error "unsupported operation in DebugNodeRequest"
   return err("unsupported operation in DebugNodeRequest")

--- a/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/debug_node_request.nim
@@ -1,5 +1,5 @@
 import std/json
-import chronicles, chronos, results, eth/p2p/discoveryv5/enr, strutils
+import chronicles, chronos, results, eth/p2p/discoveryv5/enr, strutils, libp2p/peerid
 import ../../../../waku/factory/waku, ../../../../waku/node/waku_node
 
 type DebugNodeMsgType* = enum


### PR DESCRIPTION
# Description
Adding to libwaku a proc to retrieve our own peerId

# Changes

<!-- List of detailed changes -->

- [x] adding `waku_get_my_peerid` proc to libwaku


## Issue
#3115 
