### PR TITLE
chore: CI for windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
 
       - name: Build binaries
         run: make V=1 QUICK_AND_DIRTY_COMPILER=1 all tools
+  
+  trigger-windows-build:
+    uses: ./.github/workflows/windows-build.yml@master
+    with:
+      branch: ${{ github.ref }}
 
   test:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: make V=1 QUICK_AND_DIRTY_COMPILER=1 all tools
   
   trigger-windows-build:
-    uses: ./.github/workflows/windows-build.yml@master
+    uses: ./.github/workflows/windows-build.yml
     with:
       branch: ${{ github.ref }}
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,15 +1,22 @@
-name: ci / build-windows (pull_request)
+name: ci / build-windows
 
 on:
   workflow_call:
     inputs:
       branch:
         required: true
-        type: stringi
+        type: string
 
 jobs:
   build:
     runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}  
+
+    env:
+      MSYSTEM: MINGW64
 
     steps:
     - name: Checkout code
@@ -20,6 +27,7 @@ jobs:
       with:
         update: true
         install: >-
+          git
           base-devel
           mingw-w64-x86_64-toolchain
           make
@@ -33,12 +41,63 @@ jobs:
           mingw-w64-x86_64-zlib
           mingw-w64-x86_64-openssl
           mingw-w64-x86_64-python
-
-    - name: Build Wakunode2
+          mingw-w64-x86_64-cmake
+      
+    - name: Add UPX to PATH
       run: |
-        ./scripts/build_wakunode_windows.sh
-      shell: bash
+        echo "/usr/bin:$PATH" >> $GITHUB_PATH
+        echo "/mingw64/bin:$PATH" >> $GITHUB_PATH
+        echo "/usr/lib:$PATH" >> $GITHUB_PATH
+        echo "/mingw64/lib:$PATH" >> $GITHUB_PATH 
 
+    - name: Verify dependencies
+      run: |
+        which upx gcc g++ make cmake cargo rustc python
+
+    - name: Updating submodules
+      run: git submodule update --init --recursive
+
+    - name: Creating tmp directory
+      run: mkdir -p tmp
+
+    - name: Building Nim
+      run: |
+        cd vendor/nimbus-build-system/vendor/Nim
+        ./build_all.bat
+        cd ../../../..
+ 
+    - name: Building libunwind
+      continue-on-error: true
+      run: |
+        cd vendor/nim-libbacktrace
+        make install/usr/lib/libunwind.a V=2
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        find . -name "*.a"
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        if [ -f ./vendor/libunwind/build/lib/libunwind.a ]; then
+          cp ./vendor/libunwind/build/lib/libunwind.a install/usr/lib
+        else
+          echo "libunwind.a not found, skipping copy"
+        fi
+        cd ../../
+
+    - name: Building miniupnpc
+      run: |
+        cd vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc
+        git checkout little_chore_windows_support
+        make -f Makefile.mingw CC=gcc CXX=g++ libminiupnpc.a V=1
+        cd ../../../../..
+
+    - name: Building libnatpmp
+      run: |
+        cd ./vendor/nim-nat-traversal/vendor/libnatpmp-upstream
+        make CC="gcc -fPIC -D_WIN32_WINNT=0x0600 -DNATPMP_STATICLIB" libnatpmp.a V=1
+        cd ../../../../
+
+    - name: Building wakunode2
+      run: |
+        make wakunode2 LOG_LEVEL=DEBUG V=3 -j8
+    
     - name: Check Executable
       run: |
         if [ -f "./build/wakunode2.exe" ]; then
@@ -47,10 +106,3 @@ jobs:
           echo "Build failed: wakunode2.exe not found"
           exit 1
         fi
-      shell: bash
-
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: wakunode2-windows
-        path: build/wakunode2.exe

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -69,57 +69,13 @@ jobs:
         cd ../../../..
 
     - name: Building libunwind
-      continue-on-error: true
       run: |
         cd vendor/nim-libbacktrace
