### PR TITLE
chore: better keystore management

### DIFF
--- a/waku/waku_keystore/keystore.nim
+++ b/waku/waku_keystore/keystore.nim
@@ -52,7 +52,7 @@ proc loadAppKeystore*(
   if fileExists(path) == false:
     let newKeystoreRes = createAppKeystore(path, appInfo, separator)
     if newKeystoreRes.isErr():
-      return err("failed calling createAppKeystore: " & newKeystoreRes.error)
+      return err(newKeystoreRes.error)
 
   try:
     # We read all the file contents

--- a/waku/waku_keystore/keystore.nim
+++ b/waku/waku_keystore/keystore.nim
@@ -52,7 +52,7 @@ proc loadAppKeystore*(
   if fileExists(path) == false:
     let newKeystoreRes = createAppKeystore(path, appInfo, separator)
     if newKeystoreRes.isErr():
-      return err(newKeystoreRes.error)
+      return err("failed calling createAppKeystore: " & newKeystoreRes.error)
 
   try:
     # We read all the file contents
@@ -61,7 +61,9 @@ proc loadAppKeystore*(
       return err(
         AppKeystoreError(kind: KeystoreOsError, msg: "Cannot open file for reading")
       )
-    let fileContents = readAll(f)
+
+    ## the next blocks expect the whole keystore.json content to be compacted in one single line
+    let fileContents = readAll(f).replace(" ", "").replace("\n", "")
 
     # We iterate over each substring split by separator (which we expect to correspond to a single keystore json)
     for keystore in fileContents.split(separator):
@@ -159,8 +161,7 @@ proc loadAppKeystore*(
 
   return err(
     AppKeystoreError(
-      kind: KeystoreKeystoreDoesNotExist,
-      msg: "No keystore found for the passed parameters",
+      kind: KeystoreKeystoreDoesNotExist, msg: "The keystore file could not be parsed"
     )
   )
 


### PR DESCRIPTION
# Description
While working with a keystore created by js-waku team, we've realized that the nwaku complained as it wasn't able to access the keystore file. What was happening was that the keystore file couldn't be parsed at all and the reason was that the keystore content should be given in one single line.

This PR simply adds a small protection to make sure the keystore file is always passed in a compact way to the parse phase.

This is motivated by @danisharora099 while working with a tailored keystore file.

## Issue
