### PR TITLE
chore: compiling with skipParentCfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ TARGET ?= prod
 ## Git version
 GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
 ## Compilation parameters. If defined in the CLI the assignments won't be executed
-NIM_PARAMS := $(NIM_PARAMS) -d:git_version=\"$(GIT_VERSION)\" --skipParentCfg:on
+NIM_PARAMS := $(NIM_PARAMS) -d:git_version=\"$(GIT_VERSION)\"
 
 ## Heaptracker options
 HEAPTRACKER ?= 0

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ TARGET ?= prod
 ## Git version
 GIT_VERSION ?= $(shell git describe --abbrev=6 --always --tags)
 ## Compilation parameters. If defined in the CLI the assignments won't be executed
-NIM_PARAMS := $(NIM_PARAMS) -d:git_version=\"$(GIT_VERSION)\"
+NIM_PARAMS := $(NIM_PARAMS) -d:git_version=\"$(GIT_VERSION)\" --skipParentCfg:on
 
 ## Heaptracker options
 HEAPTRACKER ?= 0
@@ -266,7 +266,7 @@ NPH:=$(shell dirname $(NIM_BINARY))/nph
 
 build-nph: | build deps
 ifeq ("$(wildcard $(NPH))","")
-		$(ENV_SCRIPT) nim c vendor/nph/src/nph.nim && \
+		$(ENV_SCRIPT) nim c --skipParentCfg:on vendor/nph/src/nph.nim && \
 		mv vendor/nph/src/nph $(shell dirname $(NPH))
 		echo "nph utility is available at " $(NPH)
 else

--- a/waku.nimble
+++ b/waku.nimble
@@ -65,11 +65,11 @@ proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
     extra_params &= " " & paramStr(i)
   if `type` == "static":
     exec "nim c" & " --out:build/" & name &
-      ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header --undef:metrics " &
+      ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header --undef:metrics --skipParentCfg:on " &
       extra_params & " " & srcDir & name & ".nim"
   else:
     exec "nim c" & " --out:build/" & name &
-      ".so --threads:on --app:lib --opt:size --noMain --mm:refc --header --undef:metrics " &
+      ".so --threads:on --app:lib --opt:size --noMain --mm:refc --header --undef:metrics --skipParentCfg:on " &
       extra_params & " " & srcDir & name & ".nim"
 
 proc buildMobileAndroid(srcDir = ".", params = "") =


### PR DESCRIPTION
# Description
When executing `make update` or when compiling libwaku inside `status-desktop`, the `status-desktop` nim configurations are picked up and compilation fails.

Adding the `skipParentCfg` flag to separate the nwaku's compilation configurations from the ones used in parent repositories.

# Changes

<!-- List of detailed changes -->

- [x] using `skipParentCfg: on` for `make update` and `make libwaku`


## Issue

#3076 
