### PR TITLE
chore: non-relay protocols cross performance measurement metrics

### DIFF
--- a/waku/common/rate_limit/request_limiter.nim
+++ b/waku/common/rate_limit/request_limiter.nim
@@ -22,6 +22,8 @@ import
   libp2p/stream/connection,
   libp2p/utility
 
+import std/times except TimeInterval, Duration, seconds, minutes
+
 import ./[single_token_limiter, service_metrics, timed_map]
 
 export token_bucket, setting, service_metrics

--- a/waku/common/rate_limit/request_limiter.nim
+++ b/waku/common/rate_limit/request_limiter.nim
@@ -76,12 +76,12 @@ template checkUsageLimit*(
     bodyWithinLimit, bodyRejected: untyped,
 ) =
   if t.checkUsage(proto, conn):
-    let requestStartTime = Moment.now()
+    let requestStartTime = getTime().toUnixFloat()
     waku_service_requests.inc(labelValues = [proto, "served"])
 
     bodyWithinLimit
 
-    let requestDurationSec = (Moment.now() - requestStartTime).milliseconds.float / 1000
+    let requestDurationSec = getTime().toUnixFloat() - requestStartTime
     waku_service_request_handling_duration_seconds.observe(
       requestDurationSec, labelValues = [proto]
     )

--- a/waku/common/rate_limit/request_limiter.nim
+++ b/waku/common/rate_limit/request_limiter.nim
@@ -76,8 +76,15 @@ template checkUsageLimit*(
     bodyWithinLimit, bodyRejected: untyped,
 ) =
   if t.checkUsage(proto, conn):
+    let requestStartTime = Moment.now()
     waku_service_requests.inc(labelValues = [proto, "served"])
+
     bodyWithinLimit
+
+    let requestDurationSec = (Moment.now() - requestStartTime).milliseconds.float / 1000
+    waku_service_request_handling_duration_seconds.observe(
+      requestDurationSec, labelValues = [proto]
+    )
   else:
     waku_service_requests.inc(labelValues = [proto, "rejected"])
     bodyRejected

--- a/waku/common/rate_limit/service_metrics.nim
+++ b/waku/common/rate_limit/service_metrics.nim
@@ -17,3 +17,6 @@ proc setServiceLimitMetric*(service: string, limit: Option[RateLimitSetting]) =
     waku_service_requests_limit.set(
       limit.get().calculateLimitPerSecond(), labelValues = [service]
     )
+
+declarePublicHistogram waku_service_request_handling_duration_seconds,
+  "duration of non-relay service handling", ["service"]

--- a/waku/common/rate_limit/single_token_limiter.nim
+++ b/waku/common/rate_limit/single_token_limiter.nim
@@ -4,6 +4,8 @@
 
 import std/[options], chronos/timer, libp2p/stream/connection, libp2p/utility
 
+import std/times except TimeInterval, Duration
+
 import ./[token_bucket, setting, service_metrics]
 export token_bucket, setting, service_metrics
 

--- a/waku/common/rate_limit/single_token_limiter.nim
+++ b/waku/common/rate_limit/single_token_limiter.nim
@@ -43,12 +43,12 @@ template checkUsageLimit*(
     bodyWithinLimit, bodyRejected: untyped,
 ) =
   if t.checkUsage(proto):
-    let requestStartTime = Moment.now()
+    let requestStartTime = getTime().toUnixFloat()
     waku_service_requests.inc(labelValues = [proto, "served"])
 
     bodyWithinLimit
 
-    let requestDurationSec = (Moment.now() - requestStartTime).milliseconds.float / 1000
+    let requestDurationSec = getTime().toUnixFloat() - requestStartTime
     waku_service_request_handling_duration_seconds.observe(
       requestDurationSec, labelValues = [proto]
     )

--- a/waku/common/rate_limit/single_token_limiter.nim
+++ b/waku/common/rate_limit/single_token_limiter.nim
@@ -43,8 +43,15 @@ template checkUsageLimit*(
     bodyWithinLimit, bodyRejected: untyped,
 ) =
   if t.checkUsage(proto):
+    let requestStartTime = Moment.now()
     waku_service_requests.inc(labelValues = [proto, "served"])
+
     bodyWithinLimit
+
+    let requestDurationSec = (Moment.now() - requestStartTime).milliseconds.float / 1000
+    waku_service_request_handling_duration_seconds.observe(
+      requestDurationSec, labelValues = [proto]
+    )
   else:
     waku_service_requests.inc(labelValues = [proto, "rejected"])
     bodyRejected


### PR DESCRIPTION
# Description
For the final stage of #3069 under #3060 we would like to test and visualize cross-effect of the different non-relay protocol performances. This can help fine tune rate limiting of those protocols and also to make recommendations for node operator configuration.

# Changes

- [X] introduce request processing time metrics for non-relay protocols

Following point finally tracked in a separate repository: https://github.com/waku-org/waku-protocol-perf-test
- Create new node performance monitoring dashboard for non-relay protocols
    - Add histograms of processing times per protocol next to each other
    - Add panels of request rate graphs
    - Possible add bandwidth / message size rates.
- Define some stress test sequence that uses non-relay protocols parallel. (possibly using sonda and lite-protocol-tester tools)    

## Issue
#3060 
