### PR TITLE
chore: Added extra debug helper via getting peer statistics

### DIFF
--- a/waku/waku_api/rest/admin/client.nim
+++ b/waku/waku_api/rest/admin/client.nim
@@ -62,6 +62,10 @@ proc getMeshPeersByShard*(
   rest, endpoint: "/admin/v1/peers/mesh/on/{shardId}", meth: HttpMethod.MethodGet
 .}
 
+proc getPeersStats*(): RestResponse[PeerStats] {.
+  rest, endpoint: "/admin/v1/peers/stats", meth: HttpMethod.MethodGet
+.}
+
 proc getFilterSubscriptions*(): RestResponse[seq[FilterSubscription]] {.
   rest, endpoint: "/admin/v1/filter/subscriptions", meth: HttpMethod.MethodGet
 .}

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -31,6 +31,8 @@ export types
 logScope:
   topics = "waku node rest admin api"
 
+const ROUTE_ADMIN_V1_PEERS_STATS* = "/admin/v1/peers/stats" # provides peer statistics
+
 const ROUTE_ADMIN_V1_PEERS* = "/admin/v1/peers" # returns all peers
 const ROUTE_ADMIN_V1_SINGLE_PEER* = "/admin/v1/peer/{peerId}"
 
@@ -93,6 +95,40 @@ proc populateAdminPeerInfoForCodecs(node: WakuNode, codecs: seq[string]): WakuPe
     populateAdminPeerInfo(peers, node, some(codec))
 
   return peers
+
+proc getRelayPeers(node: WakuNode): PeersOfShards =
+  var relayPeers: PeersOfShards = @[]
+  if not node.wakuRelay.isNil():
+    for topic in node.wakuRelay.getSubscribedTopics():
+      let relayShard = RelayShard.parse(topic).valueOr:
+        error "Invalid subscribed topic", error = error, topic = topic
+        continue
+      let pubsubPeers =
+        node.wakuRelay.getConnectedPubSubPeers(topic).get(initHashSet[PubSubPeer](0))
+      relayPeers.add(
+        PeersOfShard(
+          shard: relayShard.shardId,
+          peers: toSeq(pubsubPeers).mapIt(WakuPeer.init(it, node.peerManager)),
+        )
+      )
+  return relayPeers
+
+proc getMeshPeers(node: WakuNode): PeersOfShards =
+  var meshPeers: PeersOfShards = @[]
+  if not node.wakuRelay.isNil():
+    for topic in node.wakuRelay.getSubscribedTopics():
+      let relayShard = RelayShard.parse(topic).valueOr:
+        error "Invalid subscribed topic", error = error, topic = topic
+        continue
+      let peers =
+        node.wakuRelay.getPubSubPeersInMesh(topic).get(initHashSet[PubSubPeer](0))
+      meshPeers.add(
+        PeersOfShard(
+          shard: relayShard.shardId,
+          peers: toSeq(peers).mapIt(WakuPeer.init(it, node.peerManager)),
+        )
+      )
+  return meshPeers
 
 proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
   router.api(MethodGet, ROUTE_ADMIN_V1_PEERS) do() -> RestApiResponse:
@@ -185,19 +221,7 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
         "Error: Relay Protocol is not mounted to the node"
       )
 
-    var relayPeers: PeersOfShards = @[]
-    for topic in node.wakuRelay.getSubscribedTopics():
-      let relayShard = RelayShard.parse(topic).valueOr:
-        error "Invalid subscribed topic", error = error, topic = topic
-        continue
-      let pubsubPeers =
-        node.wakuRelay.getConnectedPubSubPeers(topic).get(initHashSet[PubSubPeer](0))
-      relayPeers.add(
-        PeersOfShard(
-          shard: relayShard.shardId,
-          peers: toSeq(pubsubPeers).mapIt(WakuPeer.init(it, node.peerManager)),
-        )
-      )
+    var relayPeers: PeersOfShards = getRelayPeers(node)
 
     let resp = RestApiResponse.jsonResponse(relayPeers, status = Http200).valueOr:
       error "An error occurred while building the json response: ", error = error
@@ -240,21 +264,9 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
         "Error: Relay Protocol is not mounted to the node"
       )
 
-    var relayPeers: PeersOfShards = @[]
-    for topic in node.wakuRelay.getSubscribedTopics():
-      let relayShard = RelayShard.parse(topic).valueOr:
-        error "Invalid subscribed topic", error = error, topic = topic
-        continue
-      let peers =
-        node.wakuRelay.getPubSubPeersInMesh(topic).get(initHashSet[PubSubPeer](0))
-      relayPeers.add(
-        PeersOfShard(
-          shard: relayShard.shardId,
-          peers: toSeq(peers).mapIt(WakuPeer.init(it, node.peerManager)),
-        )
-      )
+    var meshPeers: PeersOfShards = getMeshPeers(node)
 
