### PR TITLE
chore: saving peers enr capabilities

### DIFF
--- a/tests/test_waku_enr.nim
+++ b/tests/test_waku_enr.nim
@@ -110,7 +110,7 @@ suite "Waku ENR -  Capabilities bitfield":
       let recordRes = builder.build()
 
       ## Then
-      check recordRes.isOk()
+      assert recordRes.isOk(), $recordRes.error
       let record = recordRes.tryGet()
 
       let codecs = record.getCapabilitiesCodecs()

--- a/tests/waku_core/test_peers.nim
+++ b/tests/waku_core/test_peers.nim
@@ -1,8 +1,13 @@
 {.used.}
 
 import
-  stew/results, testutils/unittests, libp2p/multiaddress, libp2p/peerid, libp2p/errors
-import waku/waku_core
+  stew/results,
+  testutils/unittests,
+  libp2p/multiaddress,
+  libp2p/peerid,
+  libp2p/errors,
+  confutils/toml/std/net
+import waku/[waku_core, waku_core/codecs, waku_enr], ../testlib/wakucore
 
 suite "Waku Core - Peers":
   test "Peer info parses correctly":
@@ -141,3 +146,34 @@ suite "Waku Core - Peers":
     ## Then
     check:
       parsePeerInfo(address).isErr()
+
+  test "ENRs capabilities are filled when creating RemotePeerInfo":
+    let
+      enrSeqNum = 1u64
+      enrPrivKey = generatesecp256k1key()
+
+    ## When
+    var builder = EnrBuilder.init(enrPrivKey, seqNum = enrSeqNum)
+    builder.withIpAddressAndPorts(
+      ipAddr = some(parseIpAddress("127.0.0.1")),
+      tcpPort = some(Port(0)),
+      udpPort = some(Port(0)),
+    )
+    builder.withWakuCapabilities(Capabilities.Relay, Capabilities.Store)
+
+    let recordRes = builder.build()
+
+    ## Then
+    check recordRes.isOk()
+    let record = recordRes.tryGet()
+
+    let remotePeerInfoRes = record.toRemotePeerInfo()
+    assert remotePeerInfoRes.isOk(),
+      "failed creating RemotePeerInfo: " & $remotePeerInfoRes.error()
+
+    let remotePeerInfo = remotePeerInfoRes.get()
+
+    check:
+      remotePeerInfo.protocols.len == 2
+      remotePeerInfo.protocols.contains(WakuRelayCodec)
+      remotePeerInfo.protocols.contains(WakuStoreCodec)

--- a/tests/waku_core/test_peers.nim
+++ b/tests/waku_core/test_peers.nim
@@ -164,7 +164,7 @@ suite "Waku Core - Peers":
     let recordRes = builder.build()
 
     ## Then
-    check recordRes.isOk()
+    assert recordRes.isOk(), $recordRes.error
     let record = recordRes.tryGet()
 
     let remotePeerInfoRes = record.toRemotePeerInfo()

--- a/tests/waku_discv5/test_waku_discv5.nim
+++ b/tests/waku_discv5/test_waku_discv5.nim
@@ -405,20 +405,20 @@ suite "Waku Discovery v5":
       check:
         enrs.len == 0
 
-    suite "waku discv5 initialization":
-      var conf = defaultTestWakuNodeConf()
+  suite "waku discv5 initialization":
+    var conf = defaultTestWakuNodeConf()
 
-      conf.discv5BootstrapNodes = @[validEnr]
+    conf.discv5BootstrapNodes = @[validEnr]
 
-      let waku = Waku.init(conf).valueOr:
-        raiseAssert error
+    let waku = Waku.init(conf).valueOr:
+      raiseAssert error
 
