### PR TITLE
feat: connection change event

### DIFF
--- a/library/events/json_connection_change_event.nim
+++ b/library/events/json_connection_change_event.nim
@@ -1,0 +1,20 @@
+import system, std/json, libp2p/[connmanager, peerid]
+
+import ../../waku/common/base64, ./json_base_event
+
+type JsonConnectionChangeEvent* = ref object of JsonEvent
+  peerId*: PeerId
+  peerEvent*: PeerEventKind
+
+proc new*(
+    T: type JsonConnectionChangeEvent, peerId: PeerId, peerEvent: PeerEventKind
+): T =
+  # Returns a JsonConnectionChangeEvent event as indicated in
+  # https://rfc.vac.dev/spec/36/#jsonmessageevent-type
+
+  return JsonConnectionChangeEvent(
+    eventType: "relay_connection_change", peerId: peerId, peerEvent: peerEvent
+  )
+
+method `$`*(jsonConnectionChangeEvent: JsonConnectionChangeEvent): string =
+  $(%*jsonConnectionChangeEvent)

--- a/library/events/json_connection_change_event.nim
+++ b/library/events/json_connection_change_event.nim
@@ -13,7 +13,7 @@ proc new*(
   # https://rfc.vac.dev/spec/36/#jsonmessageevent-type
 
   return JsonConnectionChangeEvent(
-    eventType: "relay_connection_change", peerId: peerId, peerEvent: peerEvent
+    eventType: "connection_change", peerId: peerId, peerEvent: peerEvent
   )
 
 method `$`*(jsonConnectionChangeEvent: JsonConnectionChangeEvent): string =

--- a/library/events/json_connection_change_event.nim
+++ b/library/events/json_connection_change_event.nim
@@ -3,11 +3,11 @@ import system, std/json, libp2p/[connmanager, peerid]
 import ../../waku/common/base64, ./json_base_event
 
 type JsonConnectionChangeEvent* = ref object of JsonEvent
-  peerId*: PeerId
+  peerId*: string
   peerEvent*: PeerEventKind
 
 proc new*(
-    T: type JsonConnectionChangeEvent, peerId: PeerId, peerEvent: PeerEventKind
+    T: type JsonConnectionChangeEvent, peerId: string, peerEvent: PeerEventKind
 ): T =
   # Returns a JsonConnectionChangeEvent event as indicated in
   # https://rfc.vac.dev/spec/36/#jsonmessageevent-type

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -47,7 +47,7 @@ template checkLibwakuParams*(
   if isNil(callback):
     return RET_MISSING_CALLBACK
 
-template eventCallback(ctx: ptr WakuContext, eventName: string, body: untyped) =
+template callEventCallback(ctx: ptr WakuContext, eventName: string, body: untyped) =
   if isNil(ctx[].eventCallback):
     error eventName & " - eventCallback is nil"
     return
@@ -86,17 +86,17 @@ proc handleRequest(
 
 proc onConnectionChange(ctx: ptr WakuContext): ConnectionChangeHandler =
   return proc(peerId: PeerId, peerEvent: PeerEventKind) {.async.} =
-    eventCallback(ctx, "onConnectionChange"):
+    callEventCallback(ctx, "onConnectionChange"):
       $JsonConnectionChangeEvent.new(peerId, peerEvent)
 
 proc onReceivedMessage(ctx: ptr WakuContext): WakuRelayHandler =
   return proc(pubsubTopic: PubsubTopic, msg: WakuMessage) {.async.} =
-    eventCallback(ctx, "onReceivedMessage"):
+    callEventCallback(ctx, "onReceivedMessage"):
       $JsonMessageEvent.new(pubsubTopic, msg)
 
 proc onTopicHealthChange(ctx: ptr WakuContext): TopicHealthChangeHandler =
   return proc(pubsubTopic: PubsubTopic, topicHealth: TopicHealth) {.async.} =
-    eventCallBack(ctx, "onTopicHealthChange"):
+    callEventCallback(ctx, "onTopicHealthChange"):
       $JsonTopicHealthChangeEvent.new(pubsubTopic, topicHealth)
 
 ### End of not-exported components

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -87,7 +87,7 @@ proc handleRequest(
 proc onConnectionChange(ctx: ptr WakuContext): ConnectionChangeHandler =
   return proc(peerId: PeerId, peerEvent: PeerEventKind) {.async.} =
     callEventCallback(ctx, "onConnectionChange"):
-      $JsonConnectionChangeEvent.new(peerId, peerEvent)
+      $JsonConnectionChangeEvent.new($peerId, peerEvent)
 
 proc onReceivedMessage(ctx: ptr WakuContext): WakuRelayHandler =
   return proc(pubsubTopic: PubsubTopic, msg: WakuMessage) {.async.} =

--- a/waku/factory/app_callbacks.nim
+++ b/waku/factory/app_callbacks.nim
@@ -1,5 +1,6 @@
-import ../waku_relay
+import ../waku_relay, ../node/peer_manager
 
 type AppCallbacks* = ref object
   relayHandler*: WakuRelayHandler
   topicHealthChangeHandler*: TopicHealthChangeHandler
+  connectionChangeHandler*: ConnectionChangeHandler

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -175,6 +175,12 @@ proc setupAppCallbacks(
         err("Cannot configure topicHealthChangeHandler callback without Relay mounted")
     node.wakuRelay.onTopicHealthChange = appCallbacks.topicHealthChangeHandler
 
+  if not appCallbacks.connectionChangeHandler.isNil():
+    if node.peerManager.isNil():
+      return
+        err("Cannot configure connectionChangeHandler callback with empty peer manager")
+    node.peerManager.onConnectionChange = appCallbacks.connectionChangeHandler
+
   return ok()
 
 proc new*(

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -683,7 +683,7 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
           pm.wakuPeerStore.delete(peerId)
     if not pm.onConnectionChange.isNil():
       # we don't want to await for the callback to finish
-      discard pm.onConnectionChange(peerId, Joined)
+      asyncSpawn pm.onConnectionChange(peerId, Joined)
   of Left:
     direction = UnknownDirection
     connectedness = CanConnect
@@ -697,7 +697,7 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
         break
     if not pm.onConnectionChange.isNil():
       # we don't want to await for the callback to finish
-      discard pm.onConnectionChange(peerId, Left)
+      asyncSpawn pm.onConnectionChange(peerId, Left)
   of Identified:
     debug "event identified", peerId = peerId
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -71,6 +71,10 @@ const
   # Max peers that we allow from the same IP
   DefaultColocationLimit* = 5
 
+type ConnectionChangeHandler* = proc(
+  peerId: PeerId, peerEvent: PeerEventKind
+): Future[void] {.gcsafe, raises: [Defect].}
+
 type PeerManager* = ref object of RootObj
   switch*: Switch
   wakuPeerStore*: WakuPeerStore
@@ -87,6 +91,7 @@ type PeerManager* = ref object of RootObj
   colocationLimit*: int
   started: bool
   shardedPeerManagement: bool # temp feature flag
+  onConnectionChange*: ConnectionChangeHandler
 
 #~~~~~~~~~~~~~~~~~~~#
 # Helper Functions  #
@@ -676,6 +681,8 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
           debug "Pruning connection due to ip colocation", peerId = peerId, ip = ip
           asyncSpawn(pm.switch.disconnect(peerId))
           pm.wakuPeerStore.delete(peerId)
+    # we don't want to await for the callback to finish
+    discard pm.onConnectionChange(peerId, Joined)
   of Left:
     direction = UnknownDirection
     connectedness = CanConnect
@@ -687,6 +694,8 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
         if pm.ipTable[ip].len == 0:
           pm.ipTable.del(ip)
         break
+    # we don't want to await for the callback to finish
+    discard pm.onConnectionChange(peerId, Left)
   of Identified:
     debug "event identified", peerId = peerId
 

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -681,8 +681,9 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
           debug "Pruning connection due to ip colocation", peerId = peerId, ip = ip
           asyncSpawn(pm.switch.disconnect(peerId))
           pm.wakuPeerStore.delete(peerId)
-    # we don't want to await for the callback to finish
-    discard pm.onConnectionChange(peerId, Joined)
+    if not pm.onConnectionChange.isNil():
+      # we don't want to await for the callback to finish
+      discard pm.onConnectionChange(peerId, Joined)
   of Left:
     direction = UnknownDirection
     connectedness = CanConnect
@@ -694,8 +695,9 @@ proc onPeerEvent(pm: PeerManager, peerId: PeerId, event: PeerEvent) {.async.} =
         if pm.ipTable[ip].len == 0:
           pm.ipTable.del(ip)
         break
-    # we don't want to await for the callback to finish
-    discard pm.onConnectionChange(peerId, Left)
+    if not pm.onConnectionChange.isNil():
+      # we don't want to await for the callback to finish
+      discard pm.onConnectionChange(peerId, Left)
   of Identified:
     debug "event identified", peerId = peerId
 


### PR DESCRIPTION
# Description
Adding a connection health change event which gets triggered every time a peer connects or disconnects. When the event is triggered, a new app callback named `connectionChangeHandler` is called. This PR also integrates the event to libwaku.

# Changes

<!-- List of detailed changes -->

- [x] add a connection change event
- [x] integrating the event to libwaku
- [x] created an `eventCallback` template in libwaku to avoid code duplication 


## Issue
#3076 
