### PR TITLE
chore: wait before starting watchdog

### DIFF
--- a/library/waku_context.nim
+++ b/library/waku_context.nim
@@ -118,8 +118,12 @@ proc watchdogThreadBody(ctx: ptr WakuContext) {.thread.} =
   ## Watchdog thread that monitors the Waku thread and notifies the library user if it hangs.
 
   let watchdogRun = proc(ctx: ptr WakuContext) {.async.} =
+    const WatchdogStartDelay = 10.seconds
     const WatchdogTimeinterval = 1.seconds
     const WakuNotRespondingTimeout = 3.seconds
+
+    # Give time for the node to be created and up before sending watchdog requests
+    await sleepAsync(WatchdogStartDelay)
     while true:
       await sleepAsync(WatchdogTimeinterval)
 


### PR DESCRIPTION
# Description
Wait before starting watchdog so we doesn't send requests while the node is getting created. Notice that the watchdog thread gets created in the same libwaku proc than the one that creates the node, so it shouldn't happen that the node isn't created after this 10 second wait.

# Changes

<!-- List of detailed changes -->

- [x] wait 10 seconds from node creation call to start watchdog


## Issue

#3483 
