### PR TITLE
fix: bad HttpCode conversion, add missing lightpush v3 rest api tests

### DIFF
--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -99,6 +99,7 @@ import
   ./wakunode_rest/test_rest_relay_serdes,
   ./wakunode_rest/test_rest_serdes,
   ./wakunode_rest/test_rest_filter,
+  ./wakunode_rest/test_rest_lightpush,
   ./wakunode_rest/test_rest_lightpush_legacy,
   ./wakunode_rest/test_rest_admin,
   ./wakunode_rest/test_rest_cors,

--- a/waku/waku_lightpush/common.nim
+++ b/waku/waku_lightpush/common.nim
@@ -42,6 +42,12 @@ func lightpushSuccessResult*(relayPeerCount: uint32): WakuLightPushResult =
 func lightpushResultInternalError*(msg: string): WakuLightPushResult =
   return err((LightpushStatusCode.INTERNAL_SERVER_ERROR, some(msg)))
 
+func lightpushResultBadRequest*(msg: string): WakuLightPushResult =
+  return err((LightpushStatusCode.BAD_REQUEST, some(msg)))
+
+func lightpushResultServiceUnavailable*(msg: string): WakuLightPushResult =
+  return err((LightpushStatusCode.SERVICE_NOT_AVAILABLE, some(msg)))
+
 func lighpushErrorResult*(
     statusCode: LightpushStatusCode, desc: Option[string]
 ): WakuLightPushResult =


### PR DESCRIPTION
# Description

@s-tikhomirov in issue https://github.com/waku-org/nwaku/issues/3375 mentioned that using rest endpoint of lightpush v3 cause crash on edge node.

# Changes

- [X] Fixed bad HttpCode enum conversion from Lightpush internal enum caused unhandled RangeDefect exception
- [X] Fixed missing (probably lost while ongoing rebases during development of lightpush v3) rest API test of lightpush v3

## Issue
https://github.com/waku-org/nwaku/issues/3375
