### PR TITLE
test: testing rln with rest

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -411,7 +411,8 @@ method generateProof*(
     nullifier: nullifier,
   )
 
-  debug "Proof generated successfully"
+  debug "--------- Proof generated successfully ---------",
+    epoch = epoch, rlnIdentifier = rlnIdentifier
 
   waku_rln_remaining_proofs_per_epoch.dec()
   waku_rln_total_generated_proofs.inc()


### PR DESCRIPTION
This is solely for testing RLN using the REST API via nwaku-compose. It is not intended for review or merging.