### PR TITLE
chore: mark keep-alive as deprecated

### DIFF
--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -314,6 +314,12 @@ hence would have reachability issues.""",
       name: "staticnode"
     .}: seq[string]
 
+    keepAlive* {.
+      desc: "Deprecated since >=v0.37. This param is ignored and keep alive is always active",
+      defaultValue: true,
+      name: "keep-alive"
+    .}: bool
+
     numShardsInNetwork* {.
       desc:
         "Enables autosharding and set number of shards in the cluster, set to `0` to use static sharding",


### PR DESCRIPTION
## Description
Simple PR to mark the `keep-alive` as deprecated and not break the current possible use of it