-      discard setupDiscoveryV5(
-        waku.node.enr, waku.node.peerManager, waku.node.topicSubscriptionQueue,
-        waku.conf, waku.dynamicBootstrapNodes, waku.rng, waku.key,
+    discard setupDiscoveryV5(
+      waku.node.enr, waku.node.peerManager, waku.node.topicSubscriptionQueue, waku.conf,
+      waku.dynamicBootstrapNodes, waku.rng, waku.key,
+    )
+
+    check:
+      waku.node.peerManager.wakuPeerStore.peers().anyIt(
+        it.enr.isSome() and it.enr.get().toUri() == validEnr
       )
-
-      check:
-        waku.node.peerManager.wakuPeerStore.peers().anyIt(
-          it.enr.isSome() and it.enr.get().toUri() == validEnr
-        )

--- a/tests/waku_discv5/test_waku_discv5.nim
+++ b/tests/waku_discv5/test_waku_discv5.nim
@@ -22,9 +22,10 @@ include waku/factory/waku
 
 suite "Waku Discovery v5":
   const validEnr =
-    "enr:-I-4QG3mX250ArniAs2DLpW-QHOLKSD5x_Ibp8AYcQZbz1HhHFJtl2dNDGcha" &
-    "U5ugLbDKRgtTDZH8NsxXlTXDpYAgzgBgmlkgnY0gnJzjwAVBgABAAIABQAHAAkAC4" &
-    "lzZWNwMjU2azGhA4_KwN0NRRmmfQ-B9B2h2PZjoJvBnaIOi6sR_b2UTQBBhXdha3U" & "yAQ"
+    "enr:-K64QGAvsATunmvMT5c3LFjKS0tG39zlQ1195Z2pWu6RoB5fWP3EXz9QPlRXN" &
+    "wOtDoRLgm4bATUB53AC8uml-ZtUE_kBgmlkgnY0gmlwhApkZgOKbXVsdGlhZGRyc4" &
+    "CCcnOTAAAIAAAAAQACAAMABAAFAAYAB4lzZWNwMjU2azGhAwG-CMmXpAPj84f6dCt" &
+    "MZ6xVYOa6bdmgAiKYG6LKGQlbg3RjcILqYIV3YWt1MgE"
 
   let
     rng = eth_keys.newRng()
@@ -406,19 +407,20 @@ suite "Waku Discovery v5":
         enrs.len == 0
 
   suite "waku discv5 initialization":
-    var conf = defaultTestWakuNodeConf()
+    asyncTest "Discv5 bootstrap nodes should be added to the peer store":
+      var conf = defaultTestWakuNodeConf()
 
-    conf.discv5BootstrapNodes = @[validEnr]
+      conf.discv5BootstrapNodes = @[validEnr]
 
-    let waku = Waku.init(conf).valueOr:
-      raiseAssert error
+      let waku = Waku.init(conf).valueOr:
+        raiseAssert error
 
-    discard setupDiscoveryV5(
-      waku.node.enr, waku.node.peerManager, waku.node.topicSubscriptionQueue, waku.conf,
-      waku.dynamicBootstrapNodes, waku.rng, waku.key,
-    )
-
-    check:
-      waku.node.peerManager.wakuPeerStore.peers().anyIt(
-        it.enr.isSome() and it.enr.get().toUri() == validEnr
+      discard setupDiscoveryV5(
+        waku.node.enr, waku.node.peerManager, waku.node.topicSubscriptionQueue,
+        waku.conf, waku.dynamicBootstrapNodes, waku.rng, waku.key,
       )
+
+      check:
+        waku.node.peerManager.wakuPeerStore.peers().anyIt(
+          it.enr.isSome() and it.enr.get().toUri() == validEnr
+        )

--- a/tests/waku_discv5/test_waku_discv5.nim
+++ b/tests/waku_discv5/test_waku_discv5.nim
@@ -424,3 +424,23 @@ suite "Waku Discovery v5":
         waku.node.peerManager.wakuPeerStore.peers().anyIt(
           it.enr.isSome() and it.enr.get().toUri() == validEnr
         )
+
+    asyncTest "Invalid discv5 bootstrap node ENRs are ignored":
+      var conf = defaultTestWakuNodeConf()
+
+      let invalidEnr = "invalid-enr"
+
+      conf.discv5BootstrapNodes = @[invalidEnr]
+
+      let waku = Waku.init(conf).valueOr:
+        raiseAssert error
+
+      discard setupDiscoveryV5(
+        waku.node.enr, waku.node.peerManager, waku.node.topicSubscriptionQueue,
+        waku.conf, waku.dynamicBootstrapNodes, waku.rng, waku.key,
+      )
+
+      check:
+        not waku.node.peerManager.wakuPeerStore.peers().anyIt(
+          it.enr.isSome() and it.enr.get().toUri() == invalidEnr
+        )

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -351,9 +351,7 @@ proc parseBootstrapAddress(address: string): Result[enr.Record, cstring] =
   else:
     return err("Ignoring unrecognized bootstrap address type")
 
-proc addBootstrapNode*(
-    peerManager: PeerManager, bootstrapAddr: string, bootstrapEnrs: var seq[enr.Record]
-) =
+proc addBootstrapNode*(bootstrapAddr: string, bootstrapEnrs: var seq[enr.Record]) =
   # Ignore empty lines or lines starting with #
   if bootstrapAddr.len == 0 or bootstrapAddr[0] == '#':
     return

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -387,7 +387,7 @@ proc setupDiscoveryV5*(
       nodePeerManager.addPeer(peerInfoRes.get(), PeerOrigin.Discv5)
     else:
       debug "could not convert discv5 bootstrap node to peerInfo, not adding peer to Peer Store",
-        enr = $enr
+        enr = enr.toUri(), error = peerInfoRes.error
 
   discv5BootstrapEnrs.add(dynamicBootstrapEnrs)
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -379,7 +379,7 @@ proc setupDiscoveryV5*(
 
   # parse enrURIs from the configuration and add the resulting ENRs to the discv5BootstrapEnrs seq
   for enrUri in conf.discv5BootstrapNodes:
-    nodePeerManager.addBootstrapNode(enrUri, discv5BootstrapEnrs)
+    addBootstrapNode(enrUri, discv5BootstrapEnrs)
 
   for enr in discv5BootstrapEnrs:
     let peerInfoRes = enr.toRemotePeerInfo()

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -398,13 +398,19 @@ proc startNode*(
     return err("failed to start waku node: " & getCurrentExceptionMsg())
 
   # Connect to configured static nodes
-  if conf.relay and conf.staticnodes.len > 0:
+  if conf.staticnodes.len > 0:
+    if not conf.relay:
+      return err("waku relay (--relay=true) should be set when configuring staticnodes")
     try:
       await connectToNodes(node, conf.staticnodes, "static")
     except CatchableError:
       return err("failed to connect to static nodes: " & getCurrentExceptionMsg())
 
-  if conf.relay and dynamicBootstrapNodes.len > 0:
+  if dynamicBootstrapNodes.len > 0:
+    if not conf.relay:
+      return err(
+        "waku relay (--relay=true) should be set when configuring dynamicBootstrapNodes"
+      )
     info "Connecting to dynamic bootstrap peers"
     try:
       await connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -398,13 +398,13 @@ proc startNode*(
     return err("failed to start waku node: " & getCurrentExceptionMsg())
 
   # Connect to configured static nodes
-  if conf.staticnodes.len > 0:
+  if conf.relay and conf.staticnodes.len > 0:
     try:
       await connectToNodes(node, conf.staticnodes, "static")
     except CatchableError:
       return err("failed to connect to static nodes: " & getCurrentExceptionMsg())
 
-  if dynamicBootstrapNodes.len > 0:
+  if conf.relay and dynamicBootstrapNodes.len > 0:
     info "Connecting to dynamic bootstrap peers"
     try:
       await connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")

--- a/waku/waku_core/codecs.nim
+++ b/waku/waku_core/codecs.nim
@@ -1,0 +1,10 @@
+const
+  WakuRelayCodec* = "/vac/waku/relay/2.0.0"
+  WakuStoreCodec* = "/vac/waku/store-query/3.0.0"
+  WakuFilterSubscribeCodec* = "/vac/waku/filter-subscribe/2.0.0-beta1"
+  WakuFilterPushCodec* = "/vac/waku/filter-push/2.0.0-beta1"
+  WakuLightPushCodec* = "/vac/waku/lightpush/2.0.0-beta1"
+  WakuSyncCodec* = "/vac/waku/sync/1.0.0"
+  WakuMetadataCodec* = "/vac/waku/metadata/1.0.0"
+  WakuPeerExchangeCodec* = "/vac/waku/peer-exchange/2.0.0-alpha1"
+  WakuLegacyStoreCodec* = "/vac/waku/store/2.0.0-beta4"

--- a/waku/waku_core/peers.nim
+++ b/waku/waku_core/peers.nim
@@ -1,7 +1,7 @@
 {.push raises: [].}
 
 import
-  std/[options, sequtils, strutils, uri, net, tables],
+  std/[options, sequtils, strutils, uri, net],
   results,
   chronos,
   eth/keys,

--- a/waku/waku_core/peers.nim
+++ b/waku/waku_core/peers.nim
@@ -4,6 +4,7 @@ import
   std/[options, sequtils, strutils, uri, net],
   results,
   chronos,
+  chronicles,
   eth/keys,
   eth/p2p/discoveryv5/enr,
   eth/net/utils,
@@ -250,6 +251,8 @@ proc toRemotePeerInfo*(enr: enr.Record): Result[RemotePeerInfo, cstring] =
   var protocols: seq[string]
   if not protocolsRes.isErr():
     protocols = protocolsRes.get()
+    error "Could not retrieve supported protocols from enr",
+      peerId = peerId, msg = protocolsRes.error.msg
 
   return ok(RemotePeerInfo.init(peerId, addrs, some(enr), protocols))
 
@@ -264,7 +267,7 @@ converter toRemotePeerInfo*(peerInfo: PeerInfo): RemotePeerInfo =
   RemotePeerInfo(
     peerId: peerInfo.peerId,
     addrs: peerInfo.listenAddrs,
-    enr: none(Record),
+    enr: none(enr.Record),
     protocols: peerInfo.protocols,
     agent: peerInfo.agentVersion,
     protoVersion: peerInfo.protoVersion,

--- a/waku/waku_core/peers.nim
+++ b/waku/waku_core/peers.nim
@@ -251,6 +251,7 @@ proc toRemotePeerInfo*(enr: enr.Record): Result[RemotePeerInfo, cstring] =
   var protocols: seq[string]
   if not protocolsRes.isErr():
     protocols = protocolsRes.get()
+  else:
     error "Could not retrieve supported protocols from enr",
       peerId = peerId, msg = protocolsRes.error.msg
 

--- a/waku/waku_enr/capabilities.nim
+++ b/waku/waku_enr/capabilities.nim
@@ -2,13 +2,7 @@
 
 import
   std/[options, bitops, sequtils, net, tables], results, eth/keys, libp2p/crypto/crypto
-import ../common/enr
-
-from ../waku_relay/protocol import WakuRelayCodec
-from ../waku_store/common import WakuStoreCodec
-from ../waku_filter_v2/common import WakuFilterSubscribeCodec
-from ../waku_lightpush/common import WakuLightPushCodec
-from ../waku_sync/common import WakuSyncCodec
+import ../common/enr, ../waku_core/codecs
 
 const CapabilitiesEnrField* = "waku2"
 

--- a/waku/waku_filter_v2/common.nim
+++ b/waku/waku_filter_v2/common.nim
@@ -2,9 +2,8 @@
 
 import results
 
-const
-  WakuFilterSubscribeCodec* = "/vac/waku/filter-subscribe/2.0.0-beta1"
-  WakuFilterPushCodec* = "/vac/waku/filter-push/2.0.0-beta1"
+from ../waku_core/codecs import WakuFilterSubscribeCodec, WakuFilterPushCodec
+export WakuFilterSubscribeCodec, WakuFilterPushCodec
 
 type
   FilterSubscribeErrorKind* {.pure.} = enum

--- a/waku/waku_lightpush/common.nim
+++ b/waku/waku_lightpush/common.nim
@@ -3,7 +3,8 @@
 import results, chronos, libp2p/peerid
 import ../waku_core
 
-const WakuLightPushCodec* = "/vac/waku/lightpush/2.0.0-beta1"
+from ../waku_core/codecs import WakuLightPushCodec
+export WakuLightPushCodec
 
 type WakuLightPushResult*[T] = Result[T, string]
 

--- a/waku/waku_metadata/protocol.nim
+++ b/waku/waku_metadata/protocol.nim
@@ -12,10 +12,12 @@ import
   eth/p2p/discoveryv5/enr
 import ../common/nimchronos, ../common/enr, ../waku_core, ../waku_enr, ./rpc
 
+from ../waku_core/codecs import WakuMetadataCodec
+export WakuMetadataCodec
+
 logScope:
   topics = "waku metadata"
 
-const WakuMetadataCodec* = "/vac/waku/metadata/1.0.0"
 const RpcResponseMaxBytes* = 1024
 
 type WakuMetadata* = ref object of LPProtocol

--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -16,6 +16,9 @@ import
   ./rpc_codec,
   ../common/rate_limit/request_limiter
 
+from ../waku_core/codecs import WakuPeerExchangeCodec
+export WakuPeerExchangeCodec
+
 declarePublicGauge waku_px_peers_received_total,
   "number of ENRs received via peer exchange"
 declarePublicGauge waku_px_peers_received_unknown,
@@ -36,8 +39,6 @@ const
   MaxPeersCacheSize = 60
   CacheRefreshInterval = 10.minutes
   DefaultPXNumPeersReq* = 5.uint64()
-
-  WakuPeerExchangeCodec* = "/vac/waku/peer-exchange/2.0.0-alpha1"
 
 # Error types (metric label values)
 const

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -20,10 +20,11 @@ import
   libp2p/switch
 import ../waku_core, ./message_id, ../node/delivery_monitor/publish_observer
 
+from ../waku_core/codecs import WakuRelayCodec
+export WakuRelayCodec
+
 logScope:
   topics = "waku relay"
-
-const WakuRelayCodec* = "/vac/waku/relay/2.0.0"
 
 # see: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#overview-of-new-parameters
 const TopicParameters = TopicParams(

--- a/waku/waku_store/common.nim
+++ b/waku/waku_store/common.nim
@@ -3,9 +3,10 @@
 import std/[options], results
 import ../waku_core, ../common/paging
 
-const
-  WakuStoreCodec* = "/vac/waku/store-query/3.0.0"
+from ../waku_core/codecs import WakuStoreCodec
+export WakuStoreCodec
 
+const
   DefaultPageSize*: uint64 = 20
 
   MaxPageSize*: uint64 = 100

--- a/waku/waku_store_legacy/common.nim
+++ b/waku/waku_store_legacy/common.nim
@@ -3,9 +3,10 @@
 import std/[options, sequtils], results, stew/byteutils, nimcrypto/sha2
 import ../waku_core, ../common/paging
 
-const
-  WakuLegacyStoreCodec* = "/vac/waku/store/2.0.0-beta4"
+from ../waku_core/codecs import WakuLegacyStoreCodec
+export WakuLegacyStoreCodec
 
+const
   DefaultPageSize*: uint64 = 20
 
   MaxPageSize*: uint64 = 100

--- a/waku/waku_sync/common.nim
+++ b/waku/waku_sync/common.nim
@@ -3,11 +3,13 @@
 import std/[options], chronos, libp2p/peerId
 import ../waku_core
 
+from ../waku_core/codecs import WakuSyncCodec
+export WakuSyncCodec
+
 const
   DefaultSyncInterval*: Duration = 5.minutes
   DefaultSyncRange*: Duration = 1.hours
   RetryDelay*: Duration = 30.seconds
-  WakuSyncCodec* = "/vac/waku/sync/1.0.0"
   DefaultMaxFrameSize* = 1048576 # 1 MiB
   DefaultGossipSubJitter*: Duration = 20.seconds
 


### PR DESCRIPTION
# Description
When adding peers, we used to ignore the protocols advertised in the ENR and would fill the protocols in the Peer Store only after performing Identify.

We're now initializing the protocols with the advertised capabilities and will get updated once Identify is performed.
When mapping the ENR's capabilities to the supported protocols, we assume that the peers use the same version of the protocol as ours. If that's not the case, we'll find out during Identify, update the information and act accordingly.

In addition to that, started adding the Discv5 bootstrap nodes to the Peer Store.

I moved all the Waku protocols codec definitions to a separate file, as in the current state we had to import most of a protocol even if we only needed a codec, which caused circular dependency issues. Protocol codecs are public information, so it makes sense to be able to access them without having to import an entire protocol :)



# Changes

<!-- List of detailed changes -->

- [x] created new file with Waku Protocols' codecs
- [x] reading ENRs' capabilities and using them to fill the supported protocols when building the `RemotePeerInfo` 
- [x] only attempt Relay connections to bootstrap nodes when Relay is enabled
- [x] adding Discv5 bootstrap nodes to the Peer Store 
- [x] including tests for the new functionalities 

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->