### PR TITLE
fix: avoid performing nil check for userData

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -52,10 +52,6 @@ template callEventCallback(ctx: ptr WakuContext, eventName: string, body: untype
     error eventName & " - eventCallback is nil"
     return
 
-  if isNil(ctx[].eventUserData):
-    error eventName & " - eventUserData is nil"
-    return
-
   foreignThreadGc:
     try:
       let event = body


### PR DESCRIPTION
# Description
When using libwaku, from some languages it's not necessary to set `userData` (in C for example).

Removing the null check for userData in libwaku before our event callbacks. The client should be responsible to set `userData` if their language requires it - or in other words, clients such as `waku-go-bindings` and `waku-rust-bindings` should take care of it.


# Changes
- [x] removing null check for `userData` 

## Issue
https://github.com/waku-org/nwaku/issues/3236
