### PR TITLE
feat: add waku_get_connected_peers_info to libwaku

### DIFF
--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -168,6 +168,10 @@ int waku_get_peerids_from_peerstore(void* ctx,
                                     WakuCallBack callback,
                                     void* userData);
 
+int waku_get_all_peer_info(void* ctx,
+                                    WakuCallBack callback,
+                                    void* userData);
+
 int waku_get_peerids_by_protocol(void* ctx,
                                  const char* protocol,
                                  WakuCallBack callback,

--- a/library/libwaku.h
+++ b/library/libwaku.h
@@ -168,7 +168,7 @@ int waku_get_peerids_from_peerstore(void* ctx,
                                     WakuCallBack callback,
                                     void* userData);
 
-int waku_get_all_peer_info(void* ctx,
+int waku_get_connected_peers_info(void* ctx,
                                     WakuCallBack callback,
                                     void* userData);
 

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -692,6 +692,22 @@ proc waku_get_peerids_from_peerstore(
     userData,
   )
 
+proc waku_get_peerids_and_protocols_from_peerstore(
+    ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibwakuParams(ctx, callback, userData)
+
+  handleRequest(
+    ctx,
+    RequestType.PEER_MANAGER,
+    PeerManagementRequest.createShared(
+      PeerManagementMsgType.GET_ALL_PEER_IDS_AND_PROTOCOLS
+    ),
+    callback,
+    userData,
+  )
+
 proc waku_get_connected_peers(
     ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
 ): cint {.dynlib, exportc.} =

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -692,7 +692,7 @@ proc waku_get_peerids_from_peerstore(
     userData,
   )
 
-proc waku_get_all_peer_info(
+proc waku_get_connected_peers_info(
     ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
 ): cint {.dynlib, exportc.} =
   initializeLibrary()
@@ -701,7 +701,7 @@ proc waku_get_all_peer_info(
   handleRequest(
     ctx,
     RequestType.PEER_MANAGER,
-    PeerManagementRequest.createShared(PeerManagementMsgType.GET_ALL_PEER_INFO),
+    PeerManagementRequest.createShared(PeerManagementMsgType.GET_CONNECTED_PEERS_INFO),
     callback,
     userData,
   )

--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -692,7 +692,7 @@ proc waku_get_peerids_from_peerstore(
     userData,
   )
 
-proc waku_get_peerids_and_protocols_from_peerstore(
+proc waku_get_all_peer_info(
     ctx: ptr WakuContext, callback: WakuCallBack, userData: pointer
 ): cint {.dynlib, exportc.} =
   initializeLibrary()
@@ -701,9 +701,7 @@ proc waku_get_peerids_and_protocols_from_peerstore(
   handleRequest(
     ctx,
     RequestType.PEER_MANAGER,
-    PeerManagementRequest.createShared(
-      PeerManagementMsgType.GET_ALL_PEER_IDS_AND_PROTOCOLS
-    ),
+    PeerManagementRequest.createShared(PeerManagementMsgType.GET_ALL_PEER_INFO),
     callback,
     userData,
   )

--- a/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/peer_manager_request.nim
@@ -1,5 +1,5 @@
 import std/[sequtils, strutils]
-import chronicles, chronos, results, options
+import chronicles, chronos, results, options, json
 import
   ../../../../waku/factory/waku,
   ../../../../waku/node/waku_node,
@@ -9,6 +9,7 @@ import
 type PeerManagementMsgType* {.pure.} = enum
   CONNECT_TO
   GET_ALL_PEER_IDS
+  GET_ALL_PEER_IDS_AND_PROTOCOLS
   GET_PEER_IDS_BY_PROTOCOL
   DISCONNECT_PEER_BY_ID
   DIAL_PEER
@@ -83,6 +84,21 @@ proc process*(
     let peerIDs =
       waku.node.peerManager.wakuPeerStore.peers().mapIt($it.peerId).join(",")
     return ok(peerIDs)
+  of GET_ALL_PEER_IDS_AND_PROTOCOLS:
+    ## returns a json string that maps peerIds to protocols supported
+    var peersMap = initTable[string, seq[string]]()
+    let peers = waku.node.peerManager.wakuPeerStore.peers()
+
+    # Build a map of peer IDs to protocols
+    for peer in peers:
+      let peerIdStr = $peer.peerId
+      peersMap[peerIdStr] = peer.protocols
+
+    # Convert the map to JSON string
+    let jsonObj = %*peersMap
+    let jsonStr = $jsonObj
+
+    return ok(jsonStr)
   of GET_PEER_IDS_BY_PROTOCOL:
     ## returns a comma-separated string of peerIDs that mount the given protocol
     let connectedPeers = waku.node.peerManager.wakuPeerStore


### PR DESCRIPTION
# Description
Adding a `waku_get_connected_peers_info` function to libwaku, which returns a json-string with all the connected nodes peerId's as keys, and an object with an array of their protocols supported and and an array of their multiaddresses as values.


# Changes

<!-- List of detailed changes -->

- [x] adding `waku_get_connected_peers_info ` function to libwaku

## Issue
#3076 
