### PR TITLE
fix: libwaku's redundant allocs

### DIFF
--- a/library/libwaku.nim
+++ b/library/libwaku.nim
@@ -225,7 +225,7 @@ proc waku_content_topic(
   initializeLibrary()
   checkLibwakuParams(ctx, callback, userData)
 
-  let contentTopic = fmt"/{$appName}/{appVersion}/{$contentTopicName}/{$encoding}"
+  let contentTopic = fmt"/{$appName}/{$appVersion}/{$contentTopicName}/{$encoding}"
   callback(
     RET_OK, unsafeAddr contentTopic[0], cast[csize_t](len(contentTopic)), userData
   )


### PR DESCRIPTION
# Description
Removing redundant memory allocations in `libwaku.nim`
The shared memory is always allocated in the corresponding requests' modules


# Changes

<!-- List of detailed changes -->

- [x] remove memory allocations in `libwaku.nim`

## Issue

#3236 
