### PR TITLE
chore: rest-relay-cache-capacity 

### DIFF
--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -503,7 +503,7 @@ with the drawback of consuming some more bandwidth.""",
 
     restRelayCacheCapacity* {.
       desc: "Capacity of the Relay REST API message cache.",
-      defaultValue: 30,
+      defaultValue: 50,
       name: "rest-relay-cache-capacity"
     .}: uint32
 

--- a/waku/waku_api/rest/builder.nim
+++ b/waku/waku_api/rest/builder.nim
@@ -139,8 +139,7 @@ proc startRestServerProtocolSupport*(
   if relayEnabled:
     ## This MessageCache is used, f.e., in js-waku<>nwaku interop tests.
     ## js-waku tests asks nwaku-docker through REST whether a message is properly received.
-    const RestRelayCacheCapacity = 50
-    let cache = MessageCache.init(int(RestRelayCacheCapacity))
+    let cache = MessageCache.init(int(conf.relayCacheCapacity))
 
     let handler: WakuRelayHandler = messageCacheHandler(cache)
 


### PR DESCRIPTION
This is a small PR to eliminate hard-coded values for rest-relay-cache-capacity.

close #3444