### PR TITLE
chore: better proof handling in REST

### DIFF
--- a/tests/testlib/wakucore.nim
+++ b/tests/testlib/wakucore.nim
@@ -50,6 +50,7 @@ proc fakeWakuMessage*(
     meta: string | seq[byte] = newSeq[byte](),
     ts = now(),
     ephemeral = false,
+    proof: seq[byte] = toBytes("proof-test"),
 ): WakuMessage =
   var payloadBytes: seq[byte]
   var metaBytes: seq[byte]
@@ -71,4 +72,5 @@ proc fakeWakuMessage*(
     version: 2,
     timestamp: ts,
     ephemeral: ephemeral,
+    proof: proof,
   )

--- a/tests/testlib/wakucore.nim
+++ b/tests/testlib/wakucore.nim
@@ -50,7 +50,7 @@ proc fakeWakuMessage*(
     meta: string | seq[byte] = newSeq[byte](),
     ts = now(),
     ephemeral = false,
-    proof: seq[byte] = toBytes("proof-test"),
+    proof = newSeq[byte](),
 ): WakuMessage =
   var payloadBytes: seq[byte]
   var metaBytes: seq[byte]

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -128,7 +128,6 @@ suite "Onchain group manager":
     (await manager.startGroupSync()).isOkOr:
       raiseAssert $error
 
-
   asyncTest "startGroupSync: should guard against uninitialized state":
     (await manager.startGroupSync()).isErrOr:
       raiseAssert "Expected error when not initialized"

--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -100,7 +100,9 @@ suite "Waku v2 Rest API - lightpush":
     let restLightPushTest = await RestLightPushTest.init()
 
     let message: RelayWakuMessage = fakeWakuMessage(
-        contentTopic = DefaultContentTopic, payload = toBytes("TEST-1")
+        contentTopic = DefaultContentTopic,
+        payload = toBytes("TEST-1"),
+        proof = toBytes("proof-test"),
       )
       .toRelayWakuMessage()
 

--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -96,6 +96,27 @@ proc shutdown(self: RestLightPushTest) {.async.} =
   await allFutures(self.serviceNode.stop(), self.pushNode.stop())
 
 suite "Waku v2 Rest API - lightpush":
+  asyncTest "Push message with proof":
+    let restLightPushTest = await RestLightPushTest.init()
+
+    let message: RelayWakuMessage = fakeWakuMessage(
+        contentTopic = DefaultContentTopic, payload = toBytes("TEST-1")
+      )
+      .toRelayWakuMessage()
+
+    check message.proof.isSome()
+
+    let requestBody =
+      PushRequest(pubsubTopic: some(DefaultPubsubTopic), message: message)
+
+    let response = await restLightPushTest.client.sendPushRequest(body = requestBody)
+
+    ## Validate that the push request failed because the node is not
+    ## connected to other node but, doesn't fail because of not properly
+    ## handling the proof message attribute within the REST request.
+    check:
+      response.data == "Failed to request a message push: not_published_to_any_peer"
+
   asyncTest "Push message request":
     # Given
     let restLightPushTest = await RestLightPushTest.init()

--- a/waku/waku_api/rest/serdes.nim
+++ b/waku/waku_api/rest/serdes.nim
@@ -65,8 +65,7 @@ proc decodeFromJsonBytes*[T](
       )
     )
   except SerializationError:
-    # TODO: Do better error reporting here
-    err("Unable to deserialize data")
+    err("Unable to deserialize data: " & getCurrentExceptionMsg())
 
 proc encodeIntoJsonString*(value: auto): SerdesResult[string] =
   var encoded: string

--- a/waku/waku_store_sync.nim
+++ b/waku/waku_store_sync.nim
@@ -1,8 +1,6 @@
 {.push raises: [].}
 
 import
-  ./waku_store_sync/reconciliation,
-  ./waku_store_sync/transfer,
-  ./waku_store_sync/common
+  ./waku_store_sync/reconciliation, ./waku_store_sync/transfer, ./waku_store_sync/common
 
 export reconciliation, transfer, common


### PR DESCRIPTION
## Description

Investigating another REST lightpush issue reported by @AlbertoSoutullo in the `v0.35.0-rc.1` I noticed that we weren't supporting the example shown in https://waku-org.github.io/waku-rest-api/#post-/lightpush/v1/message

![image](https://github.com/user-attachments/assets/5125892e-e4bd-4209-9b18-34edbb138dcd)

This PR aims to support that example.

It is exptected that the `waku-interop-tests` are failing. The following `waku-interop-tests` PR was submitted to fix that: https://github.com/waku-org/waku-interop-tests/pull/105 and this issue shouldn't happen in upcoming PRs.

## Issue

- https://github.com/waku-org/nwaku/issues/3236


