### PR TITLE
chore: add waku-rlnv2-contract as vendor dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -189,3 +189,8 @@
 	url = https://github.com/vacp2p/nim-ngtcp2.git
 	ignore = untracked
 	branch = master
+[submodule "vendor/waku-rlnv2-contract"]
+	path = vendor/waku-rlnv2-contract
+	url = https://github.com/waku-org/waku-rlnv2-contract.git
+	ignore = untracked
+	branch = master


### PR DESCRIPTION
The waku-rlnv2-contract commit (a576a89) that is being added is the one the currently used by _The Waku Network_

## Issue

- https://github.com/waku-org/nwaku/issues/3236
