### PR TITLE
feat: integrate reputation manager into Lightpush behind a feature flag

### DIFF
--- a/tests/incentivization/test_poc_reputation.nim
+++ b/tests/incentivization/test_poc_reputation.nim
@@ -6,7 +6,8 @@ import
   stew/byteutils,
   stint,
   strutils,
-  tests/testlib/testasync
+  tests/testlib/testasync,
+  libp2p/[peerid, crypto/crypto]
 
 import
   waku/[node/peer_manager, waku_core],
@@ -15,16 +16,18 @@ import
 
 suite "Waku Incentivization PoC Reputation":
   var manager {.threadvar.}: ReputationManager
+  var peerId1 {.threadvar.}: PeerId
 
   setup:
     manager = ReputationManager.init()
+    peerId1 = PeerId.init(PrivateKey.random(ECDSA, (newRng())[]).tryGet()).tryGet()
 
   test "incentivization PoC: reputation: reputation table is empty after initialization":
     check manager.reputationOf.len == 0
 
   test "incentivization PoC: reputation: set and get reputation":
-    manager.setReputation("peer1", some(true)) # Encodes GoodRep
-    check manager.getReputation("peer1") == some(true)
+    manager.setReputation(peerId1, some(true)) # Encodes GoodRep
+    check manager.getReputation(peerId1) == some(true)
 
   test "incentivization PoC: reputation: evaluate PushResponse valid":
     let validLightpushResponse =
@@ -37,18 +40,14 @@ suite "Waku Incentivization PoC Reputation":
     check evaluateResponse(invalidLightpushResponse) == BadResponse
 
   test "incentivization PoC: reputation: updateReputationFromResponse valid":
-    let peerId = "peerWithValidResponse"
     let validResp = PushResponse(isSuccess: true, info: some("All good"))
-    manager.updateReputationFromResponse(peerId, validResp)
-    check manager.getReputation(peerId) == some(true)
+    manager.updateReputationFromResponse(peerId1, validResp)
+    check manager.getReputation(peerId1) == some(true)
 
   test "incentivization PoC: reputation: updateReputationFromResponse invalid":
-    let peerId = "peerWithInvalidResponse"
     let invalidResp = PushResponse(isSuccess: false, info: none(string))
-    manager.updateReputationFromResponse(peerId, invalidResp)
-  check manager.getReputation(peerId) == some(false)
+    manager.updateReputationFromResponse(peerId1, invalidResp)
+    check manager.getReputation(peerId1) == some(false)
 
   test "incentivization PoC: reputation: default is None":
-    let unknownPeerId = "unknown_peer"
-    # The peer is not in the table yet
-    check manager.getReputation(unknownPeerId) == none(bool)
+    check manager.getReputation(peerId1) == none(bool)

--- a/tests/incentivization/test_poc_reputation.nim
+++ b/tests/incentivization/test_poc_reputation.nim
@@ -46,7 +46,7 @@ suite "Waku Incentivization PoC Reputation":
     let peerId = "peerWithInvalidResponse"
     let invalidResp = PushResponse(isSuccess: false, info: none(string))
     manager.updateReputationFromResponse(peerId, invalidResp)
