### PR TITLE
chore: Avoid double relay subscription 

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -381,7 +381,9 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
   if conf.relay:
     let shards =
       conf.shards.mapIt(RelayShard(clusterId: conf.clusterId, shardId: uint16(it)))
-    await node.mountRelay(shards)
+    (await node.mountRelay(shards)).isOkOr:
+      echo "failed to mount relay: " & error
+      return
 
   await node.mountLibp2pPing()
 

--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -215,7 +215,10 @@ proc start*(cmb: Chat2MatterBridge) {.async.} =
 
   # Always mount relay for bridge
   # `triggerSelf` is false on a `bridge` to avoid duplicates
-  await cmb.nodev2.mountRelay()
+  (await cmb.nodev2.mountRelay()).isOkOr:
+    error "failed to mount relay", error = error
+    return
+
   cmb.nodev2.wakuRelay.triggerSelf = false
 
   # Bridging

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -619,7 +619,10 @@ when isMainModule:
 
   let (node, discv5) = nodeRes.get()
 
-  waitFor node.mountRelay()
+  (waitFor node.mountRelay()).isOkOr:
+    error "failed to mount waku relay protocol: ", err = error
+    quit 1
+
   waitFor node.mountLibp2pPing()
 
   var onFatalErrorAction = proc(msg: string) {.gcsafe, closure.} =

--- a/examples/publisher.nim
+++ b/examples/publisher.nim
@@ -86,7 +86,10 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
   )
 
   await node.start()
-  await node.mountRelay()
+  (await node.mountRelay()).isOkOr:
+    error "failed to mount relay", error = error
+    quit(1)
+
   node.peerManager.start()
 
   (await wakuDiscv5.start()).isOkOr:

--- a/examples/subscriber.nim
+++ b/examples/subscriber.nim
@@ -84,7 +84,9 @@ proc setupAndSubscribe(rng: ref HmacDrbgContext) {.async.} =
   )
 
   await node.start()
-  await node.mountRelay()
+  (await node.mountRelay()).isOkOr:
+    error "failed to mount relay", error = error
+    quit(1)
   node.peerManager.start()
 
   (await wakuDiscv5.start()).isOkOr:

--- a/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
+++ b/library/waku_thread/inter_thread_communication/requests/protocols/relay_request.nim
@@ -7,6 +7,7 @@ import
   ../../../../../waku/waku_core/message,
   ../../../../../waku/waku_core/time, # Timestamp
   ../../../../../waku/waku_core/topics/pubsub_topic,
+  ../../../../../waku/waku_core/topics,
   ../../../../../waku/waku_relay/protocol,
   ../../../../../waku/node/peer_manager,
   ../../../../alloc
@@ -108,12 +109,18 @@ proc process*(
 
   case self.operation
   of SUBSCRIBE:
-    # TO DO: properly perform 'subscribe'
-    waku.node.registerRelayDefaultHandler($self.pubsubTopic)
-    discard waku.node.wakuRelay.subscribe($self.pubsubTopic, self.relayEventCallback)
+    waku.node.subscribe(
+      (kind: SubscriptionKind.PubsubSub, topic: $self.pubsubTopic),
+      handler = some(self.relayEventCallback),
+    ).isOkOr:
+      let errorMsg = "Subscribe failed." & $error
+      error "SUBSCRIBE failed", error = errorMsg
+      return err(errorMsg)
   of UNSUBSCRIBE:
-    # TODO: properly perform 'unsubscribe'
-    waku.node.wakuRelay.unsubscribeAll($self.pubsubTopic)
+    waku.node.unsubscribe((kind: SubscriptionKind.PubsubSub, topic: $self.pubsubTopic)).isOkOr:
+      let errorMsg = "Unsubscribe failed." & $error
+      error "UNSUBSCRIBE failed", error = errorMsg
+      return err(errorMsg)
   of PUBLISH:
     let msg = self.message.toWakuMessage()
     let pubsubTopic = $self.pubsubTopic

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -301,12 +301,12 @@ proc setupProtocols(
 
     debug "Setting max message size", num_bytes = parsedMaxMsgSize
 
-    try:
+    (
       await mountRelay(
         node, shards, peerExchangeHandler = peerExchangeHandler, int(parsedMaxMsgSize)
       )
-    except CatchableError:
-      return err("failed to mount waku relay protocol: " & getCurrentExceptionMsg())
+    ).isOkOr:
+      return err("failed to mount waku relay protocol: " & $error)
 
     # Add validation keys to protected topics
     var subscribedProtectedShards: seq[ProtectedShard]

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -322,6 +322,10 @@ proc subscribe*(
     else:
       return
 
+  if pubSubTopic in node.wakuRelay.subscribedTopics():
+    debug "already subscribed to topic", pubsubTopic
+    return
+
   if contentTopicOp.isSome() and node.contentTopicHandlers.hasKey(contentTopicOp.get()):
     error "Invalid API call to `subscribe`. Was already subscribed"
     return


### PR DESCRIPTION
# Description
PR aimed to enhance the subscription management. Before this PR, the `cwaku_example` (or other app using libwaku) could subscribe N times to the same topic and that would cause the message handler to be called N times for the same received message. Hence, we make sure only one subscription per (pubsub) topic happens.

## Issue

closes https://github.com/waku-org/nwaku/issues/3345
