### PR TITLE
chore: supress debug for js-waku

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,6 @@ jobs:
     with:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node
-      debug: waku*
 
   js-waku-node-optional:
     needs: build-docker-image
@@ -155,7 +154,6 @@ jobs:
     with:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node-optional
-      debug: waku*
 
   lint:
     name: "Lint"


### PR DESCRIPTION
# Description
In `nwaku` repo `js-waku` interop pipeline is very noisy. 

# Changes
This PR removes debug parameter from interop pipeline as it is most likely not needed for `nwaku` team to investigate problems. And if it is the case interop should be run locally with appropriate debugging level. 

Example of a noisy pipeline: https://github.com/waku-org/nwaku/actions/runs/15188070450/job/42713899348?pr=3419
Resolves: https://github.com/waku-org/js-waku/issues/2388