### PR TITLE
chore: Partial version bumps for v0.34.0-rc.1

### DIFF
--- a/tests/test_waku_rendezvous.nim
+++ b/tests/test_waku_rendezvous.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import chronos, testutils/unittests, libp2p, libp2p/protocols/rendezvous
+import chronos, testutils/unittests, libp2p/builders, libp2p/protocols/rendezvous
 
 import waku/node/waku_switch, ./testlib/common, ./testlib/wakucore
 

--- a/tests/test_waku_switch.nim
+++ b/tests/test_waku_switch.nim
@@ -3,7 +3,7 @@
 import
   testutils/unittests,
   chronos,
-  libp2p,
+  libp2p/builders,
   libp2p/protocols/connectivity/autonat/client,
   libp2p/protocols/connectivity/relay/relay,
   libp2p/protocols/connectivity/relay/client,

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1262,11 +1262,8 @@ proc startKeepalive*(node: WakuNode, keepalive = 2.minutes) =
 proc mountRendezvous*(node: WakuNode) {.async: (raises: []).} =
   info "mounting rendezvous discovery protocol"
 
-  # Workaround for lazy libp2p change, only Rendezvous new declares possible exception.
-  # Until it not gets fixed we need to call setup separately.
   try:
-    node.rendezvous = RendezVous.new()
-    node.rendezvous.setup(node.switch)
+    node.rendezvous = RendezVous.new(node.switch)
   except Exception as e:
     error "failed to create rendezvous", error = getCurrentExceptionMsg()
     return

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1262,7 +1262,14 @@ proc startKeepalive*(node: WakuNode, keepalive = 2.minutes) =
 proc mountRendezvous*(node: WakuNode) {.async: (raises: []).} =
   info "mounting rendezvous discovery protocol"
 
-  node.rendezvous = RendezVous.new(node.switch)
+  # Workaround for lazy libp2p change, only Rendezvous new declares possible exception.
+  # Until it not gets fixed we need to call setup separately.
+  try:
+    node.rendezvous = RendezVous.new(node.switch)
+    # node.rendezvous.setup(node.switch)
+  except Exception as e:
+    error "failed to create rendezvous", error = getCurrentExceptionMsg()
+    return
 
   if node.started:
     try:

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1265,8 +1265,8 @@ proc mountRendezvous*(node: WakuNode) {.async: (raises: []).} =
   # Workaround for lazy libp2p change, only Rendezvous new declares possible exception.
   # Until it not gets fixed we need to call setup separately.
   try:
-    node.rendezvous = RendezVous.new(node.switch)
-    # node.rendezvous.setup(node.switch)
+    node.rendezvous = RendezVous.new()
+    node.rendezvous.setup(node.switch)
   except Exception as e:
     error "failed to create rendezvous", error = getCurrentExceptionMsg()
     return


### PR DESCRIPTION
# Description
Due to the issues arose in https://github.com/waku-org/nwaku/pull/3096
We decided to make a partial version bumping of vendor libs for v0.34.0-rc1.

# Changes

- [ ] nim-chronicles
- [ ] nim-eth
- [ ] nim-http-utils
- [ ] nim-json-rpc
- [ ] nim-json-serialization
- [x] nim-libp2p - tp ver 1.7.1
- [ ] nim-metrics
- [ ] nim-nat-traversal
- [ ] nim-presto
- [ ] nim-secp256k1
- [ ] nim-serialization
- [ ] nim-stew
- [ ] nim-taskpools
- [ ] nim-testutils
- [ ] nim-toml-serialization
- [ ] nim-unicodedb
- [ ] nim-unittest2
- [ ] nim-web3
- [ ] nim-websock
- [ ] nim-zlib
- [ ] nimcrypto

Due to the huge refactorings in nim-web3 and nim-eth modules:
Code changes:
- [x] waku/node/waku_node.nim
- [x] make import explicit in waku tests to avoid add new - yet unused - libp2p deps: quick and ngtcp2

## Issue
https://github.com/waku-org/nwaku/issues/3087