### PR TITLE
chore: don't support legacy store by default

### DIFF
--- a/waku/factory/conf_builder/store_service_conf_builder.nim
+++ b/waku/factory/conf_builder/store_service_conf_builder.nim
@@ -64,7 +64,7 @@ proc build*(b: StoreServiceConfBuilder): Result[Option[StoreServiceConf], string
         dbMigration: b.dbMigration.get(true),
         dbURl: b.dbUrl.get(),
         dbVacuum: b.dbVacuum.get(false),
-        supportV2: b.supportV2.get(true),
+        supportV2: b.supportV2.get(false),
         maxNumDbConnections: b.maxNumDbConnections.get(50),
         retentionPolicy: b.retentionPolicy.get("time:" & $2.days.seconds),
         resume: b.resume.get(false),

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -351,7 +351,7 @@ hence would have reachability issues.""",
 
     legacyStore* {.
       desc: "Enable/disable support of Waku Store v2 as a service",
-      defaultValue: true,
+      defaultValue: false,
       name: "legacy-store"
     .}: bool
 


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->

Disabling legacy store by default. Our current default of sqlite+legacy is broken and we've decided not to invest much in that combination as both are about to be removed.

We should have both store and legacy store removed by default, and the node operator should explicitly set them to true if they want any of those protocols to be supported.


# Changes

<!-- List of detailed changes -->

- [x] disabling legacy store by default

## Issue

closes #3479 
