### PR TITLE
fix: rest fix for sync protocol

### DIFF
--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -239,6 +239,14 @@ proc setupProtocols(
         )
       ).isOkOr:
         return err("failed to mount waku store sync protocol: " & $error)
+      
+      if conf.remoteStoreNode.isSome():
+        let storeNode = parsePeerInfo(conf.remoteStoreNode.get())
+        if storeNode.isOk():
+          node.peerManager.addServicePeer(storeNode.value, WakuReconciliationCodec)
+          node.peerManager.addServicePeer(storeNode.value, WakuTransferCodec)
+        else:
+          return err("failed to set node waku store-sync peer: " & storeNode.error)
 
   mountStoreClient(node)
   if conf.remoteStoreNode.isSome():

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -241,12 +241,11 @@ proc setupProtocols(
         return err("failed to mount waku store sync protocol: " & $error)
 
       if conf.remoteStoreNode.isSome():
-        let storeNode = parsePeerInfo(conf.remoteStoreNode.get())
-        if storeNode.isOk():
-          node.peerManager.addServicePeer(storeNode.value, WakuReconciliationCodec)
-          node.peerManager.addServicePeer(storeNode.value, WakuTransferCodec)
-        else:
-          return err("failed to set node waku store-sync peer: " & storeNode.error)
+        let storeNode = parsePeerInfo(conf.remoteStoreNode.get()).valueOr:
+          return err("failed to set node waku store-sync peer: " & error)
+
+        node.peerManager.addServicePeer(storeNode, WakuReconciliationCodec)
+        node.peerManager.addServicePeer(storeNode, WakuTransferCodec)
 
   mountStoreClient(node)
   if conf.remoteStoreNode.isSome():

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -239,7 +239,7 @@ proc setupProtocols(
         )
       ).isOkOr:
         return err("failed to mount waku store sync protocol: " & $error)
-      
+
       if conf.remoteStoreNode.isSome():
         let storeNode = parsePeerInfo(conf.remoteStoreNode.get())
         if storeNode.isOk():

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -174,7 +174,7 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
       @[
         WakuRelayCodec, WakuFilterSubscribeCodec, WakuStoreCodec, WakuLegacyStoreCodec,
         WakuLegacyLightPushCodec, WakuLightPushCodec, WakuPeerExchangeCodec,
-        WakuReconciliationCodec,
+        WakuReconciliationCodec, WakuTransferCodec,
       ],
     )
 


### PR DESCRIPTION
Now the rest will see sync-related protocol also while facing details.

Close #3492

@SionoiS 

Test Instructions

1. Start two nodes:  [ Node 1: Should have store and store-sync protocols enable ] [Node 2: A standard relay-enabled node is sufficient]
2. Run nodes using the following commands: [ ./build/wakunode2 --config-file="../config/peer1.txt" ] [ ./build/wakunode2 --config-file="../config/peer2.txt" ] seperate terminal.
3. Ensure both nodes are connected via static node configuration.
4. Once connected, send a REST request from Node 2 to Node 1 to verify peer status: [curl -X GET "http://127.0.0.1:46422/admin/v1/peers" -H "accept: application/json" ]

Note :- 

Node 1 - configuration
nodekey = "6dcae22a737a01541b2852ebe5c5157f936042e79a7fcec87d5b1559701c0e7f"
staticnode = ["/ip4/127.0.0.1/tcp/64002/p2p/16Uiu2HAm1LDVFukcPVVFFcsxofX8HNnWZjELYb2UHFek1vf2z2GQ"]
tcp-port = 64000
max-connections = 20
log-level = "TRACE"
rest = true
rest-port = 46420
rest-admin = true
relay = true
filter = true
lightpush = true
rln-relay = false
store = true
store-sync = true
rln-relay-dynamic = false
rln-relay-user-message-limit = 100

Node 2 - configuration
nodekey = "554f13e4b8cdf48edd526249f92ee653df43939a713ce95b51b74b48283d0df6i"
staticnode = ["/ip4/127.0.0.1/tcp/64000/p2p/16Uiu2HAkzqu7KFZwt9zaNYXfAkyu4AkupthsjudW45NLPuQmqL8r"]
tcp-port = 64002
log-level = "TRACE"
max-connections = 20
rest = true
rest-port = 46422
rest-admin = true
metrics-server = true
relay = true
store-sync = false
filter = false
filternode = "/ip4/127.0.0.1/tcp/64000/p2p/16Uiu2HAkzqu7KFZwt9zaNYXfAkyu4AkupthsjudW45NLPuQmqL8r"

