### PR TITLE
fix: correct legacy lightpush handling request log

### DIFF
--- a/waku/waku_lightpush_legacy/protocol.nim
+++ b/waku/waku_lightpush_legacy/protocol.nim
@@ -45,7 +45,8 @@ proc handleRequest*(
     let msg_hash = pubsubTopic.computeMessageHash(message).to0xHex()
     waku_lightpush_messages.inc(labelValues = ["PushRequest"])
 
-    notice "handling lightpush request",
+    notice "handling legacy lightpush request",
+      my_peer_id = wl.peerManager.switch.peerInfo.peerId,
       peer_id = peerId,
       requestId = requestId,
       pubsubTopic = pubsubTopic,


### PR DESCRIPTION
# Description
DST team needs unintentionally removed my_peer_id back for legacy-lightpush for their analysis tool
This was change unfortunately while implementing lightush v3 (which inherited the correct log btw)

## Issue

https://github.com/waku-org/nwaku/issues/3236