### PR TITLE
feat: adding waku_dial_peer and get_connected_peers to libwaku

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -147,6 +147,10 @@ int waku_listen_addresses(void* ctx,
                           WakuCallBack callback,
                           void* userData);
 
+int waku_get_connected_peers(void* ctx,
+                          WakuCallBack callback,
+                          void* userData);
+
 // Returns a list of multiaddress given a url to a DNS discoverable ENR tree
 // Parameters
 //     char* entTreeUrl: URL containing a discoverable ENR tree

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -120,6 +120,13 @@ int waku_disconnect_peer_by_id(void* ctx,
                  WakuCallBack callback,
                  void* userData);
 
+int waku_dial_peer(void* ctx,
+                 const char* peerMultiAddr,
+                 const char* protocol,
+                 int timeoutMs,
+                 WakuCallBack callback,
+                 void* userData);
+
 int waku_dial_peer_by_id(void* ctx,
                  const char* peerId,
                  const char* protocol,

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -498,6 +498,28 @@ proc waku_disconnect_peer_by_id(
   )
   .handleRes(callback, userData)
 
+proc waku_dial_peer(
+    ctx: ptr WakuContext,
+    peerMultiAddr: cstring,
+    protocol: cstring,
+    timeoutMs: cuint,
+    callback: WakuCallBack,
+    userData: pointer,
+): cint {.dynlib, exportc.} =
+  checkLibwakuParams(ctx, callback, userData)
+
+  waku_thread
+  .sendRequestToWakuThread(
+    ctx,
+    RequestType.PEER_MANAGER,
+    PeerManagementRequest.createShared(
+      op = PeerManagementMsgType.DIAL_PEER,
+      peerMultiAddr = $peerMultiAddr,
+      protocol = $protocol,
+    ),
+  )
+  .handleRes(callback, userData)
+
 proc waku_dial_peer_by_id(
     ctx: ptr WakuContext,
     peerId: cstring,
@@ -513,7 +535,7 @@ proc waku_dial_peer_by_id(
     ctx,
     RequestType.PEER_MANAGER,
     PeerManagementRequest.createShared(
-      op = PeerManagementMsgType.DIAL_PEER_BY_ID, peerId = $peerId
+      op = PeerManagementMsgType.DIAL_PEER_BY_ID, peerId = $peerId, protocol = $protocol
     ),
   )
   .handleRes(callback, userData)

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -553,6 +553,19 @@ proc waku_get_peerids_from_peerstore(
   )
   .handleRes(callback, userData)
 
+proc waku_get_connected_peers(
+    ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
+): cint {.dynlib, exportc.} =
+  checkLibwakuParams(ctx, callback, userData)
+
+  waku_thread
+  .sendRequestToWakuThread(
+    ctx,
+    RequestType.PEER_MANAGER,
+    PeerManagementRequest.createShared(PeerManagementMsgType.GET_CONNECTED_PEERS),
+  )
+  .handleRes(callback, userData)
+
 proc waku_get_peerids_by_protocol(
     ctx: ptr WakuContext, protocol: cstring, callback: WakuCallBack, userData: pointer
 ): cint {.dynlib, exportc.} =

--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -13,6 +13,7 @@ type PeerManagementMsgType* {.pure.} = enum
   DISCONNECT_PEER_BY_ID
   DIAL_PEER
   DIAL_PEER_BY_ID
+  GET_CONNECTED_PEERS
 
 type PeerManagementRequest* = object
   operation: PeerManagementMsgType
@@ -114,5 +115,11 @@ proc process*(
       let msg = "failed dialing peer"
       error "DIAL_PEER_BY_ID failed", error = msg
       return err(msg)
+  of GET_CONNECTED_PEERS:
+    ## returns a comma-separated string of peerIDs
+    let
+      (inPeerIds, outPeerIds) = waku.node.peerManager.connectedPeers()
+      connectedPeerids = concat(inPeerIds, outPeerIds)
+    return ok(connectedPeerids.mapIt($it).join(","))
 
   return ok("")

--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -101,7 +101,7 @@ proc process*(
       error "DIAL_PEER failed", error = $error
       return err($error)
     let conn = await waku.node.peerManager.dialPeer(remotePeerInfo, $self[].protocol)
-    if conn.isNone():
+    if $self[].protocol != "" and conn.isNone():
       let msg = "failed dialing peer"
       error "DIAL_PEER failed", error = msg
       return err(msg)
@@ -110,7 +110,7 @@ proc process*(
       error "DIAL_PEER_BY_ID failed", error = $error
       return err($error)
     let conn = await waku.node.peerManager.dialPeer(peerId, $self[].protocol)
-    if conn.isNone():
+    if $self[].protocol != "" and conn.isNone():
       let msg = "failed dialing peer"
       error "DIAL_PEER_BY_ID failed", error = msg
       return err(msg)

--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -104,7 +104,7 @@ proc process*(
     let conn = await waku.node.peerManager.dialPeer(remotePeerInfo, $self[].protocol)
     if conn.isNone():
       let msg = "failed dialing peer"
-      error "DIAL_PEER failed", error = msg
+      error "DIAL_PEER failed", error = msg, peerId = $remotePeerInfo.peerId
       return err(msg)
   of DIAL_PEER_BY_ID:
     let peerId = PeerId.init($self[].peerId).valueOr:
@@ -113,7 +113,7 @@ proc process*(
     let conn = await waku.node.peerManager.dialPeer(peerId, $self[].protocol)
     if conn.isNone():
       let msg = "failed dialing peer"
-      error "DIAL_PEER_BY_ID failed", error = msg
+      error "DIAL_PEER_BY_ID failed", error = msg, peerId = $peerId
       return err(msg)
   of GET_CONNECTED_PEERS:
     ## returns a comma-separated string of peerIDs

--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -102,7 +102,7 @@ proc process*(
       error "DIAL_PEER failed", error = $error
       return err($error)
     let conn = await waku.node.peerManager.dialPeer(remotePeerInfo, $self[].protocol)
-    if $self[].protocol != "" and conn.isNone():
+    if conn.isNone():
       let msg = "failed dialing peer"
       error "DIAL_PEER failed", error = msg
       return err(msg)
@@ -111,7 +111,7 @@ proc process*(
       error "DIAL_PEER_BY_ID failed", error = $error
       return err($error)
     let conn = await waku.node.peerManager.dialPeer(peerId, $self[].protocol)
-    if $self[].protocol != "" and conn.isNone():
+    if conn.isNone():
       let msg = "failed dialing peer"
       error "DIAL_PEER_BY_ID failed", error = msg
       return err(msg)

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -397,7 +397,7 @@ proc dialPeer(
     pm: PeerManager,
     peerId: PeerID,
     addrs: seq[MultiAddress],
-    proto = "",
+    proto: string,
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =
@@ -410,11 +410,6 @@ proc dialPeer(
     return none(Connection)
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
-
-  # Dial Peer
-  if proto == "":
-    await pm.switch.connect(peerId, addrs)
-    return none(Connection)
 
   let dialFut = pm.switch.dial(peerId, addrs, proto)
 
@@ -433,7 +428,7 @@ proc dialPeer(
 proc dialPeer*(
     pm: PeerManager,
     remotePeerInfo: RemotePeerInfo,
-    proto = "",
+    proto: string,
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =
@@ -454,7 +449,7 @@ proc dialPeer*(
 proc dialPeer*(
     pm: PeerManager,
     peerId: PeerID,
-    proto = "",
+    proto: string,
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -397,7 +397,7 @@ proc dialPeer(
     pm: PeerManager,
     peerId: PeerID,
     addrs: seq[MultiAddress],
-    proto: string,
+    proto = "",
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =
@@ -412,6 +412,10 @@ proc dialPeer(
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
 
   # Dial Peer
+  if proto == "":
+    await pm.switch.connect(peerId, addrs)
+    return none(Connection)
+
   let dialFut = pm.switch.dial(peerId, addrs, proto)
 
   let res = catch:
@@ -429,7 +433,7 @@ proc dialPeer(
 proc dialPeer*(
     pm: PeerManager,
     remotePeerInfo: RemotePeerInfo,
-    proto: string,
+    proto = "",
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =
@@ -450,7 +454,7 @@ proc dialPeer*(
 proc dialPeer*(
     pm: PeerManager,
     peerId: PeerID,
-    proto: string,
+    proto = "",
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -411,6 +411,7 @@ proc dialPeer(
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
 
+  # Dial Peer
   let dialFut = pm.switch.dial(peerId, addrs, proto)
 
   let res = catch:


### PR DESCRIPTION
# Description
Adding new procedures to libwaku to be able to dial peers using a specific protocol and to be able to retrieve the peerIds of all connected nodes
# Changes

<!-- List of detailed changes -->

- [x] added `waku_dial_peer` to libwaku
- [x] added `waku_get_connected_peers` to libwaku
- [x] passing missing parameter in `waku_dial_peer_by_id`
- [x] allowing to dial peers without specifying a protocol  


## Issue

#3076 