### PR TITLE
feat: add waku_relay_get_connected_peers to libwaku

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -117,6 +117,11 @@ int waku_relay_get_num_connected_peers(void* ctx,
                            WakuCallBack callback,
                            void* userData);
 
+int waku_relay_get_connected_peers(void* ctx,
+                           const char* pubSubTopic,
+                           WakuCallBack callback,
+                           void* userData);
+
 int waku_relay_get_num_peers_in_mesh(void* ctx,
                            const char* pubSubTopic,
                            WakuCallBack callback,

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -436,6 +436,27 @@ proc waku_relay_get_num_connected_peers(
   handleRequest(
     ctx,
     RequestType.RELAY,
+    RelayRequest.createShared(RelayMsgType.NUM_CONNECTED_PEERS, pst),
+    callback,
+    userData,
+  )
+
+proc waku_relay_get_connected_peers(
+    ctx: ptr WakuContext,
+    pubSubTopic: cstring,
+    callback: WakuCallBack,
+    userData: pointer,
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibwakuParams(ctx, callback, userData)
+
+  let pst = pubSubTopic.alloc()
+  defer:
+    deallocShared(pst)
+
+  handleRequest(
+    ctx,
+    RequestType.RELAY,
     RelayRequest.createShared(RelayMsgType.LIST_CONNECTED_PEERS, pst),
     callback,
     userData,

--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -8,6 +8,7 @@ import
   ../../../../../waku/waku_core/time, # Timestamp
   ../../../../../waku/waku_core/topics/pubsub_topic,
   ../../../../../waku/waku_relay/protocol,
+  ../../../../../waku/node/peer_manager,
   ../../../../alloc
 
 type RelayMsgType* = enum

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -573,27 +573,12 @@ proc getNumConnectedPeers*(
     w: WakuRelay, pubsubTopic: PubsubTopic
 ): Result[int, string] =
   ## Returns the number of connected peers and subscribed to the passed pubsub topic.
-  ## The 'gossipsub' atribute is defined in the GossipSub ref object.
 
-  if pubsubTopic == "":
-    ## Return all the connected peers
-    var numConnPeers = 0
-    for k, v in w.gossipsub:
-      numConnPeers.inc(v.len)
-    return ok(numConnPeers)
-
-  if not w.gossipsub.hasKey(pubsubTopic):
+  ## Return all the connected peers
+  let peers = w.getConnectedPeers(pubsubTopic).valueOr:
     return err(
-      "getNumConnectedPeers - there is no gossipsub peer for the given pubsub topic: " &
-        pubsubTopic
-    )
-
-  let peersRes = catch:
-    w.gossipsub[pubsubTopic]
-
-  let peers: HashSet[PubSubPeer] = peersRes.valueOr:
-    return err(
-      "getNumConnectedPeers - exception accessing " & pubsubTopic & ": " & error.msg
+      "getNumConnectedPeers - failed retrieving peers in mesh: " & pubsubTopic & ": " &
+        error
     )
 
   return ok(peers.len)


### PR DESCRIPTION
# Description
Adding `waku_relay_get_connected_peers` in libwaku

# Changes

<!-- List of detailed changes -->

- [x] adding new `waku_relay_get_connected_peers` function in libwaku
- [x] modify `getNumConnectedPeers` to call a new `getConnectedPeers` function


## Issue
https://github.com/waku-org/nwaku/issues/3076