### PR TITLE
fix: libwaku.so compilation

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -70,7 +70,7 @@ proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
       ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
       extra_params & " " & srcDir & name & ".nim"
   else:
-    let lib_name = (when defined(windows): toDll(name) else: name & ".so" )
+    let lib_name = (when defined(windows): toDll(name) else: name & ".so")
     when defined(windows):
       exec "nim c" & " --out:build/" & lib_name &
         " --threads:on --app:lib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:off -d:discv5_protocol_id=d5waku " &

--- a/waku.nimble
+++ b/waku.nimble
@@ -70,15 +70,12 @@ proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
       ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
       extra_params & " " & srcDir & name & ".nim"
   else:
-    var lib_name = toDll("libwaku")
+    var lib_name = name & ".so"
     when defined(windows):
-      exec "nim c" & " --out:build/" & lib_name &
-        " --threads:on --app:lib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-        extra_params & " " & srcDir & name & ".nim"
-    else:
-      exec "nim c" & " --out:build/" & lib_name &
-        " --threads:on --app:lib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
-        extra_params & " " & srcDir & name & ".nim"
+      lib_name = toDll(name)      
+    exec "nim c" & " --out:build/" & lib_name &
+      " --threads:on --app:lib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
+      extra_params & " " & srcDir & name & ".nim"
 
 proc buildMobileAndroid(srcDir = ".", params = "") =
   let cpu = getEnv("CPU")

--- a/waku.nimble
+++ b/waku.nimble
@@ -71,9 +71,14 @@ proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
       extra_params & " " & srcDir & name & ".nim"
   else:
     let lib_name = (when defined(windows): toDll(name) else: name & ".so" )
-    exec "nim c" & " --out:build/" & lib_name &
-      " --threads:on --app:lib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      extra_params & " " & srcDir & name & ".nim"
+    when defined(windows):
+      exec "nim c" & " --out:build/" & lib_name &
+        " --threads:on --app:lib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
+        extra_params & " " & srcDir & name & ".nim"
+    else:
+      exec "nim c" & " --out:build/" & lib_name &
+        " --threads:on --app:lib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
+        extra_params & " " & srcDir & name & ".nim"
 
 proc buildMobileAndroid(srcDir = ".", params = "") =
   let cpu = getEnv("CPU")

--- a/waku.nimble
+++ b/waku.nimble
@@ -70,9 +70,7 @@ proc buildLibrary(name: string, srcDir = "./", params = "", `type` = "static") =
       ".a --threads:on --app:staticlib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
       extra_params & " " & srcDir & name & ".nim"
   else:
-    var lib_name = name & ".so"
-    when defined(windows):
-      lib_name = toDll(name)      
+    let lib_name = (when defined(windows): toDll(name) else: name & ".so" )
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:lib --opt:size --noMain --mm:refc --header -d:metrics --nimMainPrefix:libwaku --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
       extra_params & " " & srcDir & name & ".nim"


### PR DESCRIPTION
# Description
Fixing library name for non-windows builds. Without this fix, we get `liblibwaku.so` as output


## Issue

#3236 