### PR TITLE
fix: static sharding setup

### DIFF
--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -127,8 +127,12 @@ proc setupAppCallbacks(
     if node.wakuRelay.isNil():
       return err("Cannot configure relayHandler callback without Relay mounted")
 
-    let autoShards = node.getAutoshards(conf.contentTopics).valueOr:
-      return err("Could not get autoshards: " & error)
+    let autoShards =
+      if node.wakuAutoSharding.isSome():
+        node.getAutoshards(conf.contentTopics).valueOr:
+          return err("Could not get autoshards: " & error)
+      else:
+        @[]
 
     let confShards = conf.subscribeShards.mapIt(
       RelayShard(clusterId: conf.clusterId, shardId: uint16(it))


### PR DESCRIPTION
# Description
When setting up the Relay libwaku callback when a node is using static sharding, node setup fails with

```
Could not get autoshards: Static sharding used, cannot get shards from content topics
```

Adding a fix so we don't attempt to get shards from content topics if autosharding isn't enabled

Thanks @fryorcraken for the fix!

# Changes

<!-- List of detailed changes -->

- [x] don't resolve autoshards when setting app callbacks if autosharding isn't enabled

## Issue

#3483 
