### PR TITLE
fix: tests using fetchMerkleRoot

### DIFF
--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -135,7 +135,7 @@ suite "Onchain group manager":
     (waitFor manager.init()).isOkOr:
       raiseAssert $error
 
-    let merkleRootBefore = manager.fetchMerkleRoot()
+    let merkleRootBefore = waitFor manager.fetchMerkleRoot()
 
     try:
       waitFor manager.register(credentials, UserMessageLimit(20))
@@ -144,7 +144,7 @@ suite "Onchain group manager":
 
     discard waitFor withTimeout(trackRootChanges(manager), 15.seconds)
 
-    let merkleRootAfter = manager.fetchMerkleRoot()
+    let merkleRootAfter = waitFor manager.fetchMerkleRoot()
 
     let metadataSetRes = manager.setMetadata()
     assert metadataSetRes.isOk(), metadataSetRes.error
@@ -170,7 +170,7 @@ suite "Onchain group manager":
     (waitFor manager.init()).isOkOr:
       raiseAssert $error
 
-    let merkleRootBefore = manager.fetchMerkleRoot()
+    let merkleRootBefore = waitFor manager.fetchMerkleRoot()
 
     try:
       for i in 0 ..< credentials.len():
@@ -180,7 +180,7 @@ suite "Onchain group manager":
     except Exception, CatchableError:
       assert false, "exception raised: " & getCurrentExceptionMsg()
 
-    let merkleRootAfter = manager.fetchMerkleRoot()
+    let merkleRootAfter = waitFor manager.fetchMerkleRoot()
 
     check:
       merkleRootBefore != merkleRootAfter
@@ -205,20 +205,16 @@ suite "Onchain group manager":
     (waitFor manager.init()).isOkOr:
       raiseAssert $error
 
-    let idCommitment = generateCredentials(manager.rlnInstance).idCommitment
-    let merkleRootBefore = manager.fetchMerkleRoot()
+    let idCredentials = generateCredentials(manager.rlnInstance)
+    let merkleRootBefore = waitFor manager.fetchMerkleRoot()
 
     try:
-      waitFor manager.register(
-        RateCommitment(
-          idCommitment: idCommitment, userMessageLimit: UserMessageLimit(20)
-        )
-      )
+      waitFor manager.register(idCredentials, UserMessageLimit(20))
     except Exception, CatchableError:
       assert false,
         "exception raised when calling register: " & getCurrentExceptionMsg()
 
-    let merkleRootAfter = manager.fetchMerkleRoot()
+    let merkleRootAfter = waitFor manager.fetchMerkleRoot()
 
     check:
       merkleRootAfter != merkleRootBefore

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -315,7 +315,8 @@ hence would have reachability issues.""",
     .}: seq[string]
 
     keepAlive* {.
-      desc: "Deprecated since >=v0.37. This param is ignored and keep alive is always active",
+      desc:
+        "Deprecated since >=v0.37. This param is ignored and keep alive is always active",
       defaultValue: true,
       name: "keep-alive"
     .}: bool


### PR DESCRIPTION
# Description
During RLN related updates some functionality was changed and it is now needed to add a `waitFor` when calling the `fetchMerkleRoot` function, because it returns a `Future`.

This fix is needed for 1 test passing without actually doing anything. (`register: should register successfully`) 
In this test the `waku/waku_rln_relay/group_manager/on_chain/group_manager.nim` `register` function being called was:
```
method register*(
    g: OnchainGroupManager, rateCommitment: RateCommitment
): Future[void] {.async: (raises: [Exception]).} =
```
but this if statement was never true:
```
 if g.registerCb.isSome():
```

Other tests also needed updates, but were running and passing properly. (`trackRootChanges: should sync to the state of the group` and `trackRootChanges: should fetch history correctly`)



# Changes

`tests/waku_rln_relay/test_rln_group_manager_onchain.nim`
Add wairFor and use normal register function that does not use thecallback.


## How to test

1. run test file `test_rln_group_manager_onchain.nim`


