### PR TITLE
chore: bump nph and nitpick change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,6 @@ jobs:
 
     secrets: inherit
 
-
   js-waku-node:
     needs: build-docker-image
     uses: waku-org/js-waku/.github/workflows/test-node.yml@master


### PR DESCRIPTION
## Description
Simple PR to update `nph` to latest `master`.

@waku-org/nwaku make sure you recompile `nph` with:
1. rm the current nph binary
2. make build-nph

offtopic - I'm also removing extra line ( nitpick change .) in ci.yml