### PR TITLE
chore: deprecating dnsDiscovery flag

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -418,7 +418,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
       dnsDiscoveryUrl = some(
         "enrtree://AIRVQ5DDA4FFWLRBCHJWUWOO6X6S4ZTZ5B667LQ6AJU6PEYDLRD5O@sandbox.waku.nodes.status.im"
       )
-  elif and conf.dnsDiscoveryUrl != "":
+  elif conf.dnsDiscoveryUrl != "":
     # No pre-selected fleet. Discover nodes via DNS using user config
     debug "Discovering nodes using Waku DNS discovery", url = conf.dnsDiscoveryUrl
     dnsDiscoveryUrl = some(conf.dnsDiscoveryUrl)

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -418,7 +418,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
       dnsDiscoveryUrl = some(
         "enrtree://AIRVQ5DDA4FFWLRBCHJWUWOO6X6S4ZTZ5B667LQ6AJU6PEYDLRD5O@sandbox.waku.nodes.status.im"
       )
-  elif conf.dnsDiscovery and conf.dnsDiscoveryUrl != "":
+  elif and conf.dnsDiscoveryUrl != "":
     # No pre-selected fleet. Discover nodes via DNS using user config
     debug "Discovering nodes using Waku DNS discovery", url = conf.dnsDiscoveryUrl
     dnsDiscoveryUrl = some(conf.dnsDiscoveryUrl)

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -157,7 +157,8 @@ type
 
     ## DNS discovery config
     dnsDiscovery* {.
-      desc: "Enable discovering nodes via DNS",
+      desc:
+        "Deprecated, please set dns-discovery-url instead. Enable discovering nodes via DNS",
       defaultValue: false,
       name: "dns-discovery"
     .}: bool

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -392,7 +392,7 @@ proc getBootstrapFromDiscDns(
   try:
     let dnsNameServers = @[parseIpAddress("1.1.1.1"), parseIpAddress("1.0.0.1")]
     let dynamicBootstrapNodesRes =
-      await retrieveDynamicBootstrapNodes(true, conf.dnsDiscoveryUrl, dnsNameServers)
+      await retrieveDynamicBootstrapNodes(conf.dnsDiscoveryUrl, dnsNameServers)
     if not dynamicBootstrapNodesRes.isOk():
       error("failed discovering peers from DNS")
     let dynamicBootstrapNodes = dynamicBootstrapNodesRes.get()

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -354,11 +354,11 @@ proc crawlNetwork(
     await sleepAsync(crawlInterval.millis - elapsed.millis)
 
 proc retrieveDynamicBootstrapNodes(
-    dnsDiscovery: bool, dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
+    dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
 ): Future[Result[seq[RemotePeerInfo], string]] {.async.} =
   ## Retrieve dynamic bootstrap nodes (DNS discovery)
 
-  if dnsDiscovery and dnsDiscoveryUrl != "":
+  if dnsDiscoveryUrl != "":
     # DNS discovery
     debug "Discovering nodes using Waku DNS discovery", url = dnsDiscoveryUrl
 

--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -324,7 +324,6 @@ int main(int argc, char** argv) {
                                     \"discv5BootstrapNodes\": \
                                         [\"enr:-QESuEB4Dchgjn7gfAvwB00CxTA-nGiyk-aALI-H4dYSZD3rUk7bZHmP8d2U6xDiQ2vZffpo45Jp7zKNdnwDUx6g4o6XAYJpZIJ2NIJpcIRA4VDAim11bHRpYWRkcnO4XAArNiZub2RlLTAxLmRvLWFtczMud2FrdS5zYW5kYm94LnN0YXR1cy5pbQZ2XwAtNiZub2RlLTAxLmRvLWFtczMud2FrdS5zYW5kYm94LnN0YXR1cy5pbQYfQN4DgnJzkwABCAAAAAEAAgADAAQABQAGAAeJc2VjcDI1NmsxoQOvD3S3jUNICsrOILlmhENiWAMmMVlAl6-Q8wRB7hidY4N0Y3CCdl-DdWRwgiMohXdha3UyDw\", \"enr:-QEkuEBIkb8q8_mrorHndoXH9t5N6ZfD-jehQCrYeoJDPHqT0l0wyaONa2-piRQsi3oVKAzDShDVeoQhy0uwN1xbZfPZAYJpZIJ2NIJpcIQiQlleim11bHRpYWRkcnO4bgA0Ni9ub2RlLTAxLmdjLXVzLWNlbnRyYWwxLWEud2FrdS5zYW5kYm94LnN0YXR1cy5pbQZ2XwA2Ni9ub2RlLTAxLmdjLXVzLWNlbnRyYWwxLWEud2FrdS5zYW5kYm94LnN0YXR1cy5pbQYfQN4DgnJzkwABCAAAAAEAAgADAAQABQAGAAeJc2VjcDI1NmsxoQKnGt-GSgqPSf3IAPM7bFgTlpczpMZZLF3geeoNNsxzSoN0Y3CCdl-DdWRwgiMohXdha3UyDw\"], \
                                     \"discv5UdpPort\": 9999, \
-                                    \"dnsDiscovery\": true, \
                                     \"dnsDiscoveryUrl\": \"enrtree://AOGYWMBYOUIMOENHXCHILPKY3ZRFEULMFI4DOM442QSZ73TT2A7VI@test.waku.nodes.status.im\", \
                                     \"dnsDiscoveryNameServers\": [\"8.8.8.8\", \"1.0.0.1\"] \
                                 }", cfgNode.host,

--- a/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/discovery_request.nim
@@ -83,7 +83,7 @@ proc retrieveBootstrapNodes(
 ): Future[Result[seq[string], string]] {.async.} =
   let dnsNameServers = @[parseIpAddress(ipDnsServer)]
   let discoveredPeers: seq[RemotePeerInfo] = (
-    await retrieveDynamicBootstrapNodes(true, enrTreeUrl, dnsNameServers)
+    await retrieveDynamicBootstrapNodes(enrTreeUrl, dnsNameServers)
   ).valueOr:
     return err("failed discovering peers from DNS: " & $error)
 

--- a/waku/discovery/waku_dnsdisc.nim
+++ b/waku/discovery/waku_dnsdisc.nim
@@ -97,11 +97,11 @@ proc init*(
   return ok(wakuDnsDisc)
 
 proc retrieveDynamicBootstrapNodes*(
-    dnsDiscovery: bool, dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
+    dnsDiscoveryUrl: string, dnsDiscoveryNameServers: seq[IpAddress]
 ): Future[Result[seq[RemotePeerInfo], string]] {.async.} =
   ## Retrieve dynamic bootstrap nodes (DNS discovery)
 
-  if dnsDiscovery and dnsDiscoveryUrl != "":
+  if dnsDiscoveryUrl != "":
     # DNS discovery
     debug "Discovering nodes using Waku DNS discovery", url = dnsDiscoveryUrl
 

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -570,7 +570,8 @@ with the drawback of consuming some more bandwidth.""",
 
     ## DNS discovery config
     dnsDiscovery* {.
-      desc: "Enable discovering nodes via DNS",
+      desc:
+        "Deprecated, please set dns-discovery-url instead. Enable discovering nodes via DNS",
       defaultValue: false,
       name: "dns-discovery"
     .}: bool

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -388,8 +388,7 @@ proc startDnsDiscoveryRetryLoop(waku: ptr Waku): Future[void] {.async.} =
   while true:
     await sleepAsync(30.seconds)
     let dynamicBootstrapNodesRes = await waku_dnsdisc.retrieveDynamicBootstrapNodes(
-      waku.conf.dnsDiscovery, waku.conf.dnsDiscoveryUrl,
-      waku.conf.dnsDiscoveryNameServers,
+      waku.conf.dnsDiscoveryUrl, waku.conf.dnsDiscoveryNameServers
     )
     if dynamicBootstrapNodesRes.isErr():
       error "Retrieving dynamic bootstrap nodes failed",
@@ -424,7 +423,7 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async.} =
   debug "Retrieve dynamic bootstrap nodes"
 
   let dynamicBootstrapNodesRes = await waku_dnsdisc.retrieveDynamicBootstrapNodes(
-    waku.conf.dnsDiscovery, waku.conf.dnsDiscoveryUrl, waku.conf.dnsDiscoveryNameServers
+    waku.conf.dnsDiscoveryUrl, waku.conf.dnsDiscoveryNameServers
   )
 
   if dynamicBootstrapNodesRes.isErr():


### PR DESCRIPTION
# Description
Deprecating the `--dns-discovery` CLI flag and activating DNS Discovery if `--dns-discovery-url` has a value.

cc @Ivansete-status @plopezlpz 

# Changes

<!-- List of detailed changes -->

- [x] marking the `--dns-discovery` flag as deprecated
- [x] removing usage of the flag 


## Issue
#3236 
