### PR TITLE
feat: Update rln contract deployment and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,8 +202,8 @@ testcommon: | build deps
 ##########
 .PHONY: testwaku wakunode2 testwakunode2 example2 chat2 chat2bridge liteprotocoltester
 
-# install anvil only for the testwaku target
-testwaku: | build deps anvil librln
+# install rln-deps only for the testwaku target
+testwaku: | build deps rln-deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim test -d:os=$(shell uname) $(NIM_PARAMS) waku.nims
 

--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,8 @@ ifeq (, $(shell which cargo))
 	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
 endif
 
-anvil: rustup
-ifeq (, $(shell which anvil 2> /dev/null))
-# Install Anvil if it's not installed
-	./scripts/install_anvil.sh
-endif
+rln-deps: rustup
+	./scripts/install_rln_tests_dependencies.sh
 
 deps: | deps-common nat-libs waku.nims
 

--- a/scripts/install_anvil.sh
+++ b/scripts/install_anvil.sh
@@ -2,13 +2,14 @@
 
 # Install Anvil
 
+if ! command -v anvil &> /dev/null; then
+    BASE_DIR="${XDG_CONFIG_HOME:-$HOME}"
+    FOUNDRY_DIR="${FOUNDRY_DIR-"$BASE_DIR/.foundry"}"
+    FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 
-BASE_DIR="${XDG_CONFIG_HOME:-$HOME}"
-FOUNDRY_DIR="${FOUNDRY_DIR-"$BASE_DIR/.foundry"}"
-FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
-
-curl -L https://foundry.paradigm.xyz | bash
-# Extract the source path from the download result
-echo "foundryup_path: $FOUNDRY_BIN_DIR"
-# run foundryup
-$FOUNDRY_BIN_DIR/foundryup
+    curl -L https://foundry.paradigm.xyz | bash
+    # Extract the source path from the download result
+    echo "foundryup_path: $FOUNDRY_BIN_DIR"
+    # run foundryup
+    $FOUNDRY_BIN_DIR/foundryup
+fi

--- a/scripts/install_pnpm.sh
+++ b/scripts/install_pnpm.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Install pnpm
+if ! command -v pnpm &> /dev/null; then
+    echo "pnpm is not installed, installing it now..."
+    curl -L https://unpkg.com/@pnpm/self-installer | node
+fi
+

--- a/scripts/install_pnpm.sh
+++ b/scripts/install_pnpm.sh
@@ -3,6 +3,6 @@
 # Install pnpm
 if ! command -v pnpm &> /dev/null; then
     echo "pnpm is not installed, installing it now..."
-    curl -L https://unpkg.com/@pnpm/self-installer | node
+    npm i pnpm --global
 fi
 

--- a/scripts/install_rln_tests_dependencies.sh
+++ b/scripts/install_rln_tests_dependencies.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
 # Install Anvil
-if ! command -v anvil &> /dev/null; then
-    ./scripts/install_anvil.sh
-fi
+./scripts/install_anvil.sh
 
 #Install pnpm
-if ! command -v pnpm &> /dev/null; then
-    ./scripts/install_pnpm.sh
-fi
+./scripts/install_pnpm.sh

--- a/scripts/install_rln_tests_dependencies.sh
+++ b/scripts/install_rln_tests_dependencies.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Install Anvil
+if ! command -v anvil &> /dev/null; then
+    ./scripts/install_anvil.sh
+fi
+
+#Install pnpm
+if ! command -v pnpm &> /dev/null; then
+    ./scripts/install_pnpm.sh
+fi

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -79,7 +79,7 @@ suite "Onchain group manager":
     assert metadata.contractAddress == manager.ethContractAddress,
       "contractAddress is not equal to " & manager.ethContractAddress
 
