### PR TITLE
Update networks_config.nim

### DIFF
--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -65,7 +65,7 @@ proc validateShards*(
     for shard in shards:
       if shard >= numShardsInCluster:
         let msg =
-          "validateShards invalid shard: " & $shard & " when numShardsInCluster: " &
+          "validateShards invalid shard: " & $shard & " when num-shards-in-network: " &
           $numShardsInCluster
         error "validateShards failed", error = msg
         return err(msg)


### PR DESCRIPTION
## Description

When incorrect sharding config is passed, the following message can appear:

```nim
ERR 2025-07-18 10:20:44.808+02:00 validateShards failed                      topics="waku networks conf" tid=17834 file=networks_config.nim:70 error="validateShards invalid shard: 32 when numShardsInCluster: 1"
ERR 2025-07-18 10:20:44.808+02:00 Waku configuration failed                  topics="wakunode main" tid=17834 file=wakunode2.nim:56 error="validateShards invalid shard: 32 when numShardsInCluster: 1
```

This aims to reflect the exact paramater that needs to be properly configured

## Issue

- https://github.com/waku-org/nwaku/issues/3483