### PR TITLE
fix: Update the upload-artifact from v3 to v4 in pre-release.yml

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -76,14 +76,14 @@ jobs:
           tar -cvzf ${{steps.vars.outputs.nwakutools}} ./build/wakucanary ./build/networkmonitor
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wakunode2
           path: ${{steps.vars.outputs.nwaku}}
           retention-days: 2
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wakutools
           path: ${{steps.vars.outputs.nwakutools}}


### PR DESCRIPTION
# Description
This PR aims to avoid the following issue in pre-release gh action:

![image](https://github.com/user-attachments/assets/140efde6-c725-4197-a5f2-5352c287670f)

The fix suggestion is inspired by the hint given in the link https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ (see above picture.) In that link, we have the following recommendation:

![image](https://github.com/user-attachments/assets/fa0e9099-d15c-4e26-9688-01db75d84ba2)


## Issue

closes:
- https://github.com/waku-org/nwaku/issues/3203
