### PR TITLE
feat: deprecate sync / local merkle tree 

### DIFF
--- a/tests/node/test_wakunode_relay_rln.nim
+++ b/tests/node/test_wakunode_relay_rln.nim
@@ -455,7 +455,7 @@ suite "Waku RlnRelay - End to End - OnChain":
       except CatchableError:
         assert true
 
-    xasyncTest "Unregistered contract":
+    asyncTest "Unregistered contract":
       # This is a very slow test due to the retries RLN does. Might take upwards of 1m-2m to finish.
       let
         invalidContractAddress = "0x0000000000000000000000000000000000000000"

--- a/tests/waku_rln_relay/rln/waku_rln_relay_utils.nim
+++ b/tests/waku_rln_relay/rln/waku_rln_relay_utils.nim
@@ -11,7 +11,6 @@ proc unsafeAppendRLNProof*(
   ## this proc derived from appendRLNProof, does not perform nonce check to
   ## facilitate bad message id generation for testing
 
-  debug "calling generateProof from unsafeAppendRLNProof from waku_rln_relay_utils"
   let input = msg.toRLNSignal()
   let epoch = rlnPeer.calcEpoch(senderEpochTime)
 

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -123,7 +123,7 @@ suite "Onchain group manager":
     try:
       discard await manager.trackRootChanges()
     except CatchableError:
-      check getCurrentExceptionMsg().len == 40
+      check getCurrentExceptionMsg().len == 38
 
   asyncTest "trackRootChanges: should sync to the state of the group":
     let credentials = generateCredentials(manager.rlnInstance)

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -117,7 +117,7 @@ suite "Onchain group manager":
   asyncTest "trackRootChanges: start tracking roots":
     (await manager.init()).isOkOr:
       raiseAssert $error
-    discard await withTimeout(trackRootChanges(manager), 5.seconds)
+    discard await withTimeout(trackRootChanges(manager), 1.seconds)
 
   asyncTest "trackRootChanges: should guard against uninitialized state":
     try:

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -117,11 +117,11 @@ suite "Onchain group manager":
   asyncTest "trackRootChanges: start tracking roots":
     (await manager.init()).isOkOr:
       raiseAssert $error
-    discard await withTimeout(trackRootChanges(manager), 1.seconds)
+    discard manager.trackRootChanges()
 
   asyncTest "trackRootChanges: should guard against uninitialized state":
     try:
-      discard await manager.trackRootChanges()
+      discard manager.trackRootChanges()
     except CatchableError:
       check getCurrentExceptionMsg().len == 38
 

--- a/tests/waku_rln_relay/utils_static.nim
+++ b/tests/waku_rln_relay/utils_static.nim
@@ -74,7 +74,6 @@ proc sendRlnMessageWithInvalidProof*(
     completionFuture: Future[bool],
     payload: seq[byte] = "Hello".toBytes(),
 ): Future[bool] {.async.} =
-  debug "calling generateProof from sendRlnMessageWithInvalidProof from utils_static"
   let
     extraBytes: seq[byte] = @[byte(1), 2, 3]
     rateLimitProofRes = client.wakuRlnRelay.groupManager.generateProof(

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -279,7 +279,6 @@ proc installRelayApiHandlers*(
       error "publish error", err = msg
       return RestApiResponse.badRequest("Failed to publish. " & msg)
 
-    debug "calling appendRLNProof from post_waku_v2_relay_v1_auto_messages_no_topic"
     # if RLN is mounted, append the proof to the message
     if not node.wakuRlnRelay.isNil():
       node.wakuRlnRelay.appendRLNProof(message, float64(getTime().toUnix())).isOkOr:
@@ -287,7 +286,6 @@ proc installRelayApiHandlers*(
           "Failed to publish: error appending RLN proof to message: " & $error
         )
 
-    debug "calling validateMessage from post_waku_v2_relay_v1_auto_messages_no_topic"
     (await node.wakuRelay.validateMessage(pubsubTopic, message)).isOkOr:
       return RestApiResponse.badRequest("Failed to publish: " & error)
 

--- a/waku/waku_lightpush_legacy/callbacks.nim
+++ b/waku/waku_lightpush_legacy/callbacks.nim
@@ -14,7 +14,6 @@ proc checkAndGenerateRLNProof*(
     rlnPeer: Option[WakuRLNRelay], message: WakuMessage
 ): Result[WakuMessage, string] =
   # check if the message already has RLN proof
-  debug "calling appendRLNProof from checkAndGenerateRLNProof from waku_lightpush_legacy"
   if message.proof.len > 0:
     return ok(message)
 

--- a/waku/waku_rln_relay/conversion_utils.nim
+++ b/waku/waku_rln_relay/conversion_utils.nim
@@ -157,20 +157,23 @@ func u256*(n: Quantity): UInt256 {.inline.} =
   n.uint64.stuint(256)
 
 proc uint64ToField*(n: uint64): array[32, byte] =
-  ## Converts uint64 to 32-byte little-endian array with zero padding
-  var bytes = toBytes(n, Endianness.littleEndian)
-  result[0 ..< bytes.len] = bytes
+  var output: array[32, byte]
+  let bytes = toBytes(n, Endianness.littleEndian)
+  output[0 ..< bytes.len] = bytes
+  return output
 
 proc UInt256ToField*(v: UInt256): array[32, byte] =
-  return cast[array[32, byte]](v)
+  return cast[array[32, byte]](v) # already doesn't use `result`
 
 proc seqToField*(s: seq[byte]): array[32, byte] =
-  result = default(array[32, byte])
+  var output: array[32, byte]
   let len = min(s.len, 32)
   for i in 0 ..< len:
-    result[i] = s[i]
+    output[i] = s[i]
+  return output
 
 proc uint64ToIndex*(index: MembershipIndex, depth: int): seq[byte] =
-  result = newSeq[byte](depth)
+  var output = newSeq[byte](depth)
   for i in 0 ..< depth:
-    result[i] = byte((index shr i) and 1) # LSB-first bit decomposition
+    output[i] = byte((index shr i) and 1) # LSB-first bit decomposition
+  return output

--- a/waku/waku_rln_relay/conversion_utils.nim
+++ b/waku/waku_rln_relay/conversion_utils.nim
@@ -116,19 +116,16 @@ proc serialize*(memIndices: seq[MembershipIndex]): seq[byte] =
 
   return memIndicesBytes
 
-proc serialize*(witness: Witness): seq[byte] =
+proc serialize*(witness: RLNWitnessInput): seq[byte] =
   ## Serializes the witness into a byte array according to the RLN protocol format
   var buffer: seq[byte]
-  # Convert Fr types to bytes and add them to buffer
   buffer.add(@(witness.identity_secret))
   buffer.add(@(witness.user_message_limit))
   buffer.add(@(witness.message_id))
-  # Add path elements length as uint64 in little-endian
   buffer.add(toBytes(uint64(witness.path_elements.len), Endianness.littleEndian))
-  # Add each path element
   for element in witness.path_elements:
     buffer.add(@element)
-  # Add remaining fields
+  buffer.add(toBytes(uint64(witness.path_elements.len), Endianness.littleEndian))
   buffer.add(witness.identity_path_index)
   buffer.add(@(witness.x))
   buffer.add(@(witness.external_nullifier))

--- a/waku/waku_rln_relay/conversion_utils.nim
+++ b/waku/waku_rln_relay/conversion_utils.nim
@@ -27,9 +27,6 @@ proc inHex*(
     valueHex = "0" & valueHex
   return toLowerAscii(valueHex)
 
-proc toUserMessageLimit*(v: UInt256): UserMessageLimit =
-  return cast[UserMessageLimit](v)
-
 proc encodeLengthPrefix*(input: openArray[byte]): seq[byte] =
   ## returns length prefixed version of the input
   ## with the following format [len<8>|input<var>]
@@ -148,3 +145,22 @@ func `+`*(a, b: Quantity): Quantity {.borrow.}
 
 func u256*(n: Quantity): UInt256 {.inline.} =
   n.uint64.stuint(256)
+
+proc uint64ToField*(n: uint64): array[32, byte] =
+  ## Converts uint64 to 32-byte little-endian array with zero padding
+  var bytes = toBytes(n, Endianness.littleEndian)
+  result[0 ..< bytes.len] = bytes
+
+proc UInt256ToField*(v: UInt256): array[32, byte] =
+  return cast[array[32, byte]](v)
+
+proc seqToField*(s: seq[byte]): array[32, byte] =
+  result = default(array[32, byte])
+  let len = min(s.len, 32)
+  for i in 0 ..< len:
+    result[i] = s[i]
+
+proc uint64ToIndex*(index: MembershipIndex, depth: int): seq[byte] =
+  result = newSeq[byte](depth)
+  for i in 0 ..< depth:
+    result[i] = byte((index shr i) and 1) # LSB-first bit decomposition

--- a/waku/waku_rln_relay/conversion_utils.nim
+++ b/waku/waku_rln_relay/conversion_utils.nim
@@ -76,7 +76,17 @@ proc serialize*(
   return output
 
 proc serialize*(witness: RLNWitnessInput): seq[byte] =
-  ## Serializes the witness into a byte array according to the RLN protocol format
+  ## Serializes the RLN witness into a byte array following zerokit's expected format.
+  ## The serialized format includes:
+  ## - identity_secret (32 bytes, little-endian with zero padding)
+  ## - user_message_limit (32 bytes, little-endian with zero padding)
+  ## - message_id (32 bytes, little-endian with zero padding)
+  ## - merkle tree depth (8 bytes, little-endian) = path_elements.len / 32
+  ## - path_elements (each 32 bytes, ordered bottom-to-top)
+  ## - merkle tree depth again (8 bytes, little-endian)
+  ## - identity_path_index (sequence of bits as bytes, 0 = left, 1 = right)
+  ## - x (32 bytes, little-endian with zero padding)
+  ## - external_nullifier (32 bytes, little-endian with zero padding)
   var buffer: seq[byte]
   buffer.add(@(witness.identity_secret))
   buffer.add(@(witness.user_message_limit))

--- a/waku/waku_rln_relay/conversion_utils.nim
+++ b/waku/waku_rln_relay/conversion_utils.nim
@@ -78,6 +78,21 @@ proc serialize*(
   )
   return output
 
+proc serialize*(witness: RLNWitnessInput): seq[byte] =
+  ## Serializes the witness into a byte array according to the RLN protocol format
+  var buffer: seq[byte]
+  buffer.add(@(witness.identity_secret))
+  buffer.add(@(witness.user_message_limit))
+  buffer.add(@(witness.message_id))
+  buffer.add(toBytes(uint64(witness.path_elements.len / 32), Endianness.littleEndian))
+  for element in witness.path_elements:
+    buffer.add(element)
+  buffer.add(toBytes(uint64(witness.path_elements.len / 32), Endianness.littleEndian))
+  buffer.add(witness.identity_path_index)
+  buffer.add(@(witness.x))
+  buffer.add(@(witness.external_nullifier))
+  return buffer
+
 proc serialize*(proof: RateLimitProof, data: openArray[byte]): seq[byte] =
   ## a private proc to convert RateLimitProof and data to a byte seq
   ## this conversion is used in the proof verification proc
@@ -115,21 +130,6 @@ proc serialize*(memIndices: seq[MembershipIndex]): seq[byte] =
     memIndicesBytes = concat(memIndicesBytes, @memIndexBytes)
 
   return memIndicesBytes
-
-proc serialize*(witness: RLNWitnessInput): seq[byte] =
-  ## Serializes the witness into a byte array according to the RLN protocol format
-  var buffer: seq[byte]
-  buffer.add(@(witness.identity_secret))
-  buffer.add(@(witness.user_message_limit))
-  buffer.add(@(witness.message_id))
-  buffer.add(toBytes(uint64(witness.path_elements.len), Endianness.littleEndian))
-  for element in witness.path_elements:
-    buffer.add(@element)
-  buffer.add(toBytes(uint64(witness.path_elements.len), Endianness.littleEndian))
-  buffer.add(witness.identity_path_index)
-  buffer.add(@(witness.x))
-  buffer.add(@(witness.external_nullifier))
-  return buffer
 
 proc toEpoch*(t: uint64): Epoch =
   ## converts `t` to `Epoch` in little-endian order

--- a/waku/waku_rln_relay/group_manager/group_manager_base.nim
+++ b/waku/waku_rln_relay/group_manager/group_manager_base.nim
@@ -122,35 +122,29 @@ method onWithdraw*(g: GroupManager, cb: OnWithdrawCallback) {.base, gcsafe.} =
 proc slideRootQueue*(
     rootQueue: var Deque[MerkleNode], root: MerkleNode
 ): seq[MerkleNode] =
+  ## updates the root queue with the latest root and pops the oldest one when the capacity of `AcceptableRootWindowSize` is reached
   let overflowCount = rootQueue.len - AcceptableRootWindowSize + 1
   var overflowedRoots = newSeq[MerkleNode]()
   if overflowCount > 0:
+    # Delete the oldest `overflowCount` roots in the deque (index 0..`overflowCount`)
+    # insert into overflowedRoots seq and return
     for i in 0 ..< overflowCount:
       overFlowedRoots.add(rootQueue.popFirst())
+  # Push the next root into the queue
   rootQueue.addLast(root)
   return overFlowedRoots
 
 method indexOfRoot*(
     g: GroupManager, root: MerkleNode
 ): int {.base, gcsafe, raises: [].} =
+  ## returns the index of the root in the merkle tree.
+  ## returns -1 if the root is not found
   return g.validRoots.find(root)
 
 method validateRoot*(
     g: GroupManager, root: MerkleNode
 ): bool {.base, gcsafe, raises: [].} =
   ## validates the root against the valid roots queue
-  # Print all validRoots in one line with square brackets
-  var rootsStr = "["
-  var first = true
-  for r in g.validRoots.items():
-    if not first:
-      rootsStr.add(", ")
-    rootsStr.add($r)
-    first = false
-  rootsStr.add("]")
-  debug "Valid Merkle roots in validateRoot", roots = rootsStr, root_to_validate = root
-
-  # Check if the root is in the valid roots queue
   if g.indexOfRoot(root) >= 0:
     return true
   return false

--- a/waku/waku_rln_relay/group_manager/group_manager_base.nim
+++ b/waku/waku_rln_relay/group_manager/group_manager_base.nim
@@ -122,23 +122,17 @@ method onWithdraw*(g: GroupManager, cb: OnWithdrawCallback) {.base, gcsafe.} =
 proc slideRootQueue*(
     rootQueue: var Deque[MerkleNode], root: MerkleNode
 ): seq[MerkleNode] =
-  ## updates the root queue with the latest root and pops the oldest one when the capacity of `AcceptableRootWindowSize` is reached
   let overflowCount = rootQueue.len - AcceptableRootWindowSize + 1
   var overflowedRoots = newSeq[MerkleNode]()
   if overflowCount > 0:
-    # Delete the oldest `overflowCount` roots in the deque (index 0..`overflowCount`)
-    # insert into overflowedRoots seq and return
     for i in 0 ..< overflowCount:
       overFlowedRoots.add(rootQueue.popFirst())
-  # Push the next root into the queue
   rootQueue.addLast(root)
   return overFlowedRoots
 
 method indexOfRoot*(
     g: GroupManager, root: MerkleNode
 ): int {.base, gcsafe, raises: [].} =
-  ## returns the index of the root in the merkle tree.
-  ## returns -1 if the root is not found
   return g.validRoots.find(root)
 
 method validateRoot*(

--- a/waku/waku_rln_relay/group_manager/group_manager_base.nim
+++ b/waku/waku_rln_relay/group_manager/group_manager_base.nim
@@ -4,7 +4,7 @@ import
   ../protocol_metrics,
   ../constants,
   ../rln
-import options, chronos, results, std/[deques, sequtils], chronicles
+import options, chronos, results, std/[deques, sequtils]
 
 export options, chronos, results, protocol_types, protocol_metrics, deques
 

--- a/waku/waku_rln_relay/group_manager/group_manager_base.nim
+++ b/waku/waku_rln_relay/group_manager/group_manager_base.nim
@@ -189,8 +189,6 @@ method generateProof*(
   if g.userMessageLimit.isNone():
     return err("user message limit is not set")
 
-  debug "calling proofGen from generateProof from group_manager_base", data = data
-
   waku_rln_proof_generation_duration_seconds.nanosecondTime:
     let proof = proofGen(
       rlnInstance = g.rlnInstance,

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -233,11 +233,10 @@ proc trackRootChanges*(g: OnchainGroupManager) {.async.} =
   while true:
     let rootUpdated = await g.updateRoots()
 
-    if rootUpdated:
-      let proofResult = await g.fetchMerkleProofElements()
-      if proofResult.isErr():
-        error "Failed to fetch Merkle proof", error = proofResult.error
-      g.merkleProofCache = proofResult.get()
+    let proofResult = await g.fetchMerkleProofElements()
+    if proofResult.isErr():
+      error "Failed to fetch Merkle proof", error = proofResult.error
+    g.merkleProofCache = proofResult.get()
 
     debug "--- track update ---",
       len = g.validRoots.len,

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -581,7 +581,9 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
   ethRpc.ondisconnect = proc() =
     asyncSpawn onDisconnect()
 
-  waku_rln_number_registered_memberships.set(int64(g.rlnInstance.leavesSet()))
+  let memberCount = cast[float64](await wakuRlnContract.commitmentIndex().call())
+  waku_rln_number_registered_memberships.set(memberCount)
+
   g.initialized = true
   return ok()
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -312,19 +312,6 @@ method generateProof*(
   if g.userMessageLimit.isNone():
     return err("user message limit is not set")
 
-  try:
-    discard waitFor g.updateRoots()
-  except CatchableError:
-    error "Failed to update roots", error = getCurrentExceptionMsg()
-
-  try:
-    let proofResult = waitFor g.fetchMerkleProofElements()
-    if proofResult.isErr():
-      return err("Failed to fetch Merkle proof: " & proofResult.error)
-    g.merkleProofCache = proofResult.get()
-  except CatchableError:
-    error "Failed to fetch merkle proof", error = getCurrentExceptionMsg()
-
   if (g.merkleProofCache.len mod 32) != 0:
     return err("Invalid merkle proof cache length")
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -204,6 +204,10 @@ proc trackRootChanges*(g: OnchainGroupManager) {.async.} =
       let memberCount = cast[float64](await wakuRlnContract.commitmentIndex().call())
       waku_rln_number_registered_memberships.set(memberCount)
 
+      debug "--- RLN membership metrics ---",
+        registered_members = memberCount,
+        active_memberships = waku_rln_number_registered_memberships.value
+
     await sleepAsync(rpcDelay)
 
 method atomicBatch*(

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -158,8 +158,8 @@ proc fetchMerkleProofElements*(
 
     let responseBytes = await g.ethRpc.get().provider.eth_call(tx, "latest")
 
-    debug "---- raw response ----", 
-      total_bytes = responseBytes.len,        # Should be 640
+    debug "---- raw response ----",
+      total_bytes = responseBytes.len, # Should be 640
       non_zero_bytes = responseBytes.countIt(it != 0),
       response = responseBytes
 
@@ -172,7 +172,12 @@ proc fetchMerkleProofElements*(
       element = responseBytes.toOpenArray(startIndex, endIndex)
       merkleProof.add(element)
       i += 1
-      debug "---- element ----", startIndex = startIndex, startElement = responseBytes[startIndex], endIndex = endIndex, endElement = responseBytes[endIndex], element = element
+      debug "---- element ----",
+        startIndex = startIndex,
+        startElement = responseBytes[startIndex],
+        endIndex = endIndex,
+        endElement = responseBytes[endIndex],
+        element = element
 
     # debug "merkleProof", responseBytes = responseBytes, merkleProof = merkleProof
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -117,6 +117,7 @@ proc fetchMerkleProofElements*(
     return ok(responseBytes)
   except CatchableError:
     error "Failed to fetch Merkle proof elements", error = getCurrentExceptionMsg()
+    return err("Failed to fetch merkle proof elements: " & getCurrentExceptionMsg())
 
 proc fetchMerkleRoot*(
     g: OnchainGroupManager
@@ -127,6 +128,7 @@ proc fetchMerkleRoot*(
     return ok(merkleRoot)
   except CatchableError:
     error "Failed to fetch Merkle root", error = getCurrentExceptionMsg()
+    return err("Failed to fetch merkle root: " & getCurrentExceptionMsg())
 
 template initializedGuard(g: OnchainGroupManager): untyped =
   if not g.initialized:

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -561,7 +561,8 @@ method verifyProof*(
     warn "verify_with_roots() returned failure status", proof = proof
     return err("could not verify the proof")
 
-  debug "Verification successfully", proof = proof, output = ffiOk
+  debug "Verification successfully", proof = proof
+  debug "------"output = ffiOk
 
   return ok(validProof)
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -375,7 +375,7 @@ method generateProof*(
   g.merkleProofCache.reverse()
   var i = 0
   while i + 31 < g.merkleProofCache.len:
-    for j in countdown(32, 1):
+    for j in countdown(31, 0):
       path_elements.add(g.merkleProofCache[i+j])
     i += 32
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -448,7 +448,7 @@ method verifyProof*(
   if not ffiOk:
     return err("could not verify the proof")
   else:
-    debug "Proof verified successfully !"
+    trace "Proof verified successfully !"
 
   return ok(validProof)
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -158,6 +158,11 @@ proc fetchMerkleProofElements*(
 
     let responseBytes = await g.ethRpc.get().provider.eth_call(tx, "latest")
 
+    debug "---- raw response ----", 
+      total_bytes = responseBytes.len,        # Should be 640
+      non_zero_bytes = responseBytes.countIt(it != 0),
+      response = responseBytes
+
     var i = 0
     var merkleProof = newSeq[array[32, byte]]()
     while (i * 32) + 31 < responseBytes.len:
@@ -167,8 +172,9 @@ proc fetchMerkleProofElements*(
       element = responseBytes.toOpenArray(startIndex, endIndex)
       merkleProof.add(element)
       i += 1
+      debug "---- element ----", i = i, element = element
 
-    debug "merkleProof", responseBytes = responseBytes, merkleProof = merkleProof
+    # debug "merkleProof", responseBytes = responseBytes, merkleProof = merkleProof
 
     return ok(merkleProof)
   except CatchableError:

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -163,10 +163,9 @@ proc updateRoots*(g: OnchainGroupManager): Future[bool] {.async.} =
 
   return false
 
-proc utils_trackRootChanges*(
-    g: OnchainGroupManager
-): Future[void] {.async: (raises: [CatchableError]).} =
+proc trackRootChanges*(g: OnchainGroupManager) {.async: (raises: [CatchableError]).} =
   try:
+    initializedGuard(g)
     let ethRpc = g.ethRpc.get()
     let wakuRlnContract = g.wakuRlnContract.get()
 
@@ -191,17 +190,6 @@ proc utils_trackRootChanges*(
       await sleepAsync(rpcDelay)
   except CatchableError:
     error "Fatal error in trackRootChanges", error = getCurrentExceptionMsg()
-
-method trackRootChanges*(
-    g: OnchainGroupManager
-): Future[GroupManagerResult[void]] {.async.} =
-  initializedGuard(g)
-  # Get archive history
-  try:
-    await utils_trackRootChanges(g)
-    return ok()
-  except CatchableError, Exception:
-    return err("failed to start root change tracking: " & getCurrentExceptionMsg())
 
 method register*(
     g: OnchainGroupManager, rateCommitment: RateCommitment

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -199,6 +199,11 @@ proc trackRootChanges*(g: OnchainGroupManager) {.async.} =
       if proofResult.isErr():
         error "Failed to fetch Merkle proof", error = proofResult.error
       g.merkleProofCache = proofResult.get()
+
+      # also need update registerd membership
+      let memberCount = cast[float64](await wakuRlnContract.commitmentIndex().call())
+      waku_rln_number_registered_memberships.set(memberCount)
+
     await sleepAsync(rpcDelay)
 
 method atomicBatch*(
@@ -580,9 +585,6 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
 
   ethRpc.ondisconnect = proc() =
     asyncSpawn onDisconnect()
-
-  let memberCount = cast[float64](await wakuRlnContract.commitmentIndex().call())
-  waku_rln_number_registered_memberships.set(memberCount)
 
   g.initialized = true
   return ok()

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -132,10 +132,7 @@ proc fetchMerkleRoot*(
 
 template initializedGuard(g: OnchainGroupManager): untyped =
   if not g.initialized:
-    raise newException(
-      CatchableError,
-      "OnchainGroupManager is not initialized: " & getCurrentExceptionMsg(),
-    )
+    raise newException(CatchableError, "OnchainGroupManager is not initialized")
 
 template retryWrapper(
     g: OnchainGroupManager, res: auto, errStr: string, body: untyped

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -91,7 +91,6 @@ proc fetchMerkleProofElements*(
     g: OnchainGroupManager
 ): Future[Result[seq[byte], string]] {.async.} =
   try:
-    debug "----- membershipIndex -----", membershipIndex = g.membershipIndex
     let membershipIndex = g.membershipIndex.get()
     let index40 = stuint(membershipIndex, 40)
 
@@ -109,7 +108,6 @@ proc fetchMerkleProofElements*(
       callData.add(b)
     callData.add(paddedParam)
 
-    debug "----- contract address -----", contractAddress = g.ethContractAddress
     var tx: TransactionArgs
     tx.to = Opt.some(fromHex(Address, g.ethContractAddress))
     tx.data = Opt.some(callData)

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -340,11 +340,6 @@ method generateProof*(
   if g.userMessageLimit.isNone():
     return err("user message limit is not set")
 
-  debug "calling generateProof from group_manager onchain",
-    data = data,
-    membershipIndex = g.membershipIndex.get(),
-    userMessageLimit = g.userMessageLimit.get()
-
   try:
     discard waitFor g.updateRoots()
   except CatchableError:
@@ -474,6 +469,7 @@ method verifyProof*(
     addr proofBuffer, # (proof + signal)
     addr rootsBuffer, # valid Merkle roots
     addr validProof # will be set by the FFI call
+    ,
   )
 
   if not ffiOk:

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -148,7 +148,7 @@ method validateRoot*(g: OnchainGroupManager, root: MerkleNode): bool =
     return true
   return false
 
-proc updateRoots(g: OnchainGroupManager): Future[bool] {.async.} =
+proc updateRoots*(g: OnchainGroupManager): Future[bool] {.async.} =
   let rootRes = await g.fetchMerkleRoot()
   if rootRes.isErr():
     return false
@@ -166,7 +166,7 @@ proc updateRoots(g: OnchainGroupManager): Future[bool] {.async.} =
 
   return false
 
-proc utils_trackRootChanges(
+proc utils_trackRootChanges*(
     g: OnchainGroupManager
 ): Future[void] {.async: (raises: [CatchableError]).} =
   try:
@@ -192,9 +192,7 @@ proc utils_trackRootChanges(
         waku_rln_number_registered_memberships.set(float64(memberCount))
 
       debug "--- roots and merkle proofs",
-        len = g.validRoots.len,
-        roots = g.validRoots,
-        proof = g.merkleProofCache
+        len = g.validRoots.len, roots = g.validRoots, proof = g.merkleProofCache
 
       await sleepAsync(rpcDelay)
   except CatchableError:

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -98,29 +98,13 @@ proc uint64ToField*(n: uint64): array[32, byte] =
   result[0 ..< bytes.len] = bytes
 
 proc UInt256ToField*(v: UInt256): array[32, byte] =
-  var bytes: array[32, byte]
-  let vBytes = v.toBytesBE()
-  for i in 0 .. 31:
-    bytes[i] = vBytes[31 - i]
-  return bytes
+  return cast[array[32, byte]](v)
 
 proc seqToField*(s: seq[byte]): array[32, byte] =
   result = default(array[32, byte])
   let len = min(s.len, 32)
   for i in 0 ..< len:
     result[i] = s[i]
-
-proc uint256ToBinarySeq*(value: UInt256, len: int): seq[byte] =
-  result = newSeq[byte](len) # Create a sequence of specified length
-  var v = value
-
-  # Fill from least significant bit (little-endian)
-  for i in 0 ..< len:
-    if v mod 2 == 1:
-      result[i] = 1
-    else:
-      result[i] = 0
-    v = v shr 1 # Shift right by 1 bit
 
 proc fetchMerkleProofElements*(
     g: OnchainGroupManager
@@ -433,6 +417,7 @@ method generateProof*(
   )
 
   let serializedWitness = serialize(witness)
+
   debug "--- serializedWitness ---", before = witness, after = serializedWitness
   var input_witness_buffer = toBuffer(serializedWitness)
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -166,7 +166,7 @@ proc fetchMerkleProofElements*(
       else:
         discard
 
-    debug "merkleProof", output = merkleProof
+    debug "merkleProof", responseBytes = responseBytes, merkleProof = merkleProof
 
     return ok(merkleProof)
   except CatchableError:
@@ -410,7 +410,8 @@ method generateProof*(
     membershipIndex = g.membershipIndex.get(),
     userMessageLimit = g.userMessageLimit.get()
 
-  let externalNullifierRes = poseidon(@[hash_to_field(@epoch).toSeq(), hash_to_field(@rlnIdentifier).toSeq()])
+  let externalNullifierRes =
+    poseidon(@[hash_to_field(@epoch).toSeq(), hash_to_field(@rlnIdentifier).toSeq()])
   let extNullifier = externalNullifierRes.get().toArray32LE()
 
   try:

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -562,7 +562,7 @@ method verifyProof*(
     return err("could not verify the proof")
 
   debug "Verification successfully", proof = proof
-  debug "------"output = ffiOk
+  debug "------", output = ffiOk
 
   return ok(validProof)
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -441,7 +441,7 @@ method generateProof*(
 
   # --- x = Keccak256(signal) ---
   let keccakDigest = keccak.keccak256.digest(data) # 32‑byte BE array
-  let x = seqToField(keccakDigest.data.reversed()) # convert to LE for BN254
+  let x = seqToField(keccakDigest.data) # convert to LE for BN254
 
   let extNullifierRes = poseidon(@[@(epoch), @(rlnIdentifier)])
   if extNullifierRes.isErr():
@@ -560,7 +560,7 @@ method verifyProof*(
     warn "verify_with_roots() returned failure status", proof = proof
     return err("could not verify the proof")
 
-  debug "Verification successfully", proof = proof
+  debug "Verification successfully", proof = proof, output = ffiOk
 
   return ok(validProof)
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -108,7 +108,7 @@ proc seqToField*(s: seq[byte]): array[32, byte] =
 
 proc uint64ToIndex*(value: uint64, numBits: int = 64): seq[uint8] =
   result = newSeq[uint8](numBits)
-  for i in 0..<numBits:
+  for i in 0 ..< numBits:
     result[i] = uint8((value shr i) and 1)
 
 proc fetchMerkleProofElements*(
@@ -372,10 +372,12 @@ method generateProof*(
   if (g.merkleProofCache.len mod 32) != 0:
     return err("Invalid merkle proof cache length")
 
+  g.merkleProofCache.reverse()
   var i = 0
-  while i < g.merkleProofCache.len:
-    path_elements.add(g.merkleProofCache[i])
-    i += 1
+  while i + 31 < g.merkleProofCache.len:
+    for j in countdown(32 .. 1):
+      path_elements.add(g.merkleProofCache[i + j])
+    i += 32
 
   debug "--- pathElements ---",
     before = g.merkleProofCache,
@@ -384,8 +386,7 @@ method generateProof*(
     after_len = path_elements.len
 
   let index_len = int(g.merkleProofCache.len / 32)
-  let identity_path_index =
-    uint64ToIndex(uint64(g.membershipIndex.get()), index_len)
+  let identity_path_index = uint64ToIndex(uint64(g.membershipIndex.get()), index_len)
 
   debug "--- identityPathIndex ---",
     before = g.membershipIndex.get(),

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -451,7 +451,7 @@ method generateProof*(
 
 method verifyProof*(
     g: OnchainGroupManager, # verifier context
-    input: openArray[byte], # raw message data (signal)
+    input: seq[byte], # raw message data (signal)
     proof: RateLimitProof, # proof received from the peer
 ): GroupManagerResult[bool] {.gcsafe, raises: [].} =
   ## -- Verifies an RLN rate-limit proof against the set of valid Merkle roots --

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -425,6 +425,7 @@ method generateProof*(
 
   debug "--- generatedRoot and contractRoots",
     generatedRoot = generatedRoot, contractRoots = g.validRoots.toSeq()
+
   # if contractRoot != generatedRoot:
   #   return err("Root mismatch: contract=" & $contractRoot & " local=" & $generatedRoot)
 
@@ -440,8 +441,8 @@ method generateProof*(
     len = identity_path_index.len
 
   # --- x = Keccak256(signal) ---
-  let keccakDigest = keccak.keccak256.digest(data) # 32‑byte BE array
-  let x = seqToField(keccakDigest.data) # convert to LE for BN254
+  let x = keccak.keccak256.digest(data) # 32‑byte BE array
+  # let x = seqToField(keccakDigest.data) 
 
   let extNullifierRes = poseidon(@[@(epoch), @(rlnIdentifier)])
   if extNullifierRes.isErr():

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -27,9 +27,6 @@ export group_manager_base
 logScope:
   topics = "waku rln_relay onchain_group_manager"
 
-type UInt40* = StUint[40]
-type UInt32* = StUint[32]
-
 # using the when predicate does not work within the contract macro, hence need to dupe
 contract(WakuRlnContract):
   # this serves as an entrypoint into the rln membership set

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -359,12 +359,12 @@ method generateProof*(
 
   var i = 0
   while i + 31 < g.merkleProofCache.len:
-    for j in 31 .. 0:
+    for j in countdown(31, 0):
       pathElements.add(g.merkleProofCache[i + j])
     i += 32
 
   debug "--- pathElements ---",
-    before = g.merkleProofCache, after = path_elements, len = path_elements.len
+    before = g.merkleProofCache, after = path_elements, before_len = g.merkleProofCache.len, after_len = path_elements.len
 
   var commitmentIndexRes: UInt256
   try:
@@ -376,7 +376,7 @@ method generateProof*(
     error "Failed to fetch commitment index", error = getCurrentExceptionMsg()
 
   let index_len = int(g.merkleProofCache.len / 32)
-  let identity_path_index = UInt256ToField(commitmentIndexRes)[0 .. index_len]
+  let identity_path_index = UInt256ToField(commitmentIndexRes)[0 .. index_len - 1]
 
   debug "--- identityPathIndex ---",
     before = g.membershipIndex.get(),

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -172,7 +172,7 @@ proc fetchMerkleProofElements*(
       element = responseBytes.toOpenArray(startIndex, endIndex)
       merkleProof.add(element)
       i += 1
-      debug "---- element ----", i = i, element = element
+      debug "---- element ----", startIndex = startIndex, startElement = responseBytes[startIndex], endIndex = endIndex, endElement = responseBytes[endIndex], element = element
 
     # debug "merkleProof", responseBytes = responseBytes, merkleProof = merkleProof
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -428,7 +428,7 @@ method generateProof*(
     return err("Failed to compute external nullifier: " & extNullifierRes.error)
   let extNullifier = extNullifierRes.get()
 
-  debug "--- x ---", before = data, after = x
+  debug "--- x ( data hash ) ---", before = data, after = x
   debug "--- externalNullifier ---", before = extNullifier, after = extNullifier
 
   let witness = RLNWitnessInput(
@@ -442,6 +442,7 @@ method generateProof*(
   )
 
   let serializedWitness = serialize(witness)
+  debug "--- serializedWitness ---", before = witness, after = serializedWitness
   var input_witness_buffer = toBuffer(serializedWitness)
 
   # Generate the proof using the zerokit API

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -102,7 +102,7 @@ proc toArray32LE*(x: UInt256): array[32, byte] {.inline.} =
     copyMem(addr result, unsafeAddr x, 32)
 
 # Hashes arbitrary signal to the underlying prime field.
-proc hashToField*(signal: seq[byte]): array[32, byte] =
+proc hash_to_field*(signal: seq[byte]): array[32, byte] =
   var ctx: keccak256
   ctx.init()
   ctx.update(signal)
@@ -377,7 +377,7 @@ proc createZerokitWitness(
   let pathIndex = indexToPath(g.membershipIndex.get()) # uint to seq[byte]
 
   # Calculate hash using zerokit's hash_to_field equivalent
-  let x = hashToField(data).toArray32LE() # convert to little-endian
+  let x = hash_to_field(data).toArray32LE() # convert to little-endian
 
   RLNWitnessInput(
     identity_secret: identitySecret,
@@ -410,7 +410,7 @@ method generateProof*(
     membershipIndex = g.membershipIndex.get(),
     userMessageLimit = g.userMessageLimit.get()
 
-  let externalNullifierRes = poseidon(@[@(epoch), @(rlnIdentifier)])
+  let externalNullifierRes = poseidon(@[hash_to_field(@epoch).toSeq(), hash_to_field(@rlnIdentifier).toSeq()])
   let extNullifier = externalNullifierRes.get().toArray32LE()
 
   try:

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -10,7 +10,7 @@ import
   nimcrypto/keccak as keccak,
   stint,
   json,
-  std/[strutils, tables],
+  std/[strutils, tables, algorithm],
   stew/[byteutils, arrayops],
   sequtils
 import
@@ -375,8 +375,8 @@ method generateProof*(
   g.merkleProofCache.reverse()
   var i = 0
   while i + 31 < g.merkleProofCache.len:
-    for j in countdown(32 .. 1):
-      path_elements.add(g.merkleProofCache[i + j])
+    for j in countdown(32, 1):
+      path_elements.add(g.merkleProofCache[i+j])
     i += 32
 
   debug "--- pathElements ---",

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -201,8 +201,8 @@ proc trackRootChanges*(g: OnchainGroupManager) {.async.} =
       g.merkleProofCache = proofResult.get()
 
       # also need update registerd membership
-      let memberCount = cast[float64](await wakuRlnContract.commitmentIndex().call())
-      waku_rln_number_registered_memberships.set(10)
+      let memberCount = cast[int64](await wakuRlnContract.commitmentIndex().call())
+      waku_rln_number_registered_memberships.set(float64(memberCount))
 
       debug "--- RLN membership metrics ---",
         registered_members = memberCount,

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -106,6 +106,11 @@ proc seqToField*(s: seq[byte]): array[32, byte] =
   for i in 0 ..< len:
     result[i] = s[i]
 
+proc uint64ToIndex*(value: uint64, numBits: int = 64): seq[uint8] =
+  result = newSeq[uint8](numBits)
+  for i in 0..<numBits:
+    result[i] = uint8((value shr i) and 1)
+
 proc fetchMerkleProofElements*(
     g: OnchainGroupManager
 ): Future[Result[seq[byte], string]] {.async.} =
@@ -380,7 +385,7 @@ method generateProof*(
 
   let index_len = int(g.merkleProofCache.len / 32)
   let identity_path_index =
-    uint64ToField(uint64(g.membershipIndex.get()))[0 .. index_len - 1]
+    uint64ToIndex(uint64(g.membershipIndex.get()), index_len)
 
   debug "--- identityPathIndex ---",
     before = g.membershipIndex.get(),

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -284,11 +284,11 @@ method withdrawBatch*(
 ): Future[void] {.async: (raises: [Exception]).} =
   initializedGuard(g)
 
-# this is a helper function to get root from merkle proof elements and index
-# it's currently not used anywhere, but can be used to verify the root from the proof and index
 proc getRootFromProofAndIndex(
     g: OnchainGroupManager, elements: seq[byte], bits: seq[byte]
 ): GroupManagerResult[array[32, byte]] =
+  # this is a helper function to get root from merkle proof elements and index
+  # it's currently not used anywhere, but can be used to verify the root from the proof and index
   # Compute leaf hash from idCommitment and messageLimit
   let messageLimitField = uint64ToField(g.userMessageLimit.get())
   let leafHashRes = poseidon(@[g.idCredentials.get().idCommitment, @messageLimitField])

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -384,10 +384,9 @@ method generateProof*(
     return err("Invalid merkle proof cache length")
 
   var i = 0
-  while i + 31 < g.merkleProofCache.len:
-    for j in countdown(31, 0):
-      pathElements.add(g.merkleProofCache[i + j])
-    i += 32
+  while i < g.merkleProofCache.len:
+    path_elements.add(g.merkleProofCache[i])
+    i += 1
 
   debug "--- pathElements ---",
     before = g.merkleProofCache,
@@ -395,17 +394,9 @@ method generateProof*(
     before_len = g.merkleProofCache.len,
     after_len = path_elements.len
 
-  var commitmentIndexRes: UInt256
-  try:
-    let tmp = waitFor g.fetchCommitmentIndex()
-    if tmp.isErr():
-      return err("Failed to fetch commitment index: " & tmp.error)
-    commitmentIndexRes = tmp.get()
-  except CatchableError:
-    error "Failed to fetch commitment index", error = getCurrentExceptionMsg()
-
   let index_len = int(g.merkleProofCache.len / 32)
-  let identity_path_index = uint256ToBinarySeq(commitmentIndexRes, index_len)
+  let identity_path_index =
+    uint64ToField(uint64(g.membershipIndex.get()))[0 .. index_len - 1]
 
   debug "--- identityPathIndex ---",
     before = g.membershipIndex.get(),

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -202,7 +202,7 @@ proc trackRootChanges*(g: OnchainGroupManager) {.async.} =
 
       # also need update registerd membership
       let memberCount = cast[float64](await wakuRlnContract.commitmentIndex().call())
-      waku_rln_number_registered_memberships.set(memberCount)
+      waku_rln_number_registered_memberships.set(10)
 
       debug "--- RLN membership metrics ---",
         registered_members = memberCount,

--- a/waku/waku_rln_relay/protocol_metrics.nim
+++ b/waku/waku_rln_relay/protocol_metrics.nim
@@ -85,6 +85,7 @@ proc getRlnMetricsLogger*(): RLNMetricsLogger =
   var cumulativeProofsVerified = 0.float64
   var cumulativeProofsGenerated = 0.float64
   var cumulativeProofsRemaining = 100.float64
+  var cumulativeRegisteredMember = 0.float64
 
   when defined(metrics):
     logMetrics = proc() =
@@ -106,6 +107,9 @@ proc getRlnMetricsLogger*(): RLNMetricsLogger =
           parseAndAccumulate(waku_rln_total_generated_proofs, cumulativeProofsGenerated)
         let freshProofsRemainingCount = parseAndAccumulate(
           waku_rln_remaining_proofs_per_epoch, cumulativeProofsRemaining
+        )
+        let freshRegisteredMemberCount = parseAndAccumulate(
+          waku_rln_number_registered_memberships, cumulativeRegisteredMember
         )
 
         info "Total messages", count = freshMsgCount

--- a/waku/waku_rln_relay/protocol_metrics.nim
+++ b/waku/waku_rln_relay/protocol_metrics.nim
@@ -120,5 +120,6 @@ proc getRlnMetricsLogger*(): RLNMetricsLogger =
         info "Total proofs verified", count = freshProofsVerifiedCount
         info "Total proofs generated", count = freshProofsGeneratedCount
         info "Total proofs remaining", count = freshProofsRemainingCount
+        info "Total registered member", count = freshRegisteredMemberCount
 
   return logMetrics

--- a/waku/waku_rln_relay/protocol_metrics.nim
+++ b/waku/waku_rln_relay/protocol_metrics.nim
@@ -120,6 +120,6 @@ proc getRlnMetricsLogger*(): RLNMetricsLogger =
         info "Total proofs verified", count = freshProofsVerifiedCount
         info "Total proofs generated", count = freshProofsGeneratedCount
         info "Total proofs remaining", count = freshProofsRemainingCount
-        info "Total registered member", count = freshRegisteredMemberCount
+        info "Total registered members", count = freshRegisteredMemberCount
 
   return logMetrics

--- a/waku/waku_rln_relay/protocol_types.nim
+++ b/waku/waku_rln_relay/protocol_types.nim
@@ -59,7 +59,7 @@ type
     identity_secret*: Fr
     user_message_limit*: Fr
     message_id*: Fr
-    path_elements*: seq[Fr]
+    path_elements*: seq[byte]
     identity_path_index*: seq[byte]
     x*: Fr
     external_nullifier*: Fr

--- a/waku/waku_rln_relay/protocol_types.nim
+++ b/waku/waku_rln_relay/protocol_types.nim
@@ -52,17 +52,19 @@ type RateLimitProof* = object
   ## the external nullifier used for the generation of the `proof` (derived from poseidon([epoch, rln_identifier]))
   externalNullifier*: ExternalNullifier
 
-type
-  Fr = array[32, byte] # Field element representation (256 bits)
+type UInt40* = StUint[40]
+type UInt32* = StUint[32]
 
+type
+  Field = array[32, byte] # Field element representation (256 bits)
   RLNWitnessInput* = object
-    identity_secret*: Fr
-    user_message_limit*: Fr
-    message_id*: Fr
+    identity_secret*: Field
+    user_message_limit*: Field
+    message_id*: Field
     path_elements*: seq[byte]
     identity_path_index*: seq[byte]
-    x*: Fr
-    external_nullifier*: Fr
+    x*: Field
+    external_nullifier*: Field
 
 type ProofMetadata* = object
   nullifier*: Nullifier

--- a/waku/waku_rln_relay/protocol_types.nim
+++ b/waku/waku_rln_relay/protocol_types.nim
@@ -55,7 +55,7 @@ type RateLimitProof* = object
 type
   Fr = array[32, byte] # Field element representation (256 bits)
 
-  Witness* = object
+  RLNWitnessInput* = object
     identity_secret*: Fr
     user_message_limit*: Fr
     message_id*: Fr

--- a/waku/waku_rln_relay/rln/rln_interface.nim
+++ b/waku/waku_rln_relay/rln/rln_interface.nim
@@ -135,6 +135,7 @@ proc generate_proof_with_witness*(
 ): bool {.importc: "generate_rln_proof_with_witness".}
 
 ## rln-v2
+## witness term refer to collection of secret inputs with proper serialization
 ## input_buffer has to be serialized as [ identity_secret<32> | user_message_limit<32> | message_id<32> | path_elements<Vec<32>> | identity_path_index<Vec<1>> | x<32> | external_nullifier<32> ]
 ## output_buffer holds the proof data and should be parsed as [ proof<128> | root<32> | external_nullifier<32> | share_x<32> | share_y<32> | nullifier<32> ]
 ## rln-v1

--- a/waku/waku_rln_relay/rln/rln_interface.nim
+++ b/waku/waku_rln_relay/rln/rln_interface.nim
@@ -135,7 +135,7 @@ proc generate_proof_with_witness*(
 ): bool {.importc: "generate_rln_proof_with_witness".}
 
 ## rln-v2
-## witness term refer to collection of secret inputs with proper serialization
+## "witness" term refer to collection of secret inputs with proper serialization
 ## input_buffer has to be serialized as [ identity_secret<32> | user_message_limit<32> | message_id<32> | path_elements<Vec<32>> | identity_path_index<Vec<1>> | x<32> | external_nullifier<32> ]
 ## output_buffer holds the proof data and should be parsed as [ proof<128> | root<32> | external_nullifier<32> | share_x<32> | share_y<32> | nullifier<32> ]
 ## rln-v1

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -478,14 +478,11 @@ proc mount(
     onFatalErrorAction: conf.onFatalErrorAction,
   )
 
-  proc runTrackRootChanges(g: OnchainGroupManager) {.async.} =
-    (await g.trackRootChanges()).isOkOr:
-      error "Failed to track root changes in background", error
-
   # track root changes on smart contract merkle tree
   if groupManager of OnchainGroupManager:
     let onchainManager = cast[OnchainGroupManager](groupManager)
-    wakuRlnRelay.rootChangesFuture = runTrackRootChanges(onchainManager)
+    (await onchainManager.trackRootChanges()).isOkOr:
+      return err("failed to track root changes in background: " & error)
 
   # Start epoch monitoring in the background
   wakuRlnRelay.epochMonitorFuture = monitorEpochs(wakuRlnRelay)

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -201,7 +201,7 @@ proc validateMessage*(
   ## `timeOption` indicates Unix epoch time (fractional part holds sub-seconds)
   ## if `timeOption` is supplied, then the current epoch is calculated based on that
 
-  debug "calling validateMessage from rln_relay", msg = msg
+  debug "calling validateMessage from rln_relay", msg_len = msg.payload.len
 
   let decodeRes = RateLimitProof.init(msg.proof)
   if decodeRes.isErr():

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -468,13 +468,13 @@ proc mount(
       onFatalErrorAction: conf.onFatalErrorAction,
     )
 
-    if groupManager of OnchainGroupManager:
-      let onchainManager = cast[OnchainGroupManager](groupManager)
-      asyncSpawn trackRootChanges(onchainManager)
-
   # Initialize the groupManager
   (await groupManager.init()).isOkOr:
     return err("could not initialize the group manager: " & $error)
+
+  if groupManager of OnchainGroupManager:
+    let onchainManager = cast[OnchainGroupManager](groupManager)
+    asyncSpawn trackRootChanges(onchainManager)
 
   wakuRlnRelay = WakuRLNRelay(
     groupManager: groupManager,

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -201,8 +201,6 @@ proc validateMessage*(
   ## `timeOption` indicates Unix epoch time (fractional part holds sub-seconds)
   ## if `timeOption` is supplied, then the current epoch is calculated based on that
 
-  debug "calling validateMessage from rln_relay", msg_len = msg.payload.len
-
   let decodeRes = RateLimitProof.init(msg.proof)
   if decodeRes.isErr():
     return MessageValidationResult.Invalid
@@ -254,6 +252,7 @@ proc validateMessage*(
     waku_rln_errors_total.inc(labelValues = ["proof_verification"])
     warn "invalid message: proof verification failed", payloadLen = msg.payload.len
     return MessageValidationResult.Invalid
+
   if not proofVerificationRes.value():
     # invalid proof
     warn "invalid message: invalid proof", payloadLen = msg.payload.len
@@ -321,8 +320,6 @@ proc appendRLNProof*(
 
   let input = msg.toRLNSignal()
   let epoch = rlnPeer.calcEpoch(senderEpochTime)
-
-  debug "calling generateProof from appendRLNProof from rln_relay", input = input
 
   let nonce = rlnPeer.nonceManager.getNonce().valueOr:
     return err("could not get new message id to generate an rln proof: " & $error)

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -481,9 +481,7 @@ proc mount(
   # track root changes on smart contract merkle tree
   if groupManager of OnchainGroupManager:
     let onchainManager = cast[OnchainGroupManager](groupManager)
-    let trackRootChangesFuture = trackRootChanges(onchainManager)
-    asyncSpawn trackRootChangesFuture
-    wakuRlnRelay.rootChangesFuture = trackRootChangesFuture
+    wakuRlnRelay.rootChangesFuture = trackRootChanges(onchainManager)
 
   # Start epoch monitoring in the background
   wakuRlnRelay.epochMonitorFuture = monitorEpochs(wakuRlnRelay)

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -481,8 +481,7 @@ proc mount(
   # track root changes on smart contract merkle tree
   if groupManager of OnchainGroupManager:
     let onchainManager = cast[OnchainGroupManager](groupManager)
-    (await onchainManager.trackRootChanges()).isOkOr:
-      return err("failed to track root changes in background: " & error)
+    wakuRlnRelay.rootChangesFuture = utils_trackRootChanges(onchainManager)
 
   # Start epoch monitoring in the background
   wakuRlnRelay.epochMonitorFuture = monitorEpochs(wakuRlnRelay)

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -481,7 +481,7 @@ proc mount(
   # track root changes on smart contract merkle tree
   if groupManager of OnchainGroupManager:
     let onchainManager = cast[OnchainGroupManager](groupManager)
-    wakuRlnRelay.rootChangesFuture = utils_trackRootChanges(onchainManager)
+    wakuRlnRelay.rootChangesFuture = onchainManager.trackRootChanges()
 
   # Start epoch monitoring in the background
   wakuRlnRelay.epochMonitorFuture = monitorEpochs(wakuRlnRelay)

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -478,10 +478,14 @@ proc mount(
     onFatalErrorAction: conf.onFatalErrorAction,
   )
 
+  proc runTrackRootChanges(g: OnchainGroupManager) {.async.} =
+    (await g.trackRootChanges()).isOkOr:
+      error "Failed to track root changes in background", error
+
   # track root changes on smart contract merkle tree
   if groupManager of OnchainGroupManager:
     let onchainManager = cast[OnchainGroupManager](groupManager)
-    wakuRlnRelay.rootChangesFuture = trackRootChanges(onchainManager)
+    wakuRlnRelay.rootChangesFuture = runTrackRootChanges(onchainManager)
 
   # Start epoch monitoring in the background
   wakuRlnRelay.epochMonitorFuture = monitorEpochs(wakuRlnRelay)


### PR DESCRIPTION
This PR deprecates the sync strategy by removing the need for each node to maintain a local Merkle tree. Previously, every node independently managed a Merkle tree and used it to generate Merkle proofs for RLN proof generation. However, constructing a local Merkle tree required syncing a large amount of blockchain data, which was highly time-consuming.

With the latest RLN contract update, we can now fetch Merkle proofs directly from the smart contract, eliminating the need for local Merkle tree maintenance.

<p align="center">
  <img width="700" alt="Screenshot 2025-03-21 at 12 19 33 PM" src="https://github.com/user-attachments/assets/1ff8f40e-d66a-49d5-a081-a4b5ccb7271c" />
</p>

Changes

- [x] Deprecated the syncing and Merkle tree maintenance code from onchainGroupManager.
- [x] Introduced a new group manager that fetches Merkle proofs directly from the smart contract and uses them for RLN proof generation.
- [x] disable effected unittest according 

closes
- #2924 
