### PR TITLE
chore: Bump nimbus and nim to latest available - nim-2.0.12

### DIFF
--- a/apps/liteprotocoltester/tester_message.nim
+++ b/apps/liteprotocoltester/tester_message.nim
@@ -87,7 +87,7 @@ proc readValue*(
         )
       size = some(reader.readValue(uint64))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if sender.isNone():
     reader.raiseUnexpectedValue("Field `sender` is missing")

--- a/waku/waku_api/rest/admin/types.nim
+++ b/waku/waku_api/rest/admin/types.nim
@@ -83,7 +83,7 @@ proc readValue*(
         )
       connected = some(reader.readValue(bool))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if connected.isNone():
     reader.raiseUnexpectedValue("Field `connected` is missing")
@@ -116,7 +116,7 @@ proc readValue*(
         reader.raiseUnexpectedField("Multiple `origin` fields found", "WakuPeer")
       origin = some(reader.readValue(PeerOrigin))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if multiaddr.isNone():
     reader.raiseUnexpectedValue("Field `multiaddr` is missing")
@@ -153,7 +153,7 @@ proc readValue*(
         )
       contentTopic = some(reader.readValue(string))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if pubsubTopic.isNone():
     reader.raiseUnexpectedValue("Field `pubsubTopic` is missing")
@@ -185,7 +185,7 @@ proc readValue*(
         )
       filterCriteria = some(reader.readValue(seq[FilterTopic]))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if peerId.isNone():
     reader.raiseUnexpectedValue("Field `peerId` is missing")

--- a/waku/waku_api/rest/debug/types.nim
+++ b/waku/waku_api/rest/debug/types.nim
@@ -2,6 +2,7 @@
 
 import chronicles, json_serialization, json_serialization/std/options
 import ../../../waku_node, ../serdes
+import std/typetraits
 
 #### Types
 
@@ -47,7 +48,7 @@ proc readValue*(
         reader.raiseUnexpectedField("Multiple `enrUri` fields found", "DebugWakuInfo")
       enrUri = some(reader.readValue(string))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if listenAddresses.isNone():
     reader.raiseUnexpectedValue("Field `listenAddresses` is missing")

--- a/waku/waku_api/rest/filter/types.nim
+++ b/waku/waku_api/rest/filter/types.nim
@@ -187,7 +187,7 @@ proc readValue*(
     of "ephemeral":
       ephemeral = some(reader.readValue(bool))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if payload.isNone():
     reader.raiseUnexpectedValue("Field `payload` is missing")
@@ -225,7 +225,7 @@ proc readValue*(
     of "contentFilters":
       contentFilters = some(reader.readValue(seq[ContentTopic]))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if contentFilters.isNone():
     reader.raiseUnexpectedValue("Field `contentFilters` is missing")
@@ -262,7 +262,7 @@ proc readValue*(
     of "requestId":
       requestId = some(reader.readValue(string))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if requestId.isNone():
     reader.raiseUnexpectedValue("Field `requestId` is missing")
@@ -296,7 +296,7 @@ proc readValue*(
     of "contentFilters":
       contentFilters = some(reader.readValue(seq[ContentTopic]))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if requestId.isNone():
     reader.raiseUnexpectedValue("Field `requestId` is missing")
@@ -344,7 +344,7 @@ proc readValue*(
     of "contentFilters":
       contentFilters = some(reader.readValue(seq[ContentTopic]))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if requestId.isNone():
     reader.raiseUnexpectedValue("Field `requestId` is missing")
@@ -385,7 +385,7 @@ proc readValue*(
     of "requestId":
       requestId = some(reader.readValue(string))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if requestId.isNone():
     reader.raiseUnexpectedValue("Field `requestId` is missing")
@@ -416,7 +416,7 @@ proc readValue*(
     of "statusDesc":
       statusDesc = some(reader.readValue(string))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if requestId.isNone():
     reader.raiseUnexpectedValue("Field `requestId` is missing")

--- a/waku/waku_api/rest/health/types.nim
+++ b/waku/waku_api/rest/health/types.nim
@@ -65,7 +65,7 @@ proc readValue*(
 
       protocolsHealth = some(reader.readValue(seq[ProtocolHealth]))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if nodeHealth.isNone():
     reader.raiseUnexpectedValue("Field `nodeHealth` is missing")

--- a/waku/waku_api/rest/lightpush/types.nim
+++ b/waku/waku_api/rest/lightpush/types.nim
@@ -52,7 +52,7 @@ proc readValue*(
     of "message":
       message = some(reader.readValue(RelayWakuMessage))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if message.isNone():
     reader.raiseUnexpectedValue("Field `message` is missing")

--- a/waku/waku_api/rest/relay/types.nim
+++ b/waku/waku_api/rest/relay/types.nim
@@ -117,7 +117,7 @@ proc readValue*(
     of "ephemeral":
       ephemeral = some(reader.readValue(bool))
     else:
-      unrecognizedFieldWarning()
+      unrecognizedFieldWarning(value)
 
   if payload.isNone() or isEmptyOrWhitespace(string(payload.get())):
     reader.raiseUnexpectedValue("Field `payload` is missing or empty")

--- a/waku/waku_api/rest/serdes.nim
+++ b/waku/waku_api/rest/serdes.nim
@@ -20,12 +20,12 @@ createJsonFlavor RestJson
 
 Json.setWriter JsonWriter, PreferredOutput = string
 
-template unrecognizedFieldWarning*() =
+template unrecognizedFieldWarning*(field: typed) =
   # TODO: There should be a different notification mechanism for informing the
   #       caller of a deserialization routine for unexpected fields.
   #       The chonicles import in this module should be removed.
   debug "JSON field not recognized by the current version of nwaku. Consider upgrading",
-    fieldName, typeName = typetraits.name(typeof value)
+    fieldName, typeName = typetraits.name(typeof field)
 
 type SerdesResult*[T] = Result[T, cstring]
 


### PR DESCRIPTION
# Description
To unstuck waku-sync v2 we need to move to latest nim version.
Currently it is 2.0.12

# Changes

- [x] nimbus-build-system is bumped to latest master that includes nim v2.0.12

# Note:

Currently, this new nim version breaks our code. We need to investigate if it is possible to adjust nim flags for backward compatible build or we can easily adjust our code.

Example error appears with latest nim version:
```
/home/nzp/dev/status/nwaku/waku/waku_api/rest/debug/types.nim(50, 31) template/generic instantiation of `unrecognizedFieldWarning` from here
/home/nzp/dev/status/nwaku/vendor/nim-chronicles/chronicles.nim(380, 10) template/generic instantiation of `log` from here
/home/nzp/dev/status/nwaku/waku/waku_api/rest/serdes.nim(28, 50) Warning: a new symbol 'value' has been injected during template or generic instantiation, however overloads of value will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this symbol explicitly [IgnoredSymbolInjection]
/home/nzp/dev/status/nwaku/waku/waku_api/rest/debug/types.nim(50, 31) template/generic instantiation of `unrecognizedFieldWarning` from here
/home/nzp/dev/status/nwaku/vendor/nim-chronicles/chronicles.nim(380, 10) template/generic instantiation of `log` from here
/home/nzp/dev/status/nwaku/waku/waku_api/rest/serdes.nim(28, 50) Error: ambiguous identifier: 'value' -- use one of the following:
  results.value: proc (self: var Result[value.T, value.E]): var T: not void{.inline, noSideEffect.}
  results.value: proc (self: Result[system.void, value.E]){.inline, noSideEffect.}
  results.value: proc (self: Result[value.T, value.E]): lent T: not void{.inline, noSideEffect.}
```

# Issue

https://github.com/waku-org/nwaku/issues/3204