### PR TITLE
feat: nix libwaku output package in .aar archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ coverage_html_report/
 .qmake.stash
 main-qt
 waku_handler.moc.cpp
+
+# Nix build result
+result

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
           src = self;
           targets = ["libwaku-android-arm64"]; 
           androidArch = "aarch64-linux-android";
+          abidir = "arm64-v8a";
           zerokitPkg = zerokit.packages.${system}.zerokit-android-arm64;
         };
         default = libwaku-android-arm64;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,6 +10,7 @@
     "x86_64-linux" "aarch64-linux"
   ],
   androidArch,
+  abidir,
   zerokitPkg,
 }:
 
@@ -32,6 +33,7 @@ in stdenv.mkDerivation rec {
   buildInputs = with pkgs; [
     openssl
     gmp
+    zip
   ];
 
   # Dependencies that should only exist in the build environment.
@@ -62,6 +64,7 @@ in stdenv.mkDerivation rec {
   ANDROID_NDK_HOME="${pkgs.androidPkgs.ndk}";
   NIMFLAGS = "-d:disableMarchNative -d:git_revision_override=${revision}";
   XDG_CACHE_HOME = "/tmp";
+  androidManifest = "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" package=\"com.example.mylibrary\" />";
 
   makeFlags = targets ++ [
     "V=${toString verbosity}"
@@ -98,8 +101,10 @@ in stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/build/android
-    cp -r ./build/android/* $out/build/android/
+    mkdir -p $out/jni
+    cp -r ./build/android/${abidir}/* $out/jni/
+    echo '${androidManifest}' > $out/jni/AndroidManifest.xml
+    cd $out && zip -r libwaku.aar *
   '';
 
   meta = with pkgs.lib; {


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
This change is only modifying the way libwaku is packaged for Android in the Nix flake. For us is beneficial so later on when we reference it in status-go and status-mobile it is already an `.aar` archive.
# Changes
- output format of the libwaku-android-arm64 nix package
<!-- List of detailed changes -->

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue 
https://github.com/waku-org/nwaku/issues/3232
closes #
-->