### PR TITLE
Update Dockerfile rust image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD NIM APP ----------------------------------------------------------------
-FROM rust:1.77.1-alpine3.18  AS nim-build
+FROM rust:1.81.0-alpine3.19  AS nim-build
 
 ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2


### PR DESCRIPTION
## Description

This PR fixes the following issue

```nim
04:32:51  0.887 error: failed to parse lock file at: /app/vendor/zerokit/Cargo.lock
04:32:51  0.887 
04:32:51  0.887 Caused by:
04:32:51  0.887   lock file version `4` was found, but this version of Cargo does not understand this lock file, perhaps Cargo needs to be updated?
04:32:51  0.888 make: *** [Makefile:177: librln_v0.7.0.a] Error 101
04:32:51  ------
04:32:51  Dockerfile:25
04:32:51  --------------------
04:32:51    23 |     
04:32:51    24 |     # Build the final node binary
04:32:51    25 | >>> RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="${NIMFLAGS}"
04:32:51    26 |     
04:32:51    27 |     
04:32:51  --------------------
```

## Issue

- https://github.com/waku-org/nwaku/issues/3236