### PR TITLE
chore: Make /debug REST endpoints /version and /info available as root

### DIFF
--- a/tests/wakunode_rest/test_rest_debug.nim
+++ b/tests/wakunode_rest/test_rest_debug.nim
@@ -33,7 +33,7 @@ proc testWakuNode(): WakuNode =
   newTestWakuNode(privkey, bindIp, port, some(extIp), some(port))
 
 suite "Waku v2 REST API - Debug":
-  asyncTest "Get node info - GET /debug/v1/info":
+  asyncTest "Get node info - GET /info":
     # Given
     let node = testWakuNode()
     await node.start()
@@ -62,7 +62,7 @@ suite "Waku v2 REST API - Debug":
     await restServer.closeWait()
     await node.stop()
 
-  asyncTest "Get node version - GET /debug/v1/version":
+  asyncTest "Get node version - GET /version":
     # Given
     let node = testWakuNode()
     await node.start()

--- a/waku/waku_api/rest/debug/client.nim
+++ b/waku/waku_api/rest/debug/client.nim
@@ -11,10 +11,10 @@ logScope:
 
 # TODO: Check how we can use a constant to set the method endpoint (improve "rest" pragma under nim-presto)
 proc debugInfoV1*(): RestResponse[DebugWakuInfo] {.
-  rest, endpoint: "/debug/v1/info", meth: HttpMethod.MethodGet
+  rest, endpoint: "/info", meth: HttpMethod.MethodGet
 .}
 
 # TODO: Check how we can use a constant to set the method endpoint (improve "rest" pragma under nim-presto)
 proc debugVersionV1*(): RestResponse[string] {.
-  rest, endpoint: "/debug/v1/version", meth: HttpMethod.MethodGet
+  rest, endpoint: "/version", meth: HttpMethod.MethodGet
 .}

--- a/waku/waku_api/rest/debug/handlers.nim
+++ b/waku/waku_api/rest/debug/handlers.nim
@@ -8,10 +8,12 @@ export types
 logScope:
   topics = "waku node rest debug_api"
 
-const ROUTE_DEBUG_INFOV1* = "/debug/v1/info"
+const ROUTE_INFOV1* = "/info"
+# /debug route is deprecated, will be removed
+const ROUTE_DEBUG_INFOV1 = "/debug/v1/info"
 
 proc installDebugInfoV1Handler(router: var RestRouter, node: WakuNode) =
-  router.api(MethodGet, ROUTE_DEBUG_INFOV1) do() -> RestApiResponse:
+  let getInfo = proc(): RestApiResponse =
     let info = node.info().toDebugWakuInfo()
     let resp = RestApiResponse.jsonResponse(info, status = Http200)
     if resp.isErr():
@@ -20,10 +22,21 @@ proc installDebugInfoV1Handler(router: var RestRouter, node: WakuNode) =
 
     return resp.get()
 
-const ROUTE_DEBUG_VERSIONV1* = "/debug/v1/version"
+  # /debug route is deprecated, will be removed
+  router.api(MethodGet, ROUTE_DEBUG_INFOV1) do() -> RestApiResponse:
+    return getInfo()
+  router.api(MethodGet, ROUTE_INFOV1) do() -> RestApiResponse:
+    return getInfo()
+
+const ROUTE_VERSIONV1* = "/version"
+# /debug route is deprecated, will be removed
+const ROUTE_DEBUG_VERSIONV1 = "/debug/v1/version"
 
 proc installDebugVersionV1Handler(router: var RestRouter, node: WakuNode) =
+  # /debug route is deprecated, will be removed
   router.api(MethodGet, ROUTE_DEBUG_VERSIONV1) do() -> RestApiResponse:
+    return RestApiResponse.textResponse(git_version, status = Http200)
+  router.api(MethodGet, ROUTE_VERSIONV1) do() -> RestApiResponse:
     return RestApiResponse.textResponse(git_version, status = Http200)
 
 proc installDebugApiHandlers*(router: var RestRouter, node: WakuNode) =


### PR DESCRIPTION
# Description

To make more convenient to use /version and /info REST API endpoints made available right under root instead of /debug/v1/...

Old endpoint are still available but shall be removed after few release as adaptation period.