### PR TITLE
fix: lightpush publish logs stated it was legacy lightpush

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1146,7 +1146,7 @@ proc lightpushPublishHandler(
 ): Future[lightpush_protocol.WakuLightPushResult] {.async.} =
   let msgHash = pubsubTopic.computeMessageHash(message).to0xHex()
   if not node.wakuLightpushClient.isNil():
-    notice "publishing message with legacy lightpush",
+    notice "publishing message with lightpush",
       pubsubTopic = pubsubTopic,
       contentTopic = message.contentTopic,
       target_peer_id = peer.peerId,
@@ -1154,7 +1154,7 @@ proc lightpushPublishHandler(
     return await node.wakuLightpushClient.publish(some(pubsubTopic), message, peer)
 
   if not node.wakuLightPush.isNil():
-    notice "publishing message with self hosted legacy lightpush",
+    notice "publishing message with self hosted lightpush",
       pubsubTopic = pubsubTopic,
       contentTopic = message.contentTopic,
       target_peer_id = peer.peerId,

--- a/waku/waku_api/rest/lightpush/handlers.nim
+++ b/waku/waku_api/rest/lightpush/handlers.nim
@@ -33,7 +33,7 @@ const NoPeerNoneFoundError =
   RestApiResponse.serviceUnavailable("No suitable service peer & none discovered")
 
 proc useSelfHostedLightPush(node: WakuNode): bool =
-  return node.wakuLegacyLightPush != nil and node.wakuLegacyLightPushClient == nil
+  return node.wakuLightPush != nil and node.wakuLightPushClient == nil
 
 proc convertErrorKindToHttpStatus(statusCode: LightpushStatusCode): HttpCode =
   ## Lightpush status codes are matching HTTP status codes by design


### PR DESCRIPTION
+ also fix on wrong mounted protocol check.


# Description

During presentation prep with REST I found that there is a misleading logs coming from waku_node while issuing lightpush v3 publish. Log stated we have been using legacy lightpush. Typo error fixed.
Also found wrong protocol mounts were checked from new lightpush REST handler.
