### PR TITLE
fix: dnsName servers is not properly set to waku node

### DIFF
--- a/waku/factory/conf_builder/dns_discovery_conf_builder.nim
+++ b/waku/factory/conf_builder/dns_discovery_conf_builder.nim
@@ -21,6 +21,9 @@ proc withEnabled*(b: var DnsDiscoveryConfBuilder, enabled: bool) =
 proc withEnrTreeUrl*(b: var DnsDiscoveryConfBuilder, enrTreeUrl: string) =
   b.enrTreeUrl = some(enrTreeUrl)
 
+proc withNameServers*(b: var DnsDiscoveryConfBuilder, nameServers: seq[IpAddress]) =
+  b.nameServers = nameServers
+
 proc build*(b: DnsDiscoveryConfBuilder): Result[Option[DnsDiscoveryConf], string] =
   if not b.enabled.get(false):
     return ok(none(DnsDiscoveryConf))

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -1005,6 +1005,7 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
 
   b.dnsDiscoveryConf.withEnabled(n.dnsDiscovery)
   b.dnsDiscoveryConf.withEnrTreeUrl(n.dnsDiscoveryUrl)
+  b.dnsDiscoveryConf.withNameServers(n.dnsAddrsNameServers)
 
   if n.discv5Discovery.isSome():
     b.discv5Conf.withEnabled(n.discv5Discovery.get())


### PR DESCRIPTION
## Description

The `wakunode2` could not properly start because the dns servers list was not passed properly
We avoid the issue discovered by @siddarthkay and mentioned in:

- https://github.com/status-im/infra-role-nim-waku/pull/40#issuecomment-2969029505

## Issue

- https://github.com/waku-org/nwaku/issues/3236
