### PR TITLE
chore: fix typo in comment

### DIFF
--- a/scripts/chkhealth.sh
+++ b/scripts/chkhealth.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# optional argument to specgify the ip address
+# Optional argument to specify the IP address
 ip_address="localhost:8645"
 plain_text_out=false
 


### PR DESCRIPTION
# Description

I noticed a typo in a comment: "specgify" should be "specify".
Fixed it to improve readability.