### PR TITLE
feat: making dns discovery async

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -439,7 +439,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
 
     var wakuDnsDiscovery = WakuDnsDiscovery.init(dnsDiscoveryUrl.get(), resolver)
     if wakuDnsDiscovery.isOk:
-      let discoveredPeers = wakuDnsDiscovery.get().findPeers()
+      let discoveredPeers = await wakuDnsDiscovery.get().findPeers()
       if discoveredPeers.isOk:
         info "Connecting to discovered peers"
         discoveredNodes = discoveredPeers.get()

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -353,9 +353,11 @@ proc crawlNetwork(
 
     await sleepAsync(crawlInterval.millis - elapsed.millis)
 
-proc retrieveDynamicBootstrapNodes(
+proc retrieveDynamicBootstrapNodes*(
     dnsDiscovery: bool, dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
-): Result[seq[RemotePeerInfo], string] =
+): Future[Result[seq[RemotePeerInfo], string]] {.async.} =
+  ## Retrieve dynamic bootstrap nodes (DNS discovery)
+
   if dnsDiscovery and dnsDiscoveryUrl != "":
     # DNS discovery
     debug "Discovering nodes using Waku DNS discovery", url = dnsDiscoveryUrl
@@ -373,10 +375,10 @@ proc retrieveDynamicBootstrapNodes(
 
     var wakuDnsDiscovery = WakuDnsDiscovery.init(dnsDiscoveryUrl, resolver)
     if wakuDnsDiscovery.isOk():
-      return wakuDnsDiscovery.get().findPeers().mapErr(
-          proc(e: cstring): string =
-            $e
-        )
+      return (await wakuDnsDiscovery.get().findPeers()).mapErr(
+        proc(e: cstring): string =
+          $e
+      )
     else:
       warn "Failed to init Waku DNS discovery"
 

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -353,7 +353,7 @@ proc crawlNetwork(
 
     await sleepAsync(crawlInterval.millis - elapsed.millis)
 
-proc retrieveDynamicBootstrapNodes*(
+proc retrieveDynamicBootstrapNodes(
     dnsDiscovery: bool, dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
 ): Future[Result[seq[RemotePeerInfo], string]] {.async.} =
   ## Retrieve dynamic bootstrap nodes (DNS discovery)

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -371,7 +371,8 @@ proc retrieveDynamicBootstrapNodes(
     proc resolver(domain: string): Future[string] {.async, gcsafe.} =
       trace "resolving", domain = domain
       let resolved = await dnsResolver.resolveTxt(domain)
-      return resolved[0] # Use only first answer
+      if resolved.len > 0:
+        return resolved[0] # Use only first answer
 
     var wakuDnsDiscovery = WakuDnsDiscovery.init(dnsDiscoveryUrl, resolver)
     if wakuDnsDiscovery.isOk():

--- a/tests/test_waku_dnsdisc.nim
+++ b/tests/test_waku_dnsdisc.nim
@@ -79,7 +79,7 @@ suite "Waku DNS Discovery":
 
     var wakuDnsDisc = WakuDnsDiscovery.init(location, resolver).get()
 
-    let res = wakuDnsDisc.findPeers()
+    let res = await wakuDnsDisc.findPeers()
 
     check:
       # We have discovered all three nodes

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -215,7 +215,8 @@ proc findRandomPeers*(
 
   var discoveredRecords = discoveredNodes.mapIt(it.record)
 
-  logDiscv5FoundPeers(discoveredRecords)
+  when defined(debugDiscv5):
+    logDiscv5FoundPeers(discoveredRecords)
 
   # Filter out nodes that do not match the predicate
   if overridePred.isSome():
@@ -236,7 +237,7 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
   info "Starting discovery v5 search"
 
   while wd.listening:
-    info "running discv5 discovery loop"
+    trace "running discv5 discovery loop"
     let discoveredRecords = await wd.findRandomPeers()
 
     var discoveredPeers: seq[RemotePeerInfo]
@@ -252,11 +253,11 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
 
       discoveredPeers.add(peerInfo)
 
-    info "discv5 discovered peers",
+    trace "discv5 discovered peers",
       num_discovered_peers = discoveredPeers.len,
       peers = toSeq(discoveredPeers.mapIt(shortLog(it.peerId)))
 
-    info "discv5 discarded wrong records",
+    trace "discv5 discarded wrong records",
       wrong_records =
         wrongRecordsReasons.mapIt("(" & it.record & "," & it.errorDescription & ")")
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -215,8 +215,7 @@ proc findRandomPeers*(
 
   var discoveredRecords = discoveredNodes.mapIt(it.record)
 
-  when defined(debugDiscv5):
-    logDiscv5FoundPeers(discoveredRecords)
+  logDiscv5FoundPeers(discoveredRecords)
 
   # Filter out nodes that do not match the predicate
   if overridePred.isSome():
@@ -237,7 +236,7 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
   info "Starting discovery v5 search"
 
   while wd.listening:
-    trace "running discv5 discovery loop"
+    info "running discv5 discovery loop"
     let discoveredRecords = await wd.findRandomPeers()
 
     var discoveredPeers: seq[RemotePeerInfo]
@@ -253,11 +252,11 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
 
       discoveredPeers.add(peerInfo)
 
-    trace "discv5 discovered peers",
+    info "discv5 discovered peers",
       num_discovered_peers = discoveredPeers.len,
       peers = toSeq(discoveredPeers.mapIt(shortLog(it.peerId)))
 
-    trace "discv5 discarded wrong records",
+    info "discv5 discarded wrong records",
       wrong_records =
         wrongRecordsReasons.mapIt("(" & it.record & "," & it.errorDescription & ")")
 

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -454,10 +454,9 @@ proc updateBootstrapRecords*(
 
 proc updateBootstrapRecords*(
     self: var WakuDiscoveryV5, updatedRecords: seq[enr.Record]
-): Result[void, string] =
+): void =
   self.protocol.bootstrapRecords = updatedRecords
 
   # If we're updating the table with nodes that already existed, it will log an error when trying
   # to add a bootstrap node that was already there. That's ok.
   self.protocol.seedTable()
-  return ok()

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -455,7 +455,7 @@ proc updateBootstrapRecords*(
 proc updateBootstrapRecords*(
     self: var WakuDiscoveryV5, updatedRecords: seq[enr.Record]
 ): Result[void, string] =
-  self.protocol.bootstrapRecords = newRecords
+  self.protocol.bootstrapRecords = updatedRecords
 
   # If we're updating the table with nodes that already existed, it will log an error when trying
   # to add a bootstrap node that was already there. That's ok.

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -448,5 +448,16 @@ proc updateBootstrapRecords*(
       return err("wrong enr given: " & enrWithoutQuotes)
 
   self.protocol.bootstrapRecords = newRecords
+  self.protocol.seedTable()
 
+  return ok()
+
+proc updateBootstrapRecords*(
+    self: var WakuDiscoveryV5, updatedRecords: seq[enr.Record]
+): Result[void, string] =
+  self.protocol.bootstrapRecords = newRecords
+
+  # If we're updating the table with nodes that already existed, it will log an error when trying
+  # to add a bootstrap node that was already there. That's ok.
+  self.protocol.seedTable()
   return ok()

--- a/waku/discovery/waku_dnsdisc.nim
+++ b/waku/discovery/waku_dnsdisc.nim
@@ -6,7 +6,7 @@
 ## EIP-1459 is defined in https://eips.ethereum.org/EIPS/eip-1459
 
 import
-  std/[options, net],
+  std/[options, net, sequtils],
   chronicles,
   chronos,
   metrics,
@@ -40,7 +40,9 @@ proc emptyResolver*(domain: string): Future[string] {.async, gcsafe.} =
   debug "Empty resolver called", domain = domain
   return ""
 
-proc findPeers*(wdd: var WakuDnsDiscovery): Result[seq[RemotePeerInfo], cstring] =
+proc findPeers*(
+    wdd: WakuDnsDiscovery
+): Future[Result[seq[RemotePeerInfo], cstring]] {.async.} =
   ## Find peers to connect to using DNS based discovery
 
   info "Finding peers using Waku DNS discovery"
@@ -48,14 +50,13 @@ proc findPeers*(wdd: var WakuDnsDiscovery): Result[seq[RemotePeerInfo], cstring]
   # Synchronise client tree using configured resolver
   var tree: Tree
   try:
-    tree = wdd.client.getTree(wdd.resolver)
-      # @TODO: this is currently a blocking operation to not violate memory safety
+    tree = (await syncTree(wdd.resolver, wdd.client.loc)).tryGet()
   except Exception:
     error "Failed to synchronise client tree"
     waku_dnsdisc_errors.inc(labelValues = ["tree_sync_failure"])
     return err("Node discovery failed")
 
-  let discoveredEnr = wdd.client.getNodeRecords()
+  let discoveredEnr = tree.getNodes().mapIt(it.record)
 
   if discoveredEnr.len > 0:
     info "Successfully discovered ENR", count = discoveredEnr.len
@@ -97,7 +98,7 @@ proc init*(
 
 proc retrieveDynamicBootstrapNodes*(
     dnsDiscovery: bool, dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
-): Result[seq[RemotePeerInfo], string] =
+): Future[Result[seq[RemotePeerInfo], string]] {.async.} =
   ## Retrieve dynamic bootstrap nodes (DNS discovery)
 
   if dnsDiscovery and dnsDiscoveryUrl != "":
@@ -117,10 +118,10 @@ proc retrieveDynamicBootstrapNodes*(
 
     var wakuDnsDiscovery = WakuDnsDiscovery.init(dnsDiscoveryUrl, resolver)
     if wakuDnsDiscovery.isOk():
-      return wakuDnsDiscovery.get().findPeers().mapErr(
-          proc(e: cstring): string =
-            $e
-        )
+      return (await wakuDnsDiscovery.get().findPeers()).mapErr(
+        proc(e: cstring): string =
+          $e
+      )
     else:
       warn "Failed to init Waku DNS discovery"
 

--- a/waku/discovery/waku_dnsdisc.nim
+++ b/waku/discovery/waku_dnsdisc.nim
@@ -114,7 +114,8 @@ proc retrieveDynamicBootstrapNodes*(
     proc resolver(domain: string): Future[string] {.async, gcsafe.} =
       trace "resolving", domain = domain
       let resolved = await dnsResolver.resolveTxt(domain)
-      return resolved[0] # Use only first answer
+      if resolved.len > 0:
+        return resolved[0] # Use only first answer
 
     var wakuDnsDiscovery = WakuDnsDiscovery.init(dnsDiscoveryUrl, resolver)
     if wakuDnsDiscovery.isOk():

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -377,7 +377,7 @@ proc setupProtocols(
 ## Start node
 
 proc startNode*(
-    node: WakuNode, conf: WakuNodeConf = @[]
+    node: WakuNode, conf: WakuNodeConf, dynamicBootstrapNodes: seq[RemotePeerInfo] = @[]
 ): Future[Result[void, string]] {.async: (raises: []).} =
   ## Start a configured node and all mounted protocols.
   ## Connect to static nodes and start
@@ -396,13 +396,13 @@ proc startNode*(
     except CatchableError:
       return err("failed to connect to static nodes: " & getCurrentExceptionMsg())
 
-  #[ if dynamicBootstrapNodes.len > 0:
+  if dynamicBootstrapNodes.len > 0:
     info "Connecting to dynamic bootstrap peers"
     try:
       await connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")
     except CatchableError:
       return
-        err("failed to connect to dynamic bootstrap nodes: " & getCurrentExceptionMsg()) ]#
+        err("failed to connect to dynamic bootstrap nodes: " & getCurrentExceptionMsg())
 
   # retrieve px peers and add the to the peer store
   if conf.peerExchangeNode != "":

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -377,7 +377,7 @@ proc setupProtocols(
 ## Start node
 
 proc startNode*(
-    node: WakuNode, conf: WakuNodeConf, dynamicBootstrapNodes: seq[RemotePeerInfo] = @[]
+    node: WakuNode, conf: WakuNodeConf = @[]
 ): Future[Result[void, string]] {.async: (raises: []).} =
   ## Start a configured node and all mounted protocols.
   ## Connect to static nodes and start
@@ -396,13 +396,13 @@ proc startNode*(
     except CatchableError:
       return err("failed to connect to static nodes: " & getCurrentExceptionMsg())
 
-  if dynamicBootstrapNodes.len > 0:
+  #[ if dynamicBootstrapNodes.len > 0:
     info "Connecting to dynamic bootstrap peers"
     try:
       await connectToNodes(node, dynamicBootstrapNodes, "dynamic bootstrap")
     except CatchableError:
       return
-        err("failed to connect to dynamic bootstrap nodes: " & getCurrentExceptionMsg())
+        err("failed to connect to dynamic bootstrap nodes: " & getCurrentExceptionMsg()) ]#
 
   # retrieve px peers and add the to the peer store
   if conf.peerExchangeNode != "":

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -386,6 +386,7 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async.} =
   if dynamicBootstrapNodesRes.isErr():
     error "Retrieving dynamic bootstrap nodes failed",
       error = dynamicBootstrapNodesRes.error
+    # Start Dns Discovery retry loop
     waku[].dnsRetryLoopHandle = some(waku.startDnsDiscoveryRetryLoop())
   else:
     waku[].dynamicBootstrapNodes = dynamicBootstrapNodesRes.get()
@@ -438,3 +439,6 @@ proc stop*(waku: Waku): Future[void] {.async: (raises: [Exception]).} =
 
   if not waku.node.isNil():
     await waku.node.stop()
+
+  if waku.dnsRetryLoopHandle.isSome():
+    await waku.dnsRetryLoopHandle.get().cancelAndWait()

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -361,7 +361,7 @@ proc updateWaku(waku: ptr Waku): Result[void, string] =
 
 proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async: (raises: []).} =
   if not waku[].conf.discv5Only:
-    (await startNode(waku.node, waku.conf, waku.dynamicBootstrapNodes)).isOkOr:
+    (await startNode(waku.node, waku.conf)).isOkOr:
       return err("error while calling startNode: " & $error)
 
     # Update waku data that is set dynamically on node start


### PR DESCRIPTION
# Description
Instead of exiting if DNS Discovery fails at startup, we now create a loop that attempts to perform DNS Discovery every 30 seconds until it succeeds.

# Changes

<!-- List of detailed changes -->

- [x] making bootstrap node retrieval procs async
- [x] introduce a DNS retry loop in `wakunode2`
- [x] updating `nim-dnsdisc` submodule 

## How to test
Run `wakunode2` configuring discv5 and dns-discovery with the internet connection off, then turn it on after some time and see that DNS Discovery is performed and Discv5 finds peers




## Issue
#3076 
