### PR TITLE
fix: waku sync 2.0 codecs ENR support

### DIFF
--- a/waku/waku_core/codecs.nim
+++ b/waku/waku_core/codecs.nim
@@ -5,7 +5,6 @@ const
   WakuFilterPushCodec* = "/vac/waku/filter-push/2.0.0-beta1"
   WakuLightPushCodec* = "/vac/waku/lightpush/3.0.0"
   WakuLegacyLightPushCodec* = "/vac/waku/lightpush/2.0.0-beta1"
-  WakuSyncCodec* = "/vac/waku/sync/1.0.0"
   WakuReconciliationCodec* = "/vac/waku/reconciliation/1.0.0"
   WakuTransferCodec* = "/vac/waku/transfer/1.0.0"
   WakuMetadataCodec* = "/vac/waku/metadata/1.0.0"

--- a/waku/waku_enr/capabilities.nim
+++ b/waku/waku_enr/capabilities.nim
@@ -26,7 +26,7 @@ const capabilityToCodec = {
   Capabilities.Store: WakuStoreCodec,
   Capabilities.Filter: WakuFilterSubscribeCodec,
   Capabilities.Lightpush: WakuLightPushCodec,
-  Capabilities.Sync: WakuSyncCodec,
+  Capabilities.Sync: WakuReconciliationCodec,
 }.toTable
 
 func init*(


### PR DESCRIPTION
# Description
Removes the old waku sync 1.0 codec and replace it with reconciliation in the ENR capability list.

A workaround for this bug https://github.com/waku-org/nwaku/issues/3324