### PR TITLE
chore: allow multiple rln eth clients

### DIFF
--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -560,7 +560,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
         dynamic: conf.rlnRelayDynamic,
         credIndex: conf.rlnRelayCredIndex,
         chainId: conf.rlnRelayChainId,
-        ethContractAddress: conf.rlnRelayEthContractAddress,
+        rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress.mapIt(string(it)),
         ethClientAddress: string(conf.rlnRelayethClientAddress),
         creds: some(
           RlnRelayCreds(

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -560,7 +560,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
         dynamic: conf.rlnRelayDynamic,
         credIndex: conf.rlnRelayCredIndex,
         chainId: conf.rlnRelayChainId,
-        ethClientUrls: conf.ethClientUrls,
+        ethClientUrls: conf.ethClientUrls.mapIt(string(it)),
         creds: some(
           RlnRelayCreds(
             path: conf.rlnRelayCredPath, password: conf.rlnRelayCredPassword

--- a/apps/chat2/chat2.nim
+++ b/apps/chat2/chat2.nim
@@ -560,8 +560,7 @@ proc processInput(rfd: AsyncFD, rng: ref HmacDrbgContext) {.async.} =
         dynamic: conf.rlnRelayDynamic,
         credIndex: conf.rlnRelayCredIndex,
         chainId: conf.rlnRelayChainId,
-        rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress.mapIt(string(it)),
-        ethClientAddress: string(conf.rlnRelayethClientAddress),
+        ethClientUrls: conf.ethClientUrls,
         creds: some(
           RlnRelayCreds(
             path: conf.rlnRelayCredPath, password: conf.rlnRelayCredPassword

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -248,7 +248,7 @@ type
       name: "rln-relay-id-commitment-key"
     .}: string
 
-    rlnRelayEthClientAddress* {.
+    ethClientUrls* {.
       desc: "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/",
       defaultValue: "http://localhost:8540/",
       name: "rln-relay-eth-client-address"

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -18,7 +18,8 @@ type
     prod
     test
 
-  EthRpcUrl = distinct string
+  EthRpcUrl* = distinct string
+
   Chat2Conf* = object ## General node config
     logLevel* {.
       desc: "Sets the log level.", defaultValue: LogLevel.INFO, name: "log-level"
@@ -250,9 +251,9 @@ type
 
     ethClientUrls* {.
       desc: "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/",
-      defaultValue: "http://localhost:8540/",
+      defaultValue: newSeq[EthRpcUrl](0),
       name: "rln-relay-eth-client-address"
-    .}: EthRpcUrl
+    .}: seq[EthRpcUrl]
 
     rlnRelayEthContractAddress* {.
       desc: "Address of membership contract on an Ethereum testnet",

--- a/apps/chat2/config_chat2.nim
+++ b/apps/chat2/config_chat2.nim
@@ -250,7 +250,8 @@ type
     .}: string
 
     ethClientUrls* {.
-      desc: "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/",
+      desc:
+        "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/. Argument may be repeated.",
       defaultValue: newSeq[EthRpcUrl](0),
       name: "rln-relay-eth-client-address"
     .}: seq[EthRpcUrl]

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -638,7 +638,7 @@ when isMainModule:
       dynamic: conf.rlnRelayDynamic,
       credIndex: some(uint(0)),
       ethContractAddress: conf.rlnRelayEthContractAddress,
-      rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress.mapIt(string(it)),
+      ethClientUrls: conf.ethClientUrls,
       treePath: conf.rlnRelayTreePath,
       epochSizeSec: conf.rlnEpochSizeSec,
       creds: none(RlnRelayCreds),

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -638,7 +638,7 @@ when isMainModule:
       dynamic: conf.rlnRelayDynamic,
       credIndex: some(uint(0)),
       ethContractAddress: conf.rlnRelayEthContractAddress,
-      ethClientAddress: string(conf.rlnRelayethClientAddress),
+      rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress.mapIt(string(it)),
       treePath: conf.rlnRelayTreePath,
       epochSizeSec: conf.rlnEpochSizeSec,
       creds: none(RlnRelayCreds),

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -638,7 +638,7 @@ when isMainModule:
       dynamic: conf.rlnRelayDynamic,
       credIndex: some(uint(0)),
       ethContractAddress: conf.rlnRelayEthContractAddress,
-      ethClientUrls: conf.ethClientUrls,
+      ethClientUrls: conf.ethClientUrls.mapIt(string(it)),
       treePath: conf.rlnRelayTreePath,
       epochSizeSec: conf.rlnEpochSizeSec,
       creds: none(RlnRelayCreds),

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -8,7 +8,7 @@ import
   stew/shims/net,
   regex
 
-type EthRpcUrl = distinct string
+type EthRpcUrl* = distinct string
 
 type NetworkMonitorConf* = object
   logLevel* {.
@@ -85,7 +85,7 @@ type NetworkMonitorConf* = object
   ethClientUrls* {.
     desc:
       "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/. Argument may be repeated.",
-    defaultValue: "http://localhost:8540/",
+    defaultValue: newSeq[EthRpcUrl](0),
     name: "rln-relay-eth-client-address"
   .}: seq[EthRpcUrl]
 

--- a/apps/networkmonitor/networkmonitor_config.nim
+++ b/apps/networkmonitor/networkmonitor_config.nim
@@ -82,11 +82,12 @@ type NetworkMonitorConf* = object
     name: "rln-relay-tree-path"
   .}: string
 
-  rlnRelayEthClientAddress* {.
-    desc: "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/",
+  ethClientUrls* {.
+    desc:
+      "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/. Argument may be repeated.",
     defaultValue: "http://localhost:8540/",
     name: "rln-relay-eth-client-address"
-  .}: EthRpcUrl
+  .}: seq[EthRpcUrl]
 
   rlnRelayEthContractAddress* {.
     desc: "Address of membership contract on an Ethereum testnet",

--- a/tests/factory/test_external_config.nim
+++ b/tests/factory/test_external_config.nim
@@ -26,7 +26,7 @@ suite "Waku config - apply preset":
       cmd: noCommand,
       preset: "twn",
       relay: true,
-      rlnRelayEthClientAddress: "http://someaddress".EthRpcUrl,
+      ethClientUrls: @["http://someaddress".EthRpcUrl],
       rlnRelayTreePath: "/tmp/sometreepath",
     )
 
@@ -109,7 +109,7 @@ suite "Waku config - apply preset":
       cmd: noCommand,
       clusterId: 1.uint16,
       relay: true,
-      rlnRelayEthClientAddress: "http://someaddress".EthRpcUrl,
+      ethClientUrls: @["http://someaddress".EthRpcUrl],
       rlnRelayTreePath: "/tmp/sometreepath",
     )
 

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -77,10 +77,10 @@ suite "Onchain group manager":
     assert metadata.contractAddress == manager.ethContractAddress,
       "contractAddress is not equal to " & manager.ethContractAddress
 
-    let differentContractAddress = await uploadRLNContract(manager.ethClientUrl)
+    let differentContractAddress = await uploadRLNContract(manager.ethClientUrls[0])
     # simulating a change in the contractAddress
     let manager2 = OnchainGroupManager(
-      ethClientUrl: EthClient,
+      ethClientUrls: @[EthClient],
       ethContractAddress: $differentContractAddress,
       rlnInstance: manager.rlnInstance,
       onFatalErrorAction: proc(errStr: string) =

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -250,7 +250,7 @@ proc stopAnvil*(runAnvil: Process) {.used.} =
     error "Anvil daemon termination failed: ", err = getCurrentExceptionMsg()
 
 proc setupOnchainGroupManager*(
-    ethClientAddress: string = EthClient, amountEth: UInt256 = 10.u256
+    ethClientUrl: string = EthClient, amountEth: UInt256 = 10.u256
 ): Future[OnchainGroupManager] {.async.} =
   let rlnInstanceRes =
     createRlnInstance(tree_path = genTempPath("rln_tree", "group_manager_onchain"))
@@ -259,9 +259,9 @@ proc setupOnchainGroupManager*(
 
   let rlnInstance = rlnInstanceRes.get()
 
-  let contractAddress = await uploadRLNContract(ethClientAddress)
+  let contractAddress = await uploadRLNContract(ethClientUrl)
   # connect to the eth client
-  let web3 = await newWeb3(ethClientAddress)
+  let web3 = await newWeb3(ethClientUrl)
 
   let accounts = await web3.provider.eth_accounts()
   web3.defaultAccount = accounts[0]
@@ -275,7 +275,7 @@ proc setupOnchainGroupManager*(
   )
 
   let manager = OnchainGroupManager(
-    ethClientUrl: ethClientAddress,
+    ethClientUrls: @[ethClientUrl],
     ethContractAddress: $contractAddress,
     chainId: CHAIN_ID,
     ethPrivateKey: some($privateKey),

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -3,7 +3,7 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import chronicles, results, std/tempfiles
+import chronicles, results, std/[tempfiles, sequtils]
 
 import
   waku/[
@@ -65,7 +65,7 @@ proc doRlnKeystoreGenerator*(conf: RlnKeystoreGeneratorConf) =
 
   # 4. initialize OnchainGroupManager
   let groupManager = OnchainGroupManager(
-    ethClientUrl: string(conf.ethClientAddress),
+    ethClientUrl: conf.rlnRelayEthClientAddress.mapIt(string(it)),
     chainId: conf.chainId,
     ethContractAddress: conf.ethContractAddress,
     rlnInstance: rlnInstance,

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -19,7 +19,7 @@ logScope:
 type RlnKeystoreGeneratorConf* = object
   execute*: bool
   ethContractAddress*: string
-  ethClientAddress*: string
+  ethClientUrls*: seq[string]
   chainId*: uint
   credPath*: string
   credPassword*: string
@@ -65,7 +65,7 @@ proc doRlnKeystoreGenerator*(conf: RlnKeystoreGeneratorConf) =
 
   # 4. initialize OnchainGroupManager
   let groupManager = OnchainGroupManager(
-    ethClientUrl: conf.rlnRelayEthClientAddress.mapIt(string(it)),
+    ethClientUrls: conf.ethClientUrls,
     chainId: conf.chainId,
     ethContractAddress: conf.ethContractAddress,
     rlnInstance: rlnInstance,

--- a/waku/factory/conf_builder/rln_relay_conf_builder.nim
+++ b/waku/factory/conf_builder/rln_relay_conf_builder.nim
@@ -9,9 +9,8 @@ logScope:
 ##############################
 type RlnRelayConfBuilder* = object
   enabled*: Option[bool]
-
   chainId*: Option[uint]
-  ethClientAddress*: Option[string]
+  ethClientUrls*: Option[seq[string]]
   ethContractAddress*: Option[string]
   credIndex*: Option[uint]
   credPassword*: Option[string]
@@ -42,8 +41,8 @@ proc withCredPath*(b: var RlnRelayConfBuilder, credPath: string) =
 proc withDynamic*(b: var RlnRelayConfBuilder, dynamic: bool) =
   b.dynamic = some(dynamic)
 
-proc withEthClientAddress*(b: var RlnRelayConfBuilder, ethClientAddress: string) =
-  b.ethClientAddress = some(ethClientAddress)
+proc withEthClientUrls*(b: var RlnRelayConfBuilder, ethClientUrls: seq[string]) =
+  b.ethClientUrls = some(ethClientUrls)
 
 proc withEthContractAddress*(b: var RlnRelayConfBuilder, ethContractAddress: string) =
   b.ethContractAddress = some(ethContractAddress)
@@ -76,8 +75,8 @@ proc build*(b: RlnRelayConfBuilder): Result[Option[RlnRelayConf], string] =
 
   if b.dynamic.isNone():
     return err("rlnRelay.dynamic is not specified")
-  if b.ethClientAddress.get("") == "":
-    return err("rlnRelay.ethClientAddress is not specified")
+  if b.ethClientUrls.get(newSeq[string](0)).len == 0:
+    return err("rlnRelay.ethClientUrls is not specified")
   if b.ethContractAddress.get("") == "":
     return err("rlnRelay.ethContractAddress is not specified")
   if b.epochSizeSec.isNone():
@@ -94,7 +93,7 @@ proc build*(b: RlnRelayConfBuilder): Result[Option[RlnRelayConf], string] =
         credIndex: b.credIndex,
         creds: creds,
         dynamic: b.dynamic.get(),
-        ethClientAddress: b.ethClientAddress.get(),
+        ethClientUrls: b.ethClientUrls.get(),
         ethContractAddress: b.ethContractAddress.get(),
         epochSizeSec: b.epochSizeSec.get(),
         userMessageLimit: b.userMessageLimit.get(),

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -78,7 +78,7 @@ type WakuNodeConf* = object
   ethClientUrls* {.
     desc:
       "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/. Argument may be repeated.",
-    defaultValue: newSeq[EthRpcUrl](0),
+    defaultValue: @[EthRpcUrl("http://localhost:8540/")],
     name: "rln-relay-eth-client-address"
   .}: seq[EthRpcUrl]
 

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -1,5 +1,5 @@
 import
-  std/[strutils, strformat],
+  std/[strutils, strformat, sequtils],
   results,
   chronicles,
   chronos,
@@ -75,7 +75,7 @@ type WakuNodeConf* = object
     name: "rln-relay-cred-path"
   .}: string
 
-  rlnRelayEthClientAddress* {.
+  ethClientUrls* {.
     desc:
       "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/. Argument may be repeated.",
     defaultValue: newSeq[EthRpcUrl](0),
@@ -868,7 +868,7 @@ proc toKeystoreGeneratorConf*(n: WakuNodeConf): RlnKeystoreGeneratorConf =
   RlnKeystoreGeneratorConf(
     execute: n.execute,
     chainId: n.rlnRelayChainId,
-    ethClientAddress: n.rlnRelayEthClientAddress.string,
+    ethClientUrls: n.ethClientUrls.mapIt(string(it)),
     ethContractAddress: n.rlnRelayEthContractAddress,
     userMessageLimit: n.rlnRelayUserMessageLimit,
     ethPrivateKey: n.rlnRelayEthPrivateKey,
@@ -908,8 +908,8 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
     b.rlnRelayConf.withCredPath(n.rlnRelayCredPath)
   if n.rlnRelayCredPassword != "":
     b.rlnRelayConf.withCredPassword(n.rlnRelayCredPassword)
-  if n.rlnRelayEthClientAddress.string != "":
-    b.rlnRelayConf.withEthClientAddress(n.rlnRelayEthClientAddress.string)
+  if n.ethClientUrls.len > 0:
+    b.rlnRelayConf.withEthClientUrls(n.ethClientUrls.mapIt(string(it)))
   if n.rlnRelayEthContractAddress != "":
     b.rlnRelayConf.withEthContractAddress(n.rlnRelayEthContractAddress)
 

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -76,10 +76,11 @@ type WakuNodeConf* = object
   .}: string
 
   rlnRelayEthClientAddress* {.
-    desc: "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/",
-    defaultValue: "http://localhost:8540/",
+    desc:
+      "HTTP address of an Ethereum testnet client e.g., http://localhost:8540/. Argument may be repeated.",
+    defaultValue: newSeq[EthRpcUrl](0),
     name: "rln-relay-eth-client-address"
-  .}: EthRpcUrl
+  .}: seq[EthRpcUrl]
 
   rlnRelayEthContractAddress* {.
     desc: "Address of membership contract on an Ethereum testnet.",

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -354,7 +354,7 @@ proc setupProtocols(
       credIndex: rlnRelayConf.credIndex,
       ethContractAddress: rlnRelayConf.ethContractAddress,
       chainId: rlnRelayConf.chainId,
-      ethClientAddress: rlnRelayConf.ethClientAddress,
+      rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress.mapIt(string(it)),
       creds: rlnRelayConf.creds,
       treePath: rlnRelayConf.treePath,
       userMessageLimit: rlnRelayConf.userMessageLimit,

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -354,7 +354,7 @@ proc setupProtocols(
       credIndex: rlnRelayConf.credIndex,
       ethContractAddress: rlnRelayConf.ethContractAddress,
       chainId: rlnRelayConf.chainId,
-      rlnRelayEthClientAddress: conf.rlnRelayEthClientAddress.mapIt(string(it)),
+      ethClientUrls: rlnRelayConf.ethClientUrls,
       creds: rlnRelayConf.creds,
       treePath: rlnRelayConf.treePath,
       userMessageLimit: rlnRelayConf.userMessageLimit,

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -72,7 +72,6 @@ type Waku* = ref object
   metricsServer*: MetricsHttpServerRef
   appCallbacks*: AppCallbacks
 
-      rlnRelayEthClientAddress = conf.rlnRelayEthClientAddress.mapIt(string(it))
 func version*(waku: Waku): string =
   waku.version
 

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -72,6 +72,7 @@ type Waku* = ref object
   metricsServer*: MetricsHttpServerRef
   appCallbacks*: AppCallbacks
 
+      rlnRelayEthClientAddress = conf.rlnRelayEthClientAddress.mapIt(string(it))
 func version*(waku: Waku): string =
   waku.version
 

--- a/waku/factory/waku_conf.nim
+++ b/waku/factory/waku_conf.nim
@@ -160,7 +160,7 @@ proc logConf*(conf: WakuConf) =
         maxMessageSize = conf.maxMessageSizeBytes,
         rlnEpochSizeSec = rlnRelayConf.epochSizeSec,
         rlnRelayUserMessageLimit = rlnRelayConf.userMessageLimit,
-        rlnRelayEthClientAddress = string(rlnRelayConf.ethClientAddress)
+        ethClientUrls = rlnRelayConf.ethClientUrls
 
 proc validateNodeKey(wakuConf: WakuConf): Result[void, string] =
   wakuConf.nodeKey.getPublicKey().isOkOr:
@@ -224,8 +224,8 @@ proc validateNoEmptyStrings(wakuConf: WakuConf): Result[void, string] =
 
     if isEmptyOrWhiteSpace(rlnRelayConf.treePath):
       return err("rlnRelayConf.treepath is an empty string")
-    if isEmptyOrWhiteSpace(rlnRelayConf.ethClientAddress):
-      return err("rlnRelayConf.ethClientAddress is an empty string")
+    if rlnRelayConf.ethClientUrls.len == 0:
+      return err("rlnRelayConf.ethClientUrls is empty")
     if isEmptyOrWhiteSpace(rlnRelayConf.ethContractAddress):
       return err("rlnRelayConf.ethContractAddress is an empty string")
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -51,7 +51,7 @@ contract(WakuRlnContract):
 type
   WakuRlnContractWithSender = Sender[WakuRlnContract]
   OnchainGroupManager* = ref object of GroupManager
-    ethClientUrl*: seq[string]
+    ethClientUrls*: seq[string]
     ethPrivateKey*: Option[string]
     ethContractAddress*: string
     ethRpc*: Option[Web3]
@@ -465,7 +465,7 @@ proc establishConnection(
 
   g.retryWrapper(ethRpc, "Failed to connect to the Ethereum client"):
     var innerEthRpc: Web3
-    for clientUrl in g.ethClientUrl:
+    for clientUrl in g.ethClientUrls:
       ## We give a chance to the user to provide multiple clients
       ## and we try to connect to each of them
       try:

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -51,7 +51,7 @@ contract(WakuRlnContract):
 type
   WakuRlnContractWithSender = Sender[WakuRlnContract]
   OnchainGroupManager* = ref object of GroupManager
-    ethClientUrl*: string
+    ethClientUrl: seq[string]
     ethPrivateKey*: Option[string]
     ethContractAddress*: string
     ethRpc*: Option[Web3]

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -465,14 +465,19 @@ proc establishConnection(
 
   g.retryWrapper(ethRpc, "Failed to connect to the Ethereum client"):
     var innerEthRpc: Web3
+    var connected = false
     for clientUrl in g.ethClientUrls:
       ## We give a chance to the user to provide multiple clients
       ## and we try to connect to each of them
       try:
         innerEthRpc = await newWeb3(clientUrl)
+        connected = true
         break
       except CatchableError:
         error "failed connect Eth client", error = getCurrentExceptionMsg()
+
+    if not connected:
+      raise newException(CatchableError, "all failed")
 
     innerEthRpc
 

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -36,13 +36,14 @@ type RlnRelayCreds* {.requiresInit.} = object
   path*: string
   password*: string
 
+type RlnRelayConf* = object of RootObj
   # TODO: severals parameters are only needed when it's dynamic
   # change the config to either nest or use enum/type variant so it's obvious
   # and then it can be set to `requiresInit`
   dynamic*: bool
   credIndex*: Option[uint]
   ethContractAddress*: string
-  ethClientAddress*: string
+  ethClientUrls*: seq[string]
   chainId*: uint
   creds*: Option[RlnRelayCreds]
   treePath*: string
@@ -454,7 +455,7 @@ proc mount(
         (none(string), none(string))
 
     groupManager = OnchainGroupManager(
-      ethClientUrl: conf.rlnRelayEthClientAddress.mapIt(string(it)),
+      ethClientUrls: conf.ethClientUrls,
       ethContractAddress: $conf.ethContractAddress,
       chainId: conf.chainId,
       rlnInstance: rlnInstance,

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -36,7 +36,6 @@ type RlnRelayCreds* {.requiresInit.} = object
   path*: string
   password*: string
 
-type RlnRelayConf* = object of RootObj
   # TODO: severals parameters are only needed when it's dynamic
   # change the config to either nest or use enum/type variant so it's obvious
   # and then it can be set to `requiresInit`

--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -455,7 +455,7 @@ proc mount(
         (none(string), none(string))
 
     groupManager = OnchainGroupManager(
-      ethClientUrl: string(conf.ethClientAddress),
+      ethClientUrl: conf.rlnRelayEthClientAddress.mapIt(string(it)),
       ethContractAddress: $conf.ethContractAddress,
       chainId: conf.chainId,
       rlnInstance: rlnInstance,


### PR DESCRIPTION
## Description

In the RLN context, nwaku needs to interact with Smart Contracts. For that, it uses Eth clients.
This PR gives the user the opportunity to the user to use multiple Eth clients and therefore, give the node more estability.
Notice that having a valid/alive Eth client connection is a strong constraint to RLN and therefore, before this PR, if the connection to the single Eth client failed, the whole node got stopped.

## Issue

closes https://github.com/waku-org/nwaku/issues/3126
