### PR TITLE
fix: addPeer could unintentionally override metadata of previously stored peer with defaults and empty

### DIFF
--- a/waku/node/peer_manager/waku_peer_store.nim
+++ b/waku/node/peer_manager/waku_peer_store.nim
@@ -100,6 +100,7 @@ proc addPeer*(peerStore: PeerStore, peer: RemotePeerInfo, origin = UnknownOrigin
       protos.add($new_proto)
   peerStore[ProtoBook][peer.peerId] = protos
 
+  ## We don't care whether the item was already present in the table or not. Hence, we always discard the hasKeyOrPut's bool returned value
   discard peerStore[AgentBook].book.hasKeyOrPut(peer.peerId, peer.agent)
   discard peerStore[ProtoVersionBook].book.hasKeyOrPut(peer.peerId, peer.protoVersion)
   discard peerStore[KeyBook].book.hasKeyOrPut(peer.peerId, peer.publicKey)

--- a/waku/node/peer_manager/waku_peer_store.nim
+++ b/waku/node/peer_manager/waku_peer_store.nim
@@ -100,16 +100,22 @@ proc addPeer*(peerStore: PeerStore, peer: RemotePeerInfo, origin = UnknownOrigin
       protos.add($new_proto)
   peerStore[ProtoBook][peer.peerId] = protos
 
-  peerStore[AgentBook][peer.peerId] = peer.agent
-  peerStore[ProtoVersionBook][peer.peerId] = peer.protoVersion
-  peerStore[KeyBook][peer.peerId] = peer.publicKey
-  peerStore[ConnectionBook][peer.peerId] = peer.connectedness
-  peerStore[DisconnectBook][peer.peerId] = peer.disconnectTime
-  peerStore[SourceBook][peer.peerId] =
-    if origin != UnknownOrigin: origin else: peer.origin
-  peerStore[DirectionBook][peer.peerId] = peer.direction
-  peerStore[LastFailedConnBook][peer.peerId] = peer.lastFailedConn
-  peerStore[NumberFailedConnBook][peer.peerId] = peer.numberFailedConn
+  discard peerStore[AgentBook].book.hasKeyOrPut(peer.peerId, peer.agent)
+  discard peerStore[ProtoVersionBook].book.hasKeyOrPut(peer.peerId, peer.protoVersion)
+  discard peerStore[KeyBook].book.hasKeyOrPut(peer.peerId, peer.publicKey)
+
+  discard peerStore[ConnectionBook].book.hasKeyOrPut(peer.peerId, peer.connectedness)
+  discard peerStore[DisconnectBook].book.hasKeyOrPut(peer.peerId, peer.disconnectTime)
+  if origin != UnknownOrigin:
+    peerStore[SourceBook][peer.peerId] = origin
+  else:
+    discard peerStore[SourceBook].book.hasKeyOrPut(peer.peerId, peer.origin)
+
+  discard peerStore[DirectionBook].book.hasKeyOrPut(peer.peerId, peer.direction)
+  discard
+    peerStore[LastFailedConnBook].book.hasKeyOrPut(peer.peerId, peer.lastFailedConn)
+  discard
+    peerStore[NumberFailedConnBook].book.hasKeyOrPut(peer.peerId, peer.numberFailedConn)
   if peer.enr.isSome():
     peerStore[ENRBook][peer.peerId] = peer.enr.get()
 


### PR DESCRIPTION
# Description

As found in #3400 connectedness info of the peer is not follows its real status.
During debugging it turned out, that by calling addPeer with a default initialized RemotePeerInfo can clean up metadata previously stored for the peer. 
Usually peer event connected and joined precedes finishing discv5 peer management.
So peer with all info already stored with joined (new peer) event will be wiped out by discv5 adding peer with RemotePeerInfo initialized with only from ENR - yet having all metadata to default.

This explains why connectedness shown always NotConnected but also other issue discovered by LiteProtocolTester, that many times agent information is empty.

# Changes

- [X] PeerStore.addPeer shall only update metadata if not already stored.

## How to test

Follow the reproduction steps in https://github.com/waku-org/nwaku/issues/3400

## Issue
https://github.com/waku-org/nwaku/issues/3400