### PR TITLE
chore: filter remove all subscription from a peer that is leaving

### DIFF
--- a/tests/node/test_wakunode_filter.nim
+++ b/tests/node/test_wakunode_filter.nim
@@ -556,7 +556,7 @@ suite "Waku Filter - End to End":
       )
 
     discard await wakuFilter.subscriptions.addSubscription(
-      clientPeerId, filterCriteria.toHashSet(), peerManager
+      clientPeerId, filterCriteria.toHashSet()
     )
 
     let
@@ -605,7 +605,6 @@ suite "Waku Filter - End to End":
         await wakuFilter.subscriptions.addSubscription(
           peers[index].switch.peerInfo.peerId,
           @[(DefaultPubsubTopic, DefaultContentTopic)].toHashSet(),
-          peerManager,
         )
       ).isOkOr:
         assert false, $error

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -962,6 +962,11 @@ proc pruneInRelayConns(pm: PeerManager, amount: int) {.async.} =
     trace "Pruning Peer", Peer = $p
     asyncSpawn(pm.switch.disconnect(p))
 
+proc addExtPeerEventHandler*(
+    pm: PeerManager, eventHandler: PeerEventHandler, eventKind: PeerEventKind
+) =
+  pm.switch.addPeerEventHandler(eventHandler, eventKind)
+
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 # Initialization and Constructor #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -186,6 +186,7 @@ proc pushToPeer(
       if connRes.isNone():
         ## We do not remove this peer, but allow the underlying peer manager
         ## to do so if it is deemed necessary
+        error "pushToPeer no connection to peer", peerId = shortLog(peerId)
         return err("pushToPeer no connection to peer: " & shortLog(peerId))
 
       let newConn = connRes.get()
@@ -231,10 +232,6 @@ proc pushToPeers(
       pushFuts.add(pushFut)
 
     await allFutures(pushFuts)
-
-    for fut in pushFuts:
-      if fut.read().isErr():
-        error "error pushing message", error = fut.read().error
 
 proc maintainSubscriptions*(wf: WakuFilter) {.async.} =
   debug "maintaining subscriptions"

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -188,7 +188,9 @@ proc pushToPeer(
         ## to do so if it is deemed necessary
         return err("pushToPeer no connection to peer: " & shortLog(peerId))
 
-      connRes.get()
+      let newConn = connRes.get()
+      wf.peerConnections[peerId] = newConn
+      newConn
 
   await conn.writeLp(buffer)
   debug "published successful", peerId = shortLog(peerId), conn

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -175,7 +175,7 @@ proc pushToPeer(
   if not wf.peerManager.wakuPeerStore.hasPeer(peerId, WakuFilterPushCodec):
     # Check that peer has not been removed from peer store
     error "no addresses for peer", peerId = shortLog(peerId)
-    return
+    return err("no addresses for peer: " & $peerId)
 
   let conn =
     if wf.peerConnections.contains(peerId):

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -69,7 +69,7 @@ proc subscribe(
   debug "subscribing peer to filter criteria",
     peerId = peerId, filterCriteria = filterCriteria
 
-  (await wf.subscriptions.addSubscription(peerId, filterCriteria, wf.peerManager)).isOkOr:
+  (await wf.subscriptions.addSubscription(peerId, filterCriteria)).isOkOr:
     return err(FilterSubscribeError.serviceUnavailable(error))
 
   debug "correct subscription", peerId = peerId
@@ -335,7 +335,7 @@ proc new*(
 ): T =
   let wf = WakuFilter(
     subscriptions: FilterSubscriptions.new(
-      subscriptionTimeout, maxFilterPeers, maxFilterCriteriaPerPeer
+      subscriptionTimeout, maxFilterPeers, maxFilterCriteriaPerPeer, peerManager
     ),
     peerManager: peerManager,
     messageCache: init(TimedCache[string], messageCacheTTL),


### PR DESCRIPTION
## Description
@fbarbu15 reported that `waku-interop-tests` started to fail.
The problem appeared when one filter-client completely disconnects, e.g., node shutdown. In this case, the `waku_filter_2/subscriptions.nim` module was still keeping an incorrect `Connection` instance. 

Therefore, the `subscriptions` module should listen for peer left events in order to completely remove all the subscription data for that peer.

## Issue

closes: https://github.com/waku-org/nwaku/issues/3263
closes: https://github.com/waku-org/nwaku/issues/3254
