### PR TITLE
chore: don't return error on double relay subscription/unsubscription

### DIFF
--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -631,7 +631,7 @@ suite "WakuNode - Relay":
     # Stop all nodes
     await allFutures(nodes.mapIt(it.stop()))
 
-  asyncTest "Only one subscription is allowed for contenttopics that generate the same shard":
+  asyncTest "Multiple subscription calls are allowed for contenttopics that generate the same shard":
     ## Setup
     let
       nodeKey = generateSecp256k1Key()
@@ -663,12 +663,12 @@ suite "WakuNode - Relay":
     ## When
     node.subscribe((kind: ContentSub, topic: contentTopicA), some(handler)).isOkOr:
       assert false, "Failed to subscribe to topic: " & $error
-    node.subscribe((kind: ContentSub, topic: contentTopicB), some(handler)).isErrOr:
+    node.subscribe((kind: ContentSub, topic: contentTopicB), some(handler)).isOkOr:
       assert false,
-        "The subscription should fail because is already subscribe to that shard"
-    node.subscribe((kind: ContentSub, topic: contentTopicC), some(handler)).isErrOr:
+        "The subscription call shouldn't error even though it's already subscribed to that shard"
+    node.subscribe((kind: ContentSub, topic: contentTopicC), some(handler)).isOkOr:
       assert false,
-        "The subscription should fail because is already subscribe to that shard"
+        "The subscription call shouldn't error even though it's already subscribed to that shard"
 
     ## Then
     node.unsubscribe((kind: ContentUnsub, topic: contentTopicB)).isOkOr:

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -323,7 +323,7 @@ proc subscribe*(
       return err("Unsupported subscription type in relay subscribe")
 
   if node.wakuRelay.isSubscribed(pubsubTopic):
-    warn "already subscribed to topic", pubsubTopic
+    warn "No-effect API call to subscribe. Already subscribed to topic", pubsubTopic
     return ok()
 
   if contentTopicOp.isSome() and node.contentTopicHandlers.hasKey(contentTopicOp.get()):

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -323,8 +323,8 @@ proc subscribe*(
       return err("Unsupported subscription type in relay subscribe")
 
   if node.wakuRelay.isSubscribed(pubsubTopic):
-    debug "already subscribed to topic", pubsubTopic
-    return err("Already subscribed to topic: " & $pubsubTopic)
+    warn "already subscribed to topic", pubsubTopic
+    return ok()
 
   if contentTopicOp.isSome() and node.contentTopicHandlers.hasKey(contentTopicOp.get()):
     error "Invalid API call to `subscribe`. Was already subscribed"

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -364,7 +364,7 @@ proc unsubscribe*(
       return err("Unsupported subscription type in relay unsubscribe")
 
   if not node.wakuRelay.isSubscribed(pubsubTopic):
-    warn "Call to `unsubscribe` for when not subscribed to topic", pubsubTopic
+    warn "Invalid API call to `unsubscribe`. Was not subscribed", pubsubTopic
     return ok()
 
   if contentTopicOp.isSome():

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -364,9 +364,8 @@ proc unsubscribe*(
       return err("Unsupported subscription type in relay unsubscribe")
 
   if not node.wakuRelay.isSubscribed(pubsubTopic):
-    error "Invalid API call to `unsubscribe`. Was not subscribed", pubsubTopic
-    return
-      err("Invalid API call to `unsubscribe`. Was not subscribed to: " & $pubsubTopic)
+    warn "Call to `unsubscribe` for when not subscribed to topic", pubsubTopic
+    return ok()
 
   if contentTopicOp.isSome():
     # Remove this handler only

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -364,7 +364,7 @@ proc unsubscribe*(
       return err("Unsupported subscription type in relay unsubscribe")
 
   if not node.wakuRelay.isSubscribed(pubsubTopic):
-    warn "Invalid API call to `unsubscribe`. Was not subscribed", pubsubTopic
+    warn "No-effect API call to `unsubscribe`. Was not subscribed", pubsubTopic
     return ok()
 
   if contentTopicOp.isSome():

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -327,7 +327,7 @@ proc subscribe*(
     return ok()
 
   if contentTopicOp.isSome() and node.contentTopicHandlers.hasKey(contentTopicOp.get()):
-    warn "Invalid API call to `subscribe`. Was already subscribed"
+    warn "No-effect API call to `subscribe`. Was already subscribed"
     return ok()
 
   node.topicSubscriptionQueue.emit((kind: PubsubSub, topic: pubsubTopic))

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -364,8 +364,9 @@ proc unsubscribe*(
       return err("Unsupported subscription type in relay unsubscribe")
 
   if not node.wakuRelay.isSubscribed(pubsubTopic):
-    warn "Call to `unsubscribe` for when not subscribed to topic", pubsubTopic
-    return ok()
+    error "Invalid API call to `unsubscribe`. Was not subscribed", pubsubTopic
+    return
+      err("Invalid API call to `unsubscribe`. Was not subscribed to: " & $pubsubTopic)
 
   if contentTopicOp.isSome():
     # Remove this handler only

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -327,8 +327,8 @@ proc subscribe*(
     return ok()
 
   if contentTopicOp.isSome() and node.contentTopicHandlers.hasKey(contentTopicOp.get()):
-    error "Invalid API call to `subscribe`. Was already subscribed"
-    return err("Invalid API call to `subscribe`. Was already subscribed")
+    warn "Invalid API call to `subscribe`. Was already subscribed"
+    return ok()
 
   node.topicSubscriptionQueue.emit((kind: PubsubSub, topic: pubsubTopic))
   node.registerRelayDefaultHandler(pubsubTopic)


### PR DESCRIPTION
# Description
When a node attempts to subscribe to a shard it's already subscribed, we shouldn't return an error and just "ignore" the request.

# Changes

<!-- List of detailed changes -->

- [x] returning `ok` when a node attempts to subscribe an already subscribed shard
- [x] returning `ok` when a node attempts to unsubscribe from a not-subscribed shard
- [x] updating test


## Issue
closes #3414 