### PR TITLE
docs: update prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ The standard developer tools, including a C compiler, GNU Make, Bash, and Git. M
 
 > In some distributions (Fedora linux for example), you may need to install `which` utility separately. Nimbus build system is relying on it.
 
+You'll also need an installation of Rust and its toolchain (specifically `rustc` and `cargo`).
+The easiest way to install these, is using `rustup`:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
 ### Wakunode
 
 ```bash


### PR DESCRIPTION
Add `rustc` and `cargo` as prerequisite to README (required for RLN compilation).

I've recently built nwaku on a clean Ubuntu installation and noticed a missing prerequisite in the README.