### PR TITLE
feat: allowing configuration of application level callbacks

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -28,7 +28,7 @@ import
   ./waku_thread/inter_thread_communication/waku_thread_request,
   ./alloc,
   ./ffi_types,
-  ../waku/factory/waku_callbacks
+  ../waku/factory/app_callbacks
 
 ################################################################################
 ### Wrapper around the waku node
@@ -139,13 +139,13 @@ proc waku_new(
 
   ctx.userData = userData
 
-  let callbacks = WakuCallbacks(relayHandler: onReceivedMessage(ctx))
+  let appCallbacks = AppCallbacks(relayHandler: onReceivedMessage(ctx))
 
   let retCode = handleRequest(
     ctx,
     RequestType.LIFECYCLE,
     NodeLifecycleRequest.createShared(
-      NodeLifecycleMsgType.CREATE_NODE, configJson, callbacks
+      NodeLifecycleMsgType.CREATE_NODE, configJson, appCallbacks
     ),
     callback,
     userData,

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -27,7 +27,8 @@ import
   ./waku_thread/inter_thread_communication/requests/ping_request,
   ./waku_thread/inter_thread_communication/waku_thread_request,
   ./alloc,
-  ./ffi_types
+  ./ffi_types,
+  ../waku/factory/waku_callbacks
 
 ################################################################################
 ### Wrapper around the waku node
@@ -138,10 +139,14 @@ proc waku_new(
 
   ctx.userData = userData
 
+  let callbacks = WakuCallbacks(relayHandler: onReceivedMessage(ctx))
+
   let retCode = handleRequest(
     ctx,
     RequestType.LIFECYCLE,
-    NodeLifecycleRequest.createShared(NodeLifecycleMsgType.CREATE_NODE, configJson),
+    NodeLifecycleRequest.createShared(
+      NodeLifecycleMsgType.CREATE_NODE, configJson, callbacks
+    ),
     callback,
     userData,
   )

--- a/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
@@ -7,6 +7,7 @@ import
   ../../../../waku/factory/waku,
   ../../../../waku/factory/node_factory,
   ../../../../waku/factory/networks_config,
+  ../../../../waku/factory/waku_callbacks,
   ../../../alloc
 
 type NodeLifecycleMsgType* = enum
@@ -17,12 +18,17 @@ type NodeLifecycleMsgType* = enum
 type NodeLifecycleRequest* = object
   operation: NodeLifecycleMsgType
   configJson: cstring ## Only used in 'CREATE_NODE' operation
+  callbacks: WakuCallbacks
 
 proc createShared*(
-    T: type NodeLifecycleRequest, op: NodeLifecycleMsgType, configJson: cstring = ""
+    T: type NodeLifecycleRequest,
+    op: NodeLifecycleMsgType,
+    configJson: cstring = "",
+    callbacks: WakuCallbacks = nil,
 ): ptr type T =
   var ret = createShared(T)
   ret[].operation = op
+  ret[].callbacks = callbacks
   ret[].configJson = configJson.alloc()
   return ret
 
@@ -30,7 +36,9 @@ proc destroyShared(self: ptr NodeLifecycleRequest) =
   deallocShared(self[].configJson)
   deallocShared(self)
 
-proc createWaku(configJson: cstring): Future[Result[Waku, string]] {.async.} =
+proc createWaku(
+    configJson: cstring, callbacks: WakuCallbacks = nil
+): Future[Result[Waku, string]] {.async.} =
   var conf = defaultWakuNodeConf().valueOr:
     return err("Failed creating node: " & error)
 
@@ -59,7 +67,7 @@ proc createWaku(configJson: cstring): Future[Result[Waku, string]] {.async.} =
             formattedString & ". expected type: " & $typeof(confValue)
         )
 
-  let wakuRes = Waku.new(conf).valueOr:
+  let wakuRes = Waku.new(conf, callbacks).valueOr:
     error "waku initialization failed", error = error
     return err("Failed setting up Waku: " & $error)
 
@@ -73,7 +81,7 @@ proc process*(
 
   case self.operation
   of CREATE_NODE:
-    waku[] = (await createWaku(self.configJson)).valueOr:
+    waku[] = (await createWaku(self.configJson, self.callbacks)).valueOr:
       error "CREATE_NODE failed", error = error
       return err("error processing createWaku request: " & $error)
   of START_NODE:

--- a/waku/factory/app_callbacks.nim
+++ b/waku/factory/app_callbacks.nim
@@ -1,4 +1,4 @@
 import ../waku_relay/protocol
 
-type WakuCallbacks* = ref object
+type AppCallbacks* = ref object
   relayHandler*: WakuRelayHandler

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -254,7 +254,7 @@ proc new*(
 
   node.setupCallbacks(confCopy, callbacks).isOkOr:
     error "Failed setting callbacks", error = error
-    return err("Failed setting up node: " & $error)
+    return err("Failed setting up callbacks: " & $error)
 
   ## Delivery Monitor
   var deliveryMonitor: DeliveryMonitor
@@ -277,6 +277,7 @@ proc new*(
     key: confCopy.nodekey.get(),
     node: node,
     deliveryMonitor: deliveryMonitor,
+    callbacks: callbacks,
   )
 
   waku.setupSwitchServices(confCopy, relay, rng)

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -148,6 +148,9 @@ proc newCircuitRelay(isRelayClient: bool): Relay =
     return RelayClient.new()
   return Relay.new()
 
+proc setupCallbacks(node: var WakuNode, callbacks: WakuCallbacks) =
+  return
+
 proc new*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
   let rng = crypto.newRng()
 
@@ -226,6 +229,8 @@ proc new*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
     return err("Failed setting up node: " & nodeRes.error)
 
   let node = nodeRes.get()
+
+  node.setupCallbacks(callbacks)
 
   ## Delivery Monitor
   var deliveryMonitor: DeliveryMonitor

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -155,9 +155,9 @@ proc setupCallbacks(
     info "No external callbacks to be set"
     return ok()
 
-  if not callbacks.onReceivedMessage.isNil():
+  if not callbacks.relayHandler.isNil():
     if node.wakuRelay.isNil():
-      return err("Cannot configure onReceivedMessage callback without Relay mounted")
+      return err("Cannot configure relayHandler callback without Relay mounted")
 
     let autoShards = node.getAutoshards(conf.contentTopics).valueOr:
       return err("Could not get autoshards: " & error)
@@ -167,7 +167,7 @@ proc setupCallbacks(
     let shards = confShards & autoShards
 
     for shard in shards:
-      discard node.wakuRelay.subscribe($shard, callbacks.onReceivedMessage)
+      discard node.wakuRelay.subscribe($shard, callbacks.relayHandler)
 
 proc new*(
     T: type Waku, confCopy: var WakuNodeConf, callbacks: WakuCallbacks = nil

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -149,9 +149,15 @@ proc newCircuitRelay(isRelayClient: bool): Relay =
   return Relay.new()
 
 proc setupCallbacks(node: var WakuNode, callbacks: WakuCallbacks) =
-  return
+  if callbacks.isNil():
+    return
 
-proc new*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
+  if not callbacks.onReceivedMessage.isNil():
+    
+
+proc new*(
+    T: type Waku, confCopy: var WakuNodeConf, callbacks: WakuCallbacks = nil
+): Result[Waku, string] =
   let rng = crypto.newRng()
 
   logging.setupLog(confCopy.logLevel, confCopy.logFormat)
@@ -230,7 +236,8 @@ proc new*(T: type Waku, confCopy: var WakuNodeConf): Result[Waku, string] =
 
   let node = nodeRes.get()
 
-  node.setupCallbacks(callbacks)
+  if not callbacks.isNil():
+    node.setupCallbacks(callbacks)
 
   ## Delivery Monitor
   var deliveryMonitor: DeliveryMonitor

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -252,7 +252,7 @@ proc new*(
 
   let node = nodeRes.get()
 
-  node.setupCallbacks(confCopy, appCallbacks).isOkOr:
+  node.setupAppCallbacks(confCopy, appCallbacks).isOkOr:
     error "Failed setting up app callbacks", error = error
     return err("Failed setting up app callbacks: " & $error)
 
@@ -277,7 +277,7 @@ proc new*(
     key: confCopy.nodekey.get(),
     node: node,
     deliveryMonitor: deliveryMonitor,
-    callbacks: callbacks,
+    appCallbacks: appCallbacks,
   )
 
   waku.setupSwitchServices(confCopy, relay, rng)

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -42,6 +42,7 @@ import
   ../factory/node_factory,
   ../factory/internal_config,
   ../factory/external_config,
+  ../factory/waku_callbacks,
   ../waku_enr/multiaddr
 
 logScope:
@@ -67,6 +68,7 @@ type Waku* = ref object
 
   restServer*: WakuRestServerRef
   metricsServer*: MetricsHttpServerRef
+  callbacks*: WakuCallbacks
 
 proc logConfig(conf: WakuNodeConf) =
   info "Configuration: Enabled protocols",

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -169,6 +169,8 @@ proc setupCallbacks(
     for shard in shards:
       discard node.wakuRelay.subscribe($shard, callbacks.relayHandler)
 
+    return ok()
+
 proc new*(
     T: type Waku, confCopy: var WakuNodeConf, callbacks: WakuCallbacks = nil
 ): Result[Waku, string] =

--- a/waku/factory/waku_callbacks.nim
+++ b/waku/factory/waku_callbacks.nim
@@ -1,4 +1,4 @@
 import ../waku_relay/protocol
 
 type WakuCallbacks* = ref object
-  onReceivedMessage*: WakuRelayHandler
+  relayHandler*: WakuRelayHandler

--- a/waku/factory/waku_callbacks.nim
+++ b/waku/factory/waku_callbacks.nim
@@ -1,4 +1,4 @@
 import ../waku_relay/protocol
 
 type WakuCallbacks* = ref object
-  onReceivedMessage: WakuRelayHandler
+  onReceivedMessage*: WakuRelayHandler

--- a/waku/factory/waku_callbacks.nim
+++ b/waku/factory/waku_callbacks.nim
@@ -1,0 +1,4 @@
+import ../waku_relay/protocol
+
+type WakuCallbacks* = ref object
+  onReceivedMessage: WakuRelayHandler


### PR DESCRIPTION
# Description

We noticed that libwaku doesn't automatically configure a callback for receiving Relay messages when creating a node. Currently, the user has to manually subscribe to each topic providing their callback.

In order to make libwaku more user friendly, we need to be able to register all the event-emitting callbacks automatically when creating a node. Therefore, I added a `WakuCallbacks` type where a user can pass all the different callbacks they need when creating a node. Currently, only `relayHandler` is defined in the type, but in a following PRs new callbacks will be added (for example, a callback that runs every time a topic health changes)


# Changes

<!-- List of detailed changes -->

- [x] introduced `WakuCallbacks` type for application-level callbacks
- [x] added `setupCallbacks` procedure that adds the configured `WakuCallbacks`
- [x] modified `Waku.new()` to accept `WakuCallbacks` and properly set them up
- [x] introduced a `callbacks` parameter to libwaku's `createWaku`so we can configure in node creation all the event-emitting callbacks

<!--
## How to test

1.
1.
1.

-->


## Issue
#3076 

