### PR TITLE
chore: decreasing wait time for updating px cache on startup

### DIFF
--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -219,11 +219,11 @@ proc populateEnrCache(wpx: WakuPeerExchange) =
 
 proc updatePxEnrCache(wpx: WakuPeerExchange) {.async.} =
   # try more aggressively to fill the cache at startup
-  var attempts = 10
+  var attempts = 50
   while wpx.enrCache.len < MaxPeersCacheSize and attempts > 0:
     attempts -= 1
     wpx.populateEnrCache()
-    await sleepAsync(5.seconds)
+    await sleepAsync(1.seconds)
 
   heartbeat "Updating px enr cache", CacheRefreshInterval:
     wpx.populateEnrCache()


### PR DESCRIPTION
# Description
On startup we attempt to populate the Peer Exchange cache once every 5 seconds for the first 50 seconds. We found that in tests from the moment that a node finds a peer until we can share it in PX, we had to wait those 5 seconds.

Updating the strategy so we update the cache once every second for those 50 seconds, as it is a lightweight operation and will help us have PX properly set much quicker.

# Changes


- [x] updating PX cache on startup once every second for 50 seconds

## Issue
#3115 

