### PR TITLE
fix: build_rln.sh simplify file name to download

### DIFF
--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -19,14 +19,7 @@ host_triplet=$(rustc --version --verbose | awk '/host:/{print $2}')
 
 tarball="${host_triplet}"
 
-# use arkzkey feature for v0.5.1
-# TODO: update this script in the future when arkzkey is default
-if [[ "${rln_version}" == "v0.5.1" ]]; then
-    tarball+="-arkzkey-rln.tar.gz"
-else
-    tarball+="-rln.tar.gz"
-fi
-
+tarball+="-rln.tar.gz"
 
 # Download the prebuilt rln library if it is available
 if curl --silent --fail-with-body -L \


### PR DESCRIPTION
## Description
This PR aims to fix the following compilation issue, detected in `status-go`'s CI pipeline:

It follows @darshankabariya 's suggestion, so kuddos to you :partying_face: 

```nim
error: failed to parse lock file at: /home/jenkins/workspace/o_prs_linux_x86_64_nwaku_PR-6454/vendor/github.com/waku-org/waku-go-bindings/third_party/nwaku/vendor/zerokit/Cargo.lock

Caused by:

lock file version 4 requires `-Znext-lockfile-bump`

make[2]: *** [Makefile:177: librln_v0.7.0.a] Error 101
```

and

```nim
Building: librln_v0.7.0.a
Failed to download x86_64-unknown-linux-gnu-rln.tar.gz
```

## Issue

- https://github.com/waku-org/nwaku/issues/3236
