### PR TITLE
fix: using nimMainPrefix in libwaku

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -107,7 +107,7 @@ proc onTopicHealthChange(ctx: ptr WakuContext): TopicHealthChangeHandler =
 
 # Every Nim library must have this function called - the name is derived from
 # the `--nimMainPrefix` command line option
-proc NimMain() {.importc.}
+proc libwakuNimMain() {.importc.}
 
 # To control when the library has been initialized
 var initialized: Atomic[bool]
@@ -122,7 +122,7 @@ if defined(android):
 
 proc initializeLibrary() {.exported.} =
   if not initialized.exchange(true):
-    NimMain() # Every Nim library needs to call `NimMain` once exactly
+    libwakuNimMain() # Every Nim library needs to call `NimMain` once exactly
   when declared(setupForeignThreadGc):
     setupForeignThreadGc()
   when declared(nimGC_setStackBottom):

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -122,7 +122,9 @@ if defined(android):
 
 proc initializeLibrary() {.exported.} =
   if not initialized.exchange(true):
-    libwakuNimMain() # Every Nim library needs to call `NimMain` once exactly
+    ## Every Nim library needs to call `<yourprefix>NimMain` once exactly, to initialize the Nim runtime.
+    ## Being `<yourprefix>` the value given in the optional compilation flag --nimMainPrefix:yourprefix
+    libwakuNimMain()
   when declared(setupForeignThreadGc):
     setupForeignThreadGc()
   when declared(nimGC_setStackBottom):

--- a/waku.nimble
+++ b/waku.nimble
@@ -65,11 +65,11 @@ proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
     extra_params &= " " & paramStr(i)
   if `type` == "static":
     exec "nim c" & " --out:build/" & name &
-      ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header --undef:metrics --skipParentCfg:on " &
+      ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header --undef:metrics --nimMainPrefix:libwaku --skipParentCfg:on " &
       extra_params & " " & srcDir & name & ".nim"
   else:
     exec "nim c" & " --out:build/" & name &
-      ".so --threads:on --app:lib --opt:size --noMain --mm:refc --header --undef:metrics --skipParentCfg:on " &
+      ".so --threads:on --app:lib --opt:size --noMain --mm:refc --header --undef:metrics --nimMainPrefix:libwaku --skipParentCfg:on " &
       extra_params & " " & srcDir & name & ".nim"
 
 proc buildMobileAndroid(srcDir = ".", params = "") =


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Compiling libwaku with `--nimMainPrefix` to avoid conflicts with other Nim libraries or applications

## Issue

#3076 
