### PR TITLE
feat: introduce reputation in PeerManager

### DIFF
--- a/tests/incentivization/test_poc_reputation.nim
+++ b/tests/incentivization/test_poc_reputation.nim
@@ -29,16 +29,6 @@ suite "Waku Incentivization PoC Reputation":
     manager.setReputation(peerId1, some(true)) # Encodes GoodRep
     check manager.getReputation(peerId1) == some(true)
 
-  #[
-    LightPushResponse* = object
-    requestId*: string
-    statusCode*: uint32
-    statusDesc*: Option[string]
-    relayPeerCount*: Option[uint32]
-
-    LightpushStatusCode
-    ]#
-
   test "incentivization PoC: reputation: evaluate LightPushResponse valid":
     let validLightLightPushResponse =
       LightPushResponse(requestId: "", statusCode: LightpushStatusCode.SUCCESS.uint32)

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -28,8 +28,7 @@ proc newTestWakuLightpushNode*(
   return proto
 
 proc newTestWakuLightpushClient*(
-  switch: Switch,
-  reputationEnabled: bool = false
+  switch: Switch, reputationEnabled: bool = false
   ): WakuLightPushClient =
-  let peerManager = PeerManager.new(switch)
-  WakuLightPushClient.new(peerManager, rng, reputationEnabled)
+  let peerManager = PeerManager.new(switch, reputationEnabled = reputationEnabled)
+  WakuLightPushClient.new(peerManager, rng)

--- a/waku/incentivization/reputation_manager.nim
+++ b/waku/incentivization/reputation_manager.nim
@@ -28,6 +28,8 @@ proc getReputation*(manager: ReputationManager, peer: PeerId): Option[bool] =
   else:
     result = none(bool)
 
+### Lightpush-specific functionality ###
+
 # Evaluate the quality of a LightPushResponse by checking its status code
 proc evaluateResponse*(response: LightPushResponse): ResponseQuality =
   if response.statusCode == LightpushStatusCode.SUCCESS.uint32:
@@ -35,7 +37,7 @@ proc evaluateResponse*(response: LightPushResponse): ResponseQuality =
   else:
     return BadResponse
 
-# Update reputation of the peer based on the quality of the response
+# Update reputation of the peer based on LightPushResponse quality
 proc updateReputationFromResponse*(
     manager: var ReputationManager, peer: PeerId, response: LightPushResponse
 ) =

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1124,8 +1124,7 @@ proc mountLightPush*(
 proc mountLightPushClient*(node: WakuNode) =
   info "mounting light push client"
 
-  node.wakuLightpushClient =
-    WakuLightPushClient.new(node.peerManager, node.rng)
+  node.wakuLightpushClient = WakuLightPushClient.new(node.peerManager, node.rng)
 
 proc lightpushPublishHandler(
     node: WakuNode,

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1125,7 +1125,7 @@ proc mountLightPushClient*(node: WakuNode) =
   info "mounting light push client"
 
   node.wakuLightpushClient =
-    WakuLightPushClient.new(node.peerManager, node.rng, reputationEnabled = false)
+    WakuLightPushClient.new(node.peerManager, node.rng)
 
 proc lightpushPublishHandler(
     node: WakuNode,

--- a/waku/waku_lightpush/client.nim
+++ b/waku/waku_lightpush/client.nim
@@ -20,23 +20,14 @@ logScope:
 type WakuLightPushClient* = ref object
   peerManager*: PeerManager
   rng*: ref rand.HmacDrbgContext
-  reputationManager*: Option[ReputationManager]
   publishObservers: seq[PublishObserver]
 
 proc new*(
     T: type WakuLightPushClient,
     peerManager: PeerManager,
     rng: ref rand.HmacDrbgContext,
-    reputationEnabled: bool,
 ): T =
-  let reputationManager =
-    if reputationEnabled:
-      some(ReputationManager.new())
-    else:
-      none(ReputationManager)
-  WakuLightPushClient(
-    peerManager: peerManager, rng: rng, reputationManager: reputationManager
-  )
+  WakuLightPushClient(peerManager: peerManager, rng: rng)
 
 proc addPublishObserver*(wl: WakuLightPushClient, obs: PublishObserver) =
   wl.publishObservers.add(obs)
@@ -57,8 +48,8 @@ proc sendPushRequest(
     buffer = await connection.readLp(DefaultMaxRpcSize.int)
   except LPStreamRemoteClosedError:
     error "Failed to read responose from peer", error = getCurrentExceptionMsg()
-    if wl.reputationManager.isSome:
-      wl.reputationManager.get().setReputation(peer.peerId, some(false))
+    if wl.peerManager.reputationManager.isSome:
+      wl.peerManager.reputationManager.get().setReputation(peer.peerId, some(false))
     return lightpushResultInternalError(
       "Failed to read response from peer: " & getCurrentExceptionMsg()
     )
@@ -66,20 +57,20 @@ proc sendPushRequest(
   let response = LightpushResponse.decode(buffer).valueOr:
     error "failed to decode response"
     waku_lightpush_v3_errors.inc(labelValues = [decodeRpcFailure])
-    if wl.reputationManager.isSome:
-      wl.reputationManager.get().setReputation(peer.peerId, some(false))
+    if wl.peerManager.reputationManager.isSome:
+      wl.peerManager.reputationManager.get().setReputation(peer.peerId, some(false))
     return lightpushResultInternalError(decodeRpcFailure)
 
   if response.requestId != req.requestId and
       response.statusCode != TOO_MANY_REQUESTS.uint32:
     error "response failure, requestId mismatch",
       requestId = req.requestId, responseRequestId = response.requestId
-    if wl.reputationManager.isSome:
-      wl.reputationManager.get().setReputation(peer.peerId, some(false))
+    if wl.peerManager.reputationManager.isSome:
+      wl.peerManager.reputationManager.get().setReputation(peer.peerId, some(false))
     return lightpushResultInternalError("response failure, requestId mismatch")
 
-  if wl.reputationManager.isSome:
-    wl.reputationManager.get().updateReputationFromResponse(peer.peerId, response)
+  if wl.peerManager.reputationManager.isSome:
+    wl.peerManager.reputationManager.get().updateReputationFromResponse(peer.peerId, response)
 
   return toPushResult(response)
 
@@ -118,8 +109,8 @@ proc selectPeerForLightPush*(
   while attempts < maxAttempts:
     let candidate = wl.peerManager.selectPeer(WakuLightPushCodec, none(PubsubTopic)).valueOr:
       return err("could not retrieve a peer supporting WakuLightPushCodec")
-    if wl.reputationManager.isSome():
-      let reputation = wl.reputationManager.get().getReputation(candidate.peerId)
+    if wl.peerManager.reputationManager.isSome():
+      let reputation = wl.peerManager.reputationManager.get().getReputation(candidate.peerId)
       info "Peer selected",
         peerId = candidate.peerId, reputation = $reputation, attempts = $attempts
       if (reputation == some(false)):


### PR DESCRIPTION
# Description

This PR moves and adapt the logic related to client-side reputation (in the context of Lightpush) to the PeerManager. This logic has been developed in the Lightpush context (see https://github.com/waku-org/nwaku/pull/3293), now it needs to be moved over to peer manager (to avoid tight coupling with Lightpush) and perhaps generalized.

# Changes

<!-- List of detailed changes -->

- [x] modify `selectPeer` in the peer manager such that, if reputation is enabled, bad-reputation peers are not selected;
- [x] adjust tests to reflect this logic.

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->