### PR TITLE
chore: return all peers from rest admin

### DIFF
--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -78,7 +78,7 @@ pipeline {
           "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres ' " +
           "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
           "--build-arg=DEBUG='${params.DEBUG ? "1" : "0"} ' " +
-          "--target=${params.HEAPTRACK ? "prod-with-heaptrack" : "prod"} ."
+          "--target=${params.HEAPTRACK ? "heaptrack-build" : "prod"} ."
         )
       } }
     }

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -274,7 +274,7 @@ suite "Waku v2 Rest API - Admin":
     check:
       postRes.status == 200
 
-    let getRes = await client.getConnectedRelayPeers()
+    let getRes = await client.getRelayPeers()
 
     check:
       getRes.status == 200
@@ -286,13 +286,13 @@ suite "Waku v2 Rest API - Admin":
       # Check peer 3
 
     # Todo: investigate why the test setup missing remote peer's shard info
-    # let getRes2 = await client.getConnectedRelayPeersByShard(0)
+    # let getRes2 = await client.getRelayPeersByShard(0)
     # check:
     #   getRes2.status == 200
     #   $getRes2.contentType == $MIMETYPE_JSON
     #   getRes2.data.peers.len() == 2
 
-    let getRes3 = await client.getConnectedRelayPeersByShard(99)
+    let getRes3 = await client.getRelayPeersByShard(99)
     check:
       getRes3.status == 200
       $getRes3.contentType == $MIMETYPE_JSON

--- a/waku/waku_api/rest/admin/client.nim
+++ b/waku/waku_api/rest/admin/client.nim
@@ -28,6 +28,10 @@ proc getPeerById*(
   rest, endpoint: "/admin/v1/peer/{peerId}", meth: HttpMethod.MethodGet
 .}
 
+proc getServicePeers*(): RestResponse[seq[WakuPeer]] {.
+  rest, endpoint: "/admin/v1/peers/service", meth: HttpMethod.MethodGet
+.}
+
 proc getConnectedPeers*(): RestResponse[seq[WakuPeer]] {.
   rest, endpoint: "/admin/v1/peers/connected", meth: HttpMethod.MethodGet
 .}
@@ -38,16 +42,14 @@ proc getConnectedPeersByShard*(
   rest, endpoint: "/admin/v1/peers/connected/on/{shardId}", meth: HttpMethod.MethodGet
 .}
 
-proc getConnectedRelayPeers*(): RestResponse[PeersOfShards] {.
-  rest, endpoint: "/admin/v1/peers/connected/relay", meth: HttpMethod.MethodGet
+proc getRelayPeers*(): RestResponse[PeersOfShards] {.
+  rest, endpoint: "/admin/v1/peers/relay", meth: HttpMethod.MethodGet
 .}
 
-proc getConnectedRelayPeersByShard*(
+proc getRelayPeersByShard*(
   shardId: uint16
 ): RestResponse[PeersOfShard] {.
-  rest,
-  endpoint: "/admin/v1/peers/connected/relay/on/{shardId}",
-  meth: HttpMethod.MethodGet
+  rest, endpoint: "/admin/v1/peers/relay/on/{shardId}", meth: HttpMethod.MethodGet
 .}
 
 proc getMeshPeers*(): RestResponse[PeersOfShards] {.


### PR DESCRIPTION
# Description
Based on our discussion @ https://discord.com/channels/1110799176264056863/1365004035668574291
This pr updates /admin/v1/peers endpoints.

# Changes

- [X] `/peers`, `/peer`, `/peers/connected` now respond with all peer regardless of their codecs support
- [X] `/admin/v1/peers/service` endpoint added to retrieve only service nodes with protocol support
- [X] renamed `/admin/v1/peers/connected/relay...` to `/admin/v1/peers/relay...`
- [X] little code cleanup/refactoring