-    check manager.getReputation(peerId) == some(false)
+  check manager.getReputation(peerId) == some(false)
 
   test "incentivization PoC: reputation: default is None":
     let unknownPeerId = "unknown_peer"

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -25,10 +25,13 @@ proc newTestWakuLightpushNode*(
 
   return proto
 
-proc newTestWakuLightpushClient*(switch: Switch): WakuLightPushClient =
+proc newTestWakuLightpushClient*(
+  switch: Switch,
+  reputationEnabled: bool = false
+  ): WakuLightPushClient =
   let peerManager = PeerManager.new(switch)
   let reputationManager =
-    if defined(reputation):
+    if reputationEnabled:
       some(ReputationManager.new())
     else:
       none(ReputationManager)

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -27,5 +27,7 @@ proc newTestWakuLightpushNode*(
 
 proc newTestWakuLightpushClient*(switch: Switch): WakuLightPushClient =
   let peerManager = PeerManager.new(switch)
-  let reputationManager = ReputationManager.new()
-  WakuLightPushClient.new(peerManager, reputationManager, rng)
+  var reputationManager = none(ReputationManager)
+  when defined(reputation):
+    reputationManager = some(ReputationManager.new())
+  WakuLightPushClient.new(peerManager, rng, reputationManager)

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -8,7 +8,8 @@ import
   waku/waku_lightpush,
   waku/waku_lightpush/[client, common],
   waku/common/rate_limit/setting,
-  ../testlib/[common, wakucore]
+  ../testlib/[common, wakucore],
+  waku/incentivization/reputation_manager
 
 proc newTestWakuLightpushNode*(
     switch: Switch,
@@ -26,4 +27,5 @@ proc newTestWakuLightpushNode*(
 
 proc newTestWakuLightpushClient*(switch: Switch): WakuLightPushClient =
   let peerManager = PeerManager.new(switch)
-  WakuLightPushClient.new(peerManager, rng)
+  let reputationManager = ReputationManager.new()
+  WakuLightPushClient.new(peerManager, reputationManager, rng)

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -27,7 +27,5 @@ proc newTestWakuLightpushNode*(
 
 proc newTestWakuLightpushClient*(switch: Switch): WakuLightPushClient =
   let peerManager = PeerManager.new(switch)
-  var reputationManager = none(ReputationManager)
-  when defined(reputation):
-    reputationManager = some(ReputationManager.new())
+  let reputationManager = if defined(reputation): some(ReputationManager.new()) else: none(ReputationManager)
   WakuLightPushClient.new(peerManager, rng, reputationManager)

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -27,5 +27,9 @@ proc newTestWakuLightpushNode*(
 
 proc newTestWakuLightpushClient*(switch: Switch): WakuLightPushClient =
   let peerManager = PeerManager.new(switch)
-  let reputationManager = if defined(reputation): some(ReputationManager.new()) else: none(ReputationManager)
+  let reputationManager =
+    if defined(reputation):
+      some(ReputationManager.new())
+    else:
+      none(ReputationManager)
   WakuLightPushClient.new(peerManager, rng, reputationManager)

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -30,9 +30,4 @@ proc newTestWakuLightpushClient*(
   reputationEnabled: bool = false
   ): WakuLightPushClient =
   let peerManager = PeerManager.new(switch)
-  let reputationManager =
-    if reputationEnabled:
-      some(ReputationManager.new())
-    else:
-      none(ReputationManager)
-  WakuLightPushClient.new(peerManager, rng, reputationManager)
+  WakuLightPushClient.new(peerManager, rng, reputationEnabled)

--- a/tests/waku_lightpush/test_client.nim
+++ b/tests/waku_lightpush/test_client.nim
@@ -75,7 +75,6 @@ suite "Waku Lightpush Client":
     server = await newTestWakuLightpushNode(serverSwitch, handler)
     serverFailsLightpush =
       await newTestWakuLightpushNode(serverSwitchFailsLightpush, handlerFailsLightpush)
-    ## FIXME: how to pass reputationEnabled from config to here? should we?
     client = newTestWakuLightpushClient(clientSwitch, reputationEnabled = true)
 
     await allFutures(

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -496,6 +496,14 @@ hence would have reachability issues.""",
       name: "lightpushnode"
     .}: string
 
+    ## Reputation config
+    ## FIXME: should be set to false by default
+    reputationEnabled* {.
+      desc: "Enable client-side reputation for light protocols: true|false",
+      defaultValue: true,
+      name: "reputation"
+    .}: bool
+
     ## Reliability config
     reliabilityEnabled* {.
       desc:

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -497,10 +497,9 @@ hence would have reachability issues.""",
     .}: string
 
     ## Reputation config
-    ## FIXME: should be set to false by default
     reputationEnabled* {.
       desc: "Enable client-side reputation for light protocols: true|false",
-      defaultValue: true,
+      defaultValue: false,
       name: "reputation"
     .}: bool
 

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -370,6 +370,8 @@ proc setupProtocols(
     else:
       return err("failed to set node waku lightpush peer: " & lightPushNode.error)
 
+  ## TODO: initialize reputation manager here??
+
   # Filter setup. NOTE Must be mounted after relay
   if conf.filter:
     try:

--- a/waku/incentivization/reputation_manager.nim
+++ b/waku/incentivization/reputation_manager.nim
@@ -12,17 +12,17 @@ type
   #   some(false) => BadRep
   #   none(bool)  => unknown / not set
   ReputationManager* = ref object
-    reputationOf*: Table[PeerID, Option[bool]]
+    reputationOf*: Table[PeerId, Option[bool]]
 
 proc init*(T: type ReputationManager): ReputationManager =
-  return ReputationManager(reputationOf: initTable[PeerID, Option[bool]]())
+  return ReputationManager(reputationOf: initTable[PeerId, Option[bool]]())
 
 proc setReputation*(
-    manager: var ReputationManager, peer: PeerID, repValue: Option[bool]
+    manager: var ReputationManager, peer: PeerId, repValue: Option[bool]
 ) =
   manager.reputationOf[peer] = repValue
 
-proc getReputation*(manager: ReputationManager, peer: PeerID): Option[bool] =
+proc getReputation*(manager: ReputationManager, peer: PeerId): Option[bool] =
   if peer in manager.reputationOf:
     result = manager.reputationOf[peer]
   else:
@@ -37,7 +37,7 @@ proc evaluateResponse*(response: PushResponse): ResponseQuality =
 
 # Update reputation of the peer based on the quality of the response
 proc updateReputationFromResponse*(
-    manager: var ReputationManager, peer: PeerID, response: PushResponse
+    manager: var ReputationManager, peer: PeerId, response: PushResponse
 ) =
   let respQuality = evaluateResponse(response)
   case respQuality

--- a/waku/incentivization/reputation_manager.nim
+++ b/waku/incentivization/reputation_manager.nim
@@ -1,9 +1,8 @@
 import tables, std/options
 import waku/waku_lightpush/rpc
+import libp2p/peerid
 
 type
-  PeerId = string
-
   ResponseQuality* = enum
     BadResponse
     GoodResponse
@@ -13,17 +12,17 @@ type
   #   some(false) => BadRep
   #   none(bool)  => unknown / not set
   ReputationManager* = ref object
-    reputationOf*: Table[PeerId, Option[bool]]
+    reputationOf*: Table[PeerID, Option[bool]]
 
 proc init*(T: type ReputationManager): ReputationManager =
-  return ReputationManager(reputationOf: initTable[PeerId, Option[bool]]())
+  return ReputationManager(reputationOf: initTable[PeerID, Option[bool]]())
 
 proc setReputation*(
-    manager: var ReputationManager, peer: PeerId, repValue: Option[bool]
+    manager: var ReputationManager, peer: PeerID, repValue: Option[bool]
 ) =
   manager.reputationOf[peer] = repValue
 
-proc getReputation*(manager: ReputationManager, peer: PeerId): Option[bool] =
+proc getReputation*(manager: ReputationManager, peer: PeerID): Option[bool] =
   if peer in manager.reputationOf:
     result = manager.reputationOf[peer]
   else:
@@ -38,7 +37,7 @@ proc evaluateResponse*(response: PushResponse): ResponseQuality =
 
 # Update reputation of the peer based on the quality of the response
 proc updateReputationFromResponse*(
-    manager: var ReputationManager, peer: PeerId, response: PushResponse
+    manager: var ReputationManager, peer: PeerID, response: PushResponse
 ) =
   let respQuality = evaluateResponse(response)
   case respQuality

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1009,10 +1009,10 @@ proc mountLightPush*(
 
   node.switch.mount(node.wakuLightPush, protocolMatcher(WakuLightPushCodec))
 
-proc mountLightPushClient*(node: WakuNode) =
+proc mountLightPushClient*(node: WakuNode, reputationEnabled: bool = false) =
   info "mounting light push client"
 
-  node.wakuLightpushClient = WakuLightPushClient.new(node.peerManager, node.rng)
+  node.wakuLightpushClient = WakuLightPushClient.new(node.peerManager, node.rng, reputationEnabled)
 
 proc lightpushPublish*(
     node: WakuNode,

--- a/waku/waku_lightpush/client.nim
+++ b/waku/waku_lightpush/client.nim
@@ -27,8 +27,13 @@ proc new*(
     T: type WakuLightPushClient,
     peerManager: PeerManager,
     rng: ref rand.HmacDrbgContext,
-    reputationManager: Option[ReputationManager],
+    reputationEnabled: bool,
 ): T =
+  let reputationManager =
+    if reputationEnabled:
+      some(ReputationManager.new())
+    else:
+      none(ReputationManager)
   WakuLightPushClient(
     peerManager: peerManager, rng: rng, reputationManager: reputationManager
   )

--- a/waku/waku_lightpush/client.nim
+++ b/waku/waku_lightpush/client.nim
@@ -26,12 +26,15 @@ type WakuLightPushClient* = ref object
 proc new*(
     T: type WakuLightPushClient,
     peerManager: PeerManager,
-    reputationManager: ReputationManager,
     rng: ref rand.HmacDrbgContext,
+    reputationManager: Option[ReputationManager] = none(ReputationManager),
 ): T =
-  WakuLightPushClient(
-    peerManager: peerManager, reputationManager: reputationManager, rng: rng
-  )
+  if reputationManager.isSome:
+    WakuLightPushClient(
+      peerManager: peerManager, rng: rng, reputationManager: reputationManager.get()
+    )
+  else:
+    WakuLightPushClient(peerManager: peerManager, rng: rng)
 
 proc addPublishObserver*(wl: WakuLightPushClient, obs: PublishObserver) =
   wl.publishObservers.add(obs)


### PR DESCRIPTION
# Description

This PR integrates a reputation system designed as part of the incentivization PoC into the Lightpush protocol behind a feature flag (`reputation`).

A Lightpush client uses the reputation manager to keep track of peers it used previously to publish messages. Peers that had failed at publishing a message get assigned a negative reputation and will not be chosen for future requests. If, however, a neutral- or positive-reputation peer isn't selected by the peer manager after a maximum number of attempts (`10`), a negative-reputation peer is still used.

This is a countinuaton of https://github.com/waku-org/nwaku/pull/3166, https://github.com/waku-org/nwaku/pull/3264, and https://github.com/waku-org/nwaku/pull/3293 with associated deliverable https://github.com/waku-org/pm/issues/245.

# Changes

<!-- List of detailed changes -->

- [x] add an optional reputation manager for Lightpush client behind a feature flag
- [x] add tests for the reputation manager
- [x] refactor the `publishToAny` logic for lightpush
- [x] add reputation-based logic to peer selection in a Lightpush client

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->