### PR TITLE
chore: python example - call waku_setup to initialize libwaku properly

### DIFF
--- a/examples/python/waku.py
+++ b/examples/python/waku.py
@@ -58,6 +58,9 @@ json_config = "{ \
 
 callback_type = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t)
 
+# libwaku setup
+libwaku.waku_setup()
+
 # Node creation
 libwaku.waku_new.restype = ctypes.c_void_p
 libwaku.waku_new.argtypes = [ctypes.c_char_p,


### PR DESCRIPTION
# Description
Change motivated by @fbarbu15 
In this case, it was missing to invoke `waku_setup` so that the libwaku library is properly initialized and the Nim runtime and gc.