### PR TITLE
chore: relax wakucanary parameters

### DIFF
--- a/apps/wakucanary/wakucanary.nim
+++ b/apps/wakucanary/wakucanary.nim
@@ -202,13 +202,6 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
 
   var enrBuilder = EnrBuilder.init(nodeKey)
 
-  let relayShards = RelayShards.init(conf.clusterId, conf.shards).valueOr:
-    error "Relay shards initialization failed", error = error
-    return 1
-  enrBuilder.withWakuRelaySharding(relayShards).isOkOr:
-    error "Building ENR with relay sharding failed", error = error
-    return 1
-
   let recordRes = enrBuilder.build()
   let record =
     if recordRes.isErr():
@@ -233,8 +226,6 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
   )
 
   let node = builder.build().tryGet()
-  node.mountMetadata(conf.clusterId).isOkOr:
-    error "failed to mount waku metadata protocol: ", err = error
 
   if conf.ping:
     try:


### PR DESCRIPTION
## Description
This is motivated by @jakubgs 
The PR's purpose is to simplify the usage of `wakucanary` and not force setting cluster-id nor shards.

For example, the following should work without complaint:

```
./build/wakucanary --address=/dns4/store-02.do-ams3.status.prod.status.im/tcp/30303/p2p/16Uiu2HAm9aDJPkhGxc2SFcEACTFdZ91Q5TJjp76qZEhq9iF59x7R
```

## Issue

- https://github.com/waku-org/nwaku/issues/3236
