### PR TITLE
refactor(libwaku): allow several multiaddresses for a single peer in store queries

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -710,7 +710,7 @@ proc waku_peer_exchange_request(
 
 proc waku_ping_peer(
     ctx: ptr WakuContext,
-    peerID: cstring,
+    peerAddr: cstring,
     timeoutMs: cuint,
     callback: WakuCallBack,
     userData: pointer,
@@ -721,7 +721,7 @@ proc waku_ping_peer(
   .sendRequestToWakuThread(
     ctx,
     RequestType.PING,
-    PingRequest.createShared(peerID, chronos.milliseconds(timeoutMs)),
+    PingRequest.createShared(peerAddr, chronos.milliseconds(timeoutMs)),
   )
   .handleRes(callback, userData)
 

--- a/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
@@ -1,4 +1,4 @@
-import std/[json, sugar, options]
+import std/[json, sugar, strutils, options]
 import chronos, chronicles, results
 import
   ../../../../../waku/factory/waku,
@@ -125,7 +125,7 @@ proc process(
 
   let storeQueryRequest = JsonStoreQueryRequest.fromJsonNode(jsonContentRes.get())
 
-  let peer = peers.parsePeerInfo($self[].peerAddr).valueOr:
+  let peer = peers.parsePeerInfo(($self[].peerAddr).split(",")).valueOr:
     return err("JsonStoreQueryRequest failed to parse peer addr: " & $error)
 
   let queryResponse = (await waku.node.wakuStoreClient.query(storeQueryRequest, peer)).valueOr:


### PR DESCRIPTION
nim-libp2p should choose then which multiaddr to use when dialing the peer. This is useful since for example in status-go the storenode list contains both the multiaddress with a DNS, and also another with an IP (for the cases in which for some reason the nameserver fail to resolve the dns name).

It also fixes a parameter name in the ping requests