### PR TITLE
chore: modifying relay subscribe return value

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -94,7 +94,7 @@ proc process*(
   case self.operation
   of SUBSCRIBE:
     # TO DO: properly perform 'subscribe'
-    discard waku.node.wakuRelay.subscribe($self.pubsubTopic, self.relayEventCallback)
+    waku.node.wakuRelay.subscribe($self.pubsubTopic, self.relayEventCallback)
   of UNSUBSCRIBE:
     # TODO: properly perform 'unsubscribe'
     waku.node.wakuRelay.unsubscribeAll($self.pubsubTopic)

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -513,7 +513,7 @@ suite "WakuNode - Relay":
     # subscribe all nodes to a topic
     let topic = "topic"
     for node in nodes:
-      discard node.wakuRelay.subscribe(topic, nil)
+      node.wakuRelay.subscribe(topic, nil)
     await sleepAsync(500.millis)
 
     # connect nodes in full mesh

--- a/tests/wakunode2/test_validators.nim
+++ b/tests/wakunode2/test_validators.nim
@@ -74,7 +74,7 @@ suite "WakuNode2 - Validators":
 
     # Subscribe all nodes to the same topic/handler
     for node in nodes:
-      discard node.wakuRelay.subscribe($spamProtectedShard, handler)
+      node.wakuRelay.subscribe($spamProtectedShard, handler)
     await sleepAsync(500.millis)
 
     # Each node publishes 10 signed messages
@@ -164,7 +164,7 @@ suite "WakuNode2 - Validators":
 
     # Subscribe all nodes to the same topic/handler
     for node in nodes:
-      discard node.wakuRelay.subscribe($spamProtectedShard, handler)
+      node.wakuRelay.subscribe($spamProtectedShard, handler)
     await sleepAsync(500.millis)
 
     # Each node sends 5 messages, signed but with a non-whitelisted key (total = 25)
@@ -292,7 +292,7 @@ suite "WakuNode2 - Validators":
 
     # Subscribe all nodes to the same topic/handler
     for node in nodes:
-      discard node.wakuRelay.subscribe($spamProtectedShard, handler)
+      node.wakuRelay.subscribe($spamProtectedShard, handler)
     await sleepAsync(500.millis)
 
     # Add signed message validator to all nodes. They will only route signed messages

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -167,7 +167,7 @@ proc setupAppCallbacks(
     let shards = confShards & autoShards
 
     for shard in shards:
-      discard node.wakuRelay.subscribe($shard, appCallbacks.relayHandler)
+      node.wakuRelay.subscribe($shard, appCallbacks.relayHandler)
 
     return ok()
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -238,7 +238,7 @@ proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
     await filterHandler(topic, msg)
     await archiveHandler(topic, msg)
 
-  discard node.wakuRelay.subscribe(topic, defaultHandler)
+  node.wakuRelay.subscribe(topic, defaultHandler)
 
 proc subscribe*(
     node: WakuNode, subscription: SubscriptionEvent, handler = none(WakuRelayHandler)
@@ -271,7 +271,8 @@ proc subscribe*(
   node.registerRelayDefaultHandler(pubsubTopic)
 
   if handler.isSome():
-    let wrappedHandler = node.wakuRelay.subscribe(pubsubTopic, handler.get())
+    node.wakuRelay.subscribe(pubsubTopic, handler.get())
+    let wrappedHandler = wrapHandler(handler.get())
 
     if contentTopicOp.isSome():
       node.contentTopicHandlers[contentTopicOp.get()] = wrappedHandler


### PR DESCRIPTION
# Description
Currently, `WakuRelay.subscribe()` has a return value that is discarded everywhere except in one place. It returns the wrapped handler that is passed to gossipsub, which is useless to most cases when we subscribe to a topic.

Therefore, defined a `wrapHandler()` procedure to return the wrapped handler in the specific cases that is needed, and changed the return type of `subscribe` to void so we don't have to discard that value everywhere 

# Changes

<!-- List of detailed changes -->

- [x] changed return value of `WakuRelay.subscribe()` to void
- [x] defined a `wrapHandler()` procedure in the `waku_relay` module