### PR TITLE
chore(networkmonitor): add missing field on RlnRelay init, set default for num of shards

### DIFF
--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -614,6 +614,12 @@ when isMainModule:
   waitFor node.mountRelay()
   waitFor node.mountLibp2pPing()
 
+  var onFatalErrorAction = proc(msg: string) {.gcsafe, closure.} =
+    ## Action to be taken when an internal error occurs during the node run.
+    ## e.g. the connection with the database is lost and not recovered.
+    error "Unrecoverable error occurred", error = msg
+    quit(QuitFailure)
+
   if conf.rlnRelay and conf.rlnRelayEthContractAddress != "":
     let rlnConf = WakuRlnConfig(
       rlnRelayDynamic: conf.rlnRelayDynamic,
@@ -624,6 +630,7 @@ when isMainModule:
       rlnRelayCredPassword: "",
       rlnRelayTreePath: conf.rlnRelayTreePath,
       rlnEpochSizeSec: conf.rlnEpochSizeSec,
+      onFatalErrorAction: onFatalErrorAction,
     )
 
     try:

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -45,7 +45,9 @@ type NetworkMonitorConf* = object
   .}: seq[uint16]
 
   numShardsInNetwork* {.
-    desc: "Number of shards in the network", name: "num-shards-in-network"
+    desc: "Number of shards in the network",
+    name: "num-shards-in-network",
+    defaultValue: 8
   .}: uint32
 
   refreshInterval* {.


### PR DESCRIPTION
# Description
This PR fixes NetworkMonitor to work with latest underlying implementation of protocols. 

# Changes

<!-- List of detailed changes -->

- [ ] Add missing `onFatalErrorAction`
- [ ] set default number of shards to `8` (to match Waku Network and avoid requiring the arg)

<!--
## How to test

1. `make networkmonitor`
1. `./build/networkmonitor  --rln-relay-eth-client-address=https://ethereum-sepolia-rpc.publicnode.com`
1. `curl http://localhost:8008/metrics | grep waku_rln_valid_messages_total_count`

-->


<!--
## Issue

closes #
-->