### PR TITLE
fix: enabling WebSocket connection also in case only websocket-secure-support enabled

### DIFF
--- a/docker/binaries/Dockerfile.bn.amd64
+++ b/docker/binaries/Dockerfile.bn.amd64
@@ -1,6 +1,5 @@
 # Dockerfile to build a distributable container image from pre-existing binaries
-# FROM debian:stable-slim AS prod
-FROM ubuntu:24.04 AS prod
+FROM debian:stable-slim AS prod
 
 ARG MAKE_TARGET=wakunode2
 


### PR DESCRIPTION
# Description

Turns out that with latest refactoring of Waku CLI argument handling, the used configuration on our fleets (in this current case waku.test) are not enabling was anymore as the configuration used only states `--websocket-secure-support=true`


# Changes

When `--websocket-secure-support` is enabled `--"websocket-support` setting must be inherently enabled too and not block setting up wss listener.

## How to test

As it is hard to test locally - you need domain with cert - we need to deploy the solution to waku.test and check if wss listeners are set.

Look for:
```
nwaku-1  | INF 2025-05-20 15:53:30.534+00:00 Listening on                               topics="waku node" tid=1 file=waku_node.nim:1436 full=[/ip4/0.0.0.0/tcp/30304/p2p/16Uiu2HAkzgmyG85tbFJ5CuwujV7HBiyRcwi2uDws4XX9dWDa4D2S][/ip4/0.0.0.0/tcp/8000/wss/p2p/16Uiu2HAkzgmyG85tbFJ5CuwujV7HBiyRcwi2uDws4XX9dWDa4D2S] localIp=172.19.0.4 switchAddress="@[/dns4/schwarzy.duckdns.org/tcp/30304, /dns4/schwarzy.duckdns.org/tcp/8000/wss]"
nwaku-1  | INF 2025-05-20 15:53:30.534+00:00 Announcing addresses                       topics="waku node" tid=1 file=waku_node.nim:1438 full=[/dns4/schwarzy.duckdns.org/tcp/30304/p2p/16Uiu2HAkzgmyG85tbFJ5CuwujV7HBiyRcwi2uDws4XX9dWDa4D2S][/dns4/schwarzy.duckdns.org/tcp/8000/wss/p2p/16Uiu2HAkzgmyG85tbFJ5CuwujV7HBiyRcwi2uDws4XX9dWDa4D2S]
```
Good if you can examine: **/wss/p2p** 
