### PR TITLE
fix: libwaku's dns discovery multiaddresses

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
@@ -91,7 +91,7 @@ proc retrieveBootstrapNodes(
 
   for discPeer in discoveredPeers:
     for address in discPeer.addrs:
-      multiAddresses.add($address & "/" & $discPeer)
+      multiAddresses.add($address & "/p2p/" & $discPeer)
 
   return ok(multiAddresses)
 


### PR DESCRIPTION
# Description
Fixing the returned multiaddresses by libwaku's `waku_dns_discovery` procedure, which were missing the `p2p`
 prefix
## Issue
#3076 