### PR TITLE
feat: waku_relay_get_peers_in_mesh to libwaku

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -127,6 +127,11 @@ int waku_relay_get_num_peers_in_mesh(void* ctx,
                            WakuCallBack callback,
                            void* userData);
 
+int waku_relay_get_peers_in_mesh(void* ctx,
+                           const char* pubSubTopic,
+                           WakuCallBack callback,
+                           void* userData);
+
 int waku_store_query(void* ctx,
                         const char* jsonQuery,
                         const char* peerAddr,

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -478,6 +478,27 @@ proc waku_relay_get_num_peers_in_mesh(
   handleRequest(
     ctx,
     RequestType.RELAY,
+    RelayRequest.createShared(RelayMsgType.NUM_MESH_PEERS, pst),
+    callback,
+    userData,
+  )
+
+proc waku_relay_get_peers_in_mesh(
+    ctx: ptr WakuContext,
+    pubSubTopic: cstring,
+    callback: WakuCallBack,
+    userData: pointer,
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibwakuParams(ctx, callback, userData)
+
+  let pst = pubSubTopic.alloc()
+  defer:
+    deallocShared(pst)
+
+  handleRequest(
+    ctx,
+    RequestType.RELAY,
     RelayRequest.createShared(RelayMsgType.LIST_MESH_PEERS, pst),
     callback,
     userData,

--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -145,7 +145,8 @@ proc process*(
     let meshPeers = waku.node.wakuRelay.getPeersInMesh($self.pubsubTopic).valueOr:
       error "LIST_MESH_PEERS failed", error = error
       return err($error)
-    return ok($meshPeers)
+    ## returns a comma-separated string of peerIDs
+    return ok(meshPeers.mapIt($it).join(","))
   of ADD_PROTECTED_SHARD:
     try:
       let relayShard =

--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -142,10 +142,10 @@ proc process*(
       return err($error)
     return ok($numPeersInMesh)
   of LIST_MESH_PEERS:
-    let numPeersInMesh = waku.node.wakuRelay.getPeersInMesh($self.pubsubTopic).valueOr:
+    let meshPeers = waku.node.wakuRelay.getPeersInMesh($self.pubsubTopic).valueOr:
       error "LIST_MESH_PEERS failed", error = error
       return err($error)
-    return ok($numPeersInMesh)
+    return ok($meshPeers)
   of ADD_PROTECTED_SHARD:
     try:
       let relayShard =

--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -18,6 +18,7 @@ type RelayMsgType* = enum
   NUM_CONNECTED_PEERS
   LIST_CONNECTED_PEERS
     ## to return the list of all connected peers to an specific pubsub topic
+  NUM_MESH_PEERS
   LIST_MESH_PEERS
     ## to return the list of only the peers that conform the mesh for a particular pubsub topic
   ADD_PROTECTED_SHARD ## Protects a shard with a public key
@@ -135,8 +136,13 @@ proc process*(
       return err($error)
     ## returns a comma-separated string of peerIDs
     return ok(connPeers.mapIt($it).join(","))
-  of LIST_MESH_PEERS:
+  of NUM_MESH_PEERS:
     let numPeersInMesh = waku.node.wakuRelay.getNumPeersInMesh($self.pubsubTopic).valueOr:
+      error "NUM_MESH_PEERS failed", error = error
+      return err($error)
+    return ok($numPeersInMesh)
+  of LIST_MESH_PEERS:
+    let numPeersInMesh = waku.node.wakuRelay.getPeersInMesh($self.pubsubTopic).valueOr:
       error "LIST_MESH_PEERS failed", error = error
       return err($error)
     return ok($numPeersInMesh)


### PR DESCRIPTION
# Description
Adding `waku_relay_get_peers_in_mesh` in libwaku

# Changes

<!-- List of detailed changes -->

- [x] adding new `waku_relay_get_peers_in_mesh` function in libwaku
- [x] modify `getNumPeersInMesh` to call a new `getPeersInMesh` function


## Issue
https://github.com/waku-org/nwaku/issues/3076