### PR TITLE
chore: enhance libwaku store protocol and more

### DIFF
--- a/library/events/json_message_event.nim
+++ b/library/events/json_message_event.nim
@@ -57,9 +57,6 @@ proc toWakuMessage*(self: JsonMessage): Result[WakuMessage, string] =
 proc `%`*(value: Base64String): JsonNode =
   %(value.string)
 
-proc `%`*(value: WakuMessageHash): JsonNode =
-  %(to0xHex(value))
-
 type JsonMessageEvent* = ref object of JsonEvent
   pubsubTopic*: string
   messageHash*: WakuMessageHash

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -297,12 +297,7 @@ proc waku_relay_publish(
   handleRequest(
     ctx,
     RequestType.RELAY,
-    RelayRequest.createShared(
-      RelayMsgType.PUBLISH,
-      PubsubTopic($pst),
-      WakuRelayHandler(onReceivedMessage(ctx)),
-      wakuMessage,
-    ),
+    RelayRequest.createShared(RelayMsgType.PUBLISH, PubsubTopic($pst), nil, wakuMessage),
     callback,
     userData,
   )

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -162,8 +162,6 @@ proc waku_destroy(
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
-  let msg = "correctly destroyed"
-  callback(RET_OK, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
   return RET_OK
 
 proc waku_version(

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -162,6 +162,8 @@ proc waku_destroy(
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
+  let msg = "correctly destroyed"
+  callback(RET_OK, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
   return RET_OK
 
 proc waku_version(

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -662,7 +662,7 @@ proc waku_store_query(
   handleRequest(
     ctx,
     RequestType.STORE,
-    JsonStoreQueryRequest.createShared(jsonQuery, peerAddr, timeoutMs),
+    StoreRequest.createShared(StoreReqType.REMOTE_QUERY, jsonQuery, peerAddr, timeoutMs),
     callback,
     userData,
   )

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -113,6 +113,9 @@ proc sendRequestToWakuThread*(
   ## wait until the Waku Thread properly received the request
   let res = ctx.reqReceivedSignal.waitSync()
   if res.isErr():
+    deallocShared(req)
     return err("Couldn't receive reqReceivedSignal signal")
 
+  ## Notice that in case of "ok", the deallocShared(req) is performed by the Waku Thread in the
+  ## process proc.
   ok()

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -10,6 +10,9 @@ type WakuContext* = object
   thread: Thread[(ptr WakuContext)]
   reqChannel: ChannelSPSCSingle[ptr WakuThreadRequest]
   reqSignal: ThreadSignalPtr
+    # to inform The Waku Thread (a.k.a TWT) that a new request is sent
+  reqReceivedSignal: ThreadSignalPtr
+    # to inform the main thread that the request is rx by TWT
   userData*: pointer
   eventCallback*: pointer
   eventUserdata*: pointer
@@ -37,6 +40,10 @@ proc runWaku(ctx: ptr WakuContext) {.async.} =
       error "waku thread could not receive a request"
       continue
 
+    let fireRes = ctx.reqReceivedSignal.fireSync()
+    if fireRes.isErr():
+      error "could not fireSync back to requester thread", error = fireRes.error
+
     ## Handle the request
     asyncSpawn WakuThreadRequest.process(request, addr waku)
 
@@ -50,6 +57,8 @@ proc createWakuThread*(): Result[ptr WakuContext, string] =
   var ctx = createShared(WakuContext, 1)
   ctx.reqSignal = ThreadSignalPtr.new().valueOr:
     return err("couldn't create reqSignal ThreadSignalPtr")
+  ctx.reqReceivedSignal = ThreadSignalPtr.new().valueOr:
+    return err("couldn't create reqReceivedSignal ThreadSignalPtr")
 
   ctx.running.store(true)
 
@@ -73,6 +82,7 @@ proc destroyWakuThread*(ctx: ptr WakuContext): Result[void, string] =
 
   joinThread(ctx.thread)
   ?ctx.reqSignal.close()
+  ?ctx.reqReceivedSignal.close()
   freeShared(ctx)
 
   return ok()
@@ -99,5 +109,10 @@ proc sendRequestToWakuThread*(
   if fireSyncRes.get() == false:
     deallocShared(req)
     return err("Couldn't fireSync in time")
+
+  ## wait until the Waku Thread properly received the request
+  let res = ctx.reqReceivedSignal.waitSync()
+  if res.isErr():
+    return err("Couldn't receive reqReceivedSignal signal")
 
   ok()


### PR DESCRIPTION
## Description
This PR was initially meant for enhancing how store protocol worked but it ended up collecting other enhancements

## Changes
- `%` not needed in `library/events/json_message_event.nim` because we want the messageHash be returned as a sequence, .e.g `[121, 9, ..., 98]`.
- `libwaku.nim`: avoid passing `WakuRelayHandler(onReceivedMessage(ctx)),` in `waku_relay_publish` because it doesn't make sense.
- simple refactor in `store_request.nim`.
- `waku_thread.nim`: addition of reqReceivedSignal to make sure every request is received (not processed) by _The Waku Thread_ before the next request is sent to _The Waku Thread_.

## How to test
Can be tested by using the `toy-chat` app. See https://github.com/waku-org/waku-rust-bindings/pull/105

## Impacted Issue
- https://github.com/waku-org/nwaku/issues/3076