-        
-        # Add additional CMake flags for Windows
-        export CMAKE_ARGS="$CMAKE_ARGS \
-          -DCMAKE_C_COMPILER=gcc \
-          -DCMAKE_CXX_COMPILER=g++ \
-          -DCMAKE_SYSTEM_NAME=Windows \
-          -DCMAKE_BUILD_TYPE=Release"
-        
-        # Build with verbose output
-        make install/usr/lib/libunwind.a V=3
-        
-        # Search for the built library in multiple locations
+        make install/usr/lib/libunwind.a V=1
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        echo "Searching for libunwind.a..."
-        find . -name "libunwind.a" -print
+        find . -name "*.a"
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        
-        # Try to copy from different possible locations
-        if [ -f ./vendor/libunwind/build/lib/libunwind.a ]; then
-          echo "Found libunwind.a in build/lib"
-          cp ./vendor/libunwind/build/lib/libunwind.a install/usr/lib
-        elif [ -f ./vendor/libunwind/build/libunwind.a ]; then
-          echo "Found libunwind.a in build directory"
-          cp ./vendor/libunwind/build/libunwind.a install/usr/lib
-        elif [ -f ./vendor/libunwind/build/runtimes/libunwind/lib/libunwind.a ]; then
-          echo "Found libunwind.a in runtimes directory"
-          cp ./vendor/libunwind/build/runtimes/libunwind/lib/libunwind.a install/usr/lib
-        else
-          echo "libunwind.a not found in any expected location"
-          exit 1
-        fi
-        
         cd ../../
-
-    # - name: Building libunwind
-    #   continue-on-error: true
-    #   run: |
-    #     cd vendor/nim-libbacktrace
-    #     make install/usr/lib/libunwind.a V=2
-    #     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    #     find . -name "*.a"
-    #     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    #     if [ -f ./vendor/libunwind/build/lib/libunwind.a ]; then
-    #       cp ./vendor/libunwind/build/lib/libunwind.a install/usr/lib
-    #     else
-    #       echo "libunwind.a not found, skipping copy"
-    #     fi
-    #     cd ../../
 
     - name: Building miniupnpc
       run: |
@@ -136,6 +92,9 @@ jobs:
 
     - name: Building wakunode2
       run: |
+        cd vendor/nim-libbacktrace
+        cp ./vendor/libunwind/build/lib/libunwind.a install/usr/lib
+        cd ../..
         make wakunode2 LOG_LEVEL=DEBUG V=3 -j8
     
     - name: Check Executable

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -71,11 +71,9 @@ jobs:
     - name: Building libunwind
       run: |
         cd vendor/nim-libbacktrace
-        # First setup the cmake build
         mkdir -p vendor/libunwind/build
         pushd vendor/libunwind
         
-        # Use MSYS2 cmake directly
         cmake -S runtimes \
           -DLLVM_ENABLE_RUNTIMES="libunwind" \
           -DLIBUNWIND_ENABLE_SHARED=OFF -DLIBUNWIND_ENABLE_STATIC=ON \
@@ -83,23 +81,14 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="$(pwd)/../install/usr" \
           -G "MinGW Makefiles" -B build
           
-        # Now explicitly use mingw32-make in the build directory
         cd build
         mingw32-make VERBOSE=1 clean
         mingw32-make VERBOSE=1 unwind_static
         mingw32-make VERBOSE=1 install-unwind
         
         popd
-        # Verify the build succeeded
-        if [ -f "./install/usr/lib/libunwind.a" ]; then
-          echo "Successfully built libunwind.a"
-        else
-          echo "Failed to build libunwind.a"
-        fi
-
-        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        find . -name "*.a"
-        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        mkdir -p install/usr/lib
+        cp -r vendor/libunwind/build/lib/libunwind.a install/usr/lib/
 
     - name: Building miniupnpc
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,56 @@
+name: ci / build-windows (pull_request)
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: stringi
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup MSYS2
+      uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: >-
+          base-devel
+          mingw-w64-x86_64-toolchain
+          make
+          cmake
+          upx
+          mingw-w64-x86_64-rust
+          mingw-w64-x86_64-postgresql
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-gcc-libs
+          mingw-w64-x86_64-libwinpthread-git
+          mingw-w64-x86_64-zlib
+          mingw-w64-x86_64-openssl
+          mingw-w64-x86_64-python
+
+    - name: Build Wakunode2
+      run: |
+        ./scripts/build_wakunode_windows.sh
+      shell: bash
+
+    - name: Check Executable
+      run: |
+        if [ -f "./build/wakunode2.exe" ]; then
+          echo "wakunode2.exe build successful"
+        else
+          echo "Build failed: wakunode2.exe not found"
+          exit 1
+        fi
+      shell: bash
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: wakunode2-windows
+        path: build/wakunode2.exe

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -71,11 +71,35 @@ jobs:
     - name: Building libunwind
       run: |
         cd vendor/nim-libbacktrace
