### PR TITLE
chore: completely remove pubsubTopics config param

### DIFF
--- a/apps/liteprotocoltester/liteprotocoltester.nim
+++ b/apps/liteprotocoltester/liteprotocoltester.nim
@@ -99,7 +99,6 @@ when isMainModule:
   wakuConf.dnsAddrs = true
   wakuConf.dnsAddrsNameServers = @[parseIpAddress("8.8.8.8"), parseIpAddress("1.1.1.1")]
 
-  wakuConf.pubsubTopics = conf.pubsubTopics
   wakuConf.contentTopics = conf.contentTopics
   wakuConf.clusterId = conf.clusterId
   ## TODO: Depending on the tester needs we might extend here with shards, clusterId, etc...

--- a/examples/wakustealthcommitments/node_spec.nim
+++ b/examples/wakustealthcommitments/node_spec.nim
@@ -26,10 +26,6 @@ proc setup*(): Waku =
   var conf = confRes.get()
 
   let twnClusterConf = ClusterConf.TheWakuNetworkConf()
-  if len(conf.shards) != 0:
-    conf.pubsubTopics = conf.shards.mapIt(twnClusterConf.pubsubTopics[it.uint16])
-  else:
-    conf.pubsubTopics = twnClusterConf.pubsubTopics
 
   # Override configuration
   conf.maxMessageSize = twnClusterConf.maxMessageSize

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -334,13 +334,6 @@ hence would have reachability issues.""",
       name: "num-shards-in-network"
     .}: uint32
 
-    pubsubTopics* {.
-      desc:
-        "Deprecated. Default pubsub topic to subscribe to. Argument may be repeated.",
-      defaultValue: @[],
-      name: "pubsub-topic"
-    .}: seq[string]
-
     shards* {.
       desc:
         "Shards index to subscribe to [0..NUM_SHARDS_IN_NETWORK-1]. Argument may be repeated.",

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -190,30 +190,6 @@ proc new*(
 
   logging.setupLog(confCopy.logLevel, confCopy.logFormat)
 
-  # TODO: remove after pubsubtopic config gets removed
-  var shards = newSeq[uint16]()
-  if confCopy.pubsubTopics.len > 0:
-    let shardsRes = topicsToRelayShards(confCopy.pubsubTopics)
-    if shardsRes.isErr():
-      error "failed to parse pubsub topic, please format according to static shard specification",
-        error = shardsRes.error
-      return err("failed to parse pubsub topic: " & $shardsRes.error)
-
-    let shardsOpt = shardsRes.get()
-
-    if shardsOpt.isSome():
-      let relayShards = shardsOpt.get()
-      if relayShards.clusterId != confCopy.clusterId:
-        error "clusterId of the pubsub topic should match the node's cluster. e.g. --pubsub-topic=/waku/2/rs/22/1 and --cluster-id=22",
-          nodeCluster = confCopy.clusterId, pubsubCluster = relayShards.clusterId
-        return err(
-          "clusterId of the pubsub topic should match the node's cluster. e.g. --pubsub-topic=/waku/2/rs/22/1 and --cluster-id=22"
-        )
-
-      for shard in relayShards.shardIds:
-        shards.add(shard)
-      confCopy.shards = shards
-
   case confCopy.clusterId
 
   # cluster-id=1 (aka The Waku Network)


### PR DESCRIPTION
## Description
Complete the deprecation of pubsubTopic parameter. From now on, the networks topology will be defined by cluster-ids and shard-ids. The "pubsubtopic" concept will be only used internally in nwaku codebase.

- [x] Remove pubsub-topic from `external_config.nim`
- [ ] Remove all pubsubTopic mentions from REST

## Issue

closes https://github.com/waku-org/nwaku/issues/3050