### PR TITLE
chore: avoid too large log lines in rest lightpush

### DIFF
--- a/waku/waku_api/rest/lightpush/handlers.nim
+++ b/waku/waku_api/rest/lightpush/handlers.nim
@@ -66,7 +66,8 @@ proc installLightPushRequestHandler*(
     contentBody: Option[ContentBody]
   ) -> RestApiResponse:
     ## Send a request to push a waku message
-    debug "post", ROUTE_LIGHTPUSH, contentBody
+    debug "post received", ROUTE_LIGHTPUSH
+    trace "content body", ROUTE_LIGHTPUSH, contentBody
 
     let req: PushRequest = decodeRequestBody[PushRequest](contentBody).valueOr:
       return


### PR DESCRIPTION
## Description

Simple PR to avoid extremely large log lines in REST lightpush, and only leaving in `trace` log level in case needed for debugging this particular feature.

## Issue

- https://github.com/waku-org/nwaku/issues/3483
