### PR TITLE
feat(libwaku): ping peer

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -177,6 +177,12 @@ int waku_peer_exchange_request(void* ctx,
                                WakuCallBack callback,
                                void* userData);
 
+int waku_ping_peer(void* ctx,
+                        const char* peerAddr,
+                        int timeoutMs,
+                        WakuCallBack callback,
+                        void* userData);
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -22,6 +22,7 @@ import
   ./waku_thread/inter_thread_communication/requests/protocols/lightpush_request,
   ./waku_thread/inter_thread_communication/requests/debug_node_request,
   ./waku_thread/inter_thread_communication/requests/discovery_request,
+  ./waku_thread/inter_thread_communication/requests/ping_request,
   ./waku_thread/inter_thread_communication/waku_thread_request,
   ./alloc,
   ./callback
@@ -656,6 +657,23 @@ proc waku_peer_exchange_request(
   waku_thread
   .sendRequestToWakuThread(
     ctx, RequestType.DISCOVERY, DiscoveryRequest.createPeerExchangeRequest(numPeers)
+  )
+  .handleRes(callback, userData)
+
+proc waku_ping_peer(
+    ctx: ptr WakuContext,
+    peerID: cstring,
+    timeoutMs: cuint,
+    callback: WakuCallBack,
+    userData: pointer,
+): cint {.dynlib, exportc.} =
+  checkLibwakuParams(ctx, callback, userData)
+
+  waku_thread
+  .sendRequestToWakuThread(
+    ctx,
+    RequestType.PING,
+    PingRequest.createShared(peerID, chronos.milliseconds(timeoutMs)),
   )
   .handleRes(callback, userData)
 

--- a/library/waku_thread/inter_thread_communication/requests/ping_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/ping_request.nim
@@ -1,0 +1,53 @@
+import std/json
+import chronos, results
+import libp2p/[protocols/ping, switch, multiaddress, multicodec]
+import ../../../../waku/[factory/waku, waku_core/peers, node/waku_node], ../../../alloc
+
+type PingRequest* = object
+  peerAddr: cstring
+  timeout: Duration
+
+proc createShared*(
+    T: type PingRequest, peerAddr: cstring, timeout: Duration
+): ptr type T =
+  var ret = createShared(T)
+  ret[].peerAddr = peerAddr.alloc()
+  ret[].timeout = timeout
+  return ret
+
+proc destroyShared(self: ptr PingRequest) =
+  deallocShared(self[].peerAddr)
+  deallocShared(self)
+
+proc process*(
+    self: ptr PingRequest, waku: ptr Waku
+): Future[Result[string, string]] {.async.} =
+  defer:
+    destroyShared(self)
+
+  let peerInfo = peers.parsePeerInfo($self[].peerAddr).valueOr:
+    return err("PingRequest failed to parse peer addr: " & $error)
+
+  proc ping(): Future[Result[Duration, string]] {.async, gcsafe.} =
+    try:
+      let conn = await waku.node.switch.dial(peerInfo.peerId, peerInfo.addrs, PingCodec)
+      let pingRTT = await waku.node.libp2pPing.ping(conn)
+      if pingRTT == 0.nanos:
+        return err("could not ping peer: rtt-0")
+      return ok(pingRTT)
+    except CatchableError:
+      return err("could not ping peer: " & getCurrentExceptionMsg())
+
+  let pingFuture = ping()
+  var pingRTT: Duration =
+    if self[].timeout == chronos.milliseconds(0): # No timeout expected
+      (await pingFuture).valueOr:
+        return err(error)
+    else:
+      let timedOut = not (await pingFuture.withTimeout(self[].timeout))
+      if timedOut:
+        return err("ping timed out")
+      pingFuture.read().valueOr:
+        return err(error)
+
+  ok($(pingRTT.nanos))

--- a/library/waku_thread/inter_thread_communication/requests/ping_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/ping_request.nim
@@ -39,7 +39,7 @@ proc process*(
       return err("could not ping peer: " & getCurrentExceptionMsg())
 
   let pingFuture = ping()
-  var pingRTT: Duration =
+  let pingRTT: Duration =
     if self[].timeout == chronos.milliseconds(0): # No timeout expected
       (await pingFuture).valueOr:
         return err(error)

--- a/library/waku_thread/inter_thread_communication/waku_thread_request.nim
+++ b/library/waku_thread/inter_thread_communication/waku_thread_request.nim
@@ -12,11 +12,13 @@ import
   ./requests/protocols/store_request,
   ./requests/protocols/lightpush_request,
   ./requests/debug_node_request,
-  ./requests/discovery_request
+  ./requests/discovery_request,
+  ./requests/ping_request
 
 type RequestType* {.pure.} = enum
   LIFECYCLE
   PEER_MANAGER
+  PING
   RELAY
   STORE
   DEBUG
@@ -50,6 +52,8 @@ proc process*(
       cast[ptr NodeLifecycleRequest](request[].reqContent).process(waku)
     of PEER_MANAGER:
       cast[ptr PeerManagementRequest](request[].reqContent).process(waku[])
+    of PING:
+      cast[ptr PingRequest](request[].reqContent).process(waku)
     of RELAY:
       cast[ptr RelayRequest](request[].reqContent).process(waku)
     of STORE:


### PR DESCRIPTION
# Description
Adds a function to ping peers via bindings
```
int waku_ping_peer(void* ctx,
                        const char* peerAddr,
                        int timeoutMs,
                        WakuCallBack callback,
                        void* userData);
```
This is required in status-go for the storenode cycle, in which a storenode is selected based on ping RTT
