### PR TITLE
fix: single test build of waku_relay 

### DIFF
--- a/tests/waku_store/store_utils.nim
+++ b/tests/waku_store/store_utils.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import std/options, chronos
+import std/options, chronos, chronicles
 
 import
   waku/[node/peer_manager, waku_store, waku_store/client], ../testlib/[common, wakucore]


### PR DESCRIPTION
# Description
make -j10 test/tests/waku_relay/test_all.nim failed due to shadowed import of chronicles

## How to test

1. make test/tests/waku_relay/test_all.nim

## Issue

closes #
https://github.com/waku-org/nwaku/issues/3473