### PR TITLE
fix:lightppush v3 not returning relayed peers count

### DIFF
--- a/tests/node/test_wakunode_lightpush.nim
+++ b/tests/node/test_wakunode_lightpush.nim
@@ -224,6 +224,7 @@ suite "Waku Lightpush message delivery":
     ## When
     let res = await lightNode.lightpushPublish(some(DefaultPubsubTopic), message)
     assert res.isOk(), $res.error
+    assert res.get() == 1, "Expected to relay the message to 1 node"
 
     ## Then
     check await completionFutRelay.withTimeout(5.seconds)

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1146,7 +1146,7 @@ proc lightpushPublishHandler(
 ): Future[lightpush_protocol.WakuLightPushResult] {.async.} =
   let msgHash = pubsubTopic.computeMessageHash(message).to0xHex()
   if not node.wakuLightpushClient.isNil():
-    notice "publishing message with legacy lightpush",
+    notice "publishing message with lightpush",
       pubsubTopic = pubsubTopic,
       contentTopic = message.contentTopic,
       target_peer_id = peer.peerId,
@@ -1154,7 +1154,7 @@ proc lightpushPublishHandler(
     return await node.wakuLightpushClient.publish(some(pubsubTopic), message, peer)
 
   if not node.wakuLightPush.isNil():
-    notice "publishing message with self hosted legacy lightpush",
+    notice "publishing message with self hosted lightpush",
       pubsubTopic = pubsubTopic,
       contentTopic = message.contentTopic,
       target_peer_id = peer.peerId,

--- a/waku/waku_api/rest/lightpush/handlers.nim
+++ b/waku/waku_api/rest/lightpush/handlers.nim
@@ -33,7 +33,7 @@ const NoPeerNoneFoundError =
   RestApiResponse.serviceUnavailable("No suitable service peer & none discovered")
 
 proc useSelfHostedLightPush(node: WakuNode): bool =
-  return node.wakuLegacyLightPush != nil and node.wakuLegacyLightPushClient == nil
+  return node.wakuLightPush != nil and node.wakuLightPushClient == nil
 
 proc convertErrorKindToHttpStatus(statusCode: LightpushStatusCode): HttpCode =
   ## Lightpush status codes are matching HTTP status codes by design

--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -98,6 +98,11 @@ proc handleRequest*(
           none[string]()
         else:
           handleRes.error.desc,
+      relayPeerCount:
+        if isSuccess:
+          some(handleRes.get())
+        else:
+          none[uint32](),
     )
 
   if not isSuccess:


### PR DESCRIPTION
# Description

During presentation prep I noticed with lightpush v3 rest api always returns 0 as relayed peers even if with success.
This should not be the case.


# Changes

- [x] Added missing lightpush response embedding relyed peer count

## How to test

1. send successful lightpush v3 with rest
2. relayPeerCount must be greater than 0