### PR TITLE
fix: subscribing to RelaydefaultHandler in libwaku

### DIFF
--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -3,6 +3,7 @@ import chronicles, chronos, stew/byteutils, results
 import
   ../../../../../waku/waku_core/message/message,
   ../../../../../waku/factory/[external_config, validator_signed, waku],
+  ../../../../../waku/waku_node,
   ../../../../../waku/waku_core/message,
   ../../../../../waku/waku_core/time, # Timestamp
   ../../../../../waku/waku_core/topics/pubsub_topic,
@@ -105,6 +106,7 @@ proc process*(
   case self.operation
   of SUBSCRIBE:
     # TO DO: properly perform 'subscribe'
+    waku.node.registerRelayDefaultHandler($self.pubsubTopic)
     discard waku.node.wakuRelay.subscribe($self.pubsubTopic, self.relayEventCallback)
   of UNSUBSCRIBE:
     # TODO: properly perform 'unsubscribe'

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -245,7 +245,7 @@ proc mountStoreSync*(
 
 ## Waku relay
 
-proc registerRelayDefaultHandler(node: WakuNode, topic: PubsubTopic) =
+proc registerRelayDefaultHandler*(node: WakuNode, topic: PubsubTopic) =
   if node.wakuRelay.isSubscribed(topic):
     return
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
In libwaku nodes, messages aren't being saved in Store for dynamically-subscribed shards. This happens because when subscribing dynamically via libwaku, we weren't setting the `defaultRelayHandler` we rely on for Store and other protocols.

We need to subscribe to the default handler when dynamically subscribing to topics too.

# Changes


- [x] calling `registerRelayDefaultHandler` when calling `waku_relay_subscribe` in libwaku 



## Issue

#3076 
