### PR TITLE
feat: incentivization POC: add double-spend check for txid-based eligibility

### DIFF
--- a/tests/incentivization/test_poc.nim
+++ b/tests/incentivization/test_poc.nim
@@ -208,7 +208,8 @@ suite "Waku Incentivization PoC Eligibility Proofs":
       eligibilityProof, receiverExpected, TxValueExpectedWei
     )
 
-    assert (isEligibleOnce.isOk() and isEligibleTwice.isErr()), isEligibleTwice.error
+    assert isEligibleOnce.isOk()
+    assert isEligibleTwice.isErr(), isEligibleTwice.error
 
   # Stop Anvil daemon
   stopAnvil(runAnvil)

--- a/tests/incentivization/test_poc.nim
+++ b/tests/incentivization/test_poc.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options],
+  std/[options, sets],
   testutils/unittests,
   chronos,
   web3,
@@ -193,6 +193,22 @@ suite "Waku Incentivization PoC Eligibility Proofs":
     )
 
     assert isEligible.isOk(), isEligible.error
+
+  asyncTest "incentivization PoC: double-spend tx is not eligible":
+    ## Test that the same tx submitted twice is not eligible the second time
+
+    let eligibilityProof =
+      EligibilityProof(proofOfPayment: some(@(txHashRightReceiverRightAmount.bytes())))
+
+    let isEligibleOnce = await manager.isEligibleTxId(
+      eligibilityProof, receiverExpected, TxValueExpectedWei
+    )
+
+    let isEligibleTwice = await manager.isEligibleTxId(
+      eligibilityProof, receiverExpected, TxValueExpectedWei
+    )
+
+    assert (isEligibleOnce.isOk() and isEligibleTwice.isErr()), isEligibleTwice.error
 
   # Stop Anvil daemon
   stopAnvil(runAnvil)

--- a/tests/incentivization/test_poc.nim
+++ b/tests/incentivization/test_poc.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options, sets],
+  std/options,
   testutils/unittests,
   chronos,
   web3,

--- a/waku/incentivization/eligibility_manager.nim
+++ b/waku/incentivization/eligibility_manager.nim
@@ -13,8 +13,7 @@ type EligibilityManager* = ref object # FIXME: make web3 private?
 proc init*(
     T: type EligibilityManager, ethClient: string
 ): Future[EligibilityManager] {.async.} =
-  result =
-    EligibilityManager(web3: await newWeb3(ethClient), seenTxIds: initHashSet[TxHash]())
+  return EligibilityManager(web3: await newWeb3(ethClient), seenTxIds: initHashSet[TxHash]())
   # TODO: handle error if web3 instance is not established
 
 # Clean up the web3 instance
@@ -66,7 +65,7 @@ proc isEligibleTxId*(
   let txHashWasSeen = (txHash in eligibilityManager.seenTxIds)
   eligibilityManager.seenTxIds.incl(txHash)
   if txHashWasSeen:
-    return err("TxHash " & $txHash & "was already checked (double-spend attempt)")
+    return err("TxHash " & $txHash & " was already checked (double-spend attempt)")
   try:
     let txAndTxReceipt = await eligibilityManager.getTxAndTxReceipt(txHash)
     txAndTxReceipt.isOkOr:

--- a/waku/incentivization/eligibility_manager.nim
+++ b/waku/incentivization/eligibility_manager.nim
@@ -1,4 +1,4 @@
-import std/options, chronos, web3, stew/byteutils, stint, results, chronicles
+import std/[options, sets], chronos, web3, stew/byteutils, stint, results, chronicles
 
 import waku/incentivization/rpc, tests/waku_rln_relay/[utils_onchain, utils]
 
@@ -7,12 +7,14 @@ const TxReceiptQueryTimeout = 3.seconds
 
 type EligibilityManager* = ref object # FIXME: make web3 private?
   web3*: Web3
+  seenTxIds*: HashSet[TxHash]
 
 # Initialize the eligibilityManager with a web3 instance
 proc init*(
     T: type EligibilityManager, ethClient: string
 ): Future[EligibilityManager] {.async.} =
-  result = EligibilityManager(web3: await newWeb3(ethClient))
+  result =
+    EligibilityManager(web3: await newWeb3(ethClient), seenTxIds: initHashSet[TxHash]())
   # TODO: handle error if web3 instance is not established
 
 # Clean up the web3 instance
@@ -60,6 +62,11 @@ proc isEligibleTxId*(
   var tx: TransactionObject
   var txReceipt: ReceiptObject
   let txHash = TxHash.fromHex(byteutils.toHex(eligibilityProof.proofOfPayment.get()))
+  # check that it is not a double-spend
+  let txHashWasSeen = (txHash in eligibilityManager.seenTxIds)
+  eligibilityManager.seenTxIds.incl(txHash)
+  if txHashWasSeen:
+    return err("TxHash " & $txHash & "was already checked (double-spend attempt)")
   try:
     let txAndTxReceipt = await eligibilityManager.getTxAndTxReceipt(txHash)
     txAndTxReceipt.isOkOr:


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->

This is a continuation of the work started in https://github.com/waku-org/nwaku/pull/3166 with associated deliverable https://github.com/waku-org/pm/issues/245.

The overall task is to implement a proof-of-concept service incentivization mechanism, where clients submit txids alongside their requests, and servers check eligibility of those txids as proofs of payment.

This PR adds a check against double-spending. A client is prevented from submitting the same txid twice. The server keeps track of txids it has seen, and checks every txid against that set. If the txid is in the set, the eligibility check fails. 

Note the assumption: a transaction once deemed ineligible will never become eligible in the future, even (for example) in a scenario where a transaction underpaid, and later the server decreased its prices. Such scenarios look too complicated for a PoC. For now, we assume that a server declares a transaction eligible or ineligible when it is first submitted as proof of payment. No matter the result of the initial check, the same txid will be ineligible on all future submissions.

# Changes

<!-- List of detailed changes -->

- [x] implement double-cpend check for eligibility PoC

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->