### PR TITLE
chore: refactor filter to react when the remote peer closes the stream

### DIFF
--- a/waku/incentivization/eligibility_manager.nim
+++ b/waku/incentivization/eligibility_manager.nim
@@ -13,7 +13,8 @@ type EligibilityManager* = ref object # FIXME: make web3 private?
 proc init*(
     T: type EligibilityManager, ethClient: string
 ): Future[EligibilityManager] {.async.} =
-  return EligibilityManager(web3: await newWeb3(ethClient), seenTxIds: initHashSet[TxHash]())
+  return
+    EligibilityManager(web3: await newWeb3(ethClient), seenTxIds: initHashSet[TxHash]())
   # TODO: handle error if web3 instance is not established
 
 # Clean up the web3 instance


### PR DESCRIPTION
# Description
Better control when the remote peer closes the WakuFilterPushCodec stream remotely.
For example, go-waku closes the stream for every received message. On the other hand, js-waku keeps the stream opened. Therefore, we support both scenarios.

## Issue

- https://github.com/waku-org/nwaku/issues/3236

closes https://github.com/waku-org/nwaku/issues/3271
