### PR TITLE
chore: easy setup fleets for lpt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,34 @@ docker-image:
 docker-push:
 	docker push $(DOCKER_IMAGE_NAME)
 
+####################################
+## Container lite-protocol-tester ##
+####################################
+# -d:insecure - Necessary to enable Prometheus HTTP endpoint for metrics
+# -d:chronicles_colors:none - Necessary to disable colors in logs for Docker
+DOCKER_LPT_NIMFLAGS ?= -d:chronicles_colors:none -d:insecure
+
+# build a docker image for the fleet
+docker-liteprotocoltester: DOCKER_LPT_TAG ?= liteprotocoltester-$(GIT_VERSION)
+docker-liteprotocoltester: DOCKER_LPT_NAME ?= wakuorg/liteprotocoltester:latest
+docker-liteprotocoltester:
+	docker build \
+	  --no-cache \
+		-D \
+		--build-arg="MAKE_TARGET=liteprotocoltester" \
+		--build-arg="NIMFLAGS=$(DOCKER_LPT_NIMFLAGS)" \
+		--build-arg="NIM_COMMIT=$(DOCKER_NIM_COMMIT)" \
+		--build-arg="LOG_LEVEL=TRACE" \
+		--label="commit=$(shell git rev-parse HEAD)" \
+		--label="version=$(GIT_VERSION)" \
+		--target $(TARGET) \
+		--tag $(DOCKER_LPT_NAME) \
+		--file apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile \
+		.
+
+docker-liteprotocoltester-push:
+	docker push $(DOCKER_LPT_NAME)
+
 
 ################
 ## C Bindings ##

--- a/Makefile
+++ b/Makefile
@@ -350,12 +350,11 @@ docker-push:
 DOCKER_LPT_NIMFLAGS ?= -d:chronicles_colors:none -d:insecure
 
 # build a docker image for the fleet
-docker-liteprotocoltester: DOCKER_LPT_TAG ?= liteprotocoltester-$(GIT_VERSION)
-docker-liteprotocoltester: DOCKER_LPT_NAME ?= wakuorg/liteprotocoltester:latest
+docker-liteprotocoltester: DOCKER_LPT_TAG ?= latest
+docker-liteprotocoltester: DOCKER_LPT_NAME ?= wakuorg/liteprotocoltester:$(DOCKER_LPT_TAG)
 docker-liteprotocoltester:
 	docker build \
 	  --no-cache \
-		-D \
 		--build-arg="MAKE_TARGET=liteprotocoltester" \
 		--build-arg="NIMFLAGS=$(DOCKER_LPT_NIMFLAGS)" \
 		--build-arg="NIM_COMMIT=$(DOCKER_NIM_COMMIT)" \

--- a/apps/liteprotocoltester/.env
+++ b/apps/liteprotocoltester/.env
@@ -17,11 +17,11 @@ MAX_MESSAGE_SIZE=145Kb
 #CLUSTER_ID=66
 
 ## for status.prod
-#PUBSUB=/waku/2/rs/16/32
-#CONTENT_TOPIC=/tester/2/light-pubsub-test/fleet
-#CLUSTER_ID=16
+PUBSUB=/waku/2/rs/16/32
+CONTENT_TOPIC=/tester/2/light-pubsub-test/fleet
+CLUSTER_ID=16
 
 ## for TWN
-PUBSUB=/waku/2/rs/1/4
-CONTENT_TOPIC=/tester/2/light-pubsub-test/twn
-CLUSTER_ID=1
+#PUBSUB=/waku/2/rs/1/4
+#CONTENT_TOPIC=/tester/2/light-pubsub-test/twn
+#CLUSTER_ID=1

--- a/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
+++ b/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
@@ -1,58 +1,57 @@
 # BUILD NIM APP ----------------------------------------------------------------
-  FROM rust:1.77.1-alpine3.18  AS nim-build
+FROM rust:1.77.1-alpine3.18  AS nim-build
 
-  ARG NIMFLAGS
-  ARG MAKE_TARGET=liteprotocoltester
-  ARG NIM_COMMIT
-  ARG LOG_LEVEL=DEBUG
+ARG NIMFLAGS
+ARG MAKE_TARGET=liteprotocoltester
+ARG NIM_COMMIT
+ARG LOG_LEVEL=TRACE
 
-  # Get build tools and required header files
-  RUN apk add --no-cache bash git build-base pcre-dev linux-headers curl jq
+# Get build tools and required header files
+RUN apk add --no-cache bash git build-base openssl-dev pcre-dev linux-headers curl jq
 
-  WORKDIR /app
-  COPY . .
+WORKDIR /app
+COPY . .
 
-  # workaround for alpine issue: https://github.com/alpinelinux/docker-alpine/issues/383
-  RUN apk update && apk upgrade
+# workaround for alpine issue: https://github.com/alpinelinux/docker-alpine/issues/383
+RUN apk update && apk upgrade
 
-  # Ran separately from 'make' to avoid re-doing
-  RUN git submodule update --init --recursive
+# Ran separately from 'make' to avoid re-doing
+RUN git submodule update --init --recursive
 
-  # Slowest build step for the sake of caching layers
-  RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1 ${NIM_COMMIT}
+# Slowest build step for the sake of caching layers
+RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1 ${NIM_COMMIT}
 
-  # Build the final node binary
-  RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="${NIMFLAGS}"
+# Build the final node binary
+RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="${NIMFLAGS}"
 
 
-  # PRODUCTION IMAGE -------------------------------------------------------------
+# PRODUCTION IMAGE -------------------------------------------------------------
 
-  FROM alpine:3.18 AS prod
+FROM alpine:3.18 AS prod
 
-  ARG MAKE_TARGET=liteprotocoltester
+ARG MAKE_TARGET=liteprotocoltester
 
-  LABEL maintainer="jakub@status.im"
-  LABEL source="https://github.com/waku-org/nwaku"
-  LABEL description="Lite Protocol Tester: Waku light-client"
-  LABEL commit="unknown"
-  LABEL version="unknown"
+LABEL maintainer="zoltan@status.im"
+LABEL source="https://github.com/waku-org/nwaku"
+LABEL description="Lite Protocol Tester: Waku light-client"
+LABEL commit="unknown"
+LABEL version="unknown"
 
-  # DevP2P, LibP2P, and JSON RPC ports
-  EXPOSE 30303 60000 8545
+# DevP2P, LibP2P, and JSON RPC ports
+EXPOSE 30303 60000 8545
 
-  # Referenced in the binary
-  RUN apk add --no-cache libgcc pcre-dev libpq-dev
+# Referenced in the binary
+RUN apk add --no-cache libgcc pcre-dev libpq-dev \
+  wget \
+  iproute2
 
-  # Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
-  RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
+# Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
+RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
-  # Copy to separate location to accomodate different MAKE_TARGET values
-  COPY --from=nim-build /app/build/$MAKE_TARGET /usr/bin/
+COPY --from=nim-build /app/build/liteprotocoltester /usr/bin/
+COPY --from=nim-build /app/apps/liteprotocoltester/run_tester_node.sh /usr/bin/
 
-  # Copy migration scripts for DB upgrades
-  COPY --from=nim-build /app/migrations/ /app/migrations/
+ENTRYPOINT ["/usr/bin/run_tester_node.sh", "/usr/bin/liteprotocoltester"]
 
-  ENTRYPOINT ["/usr/bin/liteprotocoltester"]
-
-  # By default just show help if called without arguments
-  CMD ["--help"]
+# # By default just show help if called without arguments
+CMD ["--help"]

