### PR TITLE
chore: separating heaptrack from debug build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ HEAPTRACKER_INJECT ?= 0
 ifeq ($(HEAPTRACKER), 1)
 # Needed to make nimbus-build-system use the Nim's 'heaptrack_support' branch
 DOCKER_NIM_COMMIT := NIM_COMMIT=heaptrack_support
-TARGET := debug
+TARGET := prod-with-heaptrack
 
 ifeq ($(HEAPTRACKER_INJECT), 1)
 # the Nim compiler will load 'libheaptrack_inject.so'

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -56,7 +56,12 @@ pipeline {
     )
     booleanParam(
       name: 'DEBUG',
-      description: 'Enable debug features (heaptrack).',
+      description: 'Enable debug features',
+      defaultValue: false
+    )
+    booleanParam(
+      name: 'HEAPTRACK',
+      description: 'Enable heaptrack build',
       defaultValue: false
     )
   }
@@ -73,7 +78,7 @@ pipeline {
           "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres ' " +
           "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
           "--build-arg=DEBUG='${params.DEBUG ? "1" : "0"} ' " +
-          "--target=${params.DEBUG ? "debug" : "prod"} ."
+          "--target=${params.HEAPTRACK ? "prod-with-heaptrack" : "prod"} ."
         )
       } }
     }


### PR DESCRIPTION
# Description

Debug builds currently include heaptrack. In this PR, we separate heaptrack from debug builds, and rename the Dockerfile `debug` target to `prod-with-heaptrack` which is more accurate.
# Changes

## Issue
#3236 
