### PR TITLE
fix: fix failed sync test

### DIFF
--- a/tests/waku_store_sync/test_protocol.nim
+++ b/tests/waku_store_sync/test_protocol.nim
@@ -410,7 +410,7 @@ suite "Waku Sync: reconciliation":
       diffInWin = 20
       diffOutWin = 20
       stepOutNs = 100_000_000'u64
-      outOffsetNs = 2_000_000_000'u64 # for 20 mesg they sent 2 seconds earlier 
+      outOffsetNs = 2_300_000_000'u64 # for 20 mesg they sent 2 seconds earlier 
 
     randomize()
 


### PR DESCRIPTION
# Changes

for test "sync 2 nodes, 40 msgs: 20 in-window diff, 20 out-window ignored"

the offset between in-window and out-window needed to be increased with 300ms to avoid any overlapping between the 2 ranges 