### PR TITLE
chore: peer_manager - prevent too intense loop when no peers connected

### DIFF
--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -928,7 +928,7 @@ proc relayConnectivityLoop*(pm: PeerManager) {.async.} =
         chronos.seconds(int(float(ConnectivityLoopInterval.seconds()) * factor))
 
     # Shorten the connectivity loop interval dynamically based on percentage of peers to fill or connections to prune
-    await sleepAsync(dynamicSleepInterval)
+    await sleepAsync(max(dynamicSleepInterval, chronos.seconds(1)))
 
 proc pruneInRelayConns(pm: PeerManager, amount: int) {.async.} =
   if amount <= 0:


### PR DESCRIPTION
## Description
PR aimed to prevent the node from running a very intense CPU loop. With that, at least we set a delay of one second, in case no peers are connected.

I came across that the node was running 100% CPU while testing local nodes without peers.