### PR TITLE
fix: typo from `DIRVER` to `DRIVER`

### DIFF
--- a/waku/waku_archive/common.nim
+++ b/waku/waku_archive/common.nim
@@ -44,7 +44,7 @@ type
 proc `$`*(err: ArchiveError): string =
   case err.kind
   of ArchiveErrorKind.DRIVER_ERROR:
-    "DIRVER_ERROR: " & err.cause
+    "DRIVER_ERROR: " & err.cause
   of ArchiveErrorKind.INVALID_QUERY:
     "INVALID_QUERY: " & err.cause
   of ArchiveErrorKind.UNKNOWN:

--- a/waku/waku_archive_legacy/common.nim
+++ b/waku/waku_archive_legacy/common.nim
@@ -78,7 +78,7 @@ type
 proc `$`*(err: ArchiveError): string =
   case err.kind
   of ArchiveErrorKind.DRIVER_ERROR:
-    "DIRVER_ERROR: " & err.cause
+    "DRIVER_ERROR: " & err.cause
   of ArchiveErrorKind.INVALID_QUERY:
     "INVALID_QUERY: " & err.cause
   of ArchiveErrorKind.UNKNOWN:


### PR DESCRIPTION
# Description
This PR changes the word `DIRVER` to `DRIVER` 
