### PR TITLE
feat: Extend ndoe /health REST endpoint with all protocol's state

### DIFF
--- a/waku/node/health_monitor.nim
+++ b/waku/node/health_monitor.nim
@@ -1,8 +1,8 @@
 {.push raises: [].}
 
-import std/[options], chronos
+import std/[options, sets], chronos
 
-import waku_node, ../waku_rln_relay
+import waku_node, ../waku_rln_relay, ../waku_relay
 
 type
   HealthStatus* = enum
@@ -56,29 +56,130 @@ proc init*(
 
 const FutIsReadyTimout = 5.seconds
 
+proc getRelayHealth(hm: WakuNodeHealthMonitor): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuRelay == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  let relayPeers = hm.node
+    .get().wakuRelay
+    .getConnectedPubSubPeers(pubsubTopic = "").valueOr:
+      return HealthStatus.NOT_READY
+
+  if relayPeers.len() == 0:
+    return HealthStatus.NOT_READY
+
+  return HealthStatus.READY
+
+proc getRlnRelayHealth(hm: WakuNodeHealthMonitor): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuRlnRelay == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  let isReadyStateFut = hm.node.get().wakuRlnRelay.isReady()
+  if not await isReadyStateFut.withTimeout(FutIsReadyTimout):
+    return HealthStatus.NOT_READY
+
+  try:
+    if not isReadyStateFut.completed():
+      return HealthStatus.NOT_READY
+    elif isReadyStateFut.read():
+      return HealthStatus.READY
+
+    return HealthStatus.SYNCHRONIZING
+  except:
+    error "exception reading state: " & getCurrentExceptionMsg()
+    return HealthStatus.NOT_READY
+
+proc getLightpushHealth(
+    hm: WakuNodeHealthMonitor, relayHealth: HealthStatus
+): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuLightPush == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  if relayHealth == HealthStatus.READY:
+    return HealthStatus.READY
+
+  return HealthStatus.NOT_READY
+
+proc getLegacyLightpushHealth(
+    hm: WakuNodeHealthMonitor, relayHealth: HealthStatus
+): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuLegacyLightPush == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  if relayHealth == HealthStatus.READY:
+    return HealthStatus.READY
+
+  return HealthStatus.NOT_READY
+
+proc getFilterHealth(hm: WakuNodeHealthMonitor): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuFilter == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  return HealthStatus.READY
+
+proc getStoreHealth(hm: WakuNodeHealthMonitor): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuStore == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  return HealthStatus.READY
+
+proc getLegacyStoreHealth(hm: WakuNodeHealthMonitor): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuLegacyStore == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  return HealthStatus.READY
+
+proc getPeerExchangeHealth(hm: WakuNodeHealthMonitor): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuPeerExchange == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  return HealthStatus.READY
+
+proc getRendezvousHealth(hm: WakuNodeHealthMonitor): Future[HealthStatus] {.async.} =
+  if hm.node.get().wakuRendezvous == nil:
+    return HealthStatus.NOT_MOUNTED
+
+  return HealthStatus.READY
+
 proc getNodeHealthReport*(hm: WakuNodeHealthMonitor): Future[HealthReport] {.async.} =
   result.nodeHealth = hm.nodeHealth
 
-  if hm.node.isSome() and hm.node.get().wakuRlnRelay != nil:
-    let getRlnRelayHealth = proc(): Future[HealthStatus] {.async.} =
-      let isReadyStateFut = hm.node.get().wakuRlnRelay.isReady()
-      if not await isReadyStateFut.withTimeout(FutIsReadyTimout):
-        return HealthStatus.NOT_READY
-
-      try:
-        if not isReadyStateFut.completed():
-          return HealthStatus.NOT_READY
-        elif isReadyStateFut.read():
-          return HealthStatus.READY
-
-        return HealthStatus.SYNCHRONIZING
-      except:
-        error "exception reading state: " & getCurrentExceptionMsg()
-        return HealthStatus.NOT_READY
-
+  if hm.node.isSome():
+    let relayHealth = await hm.getRelayHealth()
+    result.protocolsHealth.add(ProtocolHealth(protocol: "Relay", health: relayHealth))
     result.protocolsHealth.add(
-      ProtocolHealth(protocol: "Rln Relay", health: await getRlnRelayHealth())
+      ProtocolHealth(protocol: "Rln Relay", health: await hm.getRlnRelayHealth())
     )
+    result.protocolsHealth.add(
+      ProtocolHealth(
+        protocol: "Lightpush v3", health: await hm.getLightpushHealth(relayHealth)
+      )
+    )
+    result.protocolsHealth.add(
+      ProtocolHealth(
+        protocol: "Lightpush Legacy",
+        health: await hm.getLegacyLightpushHealth(relayHealth),
+      )
+    )
+    result.protocolsHealth.add(
+      ProtocolHealth(protocol: "Filter", health: await hm.getFilterHealth())
+    )
+    result.protocolsHealth.add(
+      ProtocolHealth(protocol: "Store", health: await hm.getStoreHealth())
+    )
+    result.protocolsHealth.add(
+      ProtocolHealth(protocol: "Legacy Store", health: await hm.getLegacyStoreHealth())
+    )
+    result.protocolsHealth.add(
+      ProtocolHealth(
+        protocol: "Peer Exchange", health: await hm.getPeerExchangeHealth()
+      )
+    )
+    result.protocolsHealth.add(
+      ProtocolHealth(protocol: "Rendezvous", health: await hm.getRendezvousHealth())
+    )
+
+  return result
 
 proc setNode*(hm: WakuNodeHealthMonitor, node: WakuNode) =
   hm.node = some(node)

--- a/waku/node/health_monitor.nim
+++ b/waku/node/health_monitor.nim
@@ -139,6 +139,9 @@ proc getRendezvousHealth(hm: WakuNodeHealthMonitor): Future[HealthStatus] {.asyn
   if hm.node.get().wakuRendezvous == nil:
     return HealthStatus.NOT_MOUNTED
 
+  if hm.node.peerManager.switch.peerStore.peers(RendezVousCodec).len() == 0:
+    return HealthStatus.NOT_READY
+
   return HealthStatus.READY
 
 proc getNodeHealthReport*(hm: WakuNodeHealthMonitor): Future[HealthReport] {.async.} =


### PR DESCRIPTION
# Description

Long time ago it was planned to have a health report over REST API that contains consistent state of a node overall and per protocol. So far it only considered RlnRelay (checking if it is syncing or not).

This PR intend to extend /health report to all relevant protocol Waku supports.

# Changes

Added report of 
- Relay
    - READY if mounted and node has Relay peers 
- Lightpush
   - READY if mounted and node has Relay peers 
- Lightpush legacy
    - READY if mounted and node has Relay peers 
- Store
- Store legacy
- Filter
- PeerExchange
- Rendezvous
    - READY if mounted and there are available peer supports Rendezvous protocol 

## How to test

1. run in nwaku-compose or standalone
2. run `curl -X GET http://127.0.0.1:8645/health | jq`
3. check result
4. repeat for some time and check if READY state changes of the protocols (Relay/RlnRelay/Lightpush)

#### Expect

```
{
  "nodeHealth": "Ready",
  "protocolsHealth": [
    {
      "Relay": "Not Ready"
    },
    {
      "Rln Relay": "Ready"
    },
    {
      "Lightpush v3": "Not Ready"
    },
    {
      "Lightpush Legacy": "Not Ready"
    },
    {
      "Filter": "Ready"
    },
    {
      "Store": "Not Mounted"
    },
    {
      "Legacy Store": "Not Mounted"
    },
    {
      "Peer Exchange": "Not Mounted"
    },
    {
      "Rendezvous": "Ready"
    }
  ]
}
```

## Issue
https://github.com/waku-org/nwaku/issues/3409

## More?

WDYT: can we add more sophisticated info about Store protocol? Can we add a way to check the underlying DB state?
Shall we consider Relay state for Filter also?