--- a/apps/liteprotocoltester/README.md
+++ b/apps/liteprotocoltester/README.md
@@ -208,3 +208,4 @@ docker run --env-file .env liteprotocoltester:latest RECEIVER <bootstrap-node-pe
 docker run --env-file .env liteprotocoltester:latest SENDER <bootstrap-node-peer-address> BOOTSTRAP
 ```
 
+> Notice that official image is also available at harbor.status.im/wakuorg/liteprotocoltester:latest

--- a/apps/liteprotocoltester/README.md
+++ b/apps/liteprotocoltester/README.md
@@ -157,6 +157,7 @@ Run a SENDER role liteprotocoltester and a RECEIVER role one on different termin
 | --rest-allow-origin | For convenience rest configuration can be done here | * |
 | --log-level | Log level for the application | DEBUG |
 | --log-format | Logging output format (TEXT or JSON) | TEXT |
+| --metrics-port | Metrics scarpe port | 8003 |
 
 ### Specifying peer addresses
 
@@ -165,7 +166,8 @@ Service node or bootstrap addresses can be specified in multiadress or ENR form.
 ### Using bootstrap nodes
 
 There are multiple benefits of using bootstrap nodes. By using them liteprotocoltester will use Peer Exchange protocol to get possible peers from the network that are capable to serve as service peers for testing. Additionally it will test dial them to verify their connectivity - this will be reported in the logs and on dashboard metrics.
-Also by using bootstrap node and peer exchange discovery, litprotocoltester will be able to simulate service peer switch in case of failures. There are built in tresholds for service peer failures during test and service peer can be switched during the test. Also these service peer failures are reported, thus extending network reliability measures.
+Also by using bootstrap node and peer exchange discovery, litprotocoltester will be able to simulate service peer switch in case of failures. There are built in tresholds count for service peer failures (3) after service peer will be switched during the test. Also there will be max 10 trials of switching peer before test declared failed and quit.
+These service peer failures are reported, thus extending network reliability measures.
 
 ### Docker image notice
 
@@ -214,7 +216,16 @@ docker run --env-file .env liteprotocoltester:latest SENDER <bootstrap-node-peer
 
 ## Examples
 
+### Bootstrap or Service node selection
+
+The easiest way to get the proper bootstrap nodes for the tests from https://fleets.status.im page.
+Adjust on which fleets you would like to run the tests.
+
+> Please note that not all of them configured to support Peer Exchange protocol, those ones cannot be for bootstrap nodes for `liteprotocoltester`.
+
+### Environment variables
 You need not necessary to use .env file, although it can be more convenient.
+Anytime you can override all or part of the environment variables defined in the .env file.
 
 ### Run standalone
 

--- a/apps/liteprotocoltester/diagnose_connections.nim
+++ b/apps/liteprotocoltester/diagnose_connections.nim
@@ -42,7 +42,7 @@ proc `$`*(cap: Capabilities): string =
 
 proc allPeers(pm: PeerManager): string =
   var allStr: string = ""
-  for idx, peer in pm.peerStore.peers():
+  for idx, peer in pm.wakuPeerStore.peers():
     allStr.add(
       "    " & $idx & ". | " & constructMultiaddrStr(peer) & " | protos: " &
         $peer.protocols & " | caps: " & $peer.enr.map(getCapabilities) & "\n"
@@ -50,10 +50,10 @@ proc allPeers(pm: PeerManager): string =
   return allStr
 
 proc logSelfPeers*(pm: PeerManager) =
-  let selfLighpushPeers = pm.peerStore.getPeersByProtocol(WakuLightPushCodec)
-  let selfRelayPeers = pm.peerStore.getPeersByProtocol(WakuRelayCodec)
-  let selfFilterPeers = pm.peerStore.getPeersByProtocol(WakuFilterSubscribeCodec)
-  let selfPxPeers = pm.peerStore.getPeersByProtocol(WakuPeerExchangeCodec)
+  let selfLighpushPeers = pm.wakuPeerStore.getPeersByProtocol(WakuLightPushCodec)
+  let selfRelayPeers = pm.wakuPeerStore.getPeersByProtocol(WakuRelayCodec)
+  let selfFilterPeers = pm.wakuPeerStore.getPeersByProtocol(WakuFilterSubscribeCodec)
+  let selfPxPeers = pm.wakuPeerStore.getPeersByProtocol(WakuPeerExchangeCodec)
 
   let printable = catch:
     """*------------------------------------------------------------------------------------------*

--- a/apps/liteprotocoltester/diagnose_connections.nim
+++ b/apps/liteprotocoltester/diagnose_connections.nim
@@ -4,60 +4,74 @@ else:
   {.push raises: [].}
 
 import
-  std/[options, strutils, os, sequtils, net, strformat],
+  std/[options, net, strformat],
   chronicles,
   chronos,
   metrics,
   libbacktrace,
-  system/ansi_c,
   libp2p/crypto/crypto,
   confutils,
   libp2p/wire
 
 import
-  ../../waku/common/logging,
-  ../../waku/factory/waku,
-  ../../waku/factory/external_config,
-  ../../waku/node/health_monitor,
-  ../../waku/node/waku_metrics,
-  ../../waku/waku_api/rest/builder as rest_server_builder,
-  ../../waku/node/peer_manager,
-  ../../waku/waku_lightpush/common,
-  ../../waku/waku_relay,
-  ../../waku/waku_filter_v2,
-  ../../waku/waku_api/rest/client,
-  ../../waku/waku_api/rest/admin/client,
-  ./tester_config,
-  ./lightpush_publisher,
-  ./filter_subscriber
-
+  waku/[
+    factory/external_config,
+    node/peer_manager,
+    waku_lightpush/common,
+    waku_relay,
+    waku_filter_v2,
+    waku_peer_exchange/protocol,
+    waku_core/multiaddrstr,
+    waku_enr/capabilities,
+  ]
 logScope:
   topics = "diagnose connections"
 
-proc logSelfPeersLoop(pm: PeerManager, interval: Duration) {.async.} =
-  trace "Starting logSelfPeersLoop diagnosis loop"
-  while true:
-    let selfLighpushPeers = pm.wakuPeerStore.getPeersByProtocol(WakuLightPushCodec)
-    let selfRelayPeers = pm.wakuPeerStore.getPeersByProtocol(WakuRelayCodec)
-    let selfFilterPeers = pm.wakuPeerStore.getPeersByProtocol(WakuFilterSubscribeCodec)
+proc `$`*(cap: Capabilities): string =
+  case cap
+  of Capabilities.Relay:
+    return "Relay"
+  of Capabilities.Store:
+    return "Store"
+  of Capabilities.Filter:
+    return "Filter"
+  of Capabilities.Lightpush:
+    return "Lightpush"
+  of Capabilities.Sync:
+    return "Sync"
 
-    let printable = catch:
-      """*------------------------------------------------------------------------------------------*
-|  Self ({pm.switch.peerInfo}) peers:
+proc allPeers(pm: PeerManager): string =
+  var allStr: string = ""
+  for idx, peer in pm.peerStore.peers():
+    allStr.add(
+      "    " & $idx & ". | " & constructMultiaddrStr(peer) & " | protos: " &
+        $peer.protocols & " | caps: " & $peer.enr.map(getCapabilities) & "\n"
+    )
+  return allStr
+
+proc logSelfPeers*(pm: PeerManager) =
+  let selfLighpushPeers = pm.peerStore.getPeersByProtocol(WakuLightPushCodec)
+  let selfRelayPeers = pm.peerStore.getPeersByProtocol(WakuRelayCodec)
+  let selfFilterPeers = pm.peerStore.getPeersByProtocol(WakuFilterSubscribeCodec)
+  let selfPxPeers = pm.peerStore.getPeersByProtocol(WakuPeerExchangeCodec)
+
+  let printable = catch:
+    """*------------------------------------------------------------------------------------------*
+|  Self ({constructMultiaddrStr(pm.switch.peerInfo)}) peers:
 *------------------------------------------------------------------------------------------*
 |  Lightpush peers({selfLighpushPeers.len()}): ${selfLighpushPeers}
 *------------------------------------------------------------------------------------------*
 |  Filter peers({selfFilterPeers.len()}): ${selfFilterPeers}
 *------------------------------------------------------------------------------------------*
 |  Relay peers({selfRelayPeers.len()}): ${selfRelayPeers}
+*------------------------------------------------------------------------------------------*
+|  PX peers({selfPxPeers.len()}): ${selfPxPeers}
+*------------------------------------------------------------------------------------------*
+| All peers with protocol support:
+{allPeers(pm)}
 *------------------------------------------------------------------------------------------*""".fmt()
 
-    if printable.isErr():
-      echo "Error while printing statistics: " & printable.error().msg
-    else:
-      echo printable.get()
-
-    await sleepAsync(interval)
-
-proc startPeriodicPeerDiagnostic*(pm: PeerManager, codec: string) {.async.} =
-  asyncSpawn logSelfPeersLoop(pm, chronos.seconds(60))
+  if printable.isErr():
+    echo "Error while printing statistics: " & printable.error().msg
+  else:
+    echo printable.get()

--- a/apps/liteprotocoltester/docker-compose.yml
+++ b/apps/liteprotocoltester/docker-compose.yml
@@ -23,6 +23,9 @@ x-test-running-conditions: &test_running_conditions
   MAX_MESSAGE_SIZE: ${MAX_MESSAGE_SIZE:-150Kb}
   START_PUBLISHING_AFTER: ${START_PUBLISHING_AFTER:-5}  # seconds
   STANDALONE: ${STANDALONE:-1}
+  RECEIVER_METRICS_PORT: 8003
+  PUBLISHER_METRICS_PORT: 8003
+
 
 # Services definitions
 services:

--- a/apps/liteprotocoltester/filter_subscriber.nim
+++ b/apps/liteprotocoltester/filter_subscriber.nim
@@ -10,23 +10,32 @@ import
   stew/byteutils,
   results,
   serialization,
-  json_serialization as js,
-  times
+  json_serialization as js
+
 import
-  waku/[common/logging, node/peer_manager, waku_node, waku_core, waku_filter_v2/client],
+  waku/[
+    common/logging,
+    node/peer_manager,
+    waku_node,
+    waku_core,
+    waku_filter_v2/client,
+    waku_filter_v2/common,
+    waku_core/multiaddrstr,
+  ],
   ./tester_config,
   ./tester_message,
-  ./statistics
+  ./statistics,
+  ./diagnose_connections,
+  ./service_peer_management
+
+var actualFilterPeer {.threadvar.}: RemotePeerInfo
 
 proc unsubscribe(
-    wakuNode: WakuNode,
-    filterPeer: RemotePeerInfo,
-    filterPubsubTopic: PubsubTopic,
-    filterContentTopic: ContentTopic,
+    wakuNode: WakuNode, filterPubsubTopic: PubsubTopic, filterContentTopic: ContentTopic
 ) {.async.} =
   notice "unsubscribing from filter"
   let unsubscribeRes = await wakuNode.wakuFilterClient.unsubscribe(
-    filterPeer, filterPubsubTopic, @[filterContentTopic]
+    actualFilterPeer, filterPubsubTopic, @[filterContentTopic]
   )
   if unsubscribeRes.isErr:
     notice "unsubscribe request failed", err = unsubscribeRes.error
@@ -34,48 +43,79 @@ proc unsubscribe(
     notice "unsubscribe request successful"
 
 proc maintainSubscription(
-    wakuNode: WakuNode,
-    filterPeer: RemotePeerInfo,
-    filterPubsubTopic: PubsubTopic,
-    filterContentTopic: ContentTopic,
+    wakuNode: WakuNode, filterPubsubTopic: PubsubTopic, filterContentTopic: ContentTopic
 ) {.async.} =
+  const maxFailedSubscribes = 3
+  const maxFailedServiceNodeSwitches = 10
+  var noFailedSubscribes = 0
+  var noFailedServiceNodeSwitches = 0
   while true:
-    trace "maintaining subscription"
+    info "maintaining subscription at", peer = constructMultiaddrStr(actualFilterPeer)
     # First use filter-ping to check if we have an active subscription
-    let pingRes = await wakuNode.wakuFilterClient.ping(filterPeer)
+    let pingRes = await wakuNode.wakuFilterClient.ping(actualFilterPeer)
     if pingRes.isErr():
       # No subscription found. Let's subscribe.
       error "ping failed.", err = pingRes.error
       trace "no subscription found. Sending subscribe request"
 
       let subscribeRes = await wakuNode.filterSubscribe(
-        some(filterPubsubTopic), filterContentTopic, filterPeer
+        some(filterPubsubTopic), filterContentTopic, actualFilterPeer
       )
 
       if subscribeRes.isErr():
-        error "subscribe request failed. Quitting.", err = subscribeRes.error
-        break
+        noFailedSubscribes += 1
+        error "Subscribe request failed.",
+          err = subscribeRes.error,
+          peer = actualFilterPeer,
+          failCount = noFailedSubscribes
+
+        # TODO: disconnet from failed actualFilterPeer
+        # asyncSpawn(wakuNode.peerManager.switch.disconnect(p))
+        # wakunode.peerManager.peerStore.delete(actualFilterPeer)
+
+        if noFailedSubscribes < maxFailedSubscribes:
+          await sleepAsync(chtimer.seconds(2)) # Wait a bit before retrying
+          continue
+        else:
+          let peerOpt = await selectRandomServicePeer(
+            wakuNode.peerManager, WakuFilterSubscribeCodec, filterPubsubTopic
+          )
+          if peerOpt.isSome():
+            actualFilterPeer = peerOpt.get()
+
+            info "Found new  peer for codec",
+              codec = filterPubsubTopic, peer = constructMultiaddrStr(actualFilterPeer)
+
+            noFailedServiceNodeSwitches = 0
+            noFailedSubscribes = 0
+          else:
+            error "Failed to find new service peer. Retrying."
+            noFailedServiceNodeSwitches += 1
+            if noFailedServiceNodeSwitches > maxFailedServiceNodeSwitches:
+              error "New service node switch failed. Exiting."
+              break
+            else:
+              continue
       else:
         notice "subscribe request successful."
     else:
-      trace "subscription found."
+      info "subscription is live."
 
-    await sleepAsync(chtimer.seconds(60)) # Subscription maintenance interval
+    await sleepAsync(chtimer.seconds(30)) # Subscription maintenance interval
 
-proc setupAndSubscribe*(wakuNode: WakuNode, conf: LiteProtocolTesterConf) =
+proc setupAndSubscribe*(
+    wakuNode: WakuNode, conf: LiteProtocolTesterConf, servicePeer: RemotePeerInfo
+) =
   if isNil(wakuNode.wakuFilterClient):
     # if we have not yet initialized lightpush client, then do it as the only way we can get here is
     # by having a service peer discovered.
     waitFor wakuNode.mountFilterClient()
 
-  info "Start receiving messages to service node using lightpush",
-    serviceNode = conf.serviceNode
+  info "Start receiving messages to service node using filter",
+    servicePeer = servicePeer
 
   var stats: PerPeerStatistics
-
-  let remotePeer = parsePeerInfo(conf.serviceNode).valueOr:
-    error "Couldn't parse the peer info properly", error = error
-    return
+  actualFilterPeer = servicePeer
 
   let pushHandler = proc(pubsubTopic: PubsubTopic, message: WakuMessage) {.async.} =
     let payloadStr = string.fromBytes(message.payload)
@@ -104,9 +144,8 @@ proc setupAndSubscribe*(wakuNode: WakuNode, conf: LiteProtocolTesterConf) =
       stats.echoStats()
 
       if conf.numMessages > 0 and waitFor stats.checkIfAllMessagesReceived():
-        waitFor unsubscribe(
-          wakuNode, remotePeer, conf.pubsubTopics[0], conf.contentTopics[0]
-        )
+        waitFor unsubscribe(wakuNode, conf.pubsubTopics[0], conf.contentTopics[0])
+        logSelfPeers(wakuNode.peerManager)
         info "All messages received. Exiting."
 
         ## for gracefull shutdown through signal hooks
@@ -118,6 +157,4 @@ proc setupAndSubscribe*(wakuNode: WakuNode, conf: LiteProtocolTesterConf) =
   discard setTimer(Moment.fromNow(interval), printStats)
 
   # Start maintaining subscription
-  asyncSpawn maintainSubscription(
-    wakuNode, remotePeer, conf.pubsubTopics[0], conf.contentTopics[0]
-  )
+  asyncSpawn maintainSubscription(wakuNode, conf.pubsubTopics[0], conf.contentTopics[0])

--- a/apps/liteprotocoltester/filter_subscriber.nim
+++ b/apps/liteprotocoltester/filter_subscriber.nim
@@ -64,8 +64,9 @@ proc maintainSubscription(
 
 proc setupAndSubscribe*(wakuNode: WakuNode, conf: LiteProtocolTesterConf) =
   if isNil(wakuNode.wakuFilterClient):
-    error "WakuFilterClient not initialized"
-    return
+    # if we have not yet initialized lightpush client, then do it as the only way we can get here is
+    # by having a service peer discovered.
+    waitFor wakuNode.mountFilterClient()
 
   info "Start receiving messages to service node using lightpush",
     serviceNode = conf.serviceNode

--- a/apps/liteprotocoltester/filter_subscriber.nim
+++ b/apps/liteprotocoltester/filter_subscriber.nim
@@ -81,7 +81,7 @@ proc maintainSubscription(
         # wakunode.peerManager.peerStore.delete(actualFilterPeer)
 
         if noFailedSubscribes < maxFailedSubscribes:
-          await sleepAsync(chtimer.seconds(2)) # Wait a bit before retrying
+          await sleepAsync(2.seconds) # Wait a bit before retrying
           continue
         else:
           let peerOpt = selectRandomServicePeer(
@@ -90,7 +90,7 @@ proc maintainSubscription(
           if peerOpt.isOk():
             actualFilterPeer = peerOpt.get()
 
-            info "Found new  peer for codec",
+            info "Found new peer for codec",
               codec = filterPubsubTopic, peer = constructMultiaddrStr(actualFilterPeer)
 
             noFailedSubscribes = 0
@@ -109,7 +109,7 @@ proc maintainSubscription(
     else:
       info "subscription is live."
 
-    await sleepAsync(chtimer.seconds(30)) # Subscription maintenance interval
+    await sleepAsync(30.seconds) # Subscription maintenance interval
 
 proc setupAndSubscribe*(
     wakuNode: WakuNode, conf: LiteProtocolTesterConf, servicePeer: RemotePeerInfo

--- a/apps/liteprotocoltester/lightpush_publisher.nim
+++ b/apps/liteprotocoltester/lightpush_publisher.nim
@@ -160,8 +160,9 @@ proc publishMessages(
 
 proc setupAndPublish*(wakuNode: WakuNode, conf: LiteProtocolTesterConf) =
   if isNil(wakuNode.wakuLightpushClient):
-    error "WakuFilterClient not initialized"
-    return
+    # if we have not yet initialized lightpush client, then do it as the only way we can get here is
+    # by having a service peer discovered.
+    wakuNode.mountLightPushClient()
 
   # give some time to receiver side to set up
   let waitTillStartTesting = conf.startPublishingAfter.seconds

--- a/apps/liteprotocoltester/liteprotocoltester.nim
+++ b/apps/liteprotocoltester/liteprotocoltester.nim
@@ -82,8 +82,7 @@ when isMainModule:
             wnconf: WakuNodeConf, sources: auto
         ) {.gcsafe, raises: [ConfigurationError].} =
           echo "Loading secondary configuration file into WakuNodeConf"
-          sources.addConfigFile(Toml, configFile)
-        ,
+          sources.addConfigFile(Toml, configFile),
       )
     except CatchableError:
       error "Loading Waku configuration failed", error = getCurrentExceptionMsg()

--- a/apps/liteprotocoltester/liteprotocoltester.nim
+++ b/apps/liteprotocoltester/liteprotocoltester.nim
@@ -110,8 +110,8 @@ when isMainModule:
   wakuConf.metricsServerPort = 8003
 
   # If bootstrap option is chosen we expect our clients will not mounted
-  # so we will mount PeerExchange to gather possible service peers, if got some
-  # we will mount the client protocols afterward.
+  # so we will mount PeerExchange manually to gather possible service peers,
+  # if got some we will mount the client protocols afterward.
   wakuConf.peerExchange = false
   wakuConf.relay = false
   wakuConf.filter = false

--- a/apps/liteprotocoltester/liteprotocoltester.nim
+++ b/apps/liteprotocoltester/liteprotocoltester.nim
@@ -106,7 +106,7 @@ when isMainModule:
 
   wakuConf.metricsServer = true
   wakuConf.metricsServerAddress = parseIpAddress("0.0.0.0")
-  wakuConf.metricsServerPort = 8003
+  wakuConf.metricsServerPort = conf.metricsPort
 
   # If bootstrap option is chosen we expect our clients will not mounted
   # so we will mount PeerExchange manually to gather possible service peers,

--- a/apps/liteprotocoltester/lpt_metrics.nim
+++ b/apps/liteprotocoltester/lpt_metrics.nim
@@ -28,3 +28,9 @@ declarePublicCounter lpt_publisher_failed_messages_count,
   "number of messages failed to publish per failure cause", ["cause"]
 
 declarePublicCounter lpt_publisher_sent_bytes, "number of total bytes sent"
+
+declarePublicCounter lpt_change_service_peer_count,
+  "number of messages received per peer", ["role"]
+
+declarePublicGauge lpt_discovered_service_peers,
+  "number of messages received per peer", ["role", "source"]

--- a/apps/liteprotocoltester/lpt_metrics.nim
+++ b/apps/liteprotocoltester/lpt_metrics.nim
@@ -22,6 +22,9 @@ declarePublicCounter lpt_receiver_duplicate_messages_count,
 declarePublicGauge lpt_receiver_distinct_duplicate_messages_count,
   "number of distinct duplicate messages per peer", ["peer"]
 
+declarePublicCounter lpt_receiver_lost_subscription_count,
+  "number of filter service peer failed PING requests - lost subscription"
+
 declarePublicCounter lpt_publisher_sent_messages_count, "number of messages published"
 
 declarePublicCounter lpt_publisher_failed_messages_count,
@@ -29,8 +32,15 @@ declarePublicCounter lpt_publisher_failed_messages_count,
 
 declarePublicCounter lpt_publisher_sent_bytes, "number of total bytes sent"
 
-declarePublicCounter lpt_change_service_peer_count,
-  "number of messages received per peer", ["role"]
+declarePublicCounter lpt_service_peer_failure_count,
+  "number of failure during using service peer [publisher/receiever]", ["role"]
 
-declarePublicGauge lpt_discovered_service_peers,
-  "number of messages received per peer", ["role", "source"]
+declarePublicCounter lpt_change_service_peer_count,
+  "number of times [publisher/receiver] had to change service peer", ["role"]
+
+declarePublicGauge lpt_px_peers,
+  "Number of peers PeerExchange discovered and can be dialed"
+
+declarePublicGauge lpt_dialed_peers, "Number of peers successfully dialed"
+
+declarePublicGauge lpt_dial_failures, "Number of dial failures by cause"

--- a/apps/liteprotocoltester/monitoring/configuration/dashboards/liter-protocol-test-monitoring.json
+++ b/apps/liteprotocoltester/monitoring/configuration/dashboards/liter-protocol-test-monitoring.json
@@ -34,6 +34,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -55,33 +56,37 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 12,
         "w": 12,
         "x": 0,
         "y": 1
       },
       "id": 8,
       "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
+        "displayMode": "lcd",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "top",
+        "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
       },
-      "pluginVersion": "10.4.2",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -89,19 +94,19 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "lpt_receiver_sender_peer_count{instance=\"receivernode:8003\"}",
+          "editorMode": "code",
+          "expr": "lpt_receiver_sender_peer_count{instance=~\".*receivernode.*\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
       "title": "Number of publisher peers",
-      "type": "gauge"
+      "type": "bargauge"
     },
     {
       "collapsed": true,
@@ -109,7 +114,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 13
       },
       "id": 11,
       "panels": [],
@@ -118,6 +123,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -133,6 +139,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -171,7 +178,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": [
           {
@@ -198,6 +206,10 @@
                   "group": "A",
                   "mode": "normal"
                 }
+              },
+              {
+                "id": "unit",
+                "value": "reqps"
               }
             ]
           }
@@ -207,13 +219,15 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 14
       },
       "id": 1,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -229,9 +243,9 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(job) (lpt_publisher_sent_messages_count_total)",
+          "expr": "sum by(instace) (lpt_publisher_sent_messages_count_total{instance=~\".*publishernode.*\"})",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -247,9 +261,9 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(job) (rate(lpt_publisher_sent_messages_count_total[$__rate_interval]))",
+          "expr": "sum by(instance) (rate(lpt_publisher_sent_messages_count_total{instance=~\".*publishernode.*\"}[$__rate_interval]))",
           "format": "time_series",
           "fullMetaSearch": false,
           "hide": false,
@@ -261,11 +275,12 @@
           "useBackend": false
         }
       ],
-      "title": "Publishes test messages",
+      "title": "Published test messages",
       "type": "timeseries"
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -281,6 +296,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -319,7 +335,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": [
           {
@@ -345,6 +362,10 @@
               {
                 "id": "custom.gradientMode",
                 "value": "hue"
+              },
+              {
+                "id": "unit",
+                "value": "reqps"
               }
             ]
           }
@@ -354,13 +375,15 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 10
+        "y": 14
       },
       "id": 2,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -376,8 +399,8 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(instance) (lpt_receiver_received_messages_count_total{instance=\"receivernode:8003\"})",
+          "editorMode": "code",
+          "expr": "sum by(instance) (lpt_receiver_received_messages_count_total{instance=~\".*receivernode.*\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -392,8 +415,8 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(instance) (rate(lpt_receiver_received_messages_count_total{instance=\"receivernode:8003\"}[$__rate_interval]))",
+          "editorMode": "code",
+          "expr": "sum by(instance) (rate(lpt_receiver_received_messages_count_total{instance=~\".*receivernode.*\"}[$__rate_interval]))",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -409,6 +432,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -425,6 +449,7 @@
             "axisLabel": "",
             "axisPlacement": "left",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -470,7 +495,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Test message transfer rate"
+              "options": "Send message transfer rate"
             },
             "properties": [
               {
@@ -497,6 +522,10 @@
                   "group": "A",
                   "mode": "normal"
                 }
+              },
+              {
+                "id": "unit",
+                "value": "KiBs"
               }
             ]
           }
@@ -506,13 +535,15 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 22
       },
       "id": 5,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -528,13 +559,13 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(job) (lpt_publisher_sent_bytes_total)",
+          "expr": "sum by(instance) (lpt_publisher_sent_bytes_total{instance=~\".*publishernode.*\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Total received bytes",
+          "legendFormat": "Total sent bytes",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -545,15 +576,15 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(job) (rate(lpt_publisher_sent_bytes_total[$__rate_interval]))",
+          "expr": "sum by(instance) (rate(lpt_publisher_sent_bytes_total{instance=~\".*publishernode.*\"}[$__rate_interval]))",
           "format": "time_series",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Test message transfer rate",
+          "legendFormat": "Send message transfer rate",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -564,6 +595,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -580,6 +612,7 @@
             "axisLabel": "",
             "axisPlacement": "left",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -652,6 +685,10 @@
                   "group": "A",
                   "mode": "normal"
                 }
+              },
+              {
+                "id": "unit",
+                "value": "KiBs"
               }
             ]
           }
@@ -661,13 +698,15 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 22
       },
       "id": 4,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -683,9 +722,9 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(instance) (lpt_receiver_received_bytes_total{instance=\"receivernode:8003\"})",
+          "expr": "sum by(instance) (lpt_receiver_received_bytes_total{instance=~\".*receivernode.*\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -700,9 +739,9 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(instance) (rate(lpt_receiver_received_bytes_total{instance=\"receivernode:8003\"}[$__rate_interval]))",
+          "expr": "sum by(instance) (rate(lpt_receiver_received_bytes_total{instance=~\".*receivernode.*\"}[$__rate_interval]))",
           "format": "time_series",
           "fullMetaSearch": false,
           "hide": false,
@@ -723,7 +762,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 30
       },
       "id": 10,
       "panels": [],
@@ -732,6 +771,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -747,6 +787,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 23,
             "gradientMode": "hue",
@@ -785,7 +826,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": [
           {
@@ -814,13 +856,15 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 31
       },
       "id": 6,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -838,12 +882,12 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "lpt_publisher_failed_messages_count_total{instance=\"publishernode:8003\"}",
+          "expr": "lpt_publisher_failed_messages_count_total{instance=~\".*publishernode.*\"}",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Failed to publish count",
+          "legendFormat": "{{instance}} - {{cause}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -854,6 +898,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -870,6 +915,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -908,7 +954,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
@@ -916,13 +963,15 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 31
       },
       "id": 7,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -939,11 +988,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(instance) (lpt_receiver_duplicate_messages_count_total{instance=\"receivernode:8003\"})",
+          "expr": "lpt_receiver_duplicate_messages_count_total{instance=~\".*receivernode.*\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Total duplicates",
+          "legendFormat": "Total duplicates at {{instance}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -955,12 +1004,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(instance) (lpt_receiver_distinct_duplicate_messages_count{instance=\"receivernode:8003\"})",
+          "expr": "lpt_receiver_distinct_duplicate_messages_count{instance=~\".*receivernode.*\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Distinct duplicates",
+          "legendFormat": "Distinct duplicates at {{instance}}",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -971,6 +1020,7 @@
     },
     {
       "datasource": {
+        "default": true,
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -987,6 +1037,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 21,
             "gradientMode": "none",
@@ -1025,7 +1076,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
@@ -1033,14 +1085,16 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 39
       },
       "id": 9,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right",
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -1055,14 +1109,14 @@
             "uid": "PBFA97CFB590B2093"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "lpt_receiver_missing_messages_count",
+          "editorMode": "code",
+          "expr": "lpt_receiver_missing_messages_count{instance=~\".*receivernode.*\"}",
           "format": "time_series",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Publisher {{peer}}",
+          "legendFormat": "Receiver {{instance}}:Publisher {{peer}}",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -1079,7 +1133,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},

--- a/apps/liteprotocoltester/monitoring/configuration/dashboards/liter-protocol-test-monitoring.json
+++ b/apps/liteprotocoltester/monitoring/configuration/dashboards/liter-protocol-test-monitoring.json
@@ -28,9 +28,766 @@
         "x": 0,
         "y": 0
       },
+      "id": 13,
+      "panels": [],
+      "title": "Peer statistics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 5,
+        "x": 0,
+        "y": 1
+      },
+      "id": 15,
+      "options": {
+        "displayMode": "lcd",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "lpt_px_peers{instance=~\".*publisher.*\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Lightpush capable peers found via PX",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 7,
+        "x": 5,
+        "y": 1
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "lpt_dialed_peers{instance=~\".*publisher.*\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Working filter peers {{instance}}",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "lpt_dial_failures{instance=~\".*publisher.*\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Failed to dial {{instance}}",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        }
+      ],
+      "title": "Tested lightpush peers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 5,
+        "x": 12,
+        "y": 1
+      },
+      "id": 21,
+      "options": {
+        "displayMode": "lcd",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "lpt_px_peers{instance=~\".*receiver.*\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Filter capable peers found via PX",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 7,
+        "x": 17,
+        "y": 1
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "lpt_dialed_peers{instance=~\".*receivernode.*\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Working filter peers {{instance}}",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "lpt_dial_failures{instance=~\".*receivernode.*\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Failed to dial {{instance}}",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        }
+      ],
+      "title": "Tested filter peers",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
       "id": 12,
       "title": "Test publisher monitor",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 23,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(instace) (lpt_service_peer_failure_count_total{instance=~\".*publishernode.*\", role=\"publisher\"})",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Push failed",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by(instace) (lpt_change_service_peer_count_total{instance=~\".*publishernode.*\", role=\"publisher\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Peer switch",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Lightpush service peer failures and switches",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 23,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(instace) (lpt_service_peer_failure_count_total{instance=~\".*receivernode.*\", role=\"receiver\"})",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Subscribe failed",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by(instace) (lpt_change_service_peer_count_total{instance=~\".*receivernode.*\", role=\"receiver\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Peer switch",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by(instace) (lpt_receiver_lost_subscription_count_total{instance=~\".*receivernode.*\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Subscription loss - ping fail",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Filter service peer failures and switches",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 18,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": false,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "count(\n  group(\n    last_over_time(lpt_px_peers{instance=~\".*publishernode.*\"}[24h])\n  ) by (instance)\n)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Number or publishers",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "count(\n  group(\n    last_over_time(lpt_px_peers{instance=~\".*receivernode.*\"}[24h])\n  ) by (instance)\n)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Number or receivers",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Number of tester nodes",
+      "type": "gauge"
     },
     {
       "datasource": {
@@ -64,8 +821,8 @@
       "gridPos": {
         "h": 12,
         "w": 12,
-        "x": 0,
-        "y": 1
+        "x": 12,
+        "y": 25
       },
       "id": 8,
       "options": {
@@ -105,7 +862,7 @@
           "useBackend": false
         }
       ],
-      "title": "Number of publisher peers",
+      "title": "Receiver detected message from number of publisher peers",
       "type": "bargauge"
     },
     {
@@ -114,7 +871,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 37
       },
       "id": 11,
       "panels": [],
@@ -219,7 +976,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 38
       },
       "id": 1,
       "options": {
@@ -375,7 +1132,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 38
       },
       "id": 2,
       "options": {
@@ -535,7 +1292,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 46
       },
       "id": 5,
       "options": {
@@ -698,7 +1455,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 46
       },
       "id": 4,
       "options": {
@@ -762,7 +1519,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 54
       },
       "id": 10,
       "panels": [],
@@ -856,7 +1613,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 55
       },
       "id": 6,
       "options": {
@@ -963,7 +1720,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 31
+        "y": 55
       },
       "id": 7,
       "options": {
@@ -1085,7 +1842,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 63
       },
       "id": 9,
       "options": {
@@ -1126,15 +1883,62 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "schemaVersion": 39,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "lpt-runner-publishernode-1:8003",
+          "value": "lpt-runner-publishernode-1:8003"
+        },
+        "definition": "label_values({instance=~\".*publishernode.*\"},instance)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "publisher",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values({instance=~\".*publishernode.*\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "lpt-runner-receivernode-1:8003",
+          "value": "lpt-runner-receivernode-1:8003"
+        },
+        "definition": "label_values({instance=~\".*receivernode.*\"},instance)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "receiver",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values({instance=~\".*receivernode.*\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
-    "from": "now-1h",
-    "to": "now"
+    "from": "2024-10-02T22:07:37.000Z",
+    "to": "2024-10-02T22:23:21.000Z"
   },
   "timepicker": {},
   "timezone": "browser",

--- a/apps/liteprotocoltester/monitoring/prometheus-config.yml
+++ b/apps/liteprotocoltester/monitoring/prometheus-config.yml
@@ -7,12 +7,29 @@ global:
 scrape_configs:
   - job_name: "liteprotocoltester"
     static_configs:
-    - targets: ["lightpush-service:8003",
-                "filter-service:8003",
-                "liteprotocoltester-publishernode-1:8003",
+    - targets: ["liteprotocoltester-publishernode-1:8003",
                 "liteprotocoltester-publishernode-2:8003",
                 "liteprotocoltester-publishernode-3:8003",
                 "liteprotocoltester-publishernode-4:8003",
                 "liteprotocoltester-publishernode-5:8003",
                 "liteprotocoltester-publishernode-6:8003",
-                "receivernode:8003"]
+                "liteprotocoltester-receivernode-1:8003",
+                "liteprotocoltester-receivernode-2:8003",
+                "liteprotocoltester-receivernode-3:8003",
+                "liteprotocoltester-receivernode-4:8003",
+                "liteprotocoltester-receivernode-5:8003",
+                "liteprotocoltester-receivernode-6:8003",
+                "publishernode:8003",
+                "publishernode-1:8003",
+                "publishernode-2:8003",
+                "publishernode-3:8003",
+                "publishernode-4:8003",
+                "publishernode-5:8003",
+                "publishernode-6:8003",
+                "receivernode:8003",
+                "receivernode-1:8003",
+                "receivernode-2:8003",
+                "receivernode-3:8003",
+                "receivernode-4:8003",
+                "receivernode-5:8003",
+                "receivernode-6:8003",]

--- a/apps/liteprotocoltester/run_tester_node.sh
+++ b/apps/liteprotocoltester/run_tester_node.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+#set -x
 
 if test -f .env; then
   echo "Using .env file"

--- a/apps/liteprotocoltester/run_tester_node.sh
+++ b/apps/liteprotocoltester/run_tester_node.sh
@@ -40,6 +40,16 @@ if [ -z "${SERIVCE_NODE_ADDR}" ]; then
   exit 1
 fi
 
+SELECTOR=$4
+if [ -z "${SELECTOR}" ] || [ "${SELECTOR}" = "SERVICE" ]; then
+  SERVICE_NODE_DIRECT=true
+elif [ "${SELECTOR}" = "BOOTSTRAP" ]; then
+  SERVICE_NODE_DIRECT=false
+else
+  echo "Invalid selector '${SELECTOR}'. Failing"
+  exit 1
+fi
+
 DO_DETECT_SERVICENODE=0
 
 if [ "${SERIVCE_NODE_ADDR}" = "servicenode" ]; then
@@ -75,6 +85,12 @@ fi
 if [ -z "${SERIVCE_NODE_ADDR}" ]; then
    echo "Could not get SERIVCE_NODE_ADDR and none provided. Failing"
    exit 1
+fi
+
+if SERVICE_NODE_DIRECT; then
+  FULL_NODE=--service-node="${SERIVCE_NODE_ADDR}"
+else
+  FULL_NODE=--bootstrap-node="${SERIVCE_NODE_ADDR}"
 fi
 
 if [ -n "${PUBSUB}" ]; then
@@ -119,8 +135,8 @@ echo "My external IP: ${MY_EXT_IP}"
 
 exec "${BINARY_PATH}"\
       --log-level=INFO\
-      --service-node="${SERIVCE_NODE_ADDR}"\
       --nat=extip:${MY_EXT_IP}\
+      ${FULL_NODE}\
       ${DELAY_MESSAGES}\
       ${NUM_MESSAGES}\
       ${PUBSUB}\

--- a/apps/liteprotocoltester/run_tester_node.sh
+++ b/apps/liteprotocoltester/run_tester_node.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#set -x
+set -x
 
 if test -f .env; then
   echo "Using .env file"
@@ -87,7 +87,7 @@ if [ -z "${SERIVCE_NODE_ADDR}" ]; then
    exit 1
 fi
 
-if SERVICE_NODE_DIRECT; then
+if $SERVICE_NODE_DIRECT; then
   FULL_NODE=--service-node="${SERIVCE_NODE_ADDR}"
 else
   FULL_NODE=--bootstrap-node="${SERIVCE_NODE_ADDR}"

--- a/apps/liteprotocoltester/service_peer_management.nim
+++ b/apps/liteprotocoltester/service_peer_management.nim
@@ -61,7 +61,7 @@ proc selectRandomCapablePeer*(
   elif codec.contains("filter"):
     cap = Capabilities.Filter
 
-  var supportivePeers = pm.peerStore.getPeersByCapability(cap)
+  var supportivePeers = pm.wakuPeerStore.getPeersByCapability(cap)
 
   debug "Found supportive peers count", count = supportivePeers.len()
   debug "Found supportive peers", supportivePeers = $supportivePeers
@@ -102,7 +102,7 @@ proc tryCallAllPxPeers*(
   elif codec.contains("filter"):
     capability = Capabilities.Filter
 
-  var supportivePeers = pm.peerStore.getPeersByCapability(capability)
+  var supportivePeers = pm.wakuPeerStore.getPeersByCapability(capability)
 
   lpt_px_peers.set(supportivePeers.len)
   debug "Found supportive peers count", count = supportivePeers.len()
@@ -197,8 +197,9 @@ proc selectRandomServicePeer*(
   if actualPeer.isSome():
     alreadyUsedServicePeers.add(actualPeer.get())
 
-  let supportivePeers =
-    pm.peerStore.getPeersByProtocol(codec).filterIt(it notin alreadyUsedServicePeers)
+  let supportivePeers = pm.wakuPeerStore.getPeersByProtocol(codec).filterIt(
+      it notin alreadyUsedServicePeers
+    )
   if supportivePeers.len == 0:
     return err()
 

--- a/apps/liteprotocoltester/service_peer_management.nim
+++ b/apps/liteprotocoltester/service_peer_management.nim
@@ -76,7 +76,7 @@ proc selectRandomCapablePeer*(
     debug "Dialing random peer",
       idx = $rndPeerIndex, peer = constructMultiaddrStr(randomPeer)
 
-    supportivePeers.delete(rndPeerIndex, rndPeerIndex)
+    supportivePeers.delete(rndPeerIndex..rndPeerIndex)
 
     let connOpt = pm.dialPeer(randomPeer, codec)
     if (await connOpt.withTimeout(10.seconds)):

--- a/apps/liteprotocoltester/service_peer_management.nim
+++ b/apps/liteprotocoltester/service_peer_management.nim
@@ -1,0 +1,234 @@
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+import
+  std/[options, net, sysrand, random, strformat, strutils, sequtils],
+  chronicles,
+  chronos,
+  metrics,
+  libbacktrace,
+  libp2p/crypto/crypto,
+  confutils,
+  libp2p/wire
+
+import
+  waku/[
+    factory/external_config,
+    common/enr,
+    waku_node,
+    node/peer_manager,
+    waku_lightpush/common,
+    waku_relay,
+    waku_filter_v2,
+    waku_peer_exchange/protocol,
+    waku_core/multiaddrstr,
+    waku_core/topics/pubsub_topic,
+    waku_enr/capabilities,
+    waku_enr/sharding,
+  ],
+  ./tester_config
+
+logScope:
+  topics = "service peer mgmt"
+
+proc translateToRemotePeerInfo*(peerAddress: string): Result[RemotePeerInfo, void] =
+  var peerInfo: RemotePeerInfo
+  var enrRec: enr.Record
+  if enrRec.fromURI(peerAddress):
+    trace "Parsed ENR", enrRec = $enrRec
+    peerInfo = enrRec.toRemotePeerInfo().valueOr:
+      error "failed to convert ENR to RemotePeerInfo", error = error
+      return err()
+  else:
+    peerInfo = parsePeerInfo(peerAddress).valueOr:
+      error "failed to parse node waku peer-exchange peerId", error = error
+      return err()
+
+  return ok(peerInfo)
+
+randomize()
+
+proc selectRandomServicePeer*(
+    pm: PeerManager, codec: string, pubsubTopic: PubsubTopic
+): Future[Option[RemotePeerInfo]] {.async.} =
+  var cap = Capabilities.Filter
+  if codec.contains("lightpush"):
+    cap = Capabilities.Lightpush
+  elif codec.contains("filter"):
+    cap = Capabilities.Filter
+
+  var supportivePeers = pm.peerStore.getPeersByCapability(cap)
+
+  debug "Found supportive peers count", count = supportivePeers.len()
+  debug "Found supportive peers", supportivePeers = $supportivePeers
+  if supportivePeers.len == 0:
+    return none(RemotePeerInfo)
+
+  var found = none(RemotePeerInfo)
+  while found.isNone() and supportivePeers.len > 0:
+    let rndPeerIndex = rand(0 .. supportivePeers.len - 1)
+    let randomPeer = supportivePeers[rndPeerIndex]
+
+    debug "Dialing random peer",
+      idx = $rndPeerIndex, peer = constructMultiaddrStr(randomPeer)
+
+    supportivePeers.delete(rndPeerIndex, rndPeerIndex)
+
+    let connOpt = pm.dialPeer(randomPeer, codec)
+    if (await connOpt.withTimeout(10.seconds)):
+      if connOpt.value().isSome():
+        found = some(randomPeer)
+        debug "Dialing successful",
+          peer = constructMultiaddrStr(randomPeer), codec = codec
+      else:
+        debug "Dialing failed", peer = constructMultiaddrStr(randomPeer), codec = codec
+    else:
+      debug "Timeout dialing service peer",
+        peer = constructMultiaddrStr(randomPeer), codec = codec
+
+  return found
+
+proc pxLookupServiceNode*(
+    node: WakuNode, conf: LiteProtocolTesterConf
+): Future[Result[RemotePeerInfo, void]] {.async.} =
+  var codec: string = WakuLightPushCodec
+  if conf.testFunc == TesterFunctionality.RECEIVER:
+    codec = WakuFilterSubscribeCodec
+
+  if node.wakuPeerExchange.isNil():
+    let peerExchangeNode = translateToRemotePeerInfo(conf.bootstrapNode).valueOr:
+      return err()
+    info "PeerExchange node", peer = constructMultiaddrStr(peerExchangeNode)
+    node.peerManager.addServicePeer(peerExchangeNode, WakuPeerExchangeCodec)
+
+    try:
+      await node.mountPeerExchange(some(conf.clusterId))
+    except CatchableError:
+      error "failed to mount waku peer-exchange protocol: ",
+        error = getCurrentExceptionMsg()
+      return err()
+
+  var trialCount = 5
+  while trialCount > 0:
+    let futPeers = node.fetchPeerExchangePeers(32)
+    if not await futPeers.withTimeout(10.seconds):
+      notice "Cannot get peers from PX", round = 5 - trialCount
+    else:
+      if futPeers.value().isErr():
+        info "PeerExchange reported error", error = futPeers.read().error
+        return err()
+
+    let peerOpt =
+      await selectRandomServicePeer(node.peerManager, codec, conf.pubsubTopics[0])
+    if peerOpt.isSome():
+      info "Found service peer for codec",
+        codec = codec, peer = constructMultiaddrStr(peerOpt.get())
+      return ok(peerOpt.get())
+
+    await sleepAsync(5.seconds)
+    trialCount -= 1
+
+  return err()
+
+# Debugging PX gathered peers connectivity
+proc selectRandomServicePeerWithTestAll*(
+    pm: PeerManager, codec: string, pubsubTopic: PubsubTopic
+): Future[Option[RemotePeerInfo]] {.async.} =
+  var cap = Capabilities.Filter
+  if codec.contains("lightpush"):
+    cap = Capabilities.Lightpush
+  elif codec.contains("filter"):
+    cap = Capabilities.Filter
+
+  var supportivePeers = pm.peerStore.getPeersByCapability(cap)
+  # .filterIt(
+  #     it.enr.isSome() and it.enr.get().containsShard(pubsubTopic)
+  #   )
+
+  debug "Found supportive peers count", count = supportivePeers.len()
+  debug "Found supportive peers", supportivePeers = $supportivePeers
+  if supportivePeers.len == 0:
+    return none(RemotePeerInfo)
+
+  var found = none(RemotePeerInfo)
+  var okPeers: seq[RemotePeerInfo] = @[]
+
+  while found.isNone() and supportivePeers.len > 0:
+    let rndPeerIndex = rand(0 .. supportivePeers.len - 1)
+    let randomPeer = supportivePeers[rndPeerIndex]
+
+    debug "Dialing random peer",
+      idx = $rndPeerIndex, peer = constructMultiaddrStr(randomPeer)
+
+    supportivePeers.delete(rndPeerIndex, rndPeerIndex)
+
+    let connOpt = pm.dialPeer(randomPeer, codec)
+    if (await connOpt.withTimeout(10.seconds)):
+      if connOpt.value().isSome():
+        okPeers.add(randomPeer)
+        debug "Dialing successful",
+          peer = constructMultiaddrStr(randomPeer), codec = codec
+      else:
+        debug "Dialing failed", peer = constructMultiaddrStr(randomPeer), codec = codec
+    else:
+      debug "Timeout dialing service peer",
+        peer = constructMultiaddrStr(randomPeer), codec = codec
+
+  var okPeersStr: string = ""
+  for idx, peer in okPeers:
+    okPeersStr.add(
+      "    " & $idx & ". | " & constructMultiaddrStr(peer) & " | protos: " &
+        $peer.protocols & " | caps: " & $peer.enr.map(getCapabilities) & "\n"
+    )
+
+  echo okPeersStr
+
+  if okPeers.len > 0:
+    found = some(okPeers[rand(0 .. okPeers.len - 1)])
+
+  return found
+
+proc pxLookupServiceNodeSlow*(
+    node: WakuNode, conf: LiteProtocolTesterConf
+): Future[Result[RemotePeerInfo, void]] {.async.} =
+  var codec: string = WakuLightPushCodec
+  if conf.testFunc == TesterFunctionality.RECEIVER:
+    codec = WakuFilterSubscribeCodec
+
+  if node.wakuPeerExchange.isNil():
+    let peerExchangeNode = translateToRemotePeerInfo(conf.bootstrapNode).valueOr:
+      return err()
+    info "PeerExchange node", peer = constructMultiaddrStr(peerExchangeNode)
+    node.peerManager.addServicePeer(peerExchangeNode, WakuPeerExchangeCodec)
+
+    try:
+      await node.mountPeerExchange(some(conf.clusterId))
+    except CatchableError:
+      error "failed to mount waku peer-exchange protocol: ",
+        error = getCurrentExceptionMsg()
+      return err()
+
+  var trialCount = 5
+  while trialCount > 0:
+    let futPeers = node.fetchPeerExchangePeers(100)
+    if not await futPeers.withTimeout(30.seconds):
+      notice "Cannot get peers from PX", round = 5 - trialCount
+    else:
+      if futPeers.value().isErr():
+        info "PeerExchange reported error", error = futPeers.read().error
+        return err()
+
+    let peerOpt = await selectRandomServicePeerWithTestAll(
+      node.peerManager, codec, conf.pubsubTopics[0]
+    )
+    if peerOpt.isSome():
+      info "Found service peer for codec",
+        codec = codec, peer = constructMultiaddrStr(peerOpt.get())
+      return ok(peerOpt.get())
+
+    await sleepAsync(5.seconds)
+    trialCount -= 1
+
+  return err()

--- a/apps/liteprotocoltester/service_peer_management.nim
+++ b/apps/liteprotocoltester/service_peer_management.nim
@@ -79,7 +79,7 @@ proc selectRandomCapablePeer*(
     debug "Dialing random peer",
       idx = $rndPeerIndex, peer = constructMultiaddrStr(randomPeer)
 
-    supportivePeers.delete(rndPeerIndex..rndPeerIndex)
+    supportivePeers.delete(rndPeerIndex .. rndPeerIndex)
 
     let connOpt = pm.dialPeer(randomPeer, codec)
     if (await connOpt.withTimeout(10.seconds)):

--- a/apps/liteprotocoltester/service_peer_management.nim
+++ b/apps/liteprotocoltester/service_peer_management.nim
@@ -1,7 +1,4 @@
-when (NimMajor, NimMinor) < (1, 4):
-  {.push raises: [Defect].}
-else:
-  {.push raises: [].}
+{.push raises: [].}
 
 import
   std/[options, net, sysrand, random, strformat, strutils, sequtils],
@@ -159,6 +156,8 @@ proc pxLookupServiceNode*(
 
   if node.wakuPeerExchange.isNil():
     let peerExchangeNode = translateToRemotePeerInfo(conf.bootstrapNode).valueOr:
+      error "Failed to parse bootstrap node - cannot use PeerExchange.",
+        node = conf.bootstrapNode
       return err()
     info "PeerExchange node", peer = constructMultiaddrStr(peerExchangeNode)
     node.peerManager.addServicePeer(peerExchangeNode, WakuPeerExchangeCodec)
@@ -166,7 +165,7 @@ proc pxLookupServiceNode*(
     try:
       await node.mountPeerExchange(some(conf.clusterId))
     except CatchableError:
-      error "failed to mount waku peer-exchange protocol: ",
+      error "failed to mount waku peer-exchange protocol",
         error = getCurrentExceptionMsg()
       return err()
 

--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -290,6 +290,6 @@ proc checkIfAllMessagesReceived*(self: PerPeerStatistics): Future[bool] {.async.
       shallWait = true
 
   if shallWait:
-    await sleepAsync(chtimer.seconds(20))
+    await sleepAsync(20.seconds)
 
   return true

--- a/apps/liteprotocoltester/statistics.nim
+++ b/apps/liteprotocoltester/statistics.nim
@@ -1,7 +1,7 @@
 {.push raises: [].}
 
 import
-  std/[sets, tables, strutils, sequtils, options, strformat],
+  std/[sets, tables, sequtils, options, strformat],
   chronos/timer as chtimer,
   chronicles,
   chronos,

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -140,6 +140,18 @@ type LiteProtocolTesterConf* = object
     name: "rest-address"
   .}: IpAddress
 
+  testPeers* {.
+    desc: "Run dial test on gathered PeerExchange peers.",
+    defaultValue: true,
+    name: "test-peers"
+  .}: bool
+
+  reqPxPeers* {.
+    desc: "Number of peers to request on PeerExchange.",
+    defaultValue: 100,
+    name: "req-px-peers"
+  .}: uint16
+
   restPort* {.
     desc: "Listening port of the REST HTTP server.",
     defaultValue: 8654,

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -1,8 +1,6 @@
 import
-  std/[strutils, strformat],
   results,
   chronos,
-  regex,
   confutils,
   confutils/defs,
   confutils/std/net,
@@ -11,9 +9,8 @@ import
   libp2p/crypto/crypto,
   libp2p/crypto/secp,
   libp2p/multiaddress,
-  nimcrypto/utils,
-  secp256k1,
-  json
+  secp256k1
+
 import
   waku/[
     common/confutils/envvar/defs as confEnvvarDefs,

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -167,6 +167,12 @@ type LiteProtocolTesterConf* = object
     name: "rest-allow-origin"
   .}: seq[string]
 
+  metricsPort* {.
+    desc: "Listening port of the REST HTTP server.",
+    defaultValue: 8003,
+    name: "metrics-port"
+  .}: uint16
+
 {.push warning[ProveInit]: off.}
 
 proc load*(T: type LiteProtocolTesterConf, version = ""): ConfResult[T] =

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -61,7 +61,7 @@ type LiteProtocolTesterConf* = object
 
   bootstrapNode* {.
     desc:
-      "Peer multiaddr of the service node. If `service-node` not set, it is used to retrieve potential service nodes of the network.",
+      "Peer multiaddr of the bootstrap node. If `service-node` not set, it is used to retrieve potential service nodes of the network.",
     defaultValue: "",
     name: "bootstrap-node"
   .}: string

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -176,8 +176,7 @@ proc load*(T: type LiteProtocolTesterConf, version = ""): ConfResult[T] =
       secondarySources = proc(
           conf: LiteProtocolTesterConf, sources: auto
       ) {.gcsafe, raises: [ConfigurationError].} =
-        sources.addConfigFile(Envvar, InputFile("liteprotocoltester"))
-      ,
+        sources.addConfigFile(Envvar, InputFile("liteprotocoltester")),
     )
     ok(conf)
   except CatchableError:

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -58,8 +58,16 @@ type LiteProtocolTesterConf* = object
   .}: logging.LogFormat
 
   ## Test configuration
-  servicenode* {.desc: "Peer multiaddr of the service node.", name: "service-node".}:
-    string
+  serviceNode* {.
+    desc: "Peer multiaddr of the service node.", defaultValue: "", name: "service-node"
+  .}: string
+
+  bootstrapNode* {.
+    desc:
+      "Peer multiaddr of the service node. If `service-node` not set, it is used to retrieve potential service nodes of the network.",
+    defaultValue: "",
+    name: "bootstrap-node"
+  .}: string
 
   nat* {.
     desc:
@@ -159,7 +167,8 @@ proc load*(T: type LiteProtocolTesterConf, version = ""): ConfResult[T] =
       secondarySources = proc(
           conf: LiteProtocolTesterConf, sources: auto
       ) {.gcsafe, raises: [ConfigurationError].} =
-        sources.addConfigFile(Envvar, InputFile("liteprotocoltester")),
+        sources.addConfigFile(Envvar, InputFile("liteprotocoltester"))
+      ,
     )
     ok(conf)
   except CatchableError:

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -168,7 +168,7 @@ type LiteProtocolTesterConf* = object
   .}: seq[string]
 
   metricsPort* {.
-    desc: "Listening port of the REST HTTP server.",
+    desc: "Listening port of the Metrics HTTP server.",
     defaultValue: 8003,
     name: "metrics-port"
   .}: uint16
@@ -182,7 +182,8 @@ proc load*(T: type LiteProtocolTesterConf, version = ""): ConfResult[T] =
       secondarySources = proc(
           conf: LiteProtocolTesterConf, sources: auto
       ) {.gcsafe, raises: [ConfigurationError].} =
-        sources.addConfigFile(Envvar, InputFile("liteprotocoltester")),
+        sources.addConfigFile(Envvar, InputFile("liteprotocoltester"))
+      ,
     )
     ok(conf)
   except CatchableError:

--- a/apps/liteprotocoltester/tester_config.nim
+++ b/apps/liteprotocoltester/tester_config.nim
@@ -182,8 +182,7 @@ proc load*(T: type LiteProtocolTesterConf, version = ""): ConfResult[T] =
       secondarySources = proc(
           conf: LiteProtocolTesterConf, sources: auto
       ) {.gcsafe, raises: [ConfigurationError].} =
-        sources.addConfigFile(Envvar, InputFile("liteprotocoltester"))
-      ,
+        sources.addConfigFile(Envvar, InputFile("liteprotocoltester")),
     )
     ok(conf)
   except CatchableError:

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -79,7 +79,7 @@ pipeline {
       when { expression { params.IMAGE_TAG != '' } }
       steps { script {
         withDockerRegistry([
-          credentialsId: params.DOCKER_CRED, url: 'https://${params.DOCKER_REGISTRY}'
+          credentialsId: params.DOCKER_CRED, url: "https://${params.DOCKER_REGISTRY}"
         ]) {
           image.push(params.IMAGE_TAG)
         }

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -47,8 +47,7 @@ pipeline {
     choice(
       name: "LOWEST_LOG_LEVEL_ALLOWED",
       choices: ['TRACE', 'DEGUG', 'INFO', 'NOTICE', 'WARN', 'ERROR', 'FATAL'],
-      description: "Defines the log level, which will be available at runtime (Chronicles log level)",
-      defaultValue: 'TRACE'
+      description: "Defines the log level, which will be available at runtime (Chronicles log level)"
     )
   }
 

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -22,17 +22,17 @@ pipeline {
     string(
       name: 'IMAGE_NAME',
       description: 'Name of Docker image to push.',
-      defaultValue: params.IMAGE_NAME ?: 'harbor.status.im/wakuorg/liteprotocoltester',
+      defaultValue: params.IMAGE_NAME ?: 'wakuorg/liteprotocoltester',
     )
     string(
       name: 'DOCKER_CRED',
       description: 'Name of Docker Registry credential.',
-      defaultValue: params.DOCKER_CRED ?: 'harbor-wakuorg-robot',
+      defaultValue: params.DOCKER_CRED ?: 'harbor-telemetry-robot',
     )
     string(
-      name: 'DOCKER_REGISTRY_URL',
+      name: 'DOCKER_REGISTRY',
       description: 'URL of the Docker Registry',
-      defaultValue: params.DOCKER_REGISTRY_URL ?: 'https://harbor.status.im'
+      defaultValue: params.DOCKER_REGISTRY ?: 'harbor.status.im'
     )
     string(
       name: 'NIMFLAGS',
@@ -55,7 +55,7 @@ pipeline {
     stage('Build') {
       steps { script {
         image = docker.build(
-          "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
+          "${DOCKER_REGISTRY}/${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
           "--label=commit='${git.commit()}' " +
           "--label=version='${git.describe('--tags')}' " +
           "--build-arg=MAKE_TARGET='liteprotocoltester' " +
@@ -79,9 +79,9 @@ pipeline {
       when { expression { params.IMAGE_TAG != '' } }
       steps { script {
         withDockerRegistry([
-          credentialsId: params.DOCKER_CRED, url: params.DOCKER_REGISTRY_URL
+          credentialsId: params.DOCKER_CRED, url: 'https://${params.DOCKER_REGISTRY}'
         ]) {
-          image.push()
+          image.push(params.IMAGE_TAG)
         }
       } }
     }

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -81,7 +81,7 @@ pipeline {
         withDockerRegistry([
           credentialsId: params.DOCKER_CRED, url: params.DOCKER_REGISTRY_URL
         ]) {
-          image.push(params.IMAGE_TAG)
+          image.push()
         }
       } }
     }

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -79,7 +79,7 @@ pipeline {
       when { expression { params.IMAGE_TAG != '' } }
       steps { script {
         withDockerRegistry([
-          credentialsId: params.DOCKER_CRED, url: "https://${params.DOCKER_REGISTRY}"
+          credentialsId: params.DOCKER_CRED, url: "https://${DOCKER_REGISTRY}"
         ]) {
           image.push(params.IMAGE_TAG)
         }

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -1,0 +1,101 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.8.17'
+
+pipeline {
+  agent { label 'linux' }
+
+  options {
+    timestamps()
+    timeout(time: 20, unit: 'MINUTES')
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+    ))
+  }
+
+  parameters {
+    string(
+      name: 'IMAGE_TAG',
+      description: 'Name of Docker tag to push. Optional Parameter.',
+      defaultValue: 'latest'
+    )
+    string(
+      name: 'IMAGE_NAME',
+      description: 'Name of Docker image to push.',
+      defaultValue: params.IMAGE_NAME ?: 'harbor.status.im/wakuorg/liteprotocoltester',
+    )
+    string(
+      name: 'DOCKER_CRED',
+      description: 'Name of Docker Registry credential.',
+      defaultValue: params.DOCKER_CRED ?: 'harbor-wakuorg-robot',
+    )
+    string(
+      name: 'DOCKER_REGISTRY_URL',
+      description: 'URL of the Docker Registry',
+      defaultValue: params.DOCKER_REGISTRY_URL ?: 'https://harbor.status.im'
+    )
+    string(
+      name: 'NIMFLAGS',
+      description: 'Flags for Nim compilation.',
+      defaultValue: params.NIMFLAGS ?: [
+        '--colors:off',
+        '-d:disableMarchNative',
+        '-d:chronicles_colors:none',
+        '-d:insecure',
+      ].join(' ')
+    )
+    choice(
+      name: "LOWEST_LOG_LEVEL_ALLOWED",
+      choices: ['TRACE', 'DEGUG', 'INFO', 'NOTICE', 'WARN', 'ERROR', 'FATAL'],
+      description: "Defines the log level, which will be available at runtime (Chronicles log level)",
+      defaultValue: 'TRACE'
+    )
+  }
+
+  stages {
+    stage('Build') {
+      steps { script {
+        image = docker.build(
+          "${params.IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
+          "--label=commit='${git.commit()}' " +
+          "--label=version='${git.describe('--tags')}' " +
+          "--build-arg=MAKE_TARGET='liteprotocoltester' " +
+          "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
+          "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
+          "--file=apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile " +
+          " ."
+        )
+      } }
+    }
+
+    stage('Check') {
+      steps { script {
+        image.inside('--entrypoint=""') { c ->
+          sh '/usr/bin/liteprotocoltester --version'
+        }
+      } }
+    }
+
+    stage('Push') {
+      when { expression { params.IMAGE_TAG != '' } }
+      steps { script {
+        withDockerRegistry([
+          credentialsId: params.DOCKER_CRED, url: params.DOCKER_REGISTRY_URL
+        ]) {
+          image.push(params.IMAGE_TAG)
+        }
+      } }
+    }
+  } // stages
+
+  post {
+    success { script {
+      discord.send(
+        header: '**Nim-Waku:liteprotocoltester deployment successful!**',
+        cred: 'discord-waku-deployments-webhook',
+        descPrefix: "Image: [`${IMAGE_NAME}:${IMAGE_TAG}`](https://hub.docker.com/r/${IMAGE_NAME}/tags?name=${IMAGE_TAG})"
+      )
+    } }
+    always { sh 'docker image prune -f' }
+  } // post
+} // pipeline

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -88,13 +88,6 @@ pipeline {
   } // stages
 
   post {
-    success { script {
-      discord.send(
-        header: '**Nim-Waku:liteprotocoltester deployment successful!**',
-        cred: 'discord-waku-deployments-webhook',
-        descPrefix: "Image: [`${IMAGE_NAME}:${IMAGE_TAG}`](https://hub.docker.com/r/${IMAGE_NAME}/tags?name=${IMAGE_TAG})"
-      )
-    } }
-    always { sh 'docker image prune -f' }
+    cleanup { cleanWs() }
   } // post
 } // pipeline

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -160,7 +160,7 @@ type WakuNodeConf* = object
     .}: uint16
 
     agentString* {.
-      defaultValue: "nwaku-" & git_version,
+      defaultValue: "nwaku-" & external_config.git_version,
       desc: "Node agent string which is used as identifier in network",
       name: "agent-string"
     .}: string


### PR DESCRIPTION
# Description
A greater upgrade for liteprotocoltester.


# Changes

- [x] Added various metrics to follow test performance and failures.
- [x] Dashboard defined to follow test performance and failure counts.
- [x] Added ENR support for service and bootstrap peer configuration.
- [x] Added bootstrap capabilities using peer exchange.
- [x] If bootstrap node is defined, max 100 nodes will be gathered via PeerExchange.
- [x] PeerExchange nodes will be tested for connectivity and report created.
- [x] If further nodes are available (via bootstrap node and PX) in case of failure during test, the service node will be switched to another service node. (derived through internal thresholds).
- [x] jenkins job defined to build and create and deploy image of liteprotocoltester

# Extension

A new repository https://github.com/waku-org/lpt-runner created to ease the usage and run against various waku networks and fleets.

# Issue

https://github.com/waku-org/nwaku/issues/2999