-    let resp = RestApiResponse.jsonResponse(relayPeers, status = Http200).valueOr:
+    let resp = RestApiResponse.jsonResponse(meshPeers, status = Http200).valueOr:
       error "An error occurred while building the json response: ", error = error
       return RestApiResponse.internalServerError(
         fmt("An error occurred while building the json response: {error}")
@@ -282,6 +294,74 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
     )
 
     let resp = RestApiResponse.jsonResponse(relayPeer, status = Http200).valueOr:
+      error "An error occurred while building the json response: ", error = error
+      return RestApiResponse.internalServerError(
+        fmt("An error occurred while building the json response: {error}")
+      )
+
+    return resp
+
+  router.api(MethodGet, ROUTE_ADMIN_V1_PEERS_STATS) do() -> RestApiResponse:
+    let peers = populateAdminPeerInfoForAll(node)
+
+    var stats: PeerStats = initOrderedTable[string, OrderedTable[string, int]]()
+
+    stats["Sum"] = {"Total peers": peers.len()}.toOrderedTable()
+
+    # stats of connectedness
+    var connectednessStats = initOrderedTable[string, int]()
+    connectednessStats[$Connectedness.Connected] =
+      peers.countIt(it.connected == Connectedness.Connected)
+    connectednessStats[$Connectedness.NotConnected] =
+      peers.countIt(it.connected == Connectedness.NotConnected)
+    connectednessStats[$Connectedness.CannotConnect] =
+      peers.countIt(it.connected == Connectedness.CannotConnect)
+    connectednessStats[$Connectedness.CanConnect] =
+      peers.countIt(it.connected == Connectedness.CanConnect)
+    stats["By Connectedness"] = connectednessStats
+
+    # stats of relay peers
+    var totalRelayPeers = 0
+    stats["Relay peers"] = block:
+      let relayPeers = getRelayPeers(node)
+      var stat = initOrderedTable[string, int]()
+      for ps in relayPeers:
+        totalRelayPeers += ps.peers.len()
+        stat[$ps.shard] = ps.peers.len()
+      stat["Total relay peers"] = relayPeers.len()
+      stat
+
+    # stats of mesh peers
+    stats["Mesh peers"] = block:
+      let meshPeers = getMeshPeers(node)
+      var totalMeshPeers = 0
+      var stat = initOrderedTable[string, int]()
+      for ps in meshPeers:
+        totalMeshPeers += ps.peers.len()
+        stat[$ps.shard] = ps.peers.len()
+      stat["Total mesh peers"] = meshPeers.len()
+      stat
+
+    var protoStats = initOrderedTable[string, int]()
+    protoStats["relay"] = peers.countIt(it.protocols.contains(WakuRelayCodec))
+    protoStats["filter"] =
+      peers.countIt(it.protocols.contains(WakuFilterSubscribeCodec))
+    protoStats["filter-client"] =
+      peers.countIt(it.protocols.contains(WakuFilterPushCodec))
+    protoStats["store"] = peers.countIt(it.protocols.contains(WakuStoreCodec))
+    protoStats["legacy_store"] =
+      peers.countIt(it.protocols.contains(WakuLegacyStoreCodec))
+    protoStats["lightpush"] = peers.countIt(it.protocols.contains(WakuLightPushCodec))
+    protoStats["legacy_lightpush"] =
+      peers.countIt(it.protocols.contains(WakuLegacyLightPushCodec))
+    protoStats["peer_exchange"] =
+      peers.countIt(it.protocols.contains(WakuPeerExchangeCodec))
+    protoStats["reconciliation"] =
+      peers.countIt(it.protocols.contains(WakuReconciliationCodec))
+
+    stats["By Protocols"] = protoStats
+
+    let resp = RestApiResponse.jsonResponse(stats, status = Http200).valueOr:
       error "An error occurred while building the json response: ", error = error
       return RestApiResponse.internalServerError(
         fmt("An error occurred while building the json response: {error}")


### PR DESCRIPTION
# Description
I really missed a detailed peer statistics while debugging node connectivity recently.
It's really hard to get clear summary with using `/admin/v1/peers/...` endpoints as they return an extensive amount of information.
I decided to add it to `/admin/va/peers/stats` endpoint quickly. I hope you find it useful too!

# Changes

Added `/admin/v1/peers/stats` that summarizes all the information can come out from the`admin/v1/peers/...` endpoints.

Result looks like this:

```
{
	"Sum": {
		"Total peers": 9
	},
	"By Connectedness": {
		"Connected": 6,
		"NotConnected": 0,
		"CannotConnect": 3,
		"CanConnect": 0
	},
	"Relay peers": {
		"0": 6,
		"1": 6,
		"5": 6,
		"4": 6,
		"6": 6,
		"3": 6,
		"7": 6,
		"2": 6,
		"Total relay peers": 8
	},
	"Mesh peers": {
		"0": 4,
		"1": 4,
		"5": 4,
		"4": 4,
		"6": 4,
		"3": 4,
		"7": 4,
		"2": 4,
		"Total mesh peers": 8
	},
	"By Protocols": {
		"relay": 9,
		"filter": 9,
		"filter-client": 2,
		"store": 9,
		"legacy_store": 6,
		"lightpush": 7,
		"legacy_lightpush": 6,
		"peer_exchange": 1,
		"reconciliation": 1
	}
}
```