### PR TITLE
chore: more efficient metrics usage

### DIFF
--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -237,46 +237,10 @@ proc isSecureString(input: string): bool =
 
 proc convertQueryToMetricLabel(query: string): string =
   ## Simple query categorization. The output label is the one that should be used in query metrics
-  if query.contains("contentTopic IN"):
-    return ContentTopicQuery
-  elif query.contains("SELECT version()"):
-    return SelectVersionQuery
-  elif query.contains("WITH min_timestamp"):
-    return MessagesLookupQuery
-  elif query.contains(
-    "SELECT messageHash FROM messages WHERE pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?"
-  ):
-    return MsgHashWithoutContentTopicQuery
-  elif query.contains("AS partition_name"):
-    return GetPartitionsListQuery
-  elif query.contains("SELECT COUNT(1) FROM messages"):
-    return CountMsgsQuery
-  elif query.contains(
-    "SELECT messageHash FROM messages WHERE (timestamp, messageHash) < (?,?) AND pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?"
-  ):
-    return MsgHashWithCursorQuery
-  elif query.contains("SELECT pg_database_size(current_database())"):
-    return GetDatabaseSizeQuery
-  elif query.contains("DELETE FROM messages_lookup WHERE timestamp"):
-    return DeleteFromMessagesLookupQuery
-  elif query.contains("DROP TABLE messages_"):
-    return DropPartitionTableQuery
-  elif query.contains("ALTER TABLE messages DETACH PARTITION"):
-    return DetachPartitionQuery
-  elif query.contains("SELECT pg_size_pretty(pg_total_relation_size(C.oid))"):
-    return GetPartitionSizeQuery
-  elif query.contains("pg_try_advisory_lock"):
-    return TryAdvisoryLockQuery
-  elif query.contains(
-    "SELECT messageHash FROM messages ORDER BY timestamp DESC, messageHash DESC LIMIT ?"
-  ):
-    return GetAllMsgHashQuery
-  elif query.contains("SELECT pg_advisory_unlock"):
-    return AdvisoryUnlockQuery
-  elif query.contains("ANALYZE messages"):
-    return AnalyzeMessagesQuery
-  elif query.contains("SELECT EXISTS"):
-    return CheckVersionTableExistsQuery
+  for snippetQuery, metric in QueriesToMetricMap.pairs():
+    if query.contains($snippetQuery):
+      return $metric
+  return "unknown_query_metric"
 
 proc dbConnQuery*(
     dbConnWrapper: DbConnWrapper,

--- a/waku/common/databases/db_postgres/dbconn.nim
+++ b/waku/common/databases/db_postgres/dbconn.nim
@@ -235,6 +235,49 @@ proc isSecureString(input: string): bool =
 
   return true
 
+proc convertQueryToMetricLabel(query: string): string =
+  ## Simple query categorization. The output label is the one that should be used in query metrics
+  if query.contains("contentTopic IN"):
+    return ContentTopicQuery
+  elif query.contains("SELECT version()"):
+    return SelectVersionQuery
+  elif query.contains("WITH min_timestamp"):
+    return MessagesLookupQuery
+  elif query.contains(
+    "SELECT messageHash FROM messages WHERE pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?"
+  ):
+    return MsgHashWithoutContentTopicQuery
+  elif query.contains("AS partition_name"):
+    return GetPartitionsListQuery
+  elif query.contains("SELECT COUNT(1) FROM messages"):
+    return CountMsgsQuery
+  elif query.contains(
+    "SELECT messageHash FROM messages WHERE (timestamp, messageHash) < (?,?) AND pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?"
+  ):
+    return MsgHashWithCursorQuery
+  elif query.contains("SELECT pg_database_size(current_database())"):
+    return GetDatabaseSizeQuery
+  elif query.contains("DELETE FROM messages_lookup WHERE timestamp"):
+    return DeleteFromMessagesLookupQuery
+  elif query.contains("DROP TABLE messages_"):
+    return DropPartitionTableQuery
+  elif query.contains("ALTER TABLE messages DETACH PARTITION"):
+    return DetachPartitionQuery
+  elif query.contains("SELECT pg_size_pretty(pg_total_relation_size(C.oid))"):
+    return GetPartitionSizeQuery
+  elif query.contains("pg_try_advisory_lock"):
+    return TryAdvisoryLockQuery
+  elif query.contains(
+    "SELECT messageHash FROM messages ORDER BY timestamp DESC, messageHash DESC LIMIT ?"
+  ):
+    return GetAllMsgHashQuery
+  elif query.contains("SELECT pg_advisory_unlock"):
+    return AdvisoryUnlockQuery
+  elif query.contains("ANALYZE messages"):
+    return AnalyzeMessagesQuery
+  elif query.contains("SELECT EXISTS"):
+    return CheckVersionTableExistsQuery
+
 proc dbConnQuery*(
     dbConnWrapper: DbConnWrapper,
     query: SqlQuery,
@@ -302,9 +345,8 @@ proc dbConnQueryPrepared*(
     error "error in dbConnQueryPrepared", error = $error
     return err("error in dbConnQueryPrepared calling sendQuery: " & $error)
 
-  let stmtNameSummary = stmtName[0 ..< min(stmtName.len, 128)]
   let sendDuration = getTime().toUnixFloat() - queryStartTime
-  query_time_secs.set(sendDuration, [stmtNameSummary, "sendToDBQuery"])
+  query_time_secs.set(sendDuration, [stmtName, "sendToDBQuery"])
 
   queryStartTime = getTime().toUnixFloat()
 
@@ -312,9 +354,9 @@ proc dbConnQueryPrepared*(
     return err("error in dbConnQueryPrepared calling waitQueryToFinish: " & $error)
 
   let waitDuration = getTime().toUnixFloat() - queryStartTime
-  query_time_secs.set(waitDuration, [stmtNameSummary, "waitFinish"])
+  query_time_secs.set(waitDuration, [stmtName, "waitFinish"])
 
-  query_count.inc(labelValues = [stmtNameSummary])
+  query_count.inc(labelValues = [stmtName])
 
   if "insert" notin stmtName.toLower():
     debug "dbConnQueryPrepared",

--- a/waku/common/databases/db_postgres/query_metrics.nim
+++ b/waku/common/databases/db_postgres/query_metrics.nim
@@ -5,3 +5,23 @@ declarePublicGauge query_time_secs,
 
 declarePublicCounter query_count,
   "number of times a query is being performed", labels = ["query"]
+
+## Possible labels
+## The above metrics can only use the following labels
+const ContentTopicQuery* = "content_topic"
+const SelectVersionQuery* = "select_version"
+const MessagesLookupQuery* = "messages_lookup"
+const MsgHashWithoutContentTopicQuery* = "msg_hash_no_ctopic"
+const MsgHashWithCursorQuery* = "msg_hash_with_cursor"
+const GetPartitionsListQuery* = "get_partitions_list"
+const CountMsgsQuery* = "count_msgs"
+const GetDatabaseSizeQuery* = "get_database_size"
+const DeleteFromMessagesLookupQuery* = "delete_from_msgs_lookup"
+const DropPartitionTableQuery* = "drop_partition_table"
+const DetachPartitionQuery* = "detach_partition"
+const GetPartitionSizeQuery* = "get_partition_size"
+const TryAdvisoryLockQuery* = "try_advisory_lock"
+const GetAllMsgHashQuery* = "get_all_msg_hash"
+const AdvisoryUnlockQuery* = "advisory_unlock"
+const AnalyzeMessagesQuery* = "analyze_messages"
+const CheckVersionTableExistsQuery* = "check_version_table_exists"

--- a/waku/common/databases/db_postgres/query_metrics.nim
+++ b/waku/common/databases/db_postgres/query_metrics.nim
@@ -11,18 +11,21 @@ const QueriesToMetricMap* = {
   "contentTopic IN": "content_topic",
   "SELECT version()": "select_version",
   "WITH min_timestamp": "messages_lookup",
-  "SELECT messageHash FROM messages WHERE pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?": "msg_hash_no_ctopic",
+  "SELECT messageHash FROM messages WHERE pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?":
+    "msg_hash_no_ctopic",
   "AS partition_name": "get_partitions_list",
   "SELECT COUNT(1) FROM messages": "count_msgs",
-  "SELECT messageHash FROM messages WHERE (timestamp, messageHash) < (?,?) AND pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?": "msg_hash_with_cursor",
+  "SELECT messageHash FROM messages WHERE (timestamp, messageHash) < (?,?) AND pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?":
+    "msg_hash_with_cursor",
   "SELECT pg_database_size(current_database())": "get_database_size",
   "DELETE FROM messages_lookup WHERE timestamp": "delete_from_msgs_lookup",
   "DROP TABLE messages_": "drop_partition_table",
   "ALTER TABLE messages DETACH PARTITION": "detach_partition",
   "SELECT pg_size_pretty(pg_total_relation_size(C.oid))": "get_partition_size",
   "pg_try_advisory_lock": "try_advisory_lock",
-  "SELECT messageHash FROM messages ORDER BY timestamp DESC, messageHash DESC LIMIT ?": "get_all_msg_hash",
+  "SELECT messageHash FROM messages ORDER BY timestamp DESC, messageHash DESC LIMIT ?":
+    "get_all_msg_hash",
   "SELECT pg_advisory_unlock": "advisory_unlock",
   "ANALYZE messages": "analyze_messages",
-  "SELECT EXISTS": "check_version_table_exists"
+  "SELECT EXISTS": "check_version_table_exists",
 }

--- a/waku/common/databases/db_postgres/query_metrics.nim
+++ b/waku/common/databases/db_postgres/query_metrics.nim
@@ -6,43 +6,23 @@ declarePublicGauge query_time_secs,
 declarePublicCounter query_count,
   "number of times a query is being performed", labels = ["query"]
 
-## Possible labels
-## The above metrics can only use the following labels
-const ContentTopicQuery = "content_topic"
-const SelectVersionQuery = "select_version"
-const MessagesLookupQuery = "messages_lookup"
-const MsgHashWithoutContentTopicQuery = "msg_hash_no_ctopic"
-const MsgHashWithCursorQuery = "msg_hash_with_cursor"
-const GetPartitionsListQuery = "get_partitions_list"
-const CountMsgsQuery = "count_msgs"
-const GetDatabaseSizeQuery = "get_database_size"
-const DeleteFromMessagesLookupQuery = "delete_from_msgs_lookup"
-const DropPartitionTableQuery = "drop_partition_table"
-const DetachPartitionQuery = "detach_partition"
-const GetPartitionSizeQuery = "get_partition_size"
-const TryAdvisoryLockQuery = "try_advisory_lock"
-const GetAllMsgHashQuery = "get_all_msg_hash"
-const AdvisoryUnlockQuery = "advisory_unlock"
-const AnalyzeMessagesQuery = "analyze_messages"
-const CheckVersionTableExistsQuery = "check_version_table_exists"
-
 ## Maps parts of the possible known queries with a fixed and shorter query label.
 const QueriesToMetricMap* = {
-  "contentTopic IN": ContentTopicQuery,
-  "SELECT version()": SelectVersionQuery,
-  "WITH min_timestamp": MessagesLookupQuery,
-  "SELECT messageHash FROM messages WHERE pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?": MsgHashWithoutContentTopicQuery,
-  "AS partition_name": GetPartitionsListQuery,
-  "SELECT COUNT(1) FROM messages": CountMsgsQuery,
-  "SELECT messageHash FROM messages WHERE (timestamp, messageHash) < (?,?) AND pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?": MsgHashWithCursorQuery,
-  "SELECT pg_database_size(current_database())": GetDatabaseSizeQuery,
-  "DELETE FROM messages_lookup WHERE timestamp": DeleteFromMessagesLookupQuery,
-  "DROP TABLE messages_": DropPartitionTableQuery,
-  "ALTER TABLE messages DETACH PARTITION": DetachPartitionQuery,
-  "SELECT pg_size_pretty(pg_total_relation_size(C.oid))": GetPartitionSizeQuery,
-  "pg_try_advisory_lock": TryAdvisoryLockQuery,
-  "SELECT messageHash FROM messages ORDER BY timestamp DESC, messageHash DESC LIMIT ?": GetAllMsgHashQuery,
-  "SELECT pg_advisory_unlock": AdvisoryUnlockQuery,
-  "ANALYZE messages": AnalyzeMessagesQuery,
-  "SELECT EXISTS": CheckVersionTableExistsQuery
+  "contentTopic IN": "content_topic",
+  "SELECT version()": "select_version",
+  "WITH min_timestamp": "messages_lookup",
+  "SELECT messageHash FROM messages WHERE pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?": "msg_hash_no_ctopic",
+  "AS partition_name": "get_partitions_list",
+  "SELECT COUNT(1) FROM messages": "count_msgs",
+  "SELECT messageHash FROM messages WHERE (timestamp, messageHash) < (?,?) AND pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?": "msg_hash_with_cursor",
+  "SELECT pg_database_size(current_database())": "get_database_size",
+  "DELETE FROM messages_lookup WHERE timestamp": "delete_from_msgs_lookup",
+  "DROP TABLE messages_": "drop_partition_table",
+  "ALTER TABLE messages DETACH PARTITION": "detach_partition",
+  "SELECT pg_size_pretty(pg_total_relation_size(C.oid))": "get_partition_size",
+  "pg_try_advisory_lock": "try_advisory_lock",
+  "SELECT messageHash FROM messages ORDER BY timestamp DESC, messageHash DESC LIMIT ?": "get_all_msg_hash",
+  "SELECT pg_advisory_unlock": "advisory_unlock",
+  "ANALYZE messages": "analyze_messages",
+  "SELECT EXISTS": "check_version_table_exists"
 }

--- a/waku/common/databases/db_postgres/query_metrics.nim
+++ b/waku/common/databases/db_postgres/query_metrics.nim
@@ -8,20 +8,41 @@ declarePublicCounter query_count,
 
 ## Possible labels
 ## The above metrics can only use the following labels
-const ContentTopicQuery* = "content_topic"
-const SelectVersionQuery* = "select_version"
-const MessagesLookupQuery* = "messages_lookup"
-const MsgHashWithoutContentTopicQuery* = "msg_hash_no_ctopic"
-const MsgHashWithCursorQuery* = "msg_hash_with_cursor"
-const GetPartitionsListQuery* = "get_partitions_list"
-const CountMsgsQuery* = "count_msgs"
-const GetDatabaseSizeQuery* = "get_database_size"
-const DeleteFromMessagesLookupQuery* = "delete_from_msgs_lookup"
-const DropPartitionTableQuery* = "drop_partition_table"
-const DetachPartitionQuery* = "detach_partition"
-const GetPartitionSizeQuery* = "get_partition_size"
-const TryAdvisoryLockQuery* = "try_advisory_lock"
-const GetAllMsgHashQuery* = "get_all_msg_hash"
-const AdvisoryUnlockQuery* = "advisory_unlock"
-const AnalyzeMessagesQuery* = "analyze_messages"
-const CheckVersionTableExistsQuery* = "check_version_table_exists"
+const ContentTopicQuery = "content_topic"
+const SelectVersionQuery = "select_version"
+const MessagesLookupQuery = "messages_lookup"
+const MsgHashWithoutContentTopicQuery = "msg_hash_no_ctopic"
+const MsgHashWithCursorQuery = "msg_hash_with_cursor"
+const GetPartitionsListQuery = "get_partitions_list"
+const CountMsgsQuery = "count_msgs"
+const GetDatabaseSizeQuery = "get_database_size"
+const DeleteFromMessagesLookupQuery = "delete_from_msgs_lookup"
+const DropPartitionTableQuery = "drop_partition_table"
+const DetachPartitionQuery = "detach_partition"
+const GetPartitionSizeQuery = "get_partition_size"
+const TryAdvisoryLockQuery = "try_advisory_lock"
+const GetAllMsgHashQuery = "get_all_msg_hash"
+const AdvisoryUnlockQuery = "advisory_unlock"
+const AnalyzeMessagesQuery = "analyze_messages"
+const CheckVersionTableExistsQuery = "check_version_table_exists"
+
+## Maps parts of the possible known queries with a fixed and shorter query label.
+const QueriesToMetricMap* = {
+  "contentTopic IN": ContentTopicQuery,
+  "SELECT version()": SelectVersionQuery,
+  "WITH min_timestamp": MessagesLookupQuery,
+  "SELECT messageHash FROM messages WHERE pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?": MsgHashWithoutContentTopicQuery,
+  "AS partition_name": GetPartitionsListQuery,
+  "SELECT COUNT(1) FROM messages": CountMsgsQuery,
+  "SELECT messageHash FROM messages WHERE (timestamp, messageHash) < (?,?) AND pubsubTopic = ? AND timestamp >= ? AND timestamp <= ? ORDER BY timestamp DESC, messageHash DESC LIMIT ?": MsgHashWithCursorQuery,
+  "SELECT pg_database_size(current_database())": GetDatabaseSizeQuery,
+  "DELETE FROM messages_lookup WHERE timestamp": DeleteFromMessagesLookupQuery,
+  "DROP TABLE messages_": DropPartitionTableQuery,
+  "ALTER TABLE messages DETACH PARTITION": DetachPartitionQuery,
+  "SELECT pg_size_pretty(pg_total_relation_size(C.oid))": GetPartitionSizeQuery,
+  "pg_try_advisory_lock": TryAdvisoryLockQuery,
+  "SELECT messageHash FROM messages ORDER BY timestamp DESC, messageHash DESC LIMIT ?": GetAllMsgHashQuery,
+  "SELECT pg_advisory_unlock": AdvisoryUnlockQuery,
+  "ANALYZE messages": AnalyzeMessagesQuery,
+  "SELECT EXISTS": CheckVersionTableExistsQuery
+}

--- a/waku/waku_store/client.nim
+++ b/waku/waku_store/client.nim
@@ -39,11 +39,11 @@ proc sendStoreRequest(
     return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: error.msg))
 
   let res = StoreQueryResponse.decode(buf).valueOr:
-    waku_store_errors.inc(labelValues = [decodeRpcFailure])
-    return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: decodeRpcFailure))
+    waku_store_errors.inc(labelValues = [DecodeRpcFailure])
+    return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: DecodeRpcFailure))
 
   if res.statusCode != uint32(StatusCode.SUCCESS):
