### PR TITLE
feat: service incentivization POC

### DIFF
--- a/README-I13N-POC.md
+++ b/README-I13N-POC.md
@@ -358,7 +358,7 @@ Expected response:
 All failed responses described above must not impact Charlie's reputation from Alice's perspective. This can be verified by checking Charlie's reputation:
 
 ```bash
-curl -X GET "http://127.0.0.1:8646/admin/v1/peer/16Uiu2HAkyxHKziUQghTarGhBSFn8GcVapDgkJjMFTUVCCfEuyzSd" -H "accept: application/json" | jq | grep reputation
+curl -s -X GET "http://127.0.0.1:8646/admin/v1/peer/16Uiu2HAkyxHKziUQghTarGhBSFn8GcVapDgkJjMFTUVCCfEuyzSd" -H "accept: application/json" | jq | grep reputation
 ```
 
 Expected response should show `"reputation": "Neutral"` indicating that Charlie's reputation remains unchanged.
@@ -388,7 +388,7 @@ Expected response:
 Alice assigns Charlie a "bad" reputation due to a valid request not being served. This can be verified by checking Charlie's reputation:
 
 ```bash
-curl -X GET "http://127.0.0.1:8646/admin/v1/peer/16Uiu2HAkyxHKziUQghTarGhBSFn8GcVapDgkJjMFTUVCCfEuyzSd" -H "accept: application/json" | jq | grep reputation
+curl -s -X GET "http://127.0.0.1:8646/admin/v1/peer/16Uiu2HAkyxHKziUQghTarGhBSFn8GcVapDgkJjMFTUVCCfEuyzSd" -H "accept: application/json" | jq | grep reputation
 ```
 
 Expected response should show `"reputation": "Bad"` indicating that Charlie has been assigned bad reputation.
@@ -411,7 +411,7 @@ curl -X POST "http://127.0.0.1:8646/admin/v1/peers" -H "accept: text/plain" -H "
 Verify that Alice is now connected to Bob:
 
 ```
-curl -X GET "http://127.0.0.1:8646/admin/v1/peers/connected" | jq . | grep multiaddr
+curl -s -X GET "http://127.0.0.1:8646/admin/v1/peers/connected" | jq . | grep multiaddr
 ```
 
 Expected response (showing both Bob’s and Charlie’s multiaddrs; `EXTERNAL_IP` is used in place of actual IP):
@@ -450,7 +450,7 @@ Expected response (indicates successful message relay):
 Bob is selected as the service peer because Charlie has bad reputation and is excluded from consideration. Upon successful message delivery, Alice assigns Bob a "good" reputation. This can be verified by checking Bob's reputation:
 
 ```bash
-curl -X GET "http://127.0.0.1:8646/admin/v1/peer/16Uiu2HAmVHRbXuE4MUZbZ4xXF5CnVT5ntNGS3z7ER1fX1aLjxE95" -H "accept: application/json" | jq | grep reputation
+curl -s -X GET "http://127.0.0.1:8646/admin/v1/peer/16Uiu2HAmVHRbXuE4MUZbZ4xXF5CnVT5ntNGS3z7ER1fX1aLjxE95" -H "accept: application/json" | jq | grep reputation
 ```
 
 Expected response should show `"reputation": "Good"` indicating that Bob has been assigned good reputation for successfully fulfilling the request.
@@ -458,7 +458,7 @@ Expected response should show `"reputation": "Good"` indicating that Bob has bee
 To verify that Alice's message reached Dave, query for the latest messages on shard `0`:
 
 ```
-curl -X GET "http://127.0.0.1:8647/relay/v1/messages/%2Fwaku%2F2%2Frs%2F1%2F0"
+curl -s -X GET "http://127.0.0.1:8647/relay/v1/messages/%2Fwaku%2F2%2Frs%2F1%2F0"
 ```
 
 Expected response (truncated example):


### PR DESCRIPTION
# Description

This is a feature branch for the service incentivization POC, which includes eligibility and reputation systems integrated into Lightpush (v3) behind a feature flag.

A Lightpush client uses the reputation manager to keep track of peers it used previously to publish messages. Peers that had failed at publishing a message get assigned a negative reputation and will not be chosen for future requests. If, however, a neutral- or positive-reputation peer isn't selected by the peer manager after a maximum number of attempts (10), a negative-reputation peer is still used.

This is a countinuaton of https://github.com/waku-org/nwaku/pull/3166, https://github.com/waku-org/nwaku/pull/3264, https://github.com/waku-org/nwaku/pull/3293, and https://github.com/waku-org/nwaku/pull/3309 with associated deliverable https://github.com/waku-org/pm/issues/245.

# Changes

<!-- List of detailed changes -->

- [x] merge the prior work (initially for Lightpush v2) onto Lightpush v3
- [x] move the reputation-based peer selection logic into PeerManager
- [x] add or adapt tests for reputation functionality

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->