### PR TITLE
fix: misc sync fixes, added debug logging

### DIFF
--- a/waku/waku_store_sync/transfer.nim
+++ b/waku/waku_store_sync/transfer.nim
@@ -97,7 +97,13 @@ proc needsReceiverLoop(self: SyncTransfer) {.async.} =
   while true: # infinite loop
     let (peerId, fingerprint) = await self.remoteNeedsRx.popFirst()
 
-    if not self.outSessions.hasKey(peerId):
+    if (not self.outSessions.hasKey(peerId)) or 
+      self.outSessions[peerId].closed() or ## sanity check, should not be possible
+      self.outSessions[peerId].isClosedRemotely: ## quite possibly remote end has closed the connection, believing transfer to be done
+      
+      debug "opening transfer connection to remote peer",
+        local = self.peerManager.switch.peerInfo.peerId, remote = peerId
+      
       let connection = (await self.openConnection(peerId)).valueOr:
         error "failed to establish transfer connection", error = error
         continue
@@ -120,6 +126,9 @@ proc needsReceiverLoop(self: SyncTransfer) {.async.} =
 
     let msg =
       WakuMessageAndTopic(pubsub: response.topics[0], message: response.messages[0])
+
+    trace "sending transfer message",
+      local = self.peerManager.switch.peerInfo.peerId, remote = peerId, msg = msg
 
     (await sendMessage(connection, msg)).isOkOr:
       self.outSessions.del(peerId)


### PR DESCRIPTION
PR contains a few things I've come across while trying to experiment with Waku Sync locally:

- few added logs/increasing the log level for useful debug logs
- two fixes:
  1. `newSeqOfCap` (in stead of `newSeq`, which creates zeroed entries and cannot be followed by `add()` operations)
  2. check to see if remote end has closed a transfer connection, otherwise the local end believes the session is still ongoing and tries to use it
  
Also see comments below. I will also add a draft PR to address/open a conversation on some race conditions.