### PR TITLE
chore: improve epoch monitoring

### DIFF
--- a/waku/waku_rln_relay/group_manager/group_manager_base.nim
+++ b/waku/waku_rln_relay/group_manager/group_manager_base.nim
@@ -201,7 +201,7 @@ method generateProof*(
     ).valueOr:
       return err("proof generation failed: " & $error)
 
-  waku_rln_remaining_proofs_per_epoch.inc()
+  waku_rln_remaining_proofs_per_epoch.dec()
   waku_rln_total_generated_proofs.inc()
   return ok(proof)
 

--- a/waku/waku_rln_relay/group_manager/group_manager_base.nim
+++ b/waku/waku_rln_relay/group_manager/group_manager_base.nim
@@ -200,14 +200,10 @@ method generateProof*(
       messageId = messageId,
     ).valueOr:
       return err("proof generation failed: " & $error)
-  return ok(proof)
 
-  if lastProcessedEpoch != epoch:
-    lastProcessedEpoch = epoch
-    waku_rln_proof_remining.set(g.userMessageLimit.get().float64 - 1)
-  else:
-    waku_rln_proof_remining.dec()
-  waku_rln_proofs_generated_total.inc()
+  waku_rln_remaining_proofs_per_epoch.inc()
+  waku_rln_total_generated_proofs.inc()
+  return ok(proof)
 
 method isReady*(g: GroupManager): Future[bool] {.base, async.} =
   raise newException(

--- a/waku/waku_rln_relay/protocol_metrics.nim
+++ b/waku/waku_rln_relay/protocol_metrics.nim
@@ -63,12 +63,12 @@ declarePublicGauge(
 )
 
 declarePublicGauge(
-  waku_rln_proof_remining,
+  waku_rln_remaining_proofs_per_epoch,
   "number of proofs remaining to be generated for the current epoch",
 )
 
 declarePublicGauge(
-  waku_rln_proofs_generated_total,
+  waku_rln_total_generated_proofs,
   "total number of proofs generated since the node started",
 )
 
@@ -84,6 +84,7 @@ proc getRlnMetricsLogger*(): RLNMetricsLogger =
   var cumulativeValidMessages = 0.float64
   var cumulativeProofsVerified = 0.float64
   var cumulativeProofsGenerated = 0.float64
+  var cumulativeProofsRemaining = 100.float64
 
   when defined(metrics):
     logMetrics = proc() =
@@ -102,7 +103,10 @@ proc getRlnMetricsLogger*(): RLNMetricsLogger =
           waku_rln_proof_verification_total, cumulativeProofsVerified
         )
         let freshProofsGeneratedCount =
-          parseAndAccumulate(waku_rln_proofs_generated_total, cumulativeProofsGenerated)
+          parseAndAccumulate(waku_rln_total_generated_proofs, cumulativeProofsGenerated)
+        let freshProofsRemainingCount = parseAndAccumulate(
+          waku_rln_remaining_proofs_per_epoch, cumulativeProofsRemaining
+        )
 
         info "Total messages", count = freshMsgCount
         info "Total spam messages", count = freshSpamCount
@@ -111,4 +115,6 @@ proc getRlnMetricsLogger*(): RLNMetricsLogger =
         info "Total errors", count = freshErrorCount
         info "Total proofs verified", count = freshProofsVerifiedCount
         info "Total proofs generated", count = freshProofsGeneratedCount
+        info "Total proofs remaining", count = freshProofsRemainingCount
+
   return logMetrics

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -408,7 +408,7 @@ proc monitorEpochs(wakuRlnRelay: WakuRLNRelay) {.async.} =
   while true:
     try:
       waku_rln_remaining_proofs_per_epoch.set(
-        wakuRlnRelay.groupManager.userMessageLimit.get().flaot64
+        wakuRlnRelay.groupManager.userMessageLimit.get().float64
       )
     except CatchableError:
       error "Error in epoch monitoring", error = getCurrentExceptionMsg()

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -89,6 +89,7 @@ type WakuRLNRelay* = ref object of RootObj
   groupManager*: GroupManager
   onFatalErrorAction*: OnFatalErrorHandler
   nonceManager*: NonceManager
+  epochMonitorFuture*: Future[void]
 
 proc calcEpoch*(rlnPeer: WakuRLNRelay, t: float64): Epoch =
   ## gets time `t` as `flaot64` with subseconds resolution in the fractional part
@@ -478,7 +479,8 @@ proc mount(
     rlnMaxEpochGap: max(uint64(MaxClockGapSeconds / float64(conf.rlnEpochSizeSec)), 1),
     onFatalErrorAction: conf.onFatalErrorAction,
   )
-
+   
+  # Start epoch monitoring in the background
   wakuRlnRelay.epochMonitorFuture = monitorEpochs(wakuRlnRelay)
   return ok(wakuRlnRelay)
 


### PR DESCRIPTION
I discovered a bug while monitoring Grafana metrics in PR #3181 Currently, the **waku_rln_proof_remining** counter is reset inside the **generateProof** function. This approach fails in the following scenario:

If a new epoch starts but no proofs are generated (i.e., no messages are sent), the counter doesn't reset. Ideally, the counter should reset immediately when a new epoch begins, regardless of whether any messages are sent.

This PR addresses the issue by implementing an independent epoch monitoring task that ensures the counter is reset as soon as a new epoch starts.

Note: The spike should occur around 23:50, but it happens around 23:53 because the user does not generate any RLN proof ( msg ) within the 3-minute timeframe.

![image](https://github.com/user-attachments/assets/fbde2075-9265-4329-b3ce-f5785cea7cf5)