-    let differentContractAddress = await executeForgeContractDeployScripts(manager.ethClientUrls[0])
+    let differentContractAddress = await executeForgeContractDeployScripts()
     # simulating a change in the contractAddress
     let manager2 = OnchainGroupManager(
       ethClientUrls: @[EthClient],

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -83,11 +83,9 @@ suite "Onchain group manager":
     web3.defaultAccount = accounts[2]
     let (privateKey, acc) = createEthAccount(web3)
 
-    let testTokenAddressRes = waitFor deployTestToken(privateKey, acc, web3)
-    if testTokenAddressRes.isErr():
-      error "Failed to deploy test token contract", error = testTokenAddressRes.error
-      raise newException(CatchableError, "Failed to deploy test token contract")
-    let TOKEN_ADDRESS = testTokenAddressRes.get()
+    let tokenAddress = (waitFor deployTestToken(privateKey, acc, web3)).valueOr:
+      assert false, "Failed to deploy test token contract: " & $error
+      return
 
     let differentContractAddress = (
       waitFor executeForgeContractDeployScripts(privateKey, acc, web3)

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -48,7 +48,7 @@ suite "Onchain group manager":
       manager.ethRpc.isSome()
       manager.wakuRlnContract.isSome()
       manager.initialized
-      manager.rlnRelayMaxMessageLimit == 100
+      manager.rlnRelayMaxMessageLimit == 600
 
   asyncTest "should error on initialization when chainId does not match":
     manager.chainId = utils_onchain.CHAIN_ID + 1
@@ -75,11 +75,11 @@ suite "Onchain group manager":
     assert metadataOpt.isSome(), "metadata is not set"
     let metadata = metadataOpt.get()
 
-    assert metadata.chainId == 1337, "chainId is not equal to 1337"
+    assert metadata.chainId == 1234, "chainId is not equal to 1234"
     assert metadata.contractAddress == manager.ethContractAddress,
       "contractAddress is not equal to " & manager.ethContractAddress
 
-    let differentContractAddress = await uploadRLNContract(manager.ethClientUrls[0])
+    let differentContractAddress = await executeForgeContractDeployScripts(manager.ethClientUrls[0])
     # simulating a change in the contractAddress
     let manager2 = OnchainGroupManager(
       ethClientUrls: @[EthClient],

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -89,14 +89,16 @@ suite "Onchain group manager":
       raise newException(CatchableError, "Failed to deploy test token contract")
     let TOKEN_ADDRESS = testTokenAddressRes.get()
 
-    let differentContractAddress =
+    let differentContractAddress = (
       waitFor executeForgeContractDeployScripts(privateKey, acc, web3)
-    if differentContractAddress.isErr():
-      error "Failed to deploy RLN contract", error = differentContractAddress.error
+    ).valueOr:
+      assert false, "Failed to deploy RLN contract: " & $error
+      return
+
     # simulating a change in the contractAddress
     let manager2 = OnchainGroupManager(
       ethClientUrls: @[EthClient],
-      ethContractAddress: $differentContractAddress.get(),
+      ethContractAddress: $differentContractAddress,
       rlnInstance: manager.rlnInstance,
       onFatalErrorAction: proc(errStr: string) =
         assert false, errStr

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -29,10 +29,7 @@ import
   ./utils_onchain
 
 suite "Onchain group manager":
-
-
   setup:
-      # We run Anvil
     let runAnvil {.used.} = runAnvil()
 
     var manager {.threadvar.}: OnchainGroupManager
@@ -92,7 +89,8 @@ suite "Onchain group manager":
       raise newException(CatchableError, "Failed to deploy test token contract")
     let TOKEN_ADDRESS = testTokenAddressRes.get()
 
-    let differentContractAddress = waitFor executeForgeContractDeployScripts(privateKey, acc, web3)
+    let differentContractAddress =
+      waitFor executeForgeContractDeployScripts(privateKey, acc, web3)
     if differentContractAddress.isErr():
       error "Failed to deploy RLN contract", error = differentContractAddress.error
     # simulating a change in the contractAddress

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -130,7 +130,7 @@ suite "Onchain group manager":
     let merkleRootBefore = manager.fetchMerkleRoot()
 
     try:
-      await manager.register(credentials, UserMessageLimit(1))
+      await manager.register(credentials, UserMessageLimit(20))
     except Exception, CatchableError:
       assert false, "exception raised: " & getCurrentExceptionMsg()
 
@@ -166,7 +166,7 @@ suite "Onchain group manager":
 
     try:
       for i in 0 ..< credentials.len():
-        await manager.register(credentials[i], UserMessageLimit(1))
+        await manager.register(credentials[i], UserMessageLimit(20))
         discard await manager.updateRoots()
     except Exception, CatchableError:
       assert false, "exception raised: " & getCurrentExceptionMsg()
@@ -183,7 +183,7 @@ suite "Onchain group manager":
     try:
       await manager.register(
         RateCommitment(
-          idCommitment: dummyCommitment, userMessageLimit: UserMessageLimit(1)
+          idCommitment: dummyCommitment, userMessageLimit: UserMessageLimit(20)
         )
       )
     except CatchableError:
@@ -202,7 +202,7 @@ suite "Onchain group manager":
     try:
       await manager.register(
         RateCommitment(
-          idCommitment: idCommitment, userMessageLimit: UserMessageLimit(1)
+          idCommitment: idCommitment, userMessageLimit: UserMessageLimit(20)
         )
       )
     except Exception, CatchableError:
@@ -222,7 +222,7 @@ suite "Onchain group manager":
     let fut = newFuture[void]()
 
     proc callback(registrations: seq[Membership]): Future[void] {.async.} =
-      let rateCommitment = getRateCommitment(idCredentials, UserMessageLimit(1)).get()
+      let rateCommitment = getRateCommitment(idCredentials, UserMessageLimit(20)).get()
       check:
         registrations.len == 1
         registrations[0].rateCommitment == rateCommitment
@@ -237,7 +237,7 @@ suite "Onchain group manager":
     try:
       await manager.register(
         RateCommitment(
-          idCommitment: idCommitment, userMessageLimit: UserMessageLimit(1)
+          idCommitment: idCommitment, userMessageLimit: UserMessageLimit(20)
         )
       )
     except Exception, CatchableError:
@@ -264,7 +264,7 @@ suite "Onchain group manager":
     proc callback(registrations: seq[Membership]): Future[void] {.async.} =
       if registrations.len == 1 and
           registrations[0].rateCommitment ==
-          getRateCommitment(idCredentials, UserMessageLimit(1)).get() and
+          getRateCommitment(idCredentials, UserMessageLimit(20)).get() and
           registrations[0].index == 0:
         manager.idCredentials = some(idCredentials)
         fut.complete()
@@ -275,7 +275,7 @@ suite "Onchain group manager":
       raiseAssert $error
 
     try:
-      await manager.register(idCredentials, UserMessageLimit(1))
+      await manager.register(idCredentials, UserMessageLimit(20))
     except Exception, CatchableError:
       assert false, "exception raised: " & getCurrentExceptionMsg()
 
@@ -313,7 +313,7 @@ suite "Onchain group manager":
     (await manager.init()).isOkOr:
       raiseAssert $error
 
-    manager.userMessageLimit = some(UserMessageLimit(1))
+    manager.userMessageLimit = some(UserMessageLimit(20))
     manager.membershipIndex = some(MembershipIndex(0))
     manager.idCredentials = some(idCredentials)
 
@@ -349,7 +349,7 @@ suite "Onchain group manager":
     proc callback(registrations: seq[Membership]): Future[void] {.async.} =
       if registrations.len == 1 and
           registrations[0].rateCommitment ==
-          getRateCommitment(credentials, UserMessageLimit(1)).get() and
+          getRateCommitment(credentials, UserMessageLimit(20)).get() and
           registrations[0].index == 0:
         manager.idCredentials = some(credentials)
         fut.complete()
@@ -357,7 +357,7 @@ suite "Onchain group manager":
     manager.onRegister(callback)
 
     try:
-      await manager.register(credentials, UserMessageLimit(1))
+      await manager.register(credentials, UserMessageLimit(20))
     except Exception, CatchableError:
       assert false, "exception raised: " & getCurrentExceptionMsg()
     await fut
@@ -395,7 +395,7 @@ suite "Onchain group manager":
     let idCredential = generateCredentials(manager.rlnInstance)
 
     try:
-      await manager.register(idCredential, UserMessageLimit(1))
+      await manager.register(idCredential, UserMessageLimit(20))
     except Exception, CatchableError:
       assert false,
         "exception raised when calling startGroupSync: " & getCurrentExceptionMsg()
@@ -445,7 +445,7 @@ suite "Onchain group manager":
       proc callback(registrations: seq[Membership]): Future[void] {.async.} =
         if registrations.len == 1 and
             registrations[0].rateCommitment ==
-            getRateCommitment(credentials[futureIndex], UserMessageLimit(1)).get() and
+            getRateCommitment(credentials[futureIndex], UserMessageLimit(20)).get() and
             registrations[0].index == MembershipIndex(futureIndex):
           futs[futureIndex].complete()
           futureIndex += 1
@@ -456,7 +456,7 @@ suite "Onchain group manager":
       manager.onRegister(generateCallback(futures, credentials))
 
       for i in 0 ..< credentials.len():
-        await manager.register(credentials[i], UserMessageLimit(1))
+        await manager.register(credentials[i], UserMessageLimit(20))
         discard await manager.updateRoots()
     except Exception, CatchableError:
       assert false, "exception raised: " & getCurrentExceptionMsg()

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -262,7 +262,7 @@ proc deployTestToken*(
     execCmdEx(fmt"""cd {submodulePath} && pnpm install""")
   trace "Executed pnpm install command", output = pnpmInstallOutput
   if pnpmInstallExitCode != 0:
-     return err("pnpm install command failed" & pnpmInstallOutput)
+    return err("pnpm install command failed" & pnpmInstallOutput)
 
   let (forgeBuildOutput, forgeBuildExitCode) =
     execCmdEx(fmt"""cd {submodulePath} && {forgePath} build""")
@@ -372,7 +372,7 @@ proc executeForgeContractDeployScripts*(
     execCmdEx(fmt"""cd {submodulePath} && pnpm install""")
   trace "Executed pnpm install command", output = pnpmInstallOutput
   if pnpmInstallExitCode != 0:
-     return err("pnpm install command failed" & pnpmInstallOutput)
+    return err("pnpm install command failed" & pnpmInstallOutput)
 
   let (forgeBuildOutput, forgeBuildExitCode) =
     execCmdEx(fmt"""cd {submodulePath} && {forgePath} build""")

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -535,7 +535,7 @@ proc runAnvil*(port: int = 8540, chainId: string = "1234"): Process =
         "--port",
         $port,
         "--accounts",
-        "20",
+        "25",
         "--gas-limit",
         "300000000000000",
         "--balance",
@@ -550,7 +550,7 @@ proc runAnvil*(port: int = 8540, chainId: string = "1234"): Process =
         "10",
         "--disable-console-log",
         "--threads", 
-        "4",
+        "0",
         "--no-request-size-limit"
       ],
       options = {poUsePath},

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -262,7 +262,7 @@ proc deployTestToken*(
     execCmdEx(fmt"""cd {submodulePath} && pnpm install""")
   trace "Executed pnpm install command", output = pnpmInstallOutput
   if pnpmInstallExitCode != 0:
-    return error("pnpm install command failed" & pnpmInstallOutput)
+     return err("pnpm install command failed" & pnpmInstallOutput)
 
   let (forgeBuildOutput, forgeBuildExitCode) =
     execCmdEx(fmt"""cd {submodulePath} && {forgePath} build""")
@@ -372,7 +372,7 @@ proc executeForgeContractDeployScripts*(
     execCmdEx(fmt"""cd {submodulePath} && pnpm install""")
   trace "Executed pnpm install command", output = pnpmInstallOutput
   if pnpmInstallExitCode != 0:
-    error("pnpm install failed")
+     return err("pnpm install command failed" & pnpmInstallOutput)
 
   let (forgeBuildOutput, forgeBuildExitCode) =
     execCmdEx(fmt"""cd {submodulePath} && {forgePath} build""")

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -175,6 +175,10 @@ proc deployTestToken*(
   let forgePath = getForgePath()
   debug "Forge path", forgePath
 
+  let forgeCleanCmd = fmt"""cd {submodulePath} && {forgePath} clean"""
+  debug "Forge clean command", forgeCleanCmd
+  # get current directory
+  debug "Current working directory", cwd = getCurrentDir()
   # Build the Foundry project
   let (forgeCleanOutput, forgeCleanExitCode) =
     execCmdEx(fmt"""cd {submodulePath} && {forgePath} clean""")

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -341,7 +341,7 @@ proc approveTokenAllowanceAndVerify*(
   return allowanceAfter >= amountWei
 
 proc executeForgeContractDeployScripts*(
-    pk: keys.PrivateKey, acc: Address,  web3: Web3
+    pk: keys.PrivateKey, acc: Address, web3: Web3
 ): Future[Result[Address, string]] {.async, gcsafe.} =
   ## Executes a set of foundry forge scripts required to deploy the RLN contract and returns the deployed proxy contract address
   ## submodulePath: path to the submodule containing contract deploy scripts
@@ -437,7 +437,7 @@ proc executeForgeContractDeployScripts*(
   let proxyAddressAddress = Address(proxyAddressBytes)
 
   info "Address of the Proxy contract", proxyAddressAddress
-  
+
   await web3.close()
   return ok(proxyAddressAddress)
 
@@ -549,9 +549,9 @@ proc runAnvil*(port: int = 8540, chainId: string = "1234"): Process =
         "--transaction-block-keeper",
         "10",
         "--disable-console-log",
-        "--threads", 
+        "--threads",
         "0",
-        "--no-request-size-limit"
+        "--no-request-size-limit",
       ],
       options = {poUsePath},
     )
@@ -618,7 +618,8 @@ proc setupOnchainGroupManager*(
   discard await sendMintCall(
     web3, web3.defaultAccount, TOKEN_ADDRESS, acc, ethToWei(1000.u256), some(0.u256)
   )
-  let contractAddressRes = await executeForgeContractDeployScripts(privateKey, acc, web3)
+  let contractAddressRes =
+    await executeForgeContractDeployScripts(privateKey, acc, web3)
   if contractAddressRes.isErr():
     error "Failed to deploy RLN contract", error = contractAddressRes.error
     raise newException(CatchableError, "Failed to deploy RLN contract")

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -262,7 +262,7 @@ proc deployTestToken*(
     execCmdEx(fmt"""cd {submodulePath} && pnpm install""")
   trace "Executed pnpm install command", output = pnpmInstallOutput
   if pnpmInstallExitCode != 0:
-    return error("pnpm install command failed")
+    return error("pnpm install command failed" & pnpmInstallOutput)
 
   let (forgeBuildOutput, forgeBuildExitCode) =
     execCmdEx(fmt"""cd {submodulePath} && {forgePath} build""")

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -239,7 +239,7 @@ proc deployTestToken*(
   ## submodulePath: path to the submodule containing contract deploy scripts
 
   # All RLN related tests should be run from the root directory of the project
-  let submodulePath = "./vendor/waku-rlnv2-contract"
+  let submodulePath = absolutePath("./vendor/waku-rlnv2-contract")
 
   let forgePath = getForgePath()
   debug "Forge path", forgePath

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -287,7 +287,7 @@ proc approveTokenAllowanceAndVerify*(
     tx.to = Opt.some(tokenAddress)
     tx.value = Opt.some(0.u256)
     tx.gasPrice = Opt.some(gasPrice)
-    tx.gas = Opt.some(Quantity(100000)) # Consider estimating gas instead
+    tx.gas = Opt.some(Quantity(100000))
     tx.data = Opt.some(byteutils.hexToSeqByte(approveCallData))
     tx.chainId = Opt.some(CHAIN_ID)
 
@@ -719,6 +719,7 @@ proc setupOnchainGroupManager*(
     testTokenAddress, # ERC20 token address
     contractAddress, # spender - the proxy contract that will spend the tokens
     ethToWei(200.u256),
+    some(0.u256) # expected allowance before approval
   )
 
   assert tokenApprovalResult.isOk, tokenApprovalResult.error()

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -502,17 +502,7 @@ proc runAnvil*(port: int = 8540, chainId: string = "1234"): Process =
         "--balance",
         "1000000000",
         "--chain-id",
-        $chainId,
-        "--prune-history",
-        "25",
-        "--memory-limit",
-        "268435456",
-        "--transaction-block-keeper",
-        "10",
-        "--disable-console-log",
-        "--threads",
-        "0",
-        "--no-request-size-limit",
+        $chainId
       ],
       options = {poUsePath},
     )

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -172,8 +172,22 @@ proc deployTestToken*(
   # All RLN related tests should be run from the root directory of the project
   let submodulePath = absolutePath("./vendor/waku-rlnv2-contract")
 
+  # Verify submodule path exists
+  if not dirExists(submodulePath):
+    error "Submodule path does not exist", submodulePath = submodulePath
+    return err("Submodule path does not exist: " & submodulePath)
+
+  debug "Submodule path verified", submodulePath = submodulePath
+
   let forgePath = getForgePath()
   debug "Forge path", forgePath
+
+  # Verify forge executable exists
+  if not fileExists(forgePath):
+    error "Forge executable not found", forgePath = forgePath
+    return err("Forge executable not found: " & forgePath)
+
+  debug "Forge executable verified", forgePath = forgePath
 
   let forgeCleanCmd = fmt"""cd {submodulePath} && {forgePath} clean"""
   debug "Forge clean command", forgeCleanCmd
@@ -315,9 +329,23 @@ proc executeForgeContractDeployScripts*(
   # All RLN related tests should be run from the root directory of the project
   let submodulePath = "./vendor/waku-rlnv2-contract"
 
+  # Verify submodule path exists
+  if not dirExists(submodulePath):
+    error "Submodule path does not exist", submodulePath = submodulePath
+    return err("Submodule path does not exist: " & submodulePath)
+
+  debug "Submodule path verified", submodulePath = submodulePath
+
   let privateKey = $pk
   let forgePath = getForgePath()
   debug "Forge path", forgePath
+
+  # Verify forge executable exists
+  if not fileExists(forgePath):
+    error "Forge executable not found", forgePath = forgePath
+    return err("Forge executable not found: " & forgePath)
+
+  debug "Forge executable verified", forgePath = forgePath
   debug "contract deployer account details", account = acc, privateKey = privateKey
 
   # Build the Foundry project

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -85,6 +85,7 @@ proc doRlnKeystoreGenerator*(conf: RlnKeystoreGeneratorConf) =
     quit(1)
 
   # 5. register on-chain
+  debug "credential idcommit", idCommitment = credential.idCommitment.inHex()
   try:
     waitFor groupManager.register(credential, conf.userMessageLimit)
   except Exception, CatchableError:

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -85,7 +85,6 @@ proc doRlnKeystoreGenerator*(conf: RlnKeystoreGeneratorConf) =
     quit(1)
 
   # 5. register on-chain
-  debug "credential idcommit", idCommitment = credential.idCommitment.inHex()
   try:
     waitFor groupManager.register(credential, conf.userMessageLimit)
   except Exception, CatchableError:

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -39,7 +39,7 @@ proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
     rlnRelayDynamic: true,
     rlnRelayChainId: RelayChainId,
     rlnEpochSizeSec: 600,
-    rlnRelayUserMessageLimit: 100,
+    rlnRelayUserMessageLimit: 20,
     numShardsInNetwork: 8,
     discv5Discovery: true,
     discv5BootstrapNodes:

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -39,7 +39,7 @@ proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
     rlnRelayDynamic: true,
     rlnRelayChainId: RelayChainId,
     rlnEpochSizeSec: 600,
-    rlnRelayUserMessageLimit: 20,
+    rlnRelayUserMessageLimit: 100,
     numShardsInNetwork: 8,
     discv5Discovery: true,
     discv5BootstrapNodes:

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -100,7 +100,7 @@ proc sendEthCallWithChainId*(
     toAddress: Address,
     chainId: UInt256,
 ): Future[Result[UInt256, string]] {.async.} =
-  ## Generic proc to make contract calls with no arguments and with explicit chainId (workaround for automatic chainId=null with web3 call())
+  ## Generic proc to make contract calls with no arguments and with explicit chainId (workaround for automatic chainId=null with web3 call() proc)
   ## 
   ## Args:
   ##   ethRpc: Web3 instance for making RPC calls
@@ -301,7 +301,7 @@ method register*(
   g.retryWrapper(gasPrice, "Failed to get gas price"):
     int(await ethRpc.provider.eth_gasPrice()) * 2
   let idCommitmentHex = identityCredential.idCommitment.inHex()
-  debug "identityCredential idCommitmentHex", idCommitmentNoConvert = idCommitmentHex
+  debug "identityCredential idCommitmentHex", idCommitment = idCommitmentHex
   let idCommitment = identityCredential.idCommitment.toUInt256()
   let idCommitmentsToErase: seq[UInt256] = @[]
   debug "registering the member",
@@ -641,6 +641,7 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
     try:
       # let membershipExists =
       #   await wakuRlnContract.isInMembershipSet(idCommitment).call()
+      # The above code is not working with the latest web3 version due to chainId being null (specifically on linea-sepolia), below is the workaround
       # Function signature with parameter type
       let functionSignature = "isInMembershipSet(uint256)"
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -30,17 +30,11 @@ logScope:
 # using the when predicate does not work within the contract macro, hence need to dupe
 contract(WakuRlnContract):
   # this serves as an entrypoint into the rln membership set
-  proc register(
-    idCommitment: UInt256, userMessageLimit: UInt32, idCommitmentsToErase: seq[UInt256]
-  )
-
+  proc register(idCommitment: UInt256, userMessageLimit: UInt32, idCommitmentsToErase: seq[UInt256])
   # Initializes the implementation contract (only used in unit tests)
   proc initialize(maxMessageLimit: UInt256)
   # this event is raised when a new member is registered
-  proc MembershipRegistered(
-    idCommitment: UInt256, membershipRateLimit: UInt256, index: UInt32
-  ) {.event.}
-
+  proc MembershipRegistered(idCommitment: UInt256, membershipRateLimit: UInt256, index: UInt32) {.event.}
   # this function denotes existence of a given user
   proc isInMembershipSet(idCommitment: Uint256): bool {.view.}
   # this constant describes the next index of a new member
@@ -301,19 +295,17 @@ method register*(
   g.retryWrapper(gasPrice, "Failed to get gas price"):
     int(await ethRpc.provider.eth_gasPrice()) * 2
   let idCommitmentHex = identityCredential.idCommitment.inHex()
-  debug "identityCredential idCommitmentHex", idCommitment = idCommitmentHex
+  debug "identityCredential idCommitmentHex",
+    idCommitmentNoConvert = idCommitmentHex
   let idCommitment = identityCredential.idCommitment.toUInt256()
-  debug "identityCredential idCommitment toUInt256", idCommitment = idCommitment
   let idCommitmentsToErase: seq[UInt256] = @[]
   debug "registering the member",
-    idCommitment = idCommitment,
-    userMessageLimit = userMessageLimit,
-    idCommitmentsToErase = idCommitmentsToErase
+    idCommitment = idCommitment, userMessageLimit = userMessageLimit, idCommitmentsToErase = idCommitmentsToErase
   var txHash: TxHash
   g.retryWrapper(txHash, "Failed to register the member"):
-    await wakuRlnContract
-    .register(idCommitment, userMessageLimit.stuint(32), idCommitmentsToErase)
-    .send(gasPrice = gasPrice)
+    await wakuRlnContract.register(idCommitment, userMessageLimit.stuint(32),idCommitmentsToErase).send(
+      gasPrice = gasPrice
+    )
 
   # wait for the transaction to be mined
   var tsReceipt: ReceiptObject
@@ -336,9 +328,7 @@ method register*(
   debug "third topic", firstTopic = firstTopic
   # the hash of the signature of MembershipRegistered(uint256,uint256,uint32) event is equal to the following hex value
   if firstTopic !=
-      cast[FixedBytes[32]](keccak.keccak256.digest(
-        "MembershipRegistered(uint256,uint256,uint32)"
-      ).data):
+      cast[FixedBytes[32]](keccak.keccak256.digest("MembershipRegistered(uint256,uint256,uint32)").data):
     raise newException(ValueError, "register: unexpected event signature")
 
   # the arguments of the raised event i.e., MembershipRegistered are encoded inside the data field
@@ -632,10 +622,16 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
     g.membershipIndex = some(keystoreCred.treeIndex)
     g.userMessageLimit = some(keystoreCred.userMessageLimit)
     # now we check on the contract if the commitment actually has a membership
-    let idCommitment = keystoreCred.identityCredential.idCommitment.toUInt256()
-    debug "checking if the idCommitment has a membership",
-      idCommitmentHex = keystoreCred.identityCredential.idCommitment.inHex(),
-      idCommitmentUInt256 = idCommitment
+    let idCommitmentBytes = keystoreCred.identityCredential.idCommitment
+    let idCommitmentUInt256 = keystoreCred.identityCredential.idCommitment.toUInt256()
+    let idCommitmentHex =  idCommitmentBytes.inHex()
+    debug "Keystore idCommitment in bytes",
+      idCommitmentBytes = idCommitmentBytes
+    debug "Keystore idCommitment in UInt256 ",
+      idCommitmentUInt256 = idCommitmentUInt256
+    debug "Keystore idCommitment in hex ",
+      idCommitmentHex = idCommitmentHex
+    let idCommitment = idCommitmentUInt256
     try:
       # let membershipExists =
       #   await wakuRlnContract.isInMembershipSet(idCommitment).call()
@@ -667,7 +663,7 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
 
       debug "membershipExists", membershipExists = membershipExists
       if membershipExists == false:
-        return err("the idCommitment does not have a membership")
+        return err("the idCommitmentUInt256 does not have a membership")
     except CatchableError:
       return err("failed to check if the commitment has a membership")
 

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -577,7 +577,6 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
   let ethRpc: Web3 = (await establishConnection(g)).valueOr:
     return err("failed to connect to Ethereum clients: " & $error)
 
-  debug "fetching chainId"
   var fetchedChainId: UInt256
   g.retryWrapper(fetchedChainId, "Failed to get the chain id"):
     await ethRpc.provider.eth_chainId()
@@ -605,8 +604,6 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
 
   let contractAddress = web3.fromHex(web3.Address, g.ethContractAddress)
   let wakuRlnContract = ethRpc.contractSender(WakuRlnContract, contractAddress)
-  debug "contract address",
-    contractAddress = contractAddress, ethContractAddress = g.ethContractAddress
 
   g.ethRpc = some(ethRpc)
   g.wakuRlnContract = some(wakuRlnContract)
@@ -668,7 +665,6 @@ method init*(g: OnchainGroupManager): Future[GroupManagerResult[void]] {.async.}
       tx.chainId = Opt.some(g.chainId)
 
       let resultBytes = await g.ethRpc.get().provider.eth_call(tx, "latest")
-      debug "resultBytes", resultBytes = resultBytes, len = resultBytes.len
       if resultBytes.len == 0:
         return err("No result returned for function call: " & $functionSignature)
       let membershipExists = resultBytes.len == 32 and resultBytes[^1] == 1'u8


### PR DESCRIPTION
# Description
This PR is part of the feature to update the contract abi code used in nwaku and needs to be merged with https://github.com/waku-org/nwaku/pull/3390 before it can be merged with master.

# Changes
- Update the commit of the waku-rlnv2-contract submodule to the latest
- Replace the `uploadRLNContract` method in the `utils_onchain.nim` with a new contract deployment using the forge deploy scripts
- Update rln dependencies that need to be installed for tests (add pnpm)
- Update all related tests that are broken by the updates in https://github.com/waku-org/nwaku/pull/3390
- Change the tests in `test_rln_group_manager_onchain.nim` to run synchronously, to avoid test failures due to Anvil port connections maxing out

## How to test

The way to test is to run the `Onchain group manager::should initialize successfully'` test in the `tests/waku_rln_relay/test_rln_group_manager_onchain.nim` test file

Run a command like this one:
1. `nim c -r --mm:refc -d:chronicles_log_level=TRACE -d:disable_libbacktrace -d:chronosStrictException --verbosity:0 --hints:off -d:chronicles_log_level=TRACE -d:git_version="v0.35.1-70-g30e22b" -d:debug --passL:-lcrypto --passL:-lssl -d:postgres  -d:rln --passL:librln_v0.7.0.a --passL:-lm -d:nimDebugDlOpen --passL:-lstdc++ tests/waku_rln_relay/test_rln_group_manager_onchain.nim test 'Onchain group manager::should initialize successfully'`

## Issue

- https://github.com/waku-org/nwaku/issues/3272
closes https://github.com/waku-org/nwaku/issues/1871
