### PR TITLE
chore: set one log to trace in waku_peer_exchang

### DIFF
--- a/waku/waku_peer_exchange/protocol.nim
+++ b/waku/waku_peer_exchange/protocol.nim
@@ -229,7 +229,7 @@ proc populateEnrCache(wpx: WakuPeerExchange) =
 
   # swap cache for new
   wpx.enrCache = newEnrCache
-  debug "ENR cache populated"
+  trace "ENR cache populated"
 
 proc updatePxEnrCache(wpx: WakuPeerExchange) {.async.} =
   # try more aggressively to fill the cache at startup


### PR DESCRIPTION
Simple change to avoid annoying log "ENR cache populated".

Suggested by https://github.com/igor-sirotin