### PR TITLE
chore: speed up local docker image builds

### DIFF
--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -78,7 +78,7 @@ pipeline {
           "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres ' " +
           "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
           "--build-arg=DEBUG='${params.DEBUG ? "1" : "0"} ' " +
-          "--target=${params.HEAPTRACK ? "prod-with-heaptrack" : "prod"} ."
+          "--target=${params.HEAPTRACK ? "heaptrack-build" : "prod"} ."
         )
       } }
     }


### PR DESCRIPTION
# Description
Running `make docker-image` takes a full build inside the docker image and can take quite long. When we test our code inside a dockerized environment it slows us down.
To speed this process up this PR adds new target `docker-quick-image` and `docker-quick-liteprotocoltester`.
This achieved through copy the locally prebuilt image to the final image.

> Notice the built image is a slim debian. 


# Changes

- [X] new make target: `docker-quick-image` to build wakunode2 docker image
- [X] new make target: `docker-quick-liteprotocoltester` to build liteprotocoltester docker image
- [X] fix for building heaptrack enabled wakunode docker image

## How to test

1. run `make docker-quick-image`
2. run `make docker-quick-liteprotocoltester`
