### PR TITLE
fix: race condition - reconciliation done before transfer start

### DIFF
--- a/waku/waku_store_sync/transfer.nim
+++ b/waku/waku_store_sync/transfer.nim
@@ -132,9 +132,9 @@ proc needsReceiverLoop(self: SyncTransfer) {.async.} =
 proc initProtocolHandler(self: SyncTransfer) =
   let handler = proc(conn: Connection, proto: string) {.async, closure.} =
     while true:
-      if not self.inSessions.contains(conn.peerId):
-        error "unwanted peer, disconnecting", remote = conn.peerId
-        break
+      # if not self.inSessions.contains(conn.peerId):
+      #   error "unwanted peer, disconnecting", remote = conn.peerId
+      #   break
 
       let readRes = catch:
         await conn.readLp(int64(DefaultMaxWakuMessageSize))


### PR DESCRIPTION
Draft PR, as I know the check I removed is probably important for security reasons, and we may want another solution.

Race condition occurs in low-latency environments where sync reconciliation is done before the transfer could kick in, which is dispatched async. Note that, although this is most apparent when running Sync between two local instances, we have low latency deployments elsewhere too, for example fleet nodes are often colocated in the same data center or even the same VS.

What I've been thinking is that the coordination between `transfer` and `reconciliation` seems quite extensive. In this case, it extends beyond message passing - i.e. it assumes that certain things happen in a certain order (not async and independently). Wouldn't it be simpler (and help us avoid race conditions) to make this explicit in a coordination module without using `AsyncQueue`?
We could have a `StoreSync` module that explicitly chooses a suitable peer for syncing, starts a reconciliation session, uses the information received from the reconciliation session to open a transfer session (at the right time), coordinates the rest of the timing, handles errors in either protocol (that could affect the other), cleans up all loose connections at the end of both sessions, etc. WDYT?