### PR TITLE
fix: properly pass userMessageLimit to OnchainGroupManager

### DIFF
--- a/waku/waku_rln_relay/rln_relay.nim
+++ b/waku/waku_rln_relay/rln_relay.nim
@@ -414,9 +414,12 @@ proc generateRlnValidator*(
 proc monitorEpochs(wakuRlnRelay: WakuRLNRelay) {.async.} =
   while true:
     try:
-      waku_rln_remaining_proofs_per_epoch.set(
-        wakuRlnRelay.groupManager.userMessageLimit.get().float64
-      )
+      if wakuRlnRelay.groupManager.userMessageLimit.isSome():
+        waku_rln_remaining_proofs_per_epoch.set(
+          wakuRlnRelay.groupManager.userMessageLimit.get().float64
+        )
+      else:
+        error "userMessageLimit is not set in monitorEpochs"
     except CatchableError:
       error "Error in epoch monitoring", error = getCurrentExceptionMsg()
 
@@ -455,6 +458,7 @@ proc mount(
         (none(string), none(string))
 
     groupManager = OnchainGroupManager(
+      userMessageLimit: some(conf.userMessageLimit),
       ethClientUrls: conf.ethClientUrls,
       ethContractAddress: $conf.ethContractAddress,
       chainId: conf.chainId,


### PR DESCRIPTION
## Description
Fixing issue discovered by @s-tikhomirov 
It happened a crash when setting value to `waku_rln_remaining_proofs_per_epoch` metric, and the reason was that we didn't properly check that the `Option` attribute had a value.

This PR:
- Adds a simple protection before giving value to the `waku_rln_remaining_proofs_per_epoch` metric.
- Build the `OnchainGroupManager` with `userMessageLimit`.

## Issue

- https://github.com/waku-org/nwaku/issues/3236

