### PR TITLE
chore: supporting parallel libwaku requests

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -79,6 +79,7 @@ proc handleRequest(
 ): cint =
   waku_thread.sendRequestToWakuThread(ctx, requestType, content, callback, userData).isOkOr:
     let msg = "libwaku error: " & $error
+    echo msg
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -79,7 +79,6 @@ proc handleRequest(
 ): cint =
   waku_thread.sendRequestToWakuThread(ctx, requestType, content, callback, userData).isOkOr:
     let msg = "libwaku error: " & $error
-    echo msg
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
 

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -123,7 +123,6 @@ proc sendRequestToWakuThread*(
 
   ## wait until the Waku Thread properly received the request
   let res = ctx.reqReceivedSignal.waitSync()
-
   if res.isErr():
     deallocShared(req)
     return err("Couldn't receive reqReceivedSignal signal")

--- a/library/waku_thread/waku_thread.nim
+++ b/library/waku_thread/waku_thread.nim
@@ -101,7 +101,7 @@ proc sendRequestToWakuThread*(
 
   # This lock is only necessary while we use a SP Channel and while the signalling
   # between threads assumes that there aren't concurrent requests.
-  # Rearchitecting the signaling + migrating to a MP Channel will allow us receive
+  # Rearchitecting the signaling + migrating to a MP Channel will allow us to receive
   # requests concurrently and spare us the need of locks
   ctx.lock.acquire()
   ## Sending the request


### PR DESCRIPTION
# Description
Adding a lock so multiple requests sent by different threads can be handled in parallel.

The lock applies only from the moment a task enters the queue to the moment it starts getting handled. Many requests can be handled in parallel, however, the requests are communicated to the Waku Thread one at a time.

# Changes

- [x] adding a lock from the moment a request is sent to the Waku Thread, to the moment it's acknowledged by it and started getting handled

## Note:
This is the same PR as https://github.com/waku-org/nwaku/pull/3273 but I wasn't able to reopen it, so created this one instead.

This is a temporary solution until https://github.com/waku-org/nwaku/issues/3295 is completed


## Issue

 - #3076 