-    waku_store_errors.inc(labelValues = [res.statusDesc])
+    waku_store_errors.inc(labelValues = [NoSuccessStatusCode])
     return err(StoreError.new(res.statusCode, res.statusDesc))
 
   return ok(res)
@@ -55,7 +55,7 @@ proc query*(
     return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: "invalid cursor"))
 
   let connection = (await self.peerManager.dialPeer(peer, WakuStoreCodec)).valueOr:
-    waku_store_errors.inc(labelValues = [dialFailure])
+    waku_store_errors.inc(labelValues = [DialFailure])
 
     return err(StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer))
 
@@ -74,7 +74,7 @@ proc queryToAny*(
     return err(StoreError(kind: BAD_RESPONSE, cause: "no service store peer connected"))
 
   let connection = (await self.peerManager.dialPeer(peer, WakuStoreCodec)).valueOr:
-    waku_store_errors.inc(labelValues = [dialFailure])
+    waku_store_errors.inc(labelValues = [DialFailure])
 
     return err(StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer))
 

--- a/waku/waku_store/protocol.nim
+++ b/waku/waku_store/protocol.nim
@@ -45,7 +45,7 @@ proc handleQueryRequest(
 
   let req = StoreQueryRequest.decode(raw_request).valueOr:
     error "failed to decode rpc", peerId = requestor, error = $error
-    waku_store_errors.inc(labelValues = [decodeRpcFailure])
+    waku_store_errors.inc(labelValues = [DecodeRpcFailure])
 
     res.statusCode = uint32(ErrorCode.BAD_REQUEST)
     res.statusDesc = "decoding rpc failed: " & $error

--- a/waku/waku_store/protocol_metrics.nim
+++ b/waku/waku_store/protocol_metrics.nim
@@ -12,8 +12,9 @@ declarePublicGauge waku_store_time_seconds,
 
 # Error types (metric label values)
 const
-  dialFailure* = "dial_failure"
-  decodeRpcFailure* = "decode_rpc_failure"
-  peerNotFoundFailure* = "peer_not_found_failure"
-  emptyRpcQueryFailure* = "empty_rpc_query_failure"
-  emptyRpcResponseFailure* = "empty_rpc_response_failure"
+  DialFailure* = "dial_failure"
+  DecodeRpcFailure* = "decode_rpc_failure"
+  PeerNotFoundFailure* = "peer_not_found_failure"
+  EmptyRpcQueryFailure* = "empty_rpc_query_failure"
+  EmptyRpcResponseFailure* = "empty_rpc_response_failure"
+  NoSuccessStatusCode* = "status_code_no_success"

--- a/waku/waku_store_legacy/protocol_metrics.nim
+++ b/waku/waku_store_legacy/protocol_metrics.nim
@@ -13,8 +13,8 @@ declarePublicGauge waku_legacy_store_time_seconds,
 
 # Error types (metric label values)
 const
-  dialFailure* = "dial_failure"
-  decodeRpcFailure* = "decode_rpc_failure"
-  peerNotFoundFailure* = "peer_not_found_failure"
-  emptyRpcQueryFailure* = "empty_rpc_query_failure"
-  emptyRpcResponseFailure* = "empty_rpc_response_failure"
+  dialFailure* = "dial_failure_legacy"
+  decodeRpcFailure* = "decode_rpc_failure_legacy"
+  peerNotFoundFailure* = "peer_not_found_failure_legacy"
+  emptyRpcQueryFailure* = "empty_rpc_query_failure_legacy"
+  emptyRpcResponseFailure* = "empty_rpc_response_failure_legacy"


### PR DESCRIPTION
# Description

* Bound the metrics-label-values in arbitrary queries.
* The metrics-label-values for prepared statements are kept as
  they already represent a fixed set.
* Store error metrics labels simplification to avoid overwhelm prometheus
* waku/waku_store_legacy/protocol_metrics.nim: change the metrics' names to separate store-v2 (legacy) metrics from store-v3

## Issue

closes https://github.com/waku-org/nwaku/issues/3282
