### PR TITLE
chore: improve connection proc

### DIFF
--- a/library/waku_thread_requests/requests/peer_manager_request.nim
+++ b/library/waku_thread_requests/requests/peer_manager_request.nim
@@ -80,10 +80,9 @@ proc process*(
 
   case self.operation
   of CONNECT_TO:
-    let ret = waku.node.connectTo($self[].peerMultiAddr, self[].dialTimeout)
-    if ret.isErr():
-      error "CONNECT_TO failed", error = ret.error
-      return err(ret.error)
+    let peers = ($self[].peerMultiAddr).split(",").mapIt(strip(it))
+    await waku.node.connectToNodes(peers, source = "static")
+    return ok("")
   of GET_ALL_PEER_IDS:
     ## returns a comma-separated string of peerIDs
     let peerIDs =

--- a/library/waku_thread_requests/requests/peer_manager_request.nim
+++ b/library/waku_thread_requests/requests/peer_manager_request.nim
@@ -56,22 +56,6 @@ proc destroyShared(self: ptr PeerManagementRequest) =
 
   deallocShared(self)
 
-proc connectTo(
-    node: WakuNode, peerMultiAddr: string, dialTimeout: Duration
-): Result[void, string] =
-  let peers = (peerMultiAddr).split(",").mapIt(strip(it))
-
-  # TODO: the dialTimeout is not being used at all!
-  let connectFut = node.connectToNodes(peers, source = "static")
-  while not connectFut.finished():
-    poll()
-
-  if not connectFut.completed():
-    let msg = "Timeout expired."
-    return err(msg)
-
-  return ok()
-
 proc process*(
     self: ptr PeerManagementRequest, waku: Waku
 ): Future[Result[string, string]] {.async.} =

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -567,6 +567,9 @@ procSuite "Peer Manager":
     # Connect to relay peers
     await nodes[0].peerManager.connectToRelayPeers()
 
+    # wait for the connections to settle
+    await sleepAsync(chronos.milliseconds(500))
+
     check:
       # Peerstore track all three peers
       nodes[0].peerManager.switch.peerStore.peers().len == 3
@@ -636,6 +639,9 @@ procSuite "Peer Manager":
 
     # Connect to relay peers
     await nodes[0].peerManager.manageRelayPeers()
+
+    # wait for the connections to settle
+    await sleepAsync(chronos.milliseconds(500))
 
     check:
       # Peerstore track all three peers

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -372,14 +372,6 @@ proc connectToNodes*(
   info "Finished dialing multiple peers",
     successfulConns = connectedPeers.len, attempted = nodes.len
 
-  # The issue seems to be around peers not being fully connected when
-  # trying to subscribe. So what we do is sleep to guarantee nodes are
-  # fully connected.
-  #
-  # This issue was known to Dmitiry on nim-libp2p and may be resolvable
-  # later.
-  await sleepAsync(chronos.seconds(5))
-
 proc disconnectNode*(pm: PeerManager, peerId: PeerId) {.async.} =
   await pm.switch.disconnect(peerId)
 


### PR DESCRIPTION
# Description
Simplifying connection operation in libwaku and removing 5 second sleep in `connectToNodes`. If a sleep is needed, it's the responsibility of the caller to add it or to check if their node is connected.

Note: if tests fail because of removing this sleep, will add the sleep to the tests

# Changes

<!-- List of detailed changes -->

- [x] simplifying libwaku's `CONNECT_TO` operation
- [x] removing timeout in `connectToNodes`


## Issue

- #3483 
