### PR TITLE
fix: peer exchange libwaku response handling

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
@@ -103,10 +103,9 @@ proc updateDiscv5BootstrapNodes(nodes: string, waku: ptr Waku): Result[void, str
 proc performPeerExchangeRequestTo(
     numPeers: uint64, waku: ptr Waku
 ): Future[Result[int, string]] {.async.} =
-  let numPeersRes = await waku.node.fetchPeerExchangePeers(numPeers)
-  if numPeersRes.isErr():
-    return err($numPeersRes.error)
-  return ok(numPeersRes.get())
+  let numPeersRecv = (await waku.node.fetchPeerExchangePeers(numPeers)).valueOr:
+    return err($error)
+  return ok(numPeersRecv)
 
 proc process*(
     self: ptr DiscoveryRequest, waku: ptr Waku

--- a/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
@@ -140,12 +140,10 @@ proc process*(
 
     return ok("discovery request processed correctly")
   of PEER_EXCHANGE:
-    let numValidPeers = await performPeerExchangeRequestTo(self[].numPeers, waku)
-    echo "---------- GABRIEL numValidPeers: ", numValidPeers
-    if numValidPeers.isErr():
-      error "PEER_EXCHANGE failed", error = numValidPeers.error
-      return err("error calling performPeerExchangeRequestTo: " & numValidPeers.error)
-    return ok($numValidPeers.get())
+    let numValidPeers = (await performPeerExchangeRequestTo(self[].numPeers, waku)).valueOr:
+      error "PEER_EXCHANGE failed", error = error
+      return err("error calling performPeerExchangeRequestTo: " & $error)
+    return ok($numValidPeers)
 
   error "discovery request not handled"
   return err("discovery request not handled")


### PR DESCRIPTION
# Description
The current way of parsing the Peer Exchange's responses in libwaku always returned an error, even if the call was successful. It also ignored the number of peers received.

Fixed the handling of `fetchPeerExchangePeers`'s response
# Changes

<!-- List of detailed changes -->

- [x] fixed the handling of `fetchPeerExchangePeers`'s response in libwaku


## Issue

#3115 
