### PR TITLE
fix: avoid sending relay callbacks if relay is disabled

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/node_lifecycle_request.nim
@@ -67,6 +67,11 @@ proc createWaku(
             formattedString & ". expected type: " & $typeof(confValue)
         )
 
+  # Don't send relay app callbacks if relay is disabled
+  if not conf.relay and not appCallbacks.isNil():
+    appCallbacks.relayHandler = nil
+    appCallbacks.topicHealthChangeHandler = nil
+
   let wakuRes = Waku.new(conf, appCallbacks).valueOr:
     error "waku initialization failed", error = error
     return err("Failed setting up Waku: " & $error)


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
When we attempt to start a node with Relay disabled using libwaku, the node creation fails because we attempt to set Relay app callbacks while having Relay disabled.

We should not attempt to configure Relay related callbacks if Relay is disabled.
Added a fix to send `nil` for the Relay related callbacks in case Relay is disabled.

Notice that I override the callbacks instead of configuring them to `nil` in the first place, and that's because when we set the callbacks, we still don't have the configuration parsed and it's not trivial to parse. I also attempted to set the callbacks after parsing the configuration but I got into a circular dependency error.

Therefore, I'm just adjusting which callbacks to actually send the moment we have the configuration parsed.

# Changes



- [x] setting Relay callbacks to `nil` in case Relay is disabled

## Issue
#3076 
