### PR TITLE
chore: Libwaku tweaks

### DIFF
--- a/library/alloc.nim
+++ b/library/alloc.nim
@@ -4,6 +4,11 @@ type SharedSeq*[T] = tuple[data: ptr UncheckedArray[T], len: int]
 proc alloc*(str: cstring): cstring =
   # Byte allocation from the given address.
   # There should be the corresponding manual deallocation with deallocShared !
+  if str.isNil():
+    var ret = cast[cstring](allocShared(1)) # Allocate memory for the null terminator
+    ret[0] = '\0' # Set the null terminator
+    return ret
+
   let ret = cast[cstring](allocShared(len(str) + 1))
   copyMem(ret, str, len(str) + 1)
   return ret

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -322,16 +322,10 @@ proc waku_relay_publish(
   defer:
     deallocShared(pst)
 
-  let targetPubSubTopic =
-    if len(pst) == 0:
-      DefaultPubsubTopic
-    else:
-      $pst
-
   handleRequest(
     ctx,
     RequestType.RELAY,
-    RelayRequest.createShared(RelayMsgType.PUBLISH, PubsubTopic($pst), nil, wakuMessage),
+    RelayRequest.createShared(RelayMsgType.PUBLISH, pst, nil, wakuMessage),
     callback,
     userData,
   )
@@ -379,9 +373,7 @@ proc waku_relay_subscribe(
   handleRequest(
     ctx,
     RequestType.RELAY,
-    RelayRequest.createShared(
-      RelayMsgType.SUBSCRIBE, PubsubTopic($pst), WakuRelayHandler(cb)
-    ),
+    RelayRequest.createShared(RelayMsgType.SUBSCRIBE, pst, WakuRelayHandler(cb)),
     callback,
     userData,
   )
@@ -407,7 +399,7 @@ proc waku_relay_add_protected_shard(
       RelayMsgType.ADD_PROTECTED_SHARD,
       clusterId = clusterId,
       shardId = shardId,
-      publicKey = $pubk,
+      publicKey = pubk,
     ),
     callback,
     userData,
@@ -430,9 +422,7 @@ proc waku_relay_unsubscribe(
     ctx,
     RequestType.RELAY,
     RelayRequest.createShared(
-      RelayMsgType.UNSUBSCRIBE,
-      PubsubTopic($pst),
-      WakuRelayHandler(onReceivedMessage(ctx)),
+      RelayMsgType.UNSUBSCRIBE, pst, WakuRelayHandler(onReceivedMessage(ctx))
     ),
     callback,
     userData,
@@ -454,7 +444,7 @@ proc waku_relay_get_num_connected_peers(
   handleRequest(
     ctx,
     RequestType.RELAY,
-    RelayRequest.createShared(RelayMsgType.LIST_CONNECTED_PEERS, PubsubTopic($pst)),
+    RelayRequest.createShared(RelayMsgType.LIST_CONNECTED_PEERS, pst),
     callback,
     userData,
   )
@@ -475,7 +465,7 @@ proc waku_relay_get_num_peers_in_mesh(
   handleRequest(
     ctx,
     RequestType.RELAY,
-    RelayRequest.createShared(RelayMsgType.LIST_MESH_PEERS, PubsubTopic($pst)),
+    RelayRequest.createShared(RelayMsgType.LIST_MESH_PEERS, pst),
     callback,
     userData,
   )
@@ -566,18 +556,10 @@ proc waku_lightpush_publish(
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 
-  let targetPubSubTopic =
-    if len(pst) == 0:
-      DefaultPubsubTopic
-    else:
-      $pst
-
   handleRequest(
     ctx,
     RequestType.LIGHTPUSH,
-    LightpushRequest.createShared(
-      LightpushMsgType.PUBLISH, PubsubTopic($pst), wakuMessage
-    ),
+    LightpushRequest.createShared(LightpushMsgType.PUBLISH, pst, wakuMessage),
     callback,
     userData,
   )

--- a/library/waku_thread/inter_thread_communication/requests/protocols/lightpush_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/lightpush_request.nim
@@ -32,7 +32,7 @@ type LightpushRequest* = object
 proc createShared*(
     T: type LightpushRequest,
     op: LightpushMsgType,
-    pubsubTopic: PubsubTopic,
+    pubsubTopic: cstring,
     m = WakuMessage(),
 ): ptr type T =
   var ret = createShared(T)

--- a/library/waku_thread/inter_thread_communication/requests/protocols/lightpush_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/lightpush_request.nim
@@ -97,12 +97,12 @@ proc process*(
       error "PUBLISH failed", error = errorMsg
       return err(errorMsg)
 
-    (
+    let msgHashHex = (
       await waku.node.wakuLightpushClient.publish(
         pubsubTopic, msg, peer = peerOpt.get()
       )
-    ).isOkOr:
+    ).valueOr:
       error "PUBLISH failed", error = error
       return err("LightpushRequest error publishing: " & $error)
 
-  return ok("")
+    return ok(msgHashHex)

--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -41,12 +41,12 @@ type RelayRequest* = object
 proc createShared*(
     T: type RelayRequest,
     op: RelayMsgType,
-    pubsubTopic: PubsubTopic = "",
+    pubsubTopic: cstring = nil,
     relayEventCallback: WakuRelayHandler = nil,
     m = WakuMessage(),
     clusterId: cint = 0,
     shardId: cint = 0,
-    publicKey: string = "",
+    publicKey: cstring = nil,
 ): ptr type T =
   var ret = createShared(T)
   ret[].operation = op

--- a/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim
@@ -106,9 +106,6 @@ proc destroyShared(self: ptr StoreRequest) =
 proc process_remote_query(
     self: ptr StoreRequest, waku: ptr Waku
 ): Future[Result[string, string]] {.async.} =
-  defer:
-    destroyShared(self)
-
   let jsonContentRes = catch:
     parseJson($self[].jsonQuery)
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -972,7 +972,7 @@ proc lightpushPublish*(
     pubsubTopic: Option[PubsubTopic],
     message: WakuMessage,
     peer: RemotePeerInfo,
-): Future[WakuLightPushResult[void]] {.async, gcsafe.} =
+): Future[WakuLightPushResult[string]] {.async, gcsafe.} =
   ## Pushes a `WakuMessage` to a node which relays it further on PubSub topic.
   ## Returns whether relaying was successful or not.
   ## `WakuMessage` should contain a `contentTopic` field for light node
@@ -986,7 +986,7 @@ proc lightpushPublish*(
       pubsubTopic: PubsubTopic,
       message: WakuMessage,
       peer: RemotePeerInfo,
-  ): Future[WakuLightPushResult[void]] {.async, gcsafe.} =
+  ): Future[WakuLightPushResult[string]] {.async, gcsafe.} =
     let msgHash = pubsubTopic.computeMessageHash(message).to0xHex()
     if not node.wakuLightpushClient.isNil():
       notice "publishing message with lightpush",
@@ -1023,7 +1023,7 @@ proc lightpushPublish*(
 # TODO: Move to application module (e.g., wakunode2.nim)
 proc lightpushPublish*(
     node: WakuNode, pubsubTopic: Option[PubsubTopic], message: WakuMessage
-): Future[WakuLightPushResult[void]] {.
+): Future[WakuLightPushResult[string]] {.
     async, gcsafe, deprecated: "Use 'node.lightpushPublish()' instead"
 .} =
   if node.wakuLightpushClient.isNil() and node.wakuLightPush.isNil():
@@ -1040,13 +1040,7 @@ proc lightpushPublish*(
   elif not node.wakuLightPush.isNil():
     peerOpt = some(RemotePeerInfo.init($node.switch.peerInfo.peerId))
 
-  let publishRes =
-    await node.lightpushPublish(pubsubTopic, message, peer = peerOpt.get())
-
-  if publishRes.isErr():
-    error "failed to publish message", error = publishRes.error
-
-  return publishRes
+  return await node.lightpushPublish(pubsubTopic, message, peer = peerOpt.get())
 
 ## Waku RLN Relay
 proc mountRlnRelay*(

--- a/waku/waku_lightpush/client.nim
+++ b/waku/waku_lightpush/client.nim
@@ -82,10 +82,10 @@ proc publish*(
     obs.onMessagePublished(pubSubTopic, message)
 
   notice "publishing message with lightpush",
-        pubsubTopic = pubsubTopic,
-        contentTopic = message.contentTopic,
-        target_peer_id = peer.peerId,
-        msg_hash = msg_hash_hex_str
+    pubsubTopic = pubsubTopic,
+    contentTopic = message.contentTopic,
+    target_peer_id = peer.peerId,
+    msg_hash = msg_hash_hex_str
 
   return ok(msg_hash_hex_str)
 

--- a/waku/waku_lightpush/client.nim
+++ b/waku/waku_lightpush/client.nim
@@ -71,24 +71,23 @@ proc publish*(
     wl: WakuLightPushClient,
     pubSubTopic: PubsubTopic,
     message: WakuMessage,
-    peer: PeerId | RemotePeerInfo,
-): Future[WakuLightPushResult[void]] {.async, gcsafe.} =
-  when peer is PeerId:
-    info "publish",
-      peerId = shortLog(peer),
-      msg_hash = computeMessageHash(pubsubTopic, message).to0xHex
-  else:
-    info "publish",
-      peerId = shortLog(peer.peerId),
-      msg_hash = computeMessageHash(pubsubTopic, message).to0xHex
-
+    peer: RemotePeerInfo,
+): Future[WakuLightPushResult[string]] {.async, gcsafe.} =
+  ## On success, returns the msg_hash of the published message
+  let msg_hash_hex_str = computeMessageHash(pubsubTopic, message).to0xHex()
   let pushRequest = PushRequest(pubSubTopic: pubSubTopic, message: message)
   ?await wl.sendPushRequest(pushRequest, peer)
 
   for obs in wl.publishObservers:
     obs.onMessagePublished(pubSubTopic, message)
 
-  return ok()
+  notice "publishing message with lightpush",
+        pubsubTopic = pubsubTopic,
+        contentTopic = message.contentTopic,
+        target_peer_id = peer.peerId,
+        msg_hash = msg_hash_hex_str
+
+  return ok(msg_hash_hex_str)
 
 proc publishToAny*(
     wl: WakuLightPushClient, pubSubTopic: PubsubTopic, message: WakuMessage


### PR DESCRIPTION
## Description
- Avoid the use of `string` type in libwaku. In fact, we should avoid any GC'ed type (`string`, `ref`, `closure`, `seq`) when performing ffi operations. Instead, we can only allocate/deallocate memory manually
- Initialize default `cstring` params with `nil` instead of an empty `string` (`""`)
- library/alloc.nim: reserve an empty cstring when `nil` is passed to `alloc` proc
- lightpush_request.nim, self_req_handler.nim: return a `msg_hash` when successful publish
- library/waku_thread/inter_thread_communication/requests/protocols/store_request.nim: rm extra `deallocShared`

