### PR TITLE
feat: shard-specific metrics tracking

### DIFF
--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -236,10 +236,12 @@ proc findRandomPeers*(
   for record in discoveredRecords:
     let typedRecord = record.toTyped().valueOr:
       # If we can't parse the record, skip it
+      waku_discv5_errors.inc(labelValues = ["ParseFailure"])
       continue
 
     let relayShards = typedRecord.relaySharding().valueOr:
       # If no relay sharding info, skip it
+      waku_discv5_errors.inc(labelValues = ["NoShardInfo"])
       continue
 
     for shardId in relayShards.shardIds:

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -34,6 +34,8 @@ declarePublicGauge waku_peers_errors, "Number of peer manager errors", ["type"]
 declarePublicGauge waku_connected_peers,
   "Number of physical connections per direction and protocol",
   labels = ["direction", "protocol"]
+declarePublicGauge waku_connected_peers_per_shard,
+  "Number of physical connections per shard", labels = ["shard"]
 declarePublicGauge waku_streams_peers,
   "Number of streams per direction and protocol", labels = ["direction", "protocol"]
 declarePublicGauge waku_peer_store_size, "Number of peers managed by the peer store"
@@ -776,6 +778,16 @@ proc logAndMetrics(pm: PeerManager) {.async.} =
       )
       waku_streams_peers.set(
         protoStreamsOut.float64, labelValues = [$Direction.Out, proto]
+      )
+
+    for shard in pm.wakuMetadata.shards.items:
+      waku_connected_peers_per_shard.set(0.0, labelValues = [$shard])
+
+    for shard in pm.wakuMetadata.shards.items:
+      let connectedPeers =
+        peerStore.getPeersByShard(uint16(pm.wakuMetadata.clusterId), uint16(shard))
+      waku_connected_peers_per_shard.set(
+        connectedPeers.len.float64, labelValues = [$shard]
       )
 
 proc getOnlineStateObserver*(pm: PeerManager): OnOnlineStateChange =

