### PR TITLE
chore: golang example end using negentropy dependency plus simple readme.md

### DIFF
--- a/examples/golang/README.md
+++ b/examples/golang/README.md
@@ -1,13 +1,19 @@
 
 ## Pre-requisite
 libwaku.so is needed to be compiled and present in build folder. To create it:
+
+1. Run only the first time and after changing the current commit
+```code
+make update
+```
+2. Run the next every time you want to compile libwaku
 ```code
 make POSTGRES=1 libwaku -j4
 ```
 
 ## Compilation
 
-From nwaku root folder, do
+From the nwaku root folder:
 
 ```code
 go build -o waku-go examples/golang/waku.go

--- a/examples/golang/README.md
+++ b/examples/golang/README.md
@@ -2,13 +2,25 @@
 ## Pre-requisite
 libwaku.so is needed to be compiled and present in build folder. To create it:
 
-1. Run only the first time and after changing the current commit
+- Run only the first time and after changing the current commit
 ```code
 make update
 ```
-2. Run the next every time you want to compile libwaku
+- Run the next every time you want to compile libwaku
 ```code
 make POSTGRES=1 libwaku -j4
+```
+
+Also needed:
+
+- Install libpq (needed by Postgres client)
+  - On Linux:
+```code
+sudo apt install libpq5
+```
+  - On MacOS (not tested)
+```code
+brew install libpq
 ```
 
 ## Compilation

--- a/examples/golang/README.md
+++ b/examples/golang/README.md
@@ -1,0 +1,26 @@
+
+## Pre-requisite
+libwaku.so is needed to be compiled and present in build folder. To create it:
+```code
+make POSTGRES=1 libwaku -j4
+```
+
+## Compilation
+
+From nwaku root folder, do
+
+```code
+go build -o waku-go examples/golang/waku.go
+```
+
+## Run
+From the nwaku root folder:
+
+
+```code
+export LD_LIBRARY_PATH=build
+```
+
+```code
+./waku-go
+```

--- a/examples/golang/waku.go
+++ b/examples/golang/waku.go
@@ -1,7 +1,7 @@
 package main
 
 /*
-	#cgo LDFLAGS: -L../../build/ -lwaku -lnegentropy
+	#cgo LDFLAGS: -L../../build/ -lwaku
 	#cgo LDFLAGS: -L../../ -Wl,-rpath,../../
 
 	#include "../../library/libwaku.h"

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -1,10 +1,10 @@
 import
   std/[times, strutils, asyncnet, os, sequtils, sets, strformat],
+  regex,
   results,
   chronos,
   chronos/threadsync,
   metrics,
-  re,
   chronicles
 import ./query_metrics
 
@@ -247,8 +247,8 @@ proc dbConnQuery*(
 
   let cleanedQuery = ($query).replace(" ", "").replace("\n", "")
   ## remove everything between ' or " all possible sequence of numbers. e.g. rm partition partition
-  var querySummary = cleanedQuery.replace(re"""(['"]).*?\1""", "")
-  querySummary = querySummary.replace(re"\d+", "")
+  var querySummary = cleanedQuery.replace(re2("""(['"]).*?\\1"""), "")
+  querySummary = querySummary.replace(re2"\d+", "")
   querySummary = "query_tag_" & querySummary[0 ..< min(querySummary.len, 200)]
 
   var queryStartTime = getTime().toUnixFloat()

--- a/waku/common/databases/db_postgres/pgasyncpool.nim
+++ b/waku/common/databases/db_postgres/pgasyncpool.nim
@@ -29,11 +29,13 @@ proc new*(T: type PgAsyncPool, dbUrl: string, maxConnections: int): DatabaseResu
     if dbUrl.match(regex, m) == false:
       return err("could not properly parse dbUrl: " & dbUrl)
 
-    let user = m.captures[0]
-    let password = m.captures[1]
-    let host = m.captures[2]
-    let port = m.captures[3]
-    let dbName = m.captures[4]
+
+    let user = dbUrl[m.captures[0]]
+      ## m.captures[i] contains an slice with the desired value
+    let password = dbUrl[m.captures[1]]
+    let host = dbUrl[m.captures[2]]
+    let port = dbUrl[m.captures[3]]
+    let dbName = dbUrl[m.captures[4]]
 
     connString =
       fmt"user={user} host={host} port={port} dbname={dbName} password={password}"

--- a/waku/common/databases/db_postgres/pgasyncpool.nim
+++ b/waku/common/databases/db_postgres/pgasyncpool.nim
@@ -3,7 +3,8 @@
 {.push raises: [].}
 
 import
-  std/[sequtils, nre, strformat],
+  std/[sequtils, strformat],
+  regex,
   results,
   chronos,
   chronos/threadsync,
@@ -23,17 +24,20 @@ proc new*(T: type PgAsyncPool, dbUrl: string, maxConnections: int): DatabaseResu
   var connString: string
 
   try:
-    let regex = re("""^postgres:\/\/([^:]+):([^@]+)@([^:]+):(\d+)\/(.+)$""")
-    let matches = find(dbUrl, regex).get.captures
-    let user = matches[0]
-    let password = matches[1]
-    let host = matches[2]
-    let port = matches[3]
-    let dbName = matches[4]
+    let regex = re2("""^postgres:\/\/([^:]+):([^@]+)@([^:]+):(\d+)\/(.+)$""")
+    var m: RegexMatch2
+    if dbUrl.match(regex, m) == false:
+      return err("could not properly parse dbUrl: " & dbUrl)
+
+    let user = m.captures[0]
+    let password = m.captures[1]
+    let host = m.captures[2]
+    let port = m.captures[3]
+    let dbName = m.captures[4]
+
     connString =
       fmt"user={user} host={host} port={port} dbname={dbName} password={password}"
-  except KeyError, InvalidUnicodeError, RegexInternalError, ValueError, StudyError,
-      SyntaxError:
+  except KeyError, ValueError:
     return err("could not parse postgres string: " & getCurrentExceptionMsg())
 
   let pool = PgAsyncPool(

--- a/waku/common/databases/db_postgres/pgasyncpool.nim
+++ b/waku/common/databases/db_postgres/pgasyncpool.nim
@@ -29,7 +29,6 @@ proc new*(T: type PgAsyncPool, dbUrl: string, maxConnections: int): DatabaseResu
     if dbUrl.match(regex, m) == false:
       return err("could not properly parse dbUrl: " & dbUrl)
 
-
     let user = dbUrl[m.captures[0]]
       ## m.captures[i] contains an slice with the desired value
     let password = dbUrl[m.captures[1]]

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1,7 +1,7 @@
 {.push raises: [].}
 
 import
-  std/[nre, options, sequtils, strutils, strformat, times, sugar],
+  std/[options, sequtils, strutils, strformat, times, sugar],
   stew/[byteutils, arrayops],
   results,
   chronos,

--- a/waku/waku_archive_legacy/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive_legacy/driver/postgres_driver/postgres_driver.nim
@@ -4,7 +4,7 @@ else:
   {.push raises: [].}
 
 import
-  std/[nre, options, sequtils, strutils, strformat, times],
+  std/[options, sequtils, strutils, strformat, times],
   stew/[byteutils, arrayops],
   results,
   chronos,


### PR DESCRIPTION
- examples/golang/waku.go: Stop linking against negentropy in cgo example.
- Add README.md for golang example.
- In the other files: avoid dependency with `libpcre` library by avoid importing `re` and `nre` and instead, import regex. With that, we will only have dependency with `libpq` (for Postgres client) library.

( thanks @AYAHASSAN287 for the help testing and validating the golang example requirements :partying_face: )
