### PR TITLE
chore: waku.nimble force libwaku compile logs with TRACE log level by default

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -163,14 +163,28 @@ task libwakuStatic, "Build the cbindings waku node library":
   let name = "libwaku"
   buildLibrary name,
     "library/",
-    """-d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client" --warning:Deprecated:off --warning:UnusedImport:on """,
+    """-d:chronicles_line_numbers \
+       -d:chronicles_runtime_filtering=on \
+       -d:chronicles_sinks="textlines,json" \
+       -d:chronicles_default_output_device=Dynamic \
+       -d:chronicles_disabled_topics="eth,dnsdisc.client" \
+       --warning:Deprecated:off \
+       --warning:UnusedImport:on \
+       -d:chronicles_log_level=TRACE """,
     "static"
 
 task libwakuDynamic, "Build the cbindings waku node library":
   let name = "libwaku"
   buildLibrary name,
     "library/",
-    """-d:chronicles_line_numbers -d:chronicles_runtime_filtering=on -d:chronicles_sinks="textlines,json" -d:chronicles_default_output_device=Dynamic -d:chronicles_disabled_topics="eth,dnsdisc.client" --warning:Deprecated:off --warning:UnusedImport:on """,
+    """-d:chronicles_line_numbers \
+       -d:chronicles_runtime_filtering=on \
+       -d:chronicles_sinks="textlines,json" \
+       -d:chronicles_default_output_device=Dynamic \
+       -d:chronicles_disabled_topics="eth,dnsdisc.client" \
+       --warning:Deprecated:off \
+       --warning:UnusedImport:on \
+       -d:chronicles_log_level=TRACE """,
     "dynamic"
 
 ### Mobile Android


### PR DESCRIPTION
# Description
When working in waku-rust-bindings I've noticed that setting the `logLevel` to `DEBUG` didn't change anything. After applying the suggested change, I could set it to `DEBUG` properly (or `TRACE`.)

## Issue

- https://github.com/waku-org/nwaku/issues/3236