### PR TITLE
chore: test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,15 +53,17 @@ endif
 # default target, because it's the first one that doesn't start with '.'
 all: | wakunode2 example2 chat2 chat2bridge libwaku
 
-TEST_FILE := $(word 2,$(MAKECMDGOALS))
-TEST_NAME := $(wordlist 3,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+test_file := $(word 2,$(MAKECMDGOALS))
+define test_name
+$(shell echo '$(MAKECMDGOALS)' | cut -d' ' -f3-)
+endef
 
 test:
-ifeq ($(strip $(TEST_FILE)),)
+ifeq ($(strip $(test_file)),)
 	$(MAKE) testcommon
 	$(MAKE) testwaku
 else
-	$(MAKE) compile-test $(TEST_FILE) $(TEST_NAME)
+	$(MAKE) compile-test TEST_FILE="$(test_file)" TEST_NAME="$(call test_name)"
 endif
 # this prevents make from erroring on unknown targets like "Index"
 %:


### PR DESCRIPTION
Found a bug during testing: if the test name contains any special characters, it doesn’t match correctly.  
<img width="1223" height="114" alt="Screenshot 2025-07-16 at 15 07 10" src="https://github.com/user-attachments/assets/7fb717ef-0376-47cd-adde-1bfc19d75a28" />
