### PR TITLE
chore: CHANGELOG add lightpush v3 in v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the one that is passed through this CLI: `--rln-relay-tree-path`.
 
 ### Features
 * lightpush v3 ([#3279](https://github.com/waku-org/nwaku/pull/3279)) ([e0b563ff](https://github.com/waku-org/nwaku/commit/e0b563ffe5af20bd26d37cd9b4eb9ed9eb82ff80))
+  Upgrade for Waku Llightpush protocol with enhanced error handling. Read specification [here](https://github.com/waku-org/specs/blob/master/standards/core/lightpush.md)
 
 This release supports the following [libp2p protocols](https://docs.libp2p.io/concepts/protocols/):
 | Protocol | Spec status | Protocol id |


### PR DESCRIPTION
# Description
We missed to properly add lightpush v3 information in our CHANGELOG
(I will update the _GitHub_ release once this is merged.)

