### PR TITLE
chore: remove flaky test debug logs from rln tests

### DIFF
--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -487,7 +487,6 @@ procSuite "WakuNode - RLN relay":
     await node3.stop()
 
   asyncTest "clearNullifierLog: should clear epochs > MaxEpochGap":
-    debug "tmp debug log analyze flaky test"
     # Given two nodes
     let
       contentTopic = ContentTopic("/waku/2/default-content/proto")
@@ -502,18 +501,15 @@ procSuite "WakuNode - RLN relay":
     await node1.mountRelay(shardSeq)
     let wakuRlnConfig1 = buildWakuRlnConfig(1, epochSizeSec, "wakunode_10")
     await node1.mountRlnRelay(wakuRlnConfig1)
-    debug "tmp debug log analyze flaky test"
 
     # Mount rlnrelay in node2 in off-chain mode
     await node2.mountRelay(@[DefaultRelayShard])
     let wakuRlnConfig2 = buildWakuRlnConfig(2, epochSizeSec, "wakunode_11")
     await node2.mountRlnRelay(wakuRlnConfig2)
-    debug "tmp debug log analyze flaky test"
 
     # Given the two nodes are started and connected
     waitFor allFutures(node1.start(), node2.start())
     await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
-    debug "tmp debug log analyze flaky test"
 
     # Given some messages
     var
@@ -550,9 +546,7 @@ procSuite "WakuNode - RLN relay":
         if msg == wm6:
           completionFut6.complete(true)
 
-    debug "tmp debug log analyze flaky test"
     node2.subscribe((kind: PubsubSub, topic: DefaultPubsubTopic), some(relayHandler))
-    debug "tmp debug log analyze flaky test"
 
     # Given all messages have an rln proof and are published by the node 1
     let publishSleepDuration: Duration = 5000.millis
@@ -561,103 +555,70 @@ procSuite "WakuNode - RLN relay":
     # Epoch 1
     node1.wakuRlnRelay.unsafeAppendRLNProof(wm1, startTime).isOkOr:
       raiseAssert $error
-    debug "tmp debug log analyze flaky test"
+
     # Message wm2 is published in the same epoch as wm1, so it'll be considered spam
     node1.wakuRlnRelay.unsafeAppendRLNProof(wm2, startTime).isOkOr:
       raiseAssert $error
-    debug "tmp debug log analyze flaky test"
+
     discard await node1.publish(some(DefaultPubsubTopic), wm1)
-    debug "tmp debug log analyze flaky test"
     discard await node1.publish(some(DefaultPubsubTopic), wm2)
-    debug "tmp debug log analyze flaky test"
     await sleepAsync(publishSleepDuration)
-    debug "tmp debug log analyze flaky test"
     check:
       await node1.waitForNullifierLog(0)
-    debug "tmp debug log analyze flaky test"
-    check:
       await node2.waitForNullifierLog(1)
 
     # Epoch 2
-    debug "tmp debug log analyze flaky test"
+
     node1.wakuRlnRelay.unsafeAppendRLNProof(wm3, startTime + float(1 * epochSizeSec)).isOkOr:
       raiseAssert $error
-    debug "tmp debug log analyze flaky test"
+
     discard await node1.publish(some(DefaultPubsubTopic), wm3)
-    debug "tmp debug log analyze flaky test"
+
     await sleepAsync(publishSleepDuration)
-    debug "tmp debug log analyze flaky test"
+
     check:
       await node1.waitForNullifierLog(0)
-    debug "tmp debug log analyze flaky test"
-    check:
       await node2.waitForNullifierLog(2)
-    debug "tmp debug log analyze flaky test"
 
     # Epoch 3
     node1.wakuRlnRelay.unsafeAppendRLNProof(wm4, startTime + float(2 * epochSizeSec)).isOkOr:
       raiseAssert $error
-    debug "tmp debug log analyze flaky test"
+
     discard await node1.publish(some(DefaultPubsubTopic), wm4)
-    debug "tmp debug log analyze flaky test"
     await sleepAsync(publishSleepDuration)
-    debug "tmp debug log analyze flaky test"
     check:
       await node1.waitForNullifierLog(0)
-    debug "tmp debug log analyze flaky test"
-    check:
       await node2.waitForNullifierLog(3)
-    debug "tmp debug log analyze flaky test"
 
     # Epoch 4
     node1.wakuRlnRelay.unsafeAppendRLNProof(wm5, startTime + float(3 * epochSizeSec)).isOkOr:
       raiseAssert $error
-    debug "tmp debug log analyze flaky test"
+
     discard await node1.publish(some(DefaultPubsubTopic), wm5)
-    debug "tmp debug log analyze flaky test"
     await sleepAsync(publishSleepDuration)
-    debug "tmp debug log analyze flaky test"
     check:
       await node1.waitForNullifierLog(0)
-    debug "tmp debug log analyze flaky test"
-    check:
       await node2.waitForNullifierLog(4)
-    debug "tmp debug log analyze flaky test"
 
     # Epoch 5
     node1.wakuRlnRelay.unsafeAppendRLNProof(wm6, startTime + float(4 * epochSizeSec)).isOkOr:
       raiseAssert $error