--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -119,6 +119,11 @@ proc handleMessage*(
   let insertDuration = getTime().toUnixFloat() - insertStartTime
   waku_archive_insert_duration_seconds.observe(insertDuration)
 
+  let shard = RelayShard.parseStaticSharding(pubsubTopic).valueOr:
+    DefaultRelayShard
+
+  waku_archive_messages_per_shard.inc(labelValues = [$shard.shardId])
+
   trace "message archived",
     msg_hash = msgHashHex,
     pubsubTopic = pubsubTopic,

--- a/waku/waku_archive/archive_metrics.nim
+++ b/waku/waku_archive/archive_metrics.nim
@@ -3,6 +3,8 @@
 import metrics
 
 declarePublicGauge waku_archive_messages, "number of historical messages", ["type"]
+declarePublicGauge waku_archive_messages_per_shard,
+  "number of historical messages per shard ", ["shard"]
 declarePublicGauge waku_archive_errors, "number of store protocol errors", ["type"]
 declarePublicGauge waku_archive_queries, "number of store queries received"
 declarePublicHistogram waku_archive_insert_duration_seconds,

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -221,8 +221,8 @@ proc logMessageInfo*(
   debug "------ message metrics -------",
     topic = topic,
     msg_id = msg_id_short,
-    payloadSizeBytes = payloadSize
-    msgCountPerShard = msgCountPerShard[topic]
+    payloadSizeBytes = payloadSize,
+    msgCountPerShard = msgCountPerShard[topic],
     msgSizeSumPerShard = msgSizeSumPerShard[topic]
 
   try:

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -213,8 +213,14 @@ proc logMessageInfo*(
       payloadSizeBytes = payloadSize
 
   try:
+    if not msgCountPerShard.hasKey(topic):
+      msgCountPerShard[topic] = 0
+    if not msgSizeSumPerShard.hasKey(topic):
+      msgSizeSumPerShard[topic] = 0
+
     msgCountPerShard[topic] += 1
     msgSizeSumPerShard[topic] += payloadSize
+
   except KeyError:
     warn "Error updating message metrics", error = getCurrentExceptionMsg()
 

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -225,13 +225,9 @@ proc logMessageInfo*(
   shardMetrics.avgSize = shardMetrics.sizeSum / shardMetrics.count
   msgMetricsPerShard[topic] = shardMetrics
 
-  waku_relay_max_msg_bytes_per_shard.set(
-    shardMetrics.maxSize, labelValues = [topic]
-  )
+  waku_relay_max_msg_bytes_per_shard.set(shardMetrics.maxSize, labelValues = [topic])
 
-  waku_relay_avg_msg_bytes_per_shard.set(
-    shardMetrics.avgSize, labelValues = [topic]
-  )
+  waku_relay_avg_msg_bytes_per_shard.set(shardMetrics.avgSize, labelValues = [topic])
 
 proc initRelayObservers(w: WakuRelay) =
   proc decodeRpcMessageInfo(

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -233,15 +233,6 @@ proc logMessageInfo*(
     shardMetrics.avgSize, labelValues = [topic]
   )
 
-  debug "------ message metrics -------",
-    topic = topic,
-    msg_id = msg_id_short,
-    payloadSizeBytes = payloadSize,
-    msgCountPerShard = shardMetrics.count,
-    msgSizeSumPerShard = shardMetrics.sizeSum,
-    msgAvgSizePerShard = shardMetrics.avgSize,
-    msgMaxSizePerShard = shardMetrics.maxSize
-
 proc initRelayObservers(w: WakuRelay) =
   proc decodeRpcMessageInfo(
       peer: PubSubPeer, msg: Message

--- a/waku/waku_rln_relay/protocol_metrics.nim
+++ b/waku/waku_rln_relay/protocol_metrics.nim
@@ -17,8 +17,9 @@ func generateBucketsForHistogram*(length: int): seq[float64] =
   return buckets
 
 declarePublicCounter(
-  waku_rln_messages_total, "number of messages published on the rln content topic"
+  waku_rln_messages_total, "number of messages seen by the rln relay"
 )
+
 declarePublicCounter(waku_rln_spam_messages_total, "number of spam messages detected")
 declarePublicCounter(
   waku_rln_invalid_messages_total, "number of invalid messages detected", ["type"]

--- a/waku/waku_store/client.nim
+++ b/waku/waku_store/client.nim
@@ -7,6 +7,8 @@ import
 logScope:
   topics = "waku store client"
 
+var storeMsgMetricsPerShard {.global, threadvar.}: Table[string, float64]
+
 const DefaultPageSize*: uint = 20
   # A recommended default number of waku messages per page
 
@@ -45,6 +47,16 @@ proc sendStoreRequest(
   if res.statusCode != uint32(StatusCode.SUCCESS):
     waku_store_errors.inc(labelValues = [NoSuccessStatusCode])
     return err(StoreError.new(res.statusCode, res.statusDesc))
+
+  let topic = req.pubsubTopic.get()
+  if not storeMsgMetricsPerShard.hasKey(topic):
+    storeMsgMetricsPerShard[topic] = 0
+  storeMsgMetricsPerShard[topic] += float64(req.encode().buffer.len)
+
+  waku_relay_fleet_store_msg_size_bytes.inc(
+    storeMsgMetricsPerShard[topic], labelValues = [topic]
+  )
+  waku_relay_fleet_store_msg_count.inc(1.0, labelValues = [topic])
 
   return ok(res)
 

--- a/waku/waku_store/client.nim
+++ b/waku/waku_store/client.nim
@@ -48,15 +48,16 @@ proc sendStoreRequest(
     waku_store_errors.inc(labelValues = [NoSuccessStatusCode])
     return err(StoreError.new(res.statusCode, res.statusDesc))
 
-  let topic = req.pubsubTopic.get()
-  if not storeMsgMetricsPerShard.hasKey(topic):
-    storeMsgMetricsPerShard[topic] = 0
-  storeMsgMetricsPerShard[topic] += float64(req.encode().buffer.len)
+  if req.pubsubTopic.isSome():
+    let topic = req.pubsubTopic.get()
+    if not storeMsgMetricsPerShard.hasKey(topic):
+      storeMsgMetricsPerShard[    topic] = 0
+    storeMsgMetricsPerShard[topic] += float64(req.encode().buffer.len)
 
-  waku_relay_fleet_store_msg_size_bytes.inc(
-    storeMsgMetricsPerShard[topic], labelValues = [topic]
-  )
-  waku_relay_fleet_store_msg_count.inc(1.0, labelValues = [topic])
+    waku_relay_fleet_store_msg_size_bytes.inc(
+      storeMsgMetricsPerShard[topic], labelValues = [topic]
+    )
+    waku_relay_fleet_store_msg_count.inc(1.0, labelValues = [topic])
 
   return ok(res)
 

--- a/waku/waku_store/client.nim
+++ b/waku/waku_store/client.nim
@@ -51,7 +51,7 @@ proc sendStoreRequest(
   if req.pubsubTopic.isSome():
     let topic = req.pubsubTopic.get()
     if not storeMsgMetricsPerShard.hasKey(topic):
-      storeMsgMetricsPerShard[    topic] = 0
+      storeMsgMetricsPerShard[topic] = 0
     storeMsgMetricsPerShard[topic] += float64(req.encode().buffer.len)
 
     waku_relay_fleet_store_msg_size_bytes.inc(

--- a/waku/waku_store/protocol_metrics.nim
+++ b/waku/waku_store/protocol_metrics.nim
@@ -10,6 +10,18 @@ declarePublicGauge waku_store_queries, "number of store queries received"
 declarePublicGauge waku_store_time_seconds,
   "Time in seconds spent by each store phase", labels = ["phase"]
 
+declarePublicGauge(
+  waku_relay_fleet_store_msg_size_bytes,
+  "Total size of messages stored by fleet store nodes per shard",
+  labels = ["shard"],
+)
+
+declarePublicGauge(
+  waku_relay_fleet_store_msg_count,
+  "Number of messages stored by fleet store nodes per shard",
+  labels = ["shard"],
+)
+
 # Error types (metric label values)
 const
   DialFailure* = "dial_failure"


### PR DESCRIPTION
## Description
As discussed in #3306, I’ve introduced 7 new metrics, listed below:

# metrics name - grafana panal name 
1. waku_discv5_discovered_per_shard – [ Discv5 discovered peers per shard ]
2. waku_connected_peers_per_shard – [ Connected peers per shard ]
3. waku_archive_messages_per_shard – [ Archived messages per shard ]
4. waku_relay_max_msg_bytes_per_shard – [ Maximum message size per shard ]
5. waku_relay_avg_msg_bytes_per_shard – [ Average message size per shard ]
6. waku_relay_fleet_store_msg_size_bytes – [ Total message size in the store fleet ]
7. waku_relay_fleet_store_msg_count – [ Total message count in the store fleet ]

I’ve also raised a PR to add a new panel for these metrics:
🔗 https://github.com/waku-org/nwaku-compose/pull/165 

I’ve tested everything to the best of my knowledge. Let me know if you notice any issues with the visualizations or metric propagation.

@apentori @fryorcraken @Ivansete-status

## Issue

closes #3306