### PR TITLE
fix: libwaku's invalid waku message error handling

### DIFF
--- a/library/events/json_message_event.nim
+++ b/library/events/json_message_event.nim
@@ -20,6 +20,13 @@ func fromJsonNode*(
     T: type JsonMessage, jsonContent: JsonNode
 ): Result[JsonMessage, string] =
   # Visit https://rfc.vac.dev/spec/14/ for further details
+
+  # Check if required fields exist
+  if not jsonContent.hasKey("payload"):
+    return err("Missing required field in WakuMessage: payload")
+  if not jsonContent.hasKey("contentTopic"):
+    return err("Missing required field in WakuMessage: contentTopic")
+
   ok(
     JsonMessage(
       payload: Base64String(jsonContent["payload"].getStr()),

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -291,6 +291,8 @@ proc waku_relay_publish(
   checkLibwakuParams(ctx, callback, userData)
 
   let jwm = jsonWakuMessage.alloc()
+  defer:
+    deallocShared(jwm)
   var jsonMessage: JsonMessage
   try:
     let jsonContent = parseJson($jwm)
@@ -300,8 +302,6 @@ proc waku_relay_publish(
     let msg = fmt"Error parsing json message: {getCurrentExceptionMsg()}"
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR
-  finally:
-    deallocShared(jwm)
 
   let wakuMessage = jsonMessage.toWakuMessage().valueOr:
     let msg = "Problem building the WakuMessage: " & $error

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -297,7 +297,6 @@ proc waku_relay_publish(
     jsonMessage = JsonMessage.fromJsonNode(jsonContent).valueOr:
       raise newException(JsonParsingError, $error)
   except JsonParsingError:
-    deallocShared(jwm)
     let msg = fmt"Error parsing json message: {getCurrentExceptionMsg()}"
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
     return RET_ERR


### PR DESCRIPTION
# Description
Checking if required `WakuMessage` fields exist before trying to access them and returning an error in case they are not present in the message.

Additionally, fixing double dealloc in case of failure.
# Changes

<!-- List of detailed changes -->

- [x] handling gracefully invalid messages in libwaku
- [x] fixing double dealloc 

## Issue
- #3076