-        make install/usr/lib/libunwind.a V=1
+        # First setup the cmake build
+        mkdir -p vendor/libunwind/build
+        pushd vendor/libunwind
+        
+        # Use MSYS2 cmake directly
+        cmake -S runtimes \
+          -DLLVM_ENABLE_RUNTIMES="libunwind" \
+          -DLIBUNWIND_ENABLE_SHARED=OFF -DLIBUNWIND_ENABLE_STATIC=ON \
+          -DLIBUNWIND_INCLUDE_DOCS=OFF -DLIBUNWIND_INSTALL_HEADERS=ON \
+          -DCMAKE_INSTALL_PREFIX="$(pwd)/../install/usr" \
+          -G "MinGW Makefiles" -B build
+          
+        # Now explicitly use mingw32-make in the build directory
+        cd build
+        mingw32-make VERBOSE=1 clean
+        mingw32-make VERBOSE=1 unwind_static
+        mingw32-make VERBOSE=1 install-unwind
+        
+        popd
+        # Verify the build succeeded
+        if [ -f "./install/usr/lib/libunwind.a" ]; then
+          echo "Successfully built libunwind.a"
+        else
+          echo "Failed to build libunwind.a"
+        fi
+
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         find . -name "*.a"
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        cd ../../
 
     - name: Building miniupnpc
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -42,6 +42,8 @@ jobs:
           mingw-w64-x86_64-openssl
           mingw-w64-x86_64-python
           mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-llvm
+          mingw-w64-x86_64-clang
       
     - name: Add UPX to PATH
       run: |
@@ -65,21 +67,59 @@ jobs:
         cd vendor/nimbus-build-system/vendor/Nim
         ./build_all.bat
         cd ../../../..
- 
+
     - name: Building libunwind
       continue-on-error: true
       run: |
         cd vendor/nim-libbacktrace
-        make install/usr/lib/libunwind.a V=2
+        
+        # Add additional CMake flags for Windows
+        export CMAKE_ARGS="$CMAKE_ARGS \
+          -DCMAKE_C_COMPILER=gcc \
+          -DCMAKE_CXX_COMPILER=g++ \
+          -DCMAKE_SYSTEM_NAME=Windows \
+          -DCMAKE_BUILD_TYPE=Release"
+        
+        # Build with verbose output
+        make install/usr/lib/libunwind.a V=3
+        
+        # Search for the built library in multiple locations
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        find . -name "*.a"
+        echo "Searching for libunwind.a..."
+        find . -name "libunwind.a" -print
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        
+        # Try to copy from different possible locations
         if [ -f ./vendor/libunwind/build/lib/libunwind.a ]; then
+          echo "Found libunwind.a in build/lib"
           cp ./vendor/libunwind/build/lib/libunwind.a install/usr/lib
+        elif [ -f ./vendor/libunwind/build/libunwind.a ]; then
+          echo "Found libunwind.a in build directory"
+          cp ./vendor/libunwind/build/libunwind.a install/usr/lib
+        elif [ -f ./vendor/libunwind/build/runtimes/libunwind/lib/libunwind.a ]; then
+          echo "Found libunwind.a in runtimes directory"
+          cp ./vendor/libunwind/build/runtimes/libunwind/lib/libunwind.a install/usr/lib
         else
-          echo "libunwind.a not found, skipping copy"
+          echo "libunwind.a not found in any expected location"
+          exit 1
         fi
+        
         cd ../../
+
+    # - name: Building libunwind
+    #   continue-on-error: true
+    #   run: |
+    #     cd vendor/nim-libbacktrace
+    #     make install/usr/lib/libunwind.a V=2
+    #     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    #     find . -name "*.a"
+    #     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    #     if [ -f ./vendor/libunwind/build/lib/libunwind.a ]; then
+    #       cp ./vendor/libunwind/build/lib/libunwind.a install/usr/lib
+    #     else
+    #       echo "libunwind.a not found, skipping copy"
+    #     fi
+    #     cd ../../
 
     - name: Building miniupnpc
       run: |


### PR DESCRIPTION
The "ci / build-windows (pull_request)" workflow verifies compatibility of changes with Windows machines by building the project on Windows using MSYS2 whenever a pull request is made.

Note:- We can't directly run the windows build script since it requires two different terminals (MSYS and Git Bash). However, replicating this setup in a CI action isn’t possible due to both terminal running isolation. To work around this, I run all commands within the MSYS terminal with some trick, that's why it's little different than scripts !

## Issues
- https://github.com/waku-org/nwaku/issues/2473