### PR TITLE
fix: avoid double db migration for sqlite

### DIFF
--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -268,12 +268,18 @@ proc setupProtocols(
     ## Regarding storage, the only diff between the current/future archive driver and the legacy
     ## one, is that the legacy stores an extra field: the id (message digest.)
 
+    ## TODO: remove this "migrate" variable once legacy store is removed
+    ## It is now necessary because sqlite's legacy store has an extra field: storedAt
+    ## This breaks compatibility between store's and legacy store's schemas in sqlite
+    ## So for now, we need to make sure that when legacy store is enabled and we use sqlite
+    ## that we migrate our db according to legacy store's schema to have the extra field
     var postgres = false
     when defined(postgres):
       postgres = true
 
     let migrate =
       if not postgres and conf.legacyStore: false else: conf.storeMessageDbMigration
+
     let archiveDriverRes = waitFor driver.ArchiveDriver.new(
       conf.storeMessageDbUrl, conf.storeMessageDbVacuum, migrate,
       conf.storeMaxNumDbConnections, onFatalErrorAction,

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -267,8 +267,9 @@ proc setupProtocols(
     ## then the legacy will be in charge of performing the archiving.
     ## Regarding storage, the only diff between the current/future archive driver and the legacy
     ## one, is that the legacy stores an extra field: the id (message digest.)
+    let migrate = if conf.legacyStore: false else: conf.storeMessageDbMigration
     let archiveDriverRes = waitFor driver.ArchiveDriver.new(
-      conf.storeMessageDbUrl, conf.storeMessageDbVacuum, conf.storeMessageDbMigration,
+      conf.storeMessageDbUrl, conf.storeMessageDbVacuum, migrate,
       conf.storeMaxNumDbConnections, onFatalErrorAction,
     )
     if archiveDriverRes.isErr():

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -267,7 +267,13 @@ proc setupProtocols(
     ## then the legacy will be in charge of performing the archiving.
     ## Regarding storage, the only diff between the current/future archive driver and the legacy
     ## one, is that the legacy stores an extra field: the id (message digest.)
-    let migrate = if conf.legacyStore: false else: conf.storeMessageDbMigration
+
+    var postgres = false
+    when defined(postgres):
+      postgres = true
+
+    let migrate =
+      if not postgres and conf.legacyStore: false else: conf.storeMessageDbMigration
     let archiveDriverRes = waitFor driver.ArchiveDriver.new(
       conf.storeMessageDbUrl, conf.storeMessageDbVacuum, migrate,
       conf.storeMaxNumDbConnections, onFatalErrorAction,


### PR DESCRIPTION

# Description
Avoiding double db migration when both Store and Legacy Store are mounted and sqlite is used.

When both store protocols are mounted, two db migrations are performed: one according to Legacy Store's migration definition and then other according to the newer Store. At the end, we end up having the DB schema set by the newer store.

However, in sqlite the schemas of Store and Legacy Store are different (Legacy Store has a `storedAt` field).Therefore, Legacy Store can't work properly with Store's schema.

Given that Legacy Store is planned to be deprecated and removed soon, instead of creating new migrations and making significant changes in the legacy archive driver to stop using the `storedAt` field, I'm introducing a pretty dirty workaround so we make sure that we don't get to a point of using a db with an incompatible schema.

The idea is to remove this piece of code as soon as we remove sqlite's Legacy Store. If the plan is to support Legacy Store for a long time, then this workaround is terrible and we should adapt sqlite's Legacy Store to stop using the `storedAt` field, the same way it's done in Postgres' Legacy Store.

However, if the plan is to remove Legacy Store soon, then this dirty workaround will spare us from lots of unnecessary work.

# Changes
- [x] avoid performing Store migration if Legacy Store is enabled and sqlite is being used


## Issue

closes #3236 