-    debug "tmp debug log analyze flaky test"
+
     discard await node1.publish(some(DefaultPubsubTopic), wm6)
-    debug "tmp debug log analyze flaky test"
     await sleepAsync(publishSleepDuration)
-    debug "tmp debug log analyze flaky test"
     check:
       await node1.waitForNullifierLog(0)
-    debug "tmp debug log analyze flaky test"
-    check:
       await node2.waitForNullifierLog(4)
 
     # Then the node 2 should have cleared the nullifier log for epochs > MaxEpochGap
     # Therefore, with 4 max epochs, the first 4 messages will be published (except wm2, which shares epoch with wm1)
     check:
       (await completionFut1.waitForResult()).value() == true
-    debug "tmp debug log analyze flaky test"
-    check:
       (await completionFut2.waitForResult()).isErr()
-    debug "tmp debug log analyze flaky test"
-    check:
       (await completionFut3.waitForResult()).value() == true
-    debug "tmp debug log analyze flaky test"
-    check:
       (await completionFut4.waitForResult()).value() == true
-    debug "tmp debug log analyze flaky test"
-    check:
       (await completionFut5.waitForResult()).value() == true
-    debug "tmp debug log analyze flaky test"
-    check:
       (await completionFut6.waitForResult()).value() == true
-    debug "tmp debug log analyze flaky test"
 
     # Cleanup
     waitFor allFutures(node1.stop(), node2.stop())

--- a/tests/waku_store/test_waku_store.nim
+++ b/tests/waku_store/test_waku_store.nim
@@ -17,15 +17,12 @@ import
 
 suite "Waku Store - query handler":
   asyncTest "history query handler should be called":
-    info "check point" # log added to track flaky test
     ## Setup
     let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
-    info "check point" # log added to track flaky test
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
-    info "check point" # log added to track flaky test
 
     ## Given
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
@@ -55,9 +52,7 @@ suite "Waku Store - query handler":
     )
 
     ## When
-    info "check point" # log added to track flaky test
     let queryRes = await client.query(req, peer = serverPeerInfo)
-    info "check point" # log added to track flaky test
 
     ## Then
     check:
@@ -74,20 +69,15 @@ suite "Waku Store - query handler":
       response.messages == @[kv]
 
     ## Cleanup
-    info "check point" # log added to track flaky test
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
-    info "check point" # log added to track flaky test
 
   asyncTest "history query handler should be called and return an error":
-    info "check point" # log added to track flaky test
     ## Setup
     let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
-    info "check point" # log added to track flaky test
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
-    info "check point" # log added to track flaky test
 
     ## Given
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
@@ -126,6 +116,4 @@ suite "Waku Store - query handler":
       error.kind == ErrorCode.BAD_REQUEST
 
     ## Cleanup
-    info "check point" # log added to track flaky test
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
-    info "check point" # log added to track flaky test

--- a/tests/waku_store_legacy/test_waku_store.nim
+++ b/tests/waku_store_legacy/test_waku_store.nim
@@ -15,19 +15,15 @@ import
 
 suite "Waku Store - query handler legacy":
   asyncTest "history query handler should be called":
-    info "check point" # log added to track flaky test
     ## Setup
     let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
-    info "check point" # log added to track flaky test
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
-    info "check point" # log added to track flaky test
 
     ## Given
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
-    info "check point" # log added to track flaky test
 
     let msg = fakeWakuMessage(contentTopic = DefaultContentTopic)
 
@@ -50,9 +46,7 @@ suite "Waku Store - query handler legacy":
     )
 
     ## When
-    info "check point" # log added to track flaky test
     let queryRes = await client.query(req, peer = serverPeerInfo)
-    info "check point" # log added to track flaky test
 
     ## Then
     check:
@@ -69,19 +63,15 @@ suite "Waku Store - query handler legacy":
       response.messages == @[msg]
 
     ## Cleanup
-    info "check point" # log added to track flaky test
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
-    info "check point" # log added to track flaky test
 
   asyncTest "history query handler should be called and return an error":
-    info "check point" # log added to track flaky test
     ## Setup
     let
       serverSwitch = newTestSwitch()
       clientSwitch = newTestSwitch()
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
-    info "check point" # log added to track flaky test
 
     ## Given
     let serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
@@ -103,10 +93,8 @@ suite "Waku Store - query handler legacy":
       requestId: "reqId",
     )
 
-    info "check point" # log added to track flaky test
     ## When
     let queryRes = await client.query(req, peer = serverPeerInfo)
-    info "check point" # log added to track flaky test
 
     ## Then
     check:
@@ -122,6 +110,4 @@ suite "Waku Store - query handler legacy":
       error.kind == HistoryErrorKind.BAD_REQUEST
 
     ## Cleanup
-    info "check point" # log added to track flaky test
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
-    info "check point" # log added to track flaky test


### PR DESCRIPTION
# Description
https://github.com/waku-org/nwaku/pull/3227 introduced a serie of debug logs to tackle flaky tests. This PR is about to remove those polluting logs out of scope now.

# Changes

Removed only tracking debug logs.

## How to test

Only test code changed.
