### PR TITLE
fix: docker gives warning while building 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="
 
 # PRODUCTION IMAGE -------------------------------------------------------------
 
-FROM alpine:3.18 as prod
+FROM alpine:3.18 AS prod
 
 ARG MAKE_TARGET=wakunode2
 

--- a/docker/binaries/Dockerfile.bn.amd64
+++ b/docker/binaries/Dockerfile.bn.amd64
@@ -1,5 +1,5 @@
 # Dockerfile to build a distributable container image from pre-existing binaries
-FROM debian:stable-slim as prod
+FROM debian:stable-slim AS prod
 
 ARG MAKE_TARGET=wakunode2
 


### PR DESCRIPTION
# Description
when i try to build docker image in my macos, it gives a warning due to incorrect case usage. 
fixed wherever i have noticed.

` => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 30)                                                                                       0.0s
`

