### PR TITLE
fix: removing keepAlive from WakuConf

### DIFF
--- a/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/waku/factory/conf_builder/waku_conf_builder.nim
@@ -121,7 +121,6 @@ type WakuConfBuilder* = object
   relayShardedPeerManagement: Option[bool]
   relayServiceRatio: Option[string]
   circuitRelayClient: Option[bool]
-  keepAlive: Option[bool]
   p2pReliability: Option[bool]
 
 proc init*(T: type WakuConfBuilder): WakuConfBuilder =
@@ -622,7 +621,6 @@ proc build*(
     relayServiceRatio: builder.relayServiceRatio.get("60:40"),
     rateLimits: rateLimits,
     circuitRelayClient: builder.circuitRelayClient.get(false),
-    keepAlive: builder.keepAlive.get(true),
     staticNodes: builder.staticNodes,
     relayShardedPeerManagement: relayShardedPeerManagement,
     p2pReliability: builder.p2pReliability.get(false),

--- a/waku/factory/waku_conf.nim
+++ b/waku/factory/waku_conf.nim
@@ -83,7 +83,6 @@ type WakuConf* {.requiresInit.} = ref object
   relayPeerExchange*: bool
   rendezvous*: bool
   circuitRelayClient*: bool
-  keepAlive*: bool
 
   discv5Conf*: Option[Discv5Conf]
   dnsDiscoveryConf*: Option[DnsDiscoveryConf]


### PR DESCRIPTION
# Description
In https://github.com/waku-org/nwaku/pull/3458 I forgot to remove `keepAlive` from `WakuConf`, fixing it now.

Thanks @fryorcraken for noticing it!


## Issue

#3236 
