### PR TITLE
chore: naming connect procedure

### DIFF
--- a/tests/node/test_wakunode_peer_exchange.nim
+++ b/tests/node/test_wakunode_peer_exchange.nim
@@ -271,9 +271,7 @@ suite "Waku Peer Exchange with discv5":
       attempts -= 1
 
     # node2 can be connected, so will be returned by peer exchange
-    require (
-      await node1.peerManager.connectRelay(node2.switch.peerInfo.toRemotePeerInfo())
-    )
+    require (await node1.peerManager.connect(node2.switch.peerInfo.toRemotePeerInfo()))
 
     # Mount peer exchange
     await node1.mountPeerExchange()

--- a/tests/node/test_wakunode_peer_exchange.nim
+++ b/tests/node/test_wakunode_peer_exchange.nim
@@ -271,7 +271,9 @@ suite "Waku Peer Exchange with discv5":
       attempts -= 1
 
     # node2 can be connected, so will be returned by peer exchange
-    require (await node1.peerManager.connect(node2.switch.peerInfo.toRemotePeerInfo()))
+    require (
+      await node1.peerManager.connectPeer(node2.switch.peerInfo.toRemotePeerInfo())
+    )
 
     # Mount peer exchange
     await node1.mountPeerExchange()

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -37,7 +37,7 @@ import
   ./testlib/wakunode
 
 procSuite "Peer Manager":
