### PR TITLE
chore: skip two flaky tests

### DIFF
--- a/tests/waku_discv5/test_waku_discv5.nim
+++ b/tests/waku_discv5/test_waku_discv5.nim
@@ -300,7 +300,9 @@ suite "Waku Discovery v5":
       # Cleanup
       await allFutures(node1.stop(), node2.stop(), node3.stop(), node4.stop())
 
-    asyncTest "find random peers with instance predicate":
+    xasyncTest "find random peers with instance predicate":
+      ## This is skipped because is flaky and made CI randomly fail but is useful to run manually
+
       ## Setup
       # Records
       let

--- a/tests/waku_discv5/test_waku_discv5.nim
+++ b/tests/waku_discv5/test_waku_discv5.nim
@@ -14,7 +14,7 @@ import
 
 import
   waku/[waku_core/topics, waku_enr, discovery/waku_discv5, waku_enr/capabilities],
-  ../testlib/[wakucore, testasync, assertions, futures, wakunode],
+  ../testlib/[wakucore, testasync, assertions, futures, wakunode, testutils],
   ../waku_enr/utils,
   ./utils as discv5_utils
 

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -486,7 +486,9 @@ procSuite "WakuNode - RLN relay":
     await node2.stop()
     await node3.stop()
 
-  asyncTest "clearNullifierLog: should clear epochs > MaxEpochGap":
+  xasyncTest "clearNullifierLog: should clear epochs > MaxEpochGap":
+    ## This is skipped because is flaky and made CI randomly fail but is useful to run manually
+
     # Given two nodes
     let
       contentTopic = ContentTopic("/waku/2/default-content/proto")


### PR DESCRIPTION
# Description
Simple PR to skip flaky tests because they need some time to run properly. They are useful for local debug operations but annoying in CI.

- `find random peers with instance predicate`
- `clearNullifierLog: should clear epochs > MaxEpochGap`