-  asyncTest "connect() works":
+  asyncTest "connectPeer() works":
     # Create 2 nodes
     let nodes = toSeq(0 ..< 2).mapIt(
         newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -45,7 +45,7 @@ procSuite "Peer Manager":
     await allFutures(nodes.mapIt(it.start()))
 
     let connOk =
-      await nodes[0].peerManager.connect(nodes[1].peerInfo.toRemotePeerInfo())
+      await nodes[0].peerManager.connectPeer(nodes[1].peerInfo.toRemotePeerInfo())
     await sleepAsync(chronos.milliseconds(500))
 
     check:
@@ -178,7 +178,7 @@ procSuite "Peer Manager":
 
     let nonExistentPeer = nonExistentPeerRes.value
     require:
-      (await nodes[0].peerManager.connect(nonExistentPeer)) == false
+      (await nodes[0].peerManager.connectPeer(nonExistentPeer)) == false
     await sleepAsync(chronos.milliseconds(500))
 
     check:
@@ -188,7 +188,8 @@ procSuite "Peer Manager":
 
     # Successful connection
     require:
-      (await nodes[0].peerManager.connect(nodes[1].peerInfo.toRemotePeerInfo())) == true
+      (await nodes[0].peerManager.connectPeer(nodes[1].peerInfo.toRemotePeerInfo())) ==
+        true
     await sleepAsync(chronos.milliseconds(500))
 
     check:
@@ -228,7 +229,7 @@ procSuite "Peer Manager":
     nodes[0].peerManager.backoffFactor = 2
 
     # try to connect to peer that doesnt exist
-    let conn1Ok = await nodes[0].peerManager.connect(nonExistentPeer)
+    let conn1Ok = await nodes[0].peerManager.connectPeer(nonExistentPeer)
     check:
       # Cannot connect to node2
       nodes[0].peerManager.wakuPeerStore.connectedness(nonExistentPeer.peerId) ==
@@ -255,7 +256,7 @@ procSuite "Peer Manager":
     nodes[0].peerManager.wakuPeerStore[NumberFailedConnBook][nodes[1].peerInfo.peerId] =
       4
     let conn2Ok =
-      await nodes[0].peerManager.connect(nodes[1].peerInfo.toRemotePeerInfo())
+      await nodes[0].peerManager.connectPeer(nodes[1].peerInfo.toRemotePeerInfo())
     check:
       conn2Ok == true
       nodes[0].peerManager.wakuPeerStore[NumberFailedConnBook][nodes[1].peerInfo.peerId] ==
@@ -285,7 +286,7 @@ procSuite "Peer Manager":
     var remotePeerInfo2 = peerInfo2.toRemotePeerInfo()
     remotePeerInfo2.enr = some(node2.enr)
 
-    let is12Connected = await node1.peerManager.connect(remotePeerInfo2)
+    let is12Connected = await node1.peerManager.connectPeer(remotePeerInfo2)
     assert is12Connected == true, "Node 1 and 2 not connected"
 
     check:
@@ -355,7 +356,7 @@ procSuite "Peer Manager":
     var remotePeerInfo2 = peerInfo2.toRemotePeerInfo()
     remotePeerInfo2.enr = some(node2.enr)
 
-    let is12Connected = await node1.peerManager.connect(remotePeerInfo2)
+    let is12Connected = await node1.peerManager.connectPeer(remotePeerInfo2)
     assert is12Connected == true, "Node 1 and 2 not connected"
 
     check:
@@ -484,7 +485,7 @@ procSuite "Peer Manager":
     node2.wakuRelay.codec = betaCodec
 
     require:
-      (await node1.peerManager.connect(peerInfo2.toRemotePeerInfo())) == true
+      (await node1.peerManager.connectPeer(peerInfo2.toRemotePeerInfo())) == true
     check:
       # Currently connected to node2
       node1.peerManager.wakuPeerStore.peers().len == 1
@@ -681,9 +682,9 @@ procSuite "Peer Manager":
 
     # all nodes connect to peer 0
     require:
-      (await nodes[1].peerManager.connect(peerInfos[0])) == true
-      (await nodes[2].peerManager.connect(peerInfos[0])) == true
-      (await nodes[3].peerManager.connect(peerInfos[0])) == true
+      (await nodes[1].peerManager.connectPeer(peerInfos[0])) == true
+      (await nodes[2].peerManager.connectPeer(peerInfos[0])) == true
+      (await nodes[3].peerManager.connectPeer(peerInfos[0])) == true
 
     await sleepAsync(chronos.milliseconds(500))
 
@@ -809,9 +810,9 @@ procSuite "Peer Manager":
     # create some connections/streams
     check:
       # some relay connections
-      (await nodes[0].peerManager.connect(pInfos[1])) == true
-      (await nodes[0].peerManager.connect(pInfos[2])) == true
-      (await nodes[1].peerManager.connect(pInfos[2])) == true
+      (await nodes[0].peerManager.connectPeer(pInfos[1])) == true
+      (await nodes[0].peerManager.connectPeer(pInfos[2])) == true
+      (await nodes[1].peerManager.connectPeer(pInfos[2])) == true
 
       (await nodes[0].peerManager.dialPeer(pInfos[1], WakuFilterSubscribeCodec)).isSome() ==
         true
@@ -1128,16 +1129,16 @@ procSuite "Peer Manager":
     nodes[0].peerManager.colocationLimit = 1
 
     # 2 in connections
-    discard await nodes[1].peerManager.connect(pInfos[0])
-    discard await nodes[2].peerManager.connect(pInfos[0])
+    discard await nodes[1].peerManager.connectPeer(pInfos[0])
+    discard await nodes[2].peerManager.connectPeer(pInfos[0])
     await sleepAsync(chronos.milliseconds(500))
 
     # but one is pruned
     check nodes[0].peerManager.switch.connManager.getConnections().len == 1
 
     # 2 out connections
-    discard await nodes[0].peerManager.connect(pInfos[3])
-    discard await nodes[0].peerManager.connect(pInfos[4])
+    discard await nodes[0].peerManager.connectPeer(pInfos[3])
+    discard await nodes[0].peerManager.connectPeer(pInfos[4])
     await sleepAsync(chronos.milliseconds(500))
 
     # they are also prunned

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -37,7 +37,7 @@ import
   ./testlib/wakunode
 
 procSuite "Peer Manager":
-  asyncTest "connectRelay() works":
+  asyncTest "connect() works":
     # Create 2 nodes
     let nodes = toSeq(0 ..< 2).mapIt(
         newTestWakuNode(generateSecp256k1Key(), ValidIpAddress.init("0.0.0.0"), Port(0))
@@ -45,7 +45,7 @@ procSuite "Peer Manager":
     await allFutures(nodes.mapIt(it.start()))
 
     let connOk =
-      await nodes[0].peerManager.connectRelay(nodes[1].peerInfo.toRemotePeerInfo())
+      await nodes[0].peerManager.connect(nodes[1].peerInfo.toRemotePeerInfo())
     await sleepAsync(chronos.milliseconds(500))
 
     check:
@@ -178,7 +178,7 @@ procSuite "Peer Manager":
 
     let nonExistentPeer = nonExistentPeerRes.value
     require:
-      (await nodes[0].peerManager.connectRelay(nonExistentPeer)) == false
+      (await nodes[0].peerManager.connect(nonExistentPeer)) == false
     await sleepAsync(chronos.milliseconds(500))
 
     check:
@@ -188,8 +188,7 @@ procSuite "Peer Manager":
 
     # Successful connection
     require:
-      (await nodes[0].peerManager.connectRelay(nodes[1].peerInfo.toRemotePeerInfo())) ==
-        true
+      (await nodes[0].peerManager.connect(nodes[1].peerInfo.toRemotePeerInfo())) == true
     await sleepAsync(chronos.milliseconds(500))
 
     check:
@@ -229,7 +228,7 @@ procSuite "Peer Manager":
     nodes[0].peerManager.backoffFactor = 2
 
     # try to connect to peer that doesnt exist
-    let conn1Ok = await nodes[0].peerManager.connectRelay(nonExistentPeer)
+    let conn1Ok = await nodes[0].peerManager.connect(nonExistentPeer)
     check:
       # Cannot connect to node2
       nodes[0].peerManager.wakuPeerStore.connectedness(nonExistentPeer.peerId) ==
@@ -256,7 +255,7 @@ procSuite "Peer Manager":
     nodes[0].peerManager.wakuPeerStore[NumberFailedConnBook][nodes[1].peerInfo.peerId] =
       4
     let conn2Ok =
-      await nodes[0].peerManager.connectRelay(nodes[1].peerInfo.toRemotePeerInfo())
+      await nodes[0].peerManager.connect(nodes[1].peerInfo.toRemotePeerInfo())
     check:
       conn2Ok == true
       nodes[0].peerManager.wakuPeerStore[NumberFailedConnBook][nodes[1].peerInfo.peerId] ==
@@ -286,7 +285,7 @@ procSuite "Peer Manager":
     var remotePeerInfo2 = peerInfo2.toRemotePeerInfo()
     remotePeerInfo2.enr = some(node2.enr)
 
-    let is12Connected = await node1.peerManager.connectRelay(remotePeerInfo2)
+    let is12Connected = await node1.peerManager.connect(remotePeerInfo2)
     assert is12Connected == true, "Node 1 and 2 not connected"
 
     check:
@@ -356,7 +355,7 @@ procSuite "Peer Manager":
     var remotePeerInfo2 = peerInfo2.toRemotePeerInfo()
     remotePeerInfo2.enr = some(node2.enr)
 
-    let is12Connected = await node1.peerManager.connectRelay(remotePeerInfo2)
+    let is12Connected = await node1.peerManager.connect(remotePeerInfo2)
     assert is12Connected == true, "Node 1 and 2 not connected"
 
     check:
@@ -485,7 +484,7 @@ procSuite "Peer Manager":
     node2.wakuRelay.codec = betaCodec
 
     require:
-      (await node1.peerManager.connectRelay(peerInfo2.toRemotePeerInfo())) == true
+      (await node1.peerManager.connect(peerInfo2.toRemotePeerInfo())) == true
     check:
       # Currently connected to node2
       node1.peerManager.wakuPeerStore.peers().len == 1
@@ -682,9 +681,9 @@ procSuite "Peer Manager":
 
     # all nodes connect to peer 0
     require:
-      (await nodes[1].peerManager.connectRelay(peerInfos[0])) == true
-      (await nodes[2].peerManager.connectRelay(peerInfos[0])) == true
-      (await nodes[3].peerManager.connectRelay(peerInfos[0])) == true
+      (await nodes[1].peerManager.connect(peerInfos[0])) == true
+      (await nodes[2].peerManager.connect(peerInfos[0])) == true
+      (await nodes[3].peerManager.connect(peerInfos[0])) == true
 
     await sleepAsync(chronos.milliseconds(500))
 
@@ -810,9 +809,9 @@ procSuite "Peer Manager":
     # create some connections/streams
     check:
       # some relay connections
-      (await nodes[0].peerManager.connectRelay(pInfos[1])) == true
-      (await nodes[0].peerManager.connectRelay(pInfos[2])) == true
-      (await nodes[1].peerManager.connectRelay(pInfos[2])) == true
+      (await nodes[0].peerManager.connect(pInfos[1])) == true
+      (await nodes[0].peerManager.connect(pInfos[2])) == true
+      (await nodes[1].peerManager.connect(pInfos[2])) == true
 
       (await nodes[0].peerManager.dialPeer(pInfos[1], WakuFilterSubscribeCodec)).isSome() ==
         true
@@ -1129,16 +1128,16 @@ procSuite "Peer Manager":
     nodes[0].peerManager.colocationLimit = 1
 
     # 2 in connections
-    discard await nodes[1].peerManager.connectRelay(pInfos[0])
-    discard await nodes[2].peerManager.connectRelay(pInfos[0])
+    discard await nodes[1].peerManager.connect(pInfos[0])
+    discard await nodes[2].peerManager.connect(pInfos[0])
     await sleepAsync(chronos.milliseconds(500))
 
     # but one is pruned
     check nodes[0].peerManager.switch.connManager.getConnections().len == 1
 
     # 2 out connections
-    discard await nodes[0].peerManager.connectRelay(pInfos[3])
-    discard await nodes[0].peerManager.connectRelay(pInfos[4])
+    discard await nodes[0].peerManager.connect(pInfos[3])
+    discard await nodes[0].peerManager.connect(pInfos[4])
     await sleepAsync(chronos.milliseconds(500))
 
     # they are also prunned

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -137,11 +137,9 @@ suite "WakuNode":
     await node3.start()
     await node3.mountRelay()
 
-    discard
-      await node1.peerManager.connectRelay(node2.switch.peerInfo.toRemotePeerInfo())
+    discard await node1.peerManager.connect(node2.switch.peerInfo.toRemotePeerInfo())
     await sleepAsync(3.seconds)
-    discard
-      await node1.peerManager.connectRelay(node3.switch.peerInfo.toRemotePeerInfo())
+    discard await node1.peerManager.connect(node3.switch.peerInfo.toRemotePeerInfo())
 
     check:
       # Verify that only the first connection succeeded

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -137,9 +137,11 @@ suite "WakuNode":
     await node3.start()
     await node3.mountRelay()
 
-    discard await node1.peerManager.connect(node2.switch.peerInfo.toRemotePeerInfo())
+    discard
+      await node1.peerManager.connectPeer(node2.switch.peerInfo.toRemotePeerInfo())
     await sleepAsync(3.seconds)
-    discard await node1.peerManager.connect(node3.switch.peerInfo.toRemotePeerInfo())
+    discard
+      await node1.peerManager.connectPeer(node3.switch.peerInfo.toRemotePeerInfo())
 
     check:
       # Verify that only the first connection succeeded

--- a/tests/waku_peer_exchange/test_protocol.nim
+++ b/tests/waku_peer_exchange/test_protocol.nim
@@ -120,7 +120,7 @@ suite "Waku Peer Exchange":
 
       # node2 can be connected, so will be returned by peer exchange
       require (
-        await node1.peerManager.connectRelay(node2.switch.peerInfo.toRemotePeerInfo())
+        await node1.peerManager.connect(node2.switch.peerInfo.toRemotePeerInfo())
       )
 
       # Mount peer exchange

--- a/tests/waku_peer_exchange/test_protocol.nim
+++ b/tests/waku_peer_exchange/test_protocol.nim
@@ -120,7 +120,7 @@ suite "Waku Peer Exchange":
 
       # node2 can be connected, so will be returned by peer exchange
       require (
-        await node1.peerManager.connect(node2.switch.peerInfo.toRemotePeerInfo())
+        await node1.peerManager.connectPeer(node2.switch.peerInfo.toRemotePeerInfo())
       )
 
       # Mount peer exchange

--- a/tests/waku_relay/test_protocol.nim
+++ b/tests/waku_relay/test_protocol.nim
@@ -1252,7 +1252,7 @@ suite "Waku Relay":
 
       check await peerManager.connectPeer(otherRemotePeerInfo)
 
-      # FIXME: Once stopped and started, nodes are not considered connected, nor do they reconnect after running connect, as below
+      # FIXME: Once stopped and started, nodes are not considered connected, nor do they reconnect after running connectPeer, as below
       # check await otherPeerManager.connectPeer(otherRemotePeerInfo)
 
       # When sending a message from node

--- a/tests/waku_relay/test_protocol.nim
+++ b/tests/waku_relay/test_protocol.nim
@@ -104,7 +104,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(
@@ -165,7 +165,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(
@@ -284,7 +284,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(
@@ -374,7 +374,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(
@@ -456,8 +456,8 @@ suite "Waku Relay":
         anotherPeerId = anotherRemotePeerInfo.peerId
 
       check:
-        await peerManager.connect(otherRemotePeerInfo)
-        await peerManager.connect(anotherRemotePeerInfo)
+        await peerManager.connectPeer(otherRemotePeerInfo)
+        await peerManager.connectPeer(anotherRemotePeerInfo)
 
       # Given the first node is subscribed to two pubsub topics
       var handlerFuture2 = newPushHandlerFuture()
@@ -673,7 +673,7 @@ suite "Waku Relay":
         otherMsg6 == fromOtherNodeWakuMessage3
 
       # Given anotherNode is reconnected, but to otherNode
-      check await anotherPeerManager.connect(otherRemotePeerInfo)
+      check await anotherPeerManager.connectPeer(otherRemotePeerInfo)
       check:
         anotherPeerManager.switch.isConnected(otherPeerId)
         otherPeerManager.switch.isConnected(anotherPeerId)
@@ -848,7 +848,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       var otherHandlerFuture = newPushHandlerFuture()
@@ -1014,7 +1014,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       var otherHandlerFuture = newPushHandlerFuture()
@@ -1145,7 +1145,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       # Create a different handler than the default to include messages in a seq
@@ -1230,7 +1230,7 @@ suite "Waku Relay":
         otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
         otherPeerId = otherRemotePeerInfo.peerId
 
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       var otherHandlerFuture = newPushHandlerFuture()
@@ -1250,10 +1250,10 @@ suite "Waku Relay":
       await otherSwitch.stop()
       await otherSwitch.start()
 
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       # FIXME: Once stopped and started, nodes are not considered connected, nor do they reconnect after running connect, as below
-      # check await otherPeerManager.connect(otherRemotePeerInfo)
+      # check await otherPeerManager.connectPeer(otherRemotePeerInfo)
 
       # When sending a message from node
       let msg1 = fakeWakuMessage(testMessage, pubsubTopic)
@@ -1282,7 +1282,7 @@ suite "Waku Relay":
       # Given node is stopped and restarted
       await switch.stop()
       await switch.start()
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       # When sending a message from node
       handlerFuture = newPushHandlerFuture()
@@ -1325,7 +1325,7 @@ suite "Waku Relay":
         otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
         otherPeerId = otherRemotePeerInfo.peerId
 
-      check await peerManager.connect(otherRemotePeerInfo)
+      check await peerManager.connectPeer(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       var otherHandlerFuture = newPushHandlerFuture()

--- a/tests/waku_relay/test_protocol.nim
+++ b/tests/waku_relay/test_protocol.nim
@@ -104,7 +104,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(
@@ -165,7 +165,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(
@@ -284,7 +284,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(
@@ -374,7 +374,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       var otherHandlerFuture = newPushHandlerFuture()
       proc otherSimpleFutureHandler(
@@ -456,8 +456,8 @@ suite "Waku Relay":
         anotherPeerId = anotherRemotePeerInfo.peerId
 
       check:
-        await peerManager.connectRelay(otherRemotePeerInfo)
-        await peerManager.connectRelay(anotherRemotePeerInfo)
+        await peerManager.connect(otherRemotePeerInfo)
+        await peerManager.connect(anotherRemotePeerInfo)
 
       # Given the first node is subscribed to two pubsub topics
       var handlerFuture2 = newPushHandlerFuture()
@@ -673,7 +673,7 @@ suite "Waku Relay":
         otherMsg6 == fromOtherNodeWakuMessage3
 
       # Given anotherNode is reconnected, but to otherNode
-      check await anotherPeerManager.connectRelay(otherRemotePeerInfo)
+      check await anotherPeerManager.connect(otherRemotePeerInfo)
       check:
         anotherPeerManager.switch.isConnected(otherPeerId)
         otherPeerManager.switch.isConnected(anotherPeerId)
@@ -848,7 +848,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       var otherHandlerFuture = newPushHandlerFuture()
@@ -1014,7 +1014,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       var otherHandlerFuture = newPushHandlerFuture()
@@ -1145,7 +1145,7 @@ suite "Waku Relay":
 
       await allFutures(otherSwitch.start(), otherNode.start())
       let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       # Create a different handler than the default to include messages in a seq
@@ -1230,7 +1230,7 @@ suite "Waku Relay":
         otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
         otherPeerId = otherRemotePeerInfo.peerId
 
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       var otherHandlerFuture = newPushHandlerFuture()
@@ -1250,10 +1250,10 @@ suite "Waku Relay":
       await otherSwitch.stop()
       await otherSwitch.start()
 
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
-      # FIXME: Once stopped and started, nodes are not considered connected, nor do they reconnect after running connectRelay, as below
-      # check await otherPeerManager.connectRelay(otherRemotePeerInfo)
+      # FIXME: Once stopped and started, nodes are not considered connected, nor do they reconnect after running connect, as below
+      # check await otherPeerManager.connect(otherRemotePeerInfo)
 
       # When sending a message from node
       let msg1 = fakeWakuMessage(testMessage, pubsubTopic)
@@ -1282,7 +1282,7 @@ suite "Waku Relay":
       # Given node is stopped and restarted
       await switch.stop()
       await switch.start()
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       # When sending a message from node
       handlerFuture = newPushHandlerFuture()
@@ -1325,7 +1325,7 @@ suite "Waku Relay":
         otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
         otherPeerId = otherRemotePeerInfo.peerId
 
-      check await peerManager.connectRelay(otherRemotePeerInfo)
+      check await peerManager.connect(otherRemotePeerInfo)
 
       # Given both are subscribed to the same pubsub topic
       var otherHandlerFuture = newPushHandlerFuture()

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -213,9 +213,8 @@ suite "WakuNode - Relay":
     await allFutures(nodes.mapIt(it.mountRelay()))
 
     # Connect nodes
-    let connOk = await nodes[0].peerManager.connectRelay(
-      nodes[1].switch.peerInfo.toRemotePeerInfo()
-    )
+    let connOk =
+      await nodes[0].peerManager.connect(nodes[1].switch.peerInfo.toRemotePeerInfo())
     require:
       connOk == true
 
@@ -521,7 +520,7 @@ suite "WakuNode - Relay":
       for j in 0 ..< 5:
         if i == j:
           continue
-        let connOk = await nodes[i].peerManager.connectRelay(
+        let connOk = await nodes[i].peerManager.connect(
           nodes[j].switch.peerInfo.toRemotePeerInfo()
         )
         require connOk

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -213,8 +213,9 @@ suite "WakuNode - Relay":
     await allFutures(nodes.mapIt(it.mountRelay()))
 
     # Connect nodes
-    let connOk =
-      await nodes[0].peerManager.connect(nodes[1].switch.peerInfo.toRemotePeerInfo())
+    let connOk = await nodes[0].peerManager.connectPeer(
+      nodes[1].switch.peerInfo.toRemotePeerInfo()
+    )
     require:
       connOk == true
 
@@ -520,7 +521,7 @@ suite "WakuNode - Relay":
       for j in 0 ..< 5:
         if i == j:
           continue
-        let connOk = await nodes[i].peerManager.connect(
+        let connOk = await nodes[i].peerManager.connectPeer(
           nodes[j].switch.peerInfo.toRemotePeerInfo()
         )
         require connOk

--- a/tests/wakunode2/test_validators.nim
+++ b/tests/wakunode2/test_validators.nim
@@ -60,7 +60,7 @@ suite "WakuNode2 - Validators":
       for j in 0 ..< 5:
         if i == j:
           continue
-        let connOk = await nodes[i].peerManager.connect(
+        let connOk = await nodes[i].peerManager.connectPeer(
           nodes[j].switch.peerInfo.toRemotePeerInfo()
         )
         require connOk
@@ -150,7 +150,7 @@ suite "WakuNode2 - Validators":
       for j in 0 ..< 5:
         if i == j:
           continue
-        let connOk = await nodes[i].peerManager.connect(
+        let connOk = await nodes[i].peerManager.connectPeer(
           nodes[j].switch.peerInfo.toRemotePeerInfo()
         )
         require connOk
@@ -305,8 +305,9 @@ suite "WakuNode2 - Validators":
       )
 
     # nodes[0] is connected only to nodes[1]
-    let connOk1 =
-      await nodes[0].peerManager.connect(nodes[1].switch.peerInfo.toRemotePeerInfo())
+    let connOk1 = await nodes[0].peerManager.connectPeer(
+      nodes[1].switch.peerInfo.toRemotePeerInfo()
+    )
     require connOk1
 
     # rest of nodes[1..4] are connected in a full mesh
@@ -314,7 +315,7 @@ suite "WakuNode2 - Validators":
       for j in 1 ..< 5:
         if i == j:
           continue
-        let connOk2 = await nodes[i].peerManager.connect(
+        let connOk2 = await nodes[i].peerManager.connectPeer(
           nodes[j].switch.peerInfo.toRemotePeerInfo()
         )
         require connOk2

--- a/tests/wakunode2/test_validators.nim
+++ b/tests/wakunode2/test_validators.nim
@@ -60,7 +60,7 @@ suite "WakuNode2 - Validators":
       for j in 0 ..< 5:
         if i == j:
           continue
-        let connOk = await nodes[i].peerManager.connectRelay(
+        let connOk = await nodes[i].peerManager.connect(
           nodes[j].switch.peerInfo.toRemotePeerInfo()
         )
         require connOk
@@ -150,7 +150,7 @@ suite "WakuNode2 - Validators":
       for j in 0 ..< 5:
         if i == j:
           continue
-        let connOk = await nodes[i].peerManager.connectRelay(
+        let connOk = await nodes[i].peerManager.connect(
           nodes[j].switch.peerInfo.toRemotePeerInfo()
         )
         require connOk
@@ -305,9 +305,8 @@ suite "WakuNode2 - Validators":
       )
 
     # nodes[0] is connected only to nodes[1]
-    let connOk1 = await nodes[0].peerManager.connectRelay(
-      nodes[1].switch.peerInfo.toRemotePeerInfo()
-    )
+    let connOk1 =
+      await nodes[0].peerManager.connect(nodes[1].switch.peerInfo.toRemotePeerInfo())
     require connOk1
 
     # rest of nodes[1..4] are connected in a full mesh
@@ -315,7 +314,7 @@ suite "WakuNode2 - Validators":
       for j in 1 ..< 5:
         if i == j:
           continue
-        let connOk2 = await nodes[i].peerManager.connectRelay(
+        let connOk2 = await nodes[i].peerManager.connect(
           nodes[j].switch.peerInfo.toRemotePeerInfo()
         )
         require connOk2

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -184,8 +184,8 @@ suite "Waku v2 Rest API - Admin":
     node1.peerManager.addPeer(peerInfo3, PeerExchange)
 
     # Connecting to both peers
-    let conn2 = await node1.peerManager.connectRelay(peerInfo2)
-    let conn3 = await node1.peerManager.connectRelay(peerInfo3)
+    let conn2 = await node1.peerManager.connect(peerInfo2)
+    let conn3 = await node1.peerManager.connect(peerInfo3)
 
     # Check successful connections
     check:

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -184,8 +184,8 @@ suite "Waku v2 Rest API - Admin":
     node1.peerManager.addPeer(peerInfo3, PeerExchange)
 
     # Connecting to both peers
-    let conn2 = await node1.peerManager.connect(peerInfo2)
-    let conn3 = await node1.peerManager.connect(peerInfo3)
+    let conn2 = await node1.peerManager.connectPeer(peerInfo2)
+    let conn3 = await node1.peerManager.connectPeer(peerInfo3)
 
     # Check successful connections
     check:

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -430,9 +430,6 @@ proc startNode*(
       error "error while fetching peers from peer exchange", error = error
       quit(QuitFailure)
 
-  #[   if conf.dnsDiscovery and dynamicBootstrapNodes.len == 0:
-    retrieveDynamicBootstrapNodes() ]#
-
   # Start keepalive, if enabled
   if conf.keepAlive:
     node.startKeepalive()

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -402,18 +402,12 @@ proc startNode*(
 
   # Connect to configured static nodes
   if conf.staticnodes.len > 0:
-    if not conf.relay:
-      return err("waku relay (--relay=true) should be set when configuring staticnodes")
     try:
       await connectToNodes(node, conf.staticnodes, "static")
     except CatchableError:
       return err("failed to connect to static nodes: " & getCurrentExceptionMsg())
 
   if dynamicBootstrapNodes.len > 0:
-    if not conf.relay:
-      return err(
-        "waku relay (--relay=true) should be set when configuring dynamicBootstrapNodes"
-      )
     info "Connecting to dynamic bootstrap peers"
     try:
       await connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -430,6 +430,9 @@ proc startNode*(
       error "error while fetching peers from peer exchange", error = error
       quit(QuitFailure)
 
+  #[   if conf.dnsDiscovery and dynamicBootstrapNodes.len == 0:
+    retrieveDynamicBootstrapNodes() ]#
+
   # Start keepalive, if enabled
   if conf.keepAlive:
     node.startKeepalive()

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -416,7 +416,7 @@ proc dialPeer(
 
   let res = catch:
     if await dialFut.withTimeout(dialTimeout):
-      return ok(some(dialFut.read()))
+      return some(dialFut.read())
     else:
       await cancelAndWait(dialFut)
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -279,7 +279,7 @@ proc pruneInRelayConns(pm: PeerManager, amount: int) {.async.}
 # Connects to a given node. Note that this function uses `connect` and
 # does not provide a protocol. Streams for relay (gossipsub) are created
 # automatically without the needing to dial.
-proc connect*(
+proc connectPeer*(
     pm: PeerManager,
     peer: RemotePeerInfo,
     dialTimeout = DefaultDialTimeout,
@@ -352,7 +352,7 @@ proc connectToNodes*(
   for node in nodes:
     let node = parsePeerInfo(node)
     if node.isOk():
-      futConns.add(pm.connect(node.value))
+      futConns.add(pm.connectPeer(node.value))
       connectedPeers.add(node.value)
     else:
       error "Couldn't parse node info", error = node.error

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -400,28 +400,18 @@ proc dialPeer(
     proto: "",
     dialTimeout = DefaultDialTimeout,
     source = "api",
-): Future[Result[Option[Connection], string]] {.async.} =
+): Future[Option[Connection]] {.async.} =
   if peerId == pm.switch.peerInfo.peerId:
-    let msg = "could not dial self"
-    error "dialPeer failed", error = msg
-    return err(msg)
+    error "could not dial self"
+    return none(Connection)
 
   if proto == WakuRelayCodec:
-    let msg = "dial shall not be used to connect to relays"
-    error "dialPeer failed", error = msg
-    return err(msg)
+    error "dial shall not be used to connect to relays"
+    return none(Connection)
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
 
   # Dial Peer
-
-  if proto == "":
-    if not await pm.switch.connect(peerId, addrs).withTimeout(dialTimeout):
-      let msg = "connection attempt timed out"
-      error "dialPeer failed", peerId = peerId, error = msg
-      return err(msg)
-    return ok(none(Connection))
-
   let dialFut = pm.switch.dial(peerId, addrs, proto)
 
   let res = catch:
@@ -434,7 +424,7 @@ proc dialPeer(
 
   trace "Dialing peer failed", peerId = peerId, reason = reasonFailed, proto = proto
 
-  return err(reasonFailed)
+  return none(Connection)
 
 proc dialPeer*(
     pm: PeerManager,
@@ -442,7 +432,7 @@ proc dialPeer*(
     proto: "",
     dialTimeout = DefaultDialTimeout,
     source = "api",
-): Future[Result[Option[Connection]]] {.async.} =
+): Future[Option[Connection]] {.async.} =
   # Dial a given peer and add it to the list of known peers
   # TODO: check peer validity and score before continuing. Limit number of peers to be managed.
 
@@ -463,7 +453,7 @@ proc dialPeer*(
     proto: "",
     dialTimeout = DefaultDialTimeout,
     source = "api",
-): Future[Result[Option[Connection]]] {.async.} =
+): Future[Option[Connection]] {.async.} =
   # Dial an existing peer by looking up it's existing addrs in the switch's peerStore
   # TODO: check peer validity and score before continuing. Limit number of peers to be managed.
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -397,7 +397,7 @@ proc dialPeer(
     pm: PeerManager,
     peerId: PeerID,
     addrs: seq[MultiAddress],
-    proto: "",
+    proto: string,
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =
@@ -429,7 +429,7 @@ proc dialPeer(
 proc dialPeer*(
     pm: PeerManager,
     remotePeerInfo: RemotePeerInfo,
-    proto: "",
+    proto: string,
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =
@@ -450,7 +450,7 @@ proc dialPeer*(
 proc dialPeer*(
     pm: PeerManager,
     peerId: PeerID,
-    proto: "",
+    proto: string,
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Option[Connection]] {.async.} =

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1215,18 +1215,6 @@ proc mountLibp2pPing*(node: WakuNode) {.async: (raises: []).} =
   except LPError:
     error "failed to mount libp2pPing", error = getCurrentExceptionMsg()
 
-#[ proc dnsDiscoverWithBackoff*(
-    node: WakuNode, dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
-) {.async.} =
-  var discoveredPeers: seq[RemotePeerInfo] = @[]
-
-  while node.started and bootstrapNodes.len == 0:
-    discoveredPeers:
-      seq[RemotePeerInfo] = retrieveDynamicBootstrapNodes(
-        true, dnsDiscoveryUrl, dnsDiscoveryNameServers
-      ).valueOr:
-        await sleepAsync(30.seconds) ]#
-
 # TODO: Move this logic to PeerManager
 proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
   while node.started:

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1215,6 +1215,18 @@ proc mountLibp2pPing*(node: WakuNode) {.async: (raises: []).} =
   except LPError:
     error "failed to mount libp2pPing", error = getCurrentExceptionMsg()
 
+#[ proc dnsDiscoverWithBackoff*(
+    node: WakuNode, dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
+) {.async.} =
+  var discoveredPeers: seq[RemotePeerInfo] = @[]
+
+  while node.started and bootstrapNodes.len == 0:
+    discoveredPeers:
+      seq[RemotePeerInfo] = retrieveDynamicBootstrapNodes(
+        true, dnsDiscoveryUrl, dnsDiscoveryNameServers
+      ).valueOr:
+        await sleepAsync(30.seconds) ]#
+
 # TODO: Move this logic to PeerManager
 proc keepaliveLoop(node: WakuNode, keepalive: chronos.Duration) {.async.} =
   while node.started:

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -140,7 +140,7 @@ proc installAdminV1PostPeersHandler(router: var RestRouter, node: WakuNode) =
         let e = $error
         return RestApiResponse.badRequest(fmt("Couldn't parse remote peer info: {e}"))
 
-      if not (await node.peerManager.connectRelay(peerInfo, source = "rest")):
+      if not (await node.peerManager.connect(peerInfo, source = "rest")):
         return RestApiResponse.badRequest(
           fmt("Failed to connect to peer at index: {i} - {peer}")
         )

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -140,7 +140,7 @@ proc installAdminV1PostPeersHandler(router: var RestRouter, node: WakuNode) =
         let e = $error
         return RestApiResponse.badRequest(fmt("Couldn't parse remote peer info: {e}"))
 
-      if not (await node.peerManager.connect(peerInfo, source = "rest")):
+      if not (await node.peerManager.connectPeer(peerInfo, source = "rest")):
         return RestApiResponse.badRequest(
           fmt("Failed to connect to peer at index: {i} - {peer}")
         )


### PR DESCRIPTION
# Description
Looking deeper at the code, I noticed that the `connectRelay` procedure uses the `nim-libp2p` `connect` procedure that connects to a node without setting a protocol. `connectRelay` was a misnomer and it's more correct to call it`connectPeer` 

# Changes

<!-- List of detailed changes -->

- [x] renaming `connectRelay` to `connectPeer`
- [x] removing checks for `Relay` being configured before calling `connectPeer`
- [x] in `connectPeer`, add peer if it's not found in the peer store instead of looking specifically for Waku Relay's codec 

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->