### PR TITLE
chore: Adapt heaptrack support builds and description to latest nim 2.2.4 compiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2
 ARG NIM_COMMIT
 ARG LOG_LEVEL=TRACE
+ARG HEAPTRACK_BUILD=0
 
 # Get build tools and required header files
 RUN apk add --no-cache bash git build-base openssl-dev pcre-dev linux-headers curl jq
@@ -17,6 +18,10 @@ RUN apk update && apk upgrade
 
 # Ran separately from 'make' to avoid re-doing
 RUN git submodule update --init --recursive
+
+RUN if [ "$HEAPTRACK_BUILD" = "1" ]; then \
+      git apply --directory=vendor/nimbus-build-system/vendor/Nim docs/tutorial/nim.2.2.4_heaptracker_addon.patch; \
+    fi
 
 # Slowest build step for the sake of caching layers
 RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1 ${NIM_COMMIT}

--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,8 @@ NIM_PARAMS := $(NIM_PARAMS) -d:git_version=\"$(GIT_VERSION)\"
 HEAPTRACKER ?= 0
 HEAPTRACKER_INJECT ?= 0
 ifeq ($(HEAPTRACKER), 1)
-# Needed to make nimbus-build-system use the Nim's 'heaptrack_support' branch
-DOCKER_NIM_COMMIT := NIM_COMMIT=heaptrack_support_v2.0.12
+# Assumes Nim's lib/system/alloc.nim is patched!
 TARGET := debug-with-heaptrack
-NIM_COMMIT := heaptrack_support_v2.0.12
 
 ifeq ($(HEAPTRACKER_INJECT), 1)
 # the Nim compiler will load 'libheaptrack_inject.so'
@@ -349,6 +347,7 @@ docker-image:
 		--build-arg="NIMFLAGS=$(DOCKER_IMAGE_NIMFLAGS)" \
 		--build-arg="NIM_COMMIT=$(DOCKER_NIM_COMMIT)" \
 		--build-arg="LOG_LEVEL=$(LOG_LEVEL)" \
+		--build-arg="HEAPTRACK_BUILD=$(HEAPTRACKER)" \
 		--label="commit=$(shell git rev-parse HEAD)" \
 		--label="version=$(GIT_VERSION)" \
 		--target $(TARGET) \
@@ -357,6 +356,7 @@ docker-image:
 docker-quick-image: MAKE_TARGET ?= wakunode2
 docker-quick-image: DOCKER_IMAGE_TAG ?= $(MAKE_TARGET)-$(GIT_VERSION)
 docker-quick-image: DOCKER_IMAGE_NAME ?= wakuorg/nwaku:$(DOCKER_IMAGE_TAG)
+docker-quick-image: NIM_PARAMS := $(NIM_PARAMS) -d:chronicles_colors:none -d:insecure -d:postgres --passL:$(LIBRLN_FILE) --passL:-lm
 docker-quick-image: | build deps librln wakunode2
 	docker build \
 		--build-arg="MAKE_TARGET=$(MAKE_TARGET)" \

--- a/docs/tutorial/heaptrack.md
+++ b/docs/tutorial/heaptrack.md
@@ -88,7 +88,7 @@ That will create a Docker image with both nwaku and heaptrack. The container's e
 
 #### Notice for using heaptrack supporting image with `docker compose`
 
-Take case of the wakunode2 should started as
+Take care that wakunode2 should be started as
 ```
 exec /heaptrack/build/bin/heaptrack /usr/bin/wakunode\
 ... all the arguments you want to pass to wakunode ...
@@ -112,4 +112,3 @@ You should be able to see memory allocations. It is important
 to see a legend like shown below:
 
 ![Example of a good heaptrack report](imgs/good_heaptrack_report_example.png)
-sudo make docker-image DOCKER_IMAGE_NAME=docker_repo:docker_tag HEAPTRACKER=1

--- a/docs/tutorial/heaptrack.md
+++ b/docs/tutorial/heaptrack.md
@@ -33,29 +33,29 @@ It operates in two modes:
    - `sudo apt install libkf5kio-dev`
    - `sudo apt install libkf5iconthemes-dev`
 - `make`
-- On completion, the `bin/heaptrack_gui` and `bin/heaptrack` binaries will get generated.
+- On completion, the `bin/heaptrack_gui` and `bin/heaptrack` binaries will be generated.
     - heaptrack: needed to generate the report.
     - heaptrack_gui: needed to analyse the report.
 
 ## Heaptrack & Nwaku
-nwaku supports heaptrack but it needs a special compilation setting.
+nwaku supports heaptrack, but it needs a special compilation setting.
 
 ### Patch Nim compiler to register allocations on Heaptrack
 
-Currently we are rely on official Nim repository. So we need to patch the Nim compiler to register allocations and deallocations on Heaptrack.
-For Nim 2.2.4 version we created a patch that can be applied as:
+Currently, we rely on the official Nim repository. So we need to patch the Nim compiler to register allocations and deallocations on Heaptrack.
+For Nim 2.2.4 version, we created a patch that can be applied as:
 ```bash
 git apply --directory=vendor/nimbus-build-system/vendor/Nim docs/tutorial/nim.2.2.4_heaptracker_addon.patch
 git add .
 git commit -m "Add heaptrack support to Nim compiler - temporary patch"
 ```
 
-> We are never going to merge this patch into the official Nim repository, so it is important to keep it in the `nimbus-build-system` repository.
+> Until heaptrack support is not available in official Nim, so it is important to keep it in the `nimbus-build-system` repository.
 > Commit ensures that `make update` will not override the patch unintentionally.
 
-> We are planning to make it avail through an official PR for Nim.
+> We are planning to make it available through an official PR for Nim.
 
-When the patch is applied we can build wakunode2 with heaptrack support.
+When the patch is applied, we can build wakunode2 with heaptrack support.
 
 ### Build nwaku with heaptrack support
 

--- a/docs/tutorial/nim.2.2.4_heaptracker_addon.patch
+++ b/docs/tutorial/nim.2.2.4_heaptracker_addon.patch
@@ -1,0 +1,44 @@
+diff --git a/lib/system/alloc.nim b/lib/system/alloc.nim
+index e2dd43075..7f8c8e04e 100644
+--- a/lib/system/alloc.nim
++++ b/lib/system/alloc.nim
+@@ -1,4 +1,4 @@
+-#
++#!fmt: off
+ #
+ #            Nim's Runtime Library
+ #        (c) Copyright 2012 Andreas Rumpf
+@@ -862,6 +862,15 @@ when defined(gcDestructors):
+       dec maxIters
+       if it == nil: break
+ 
++when defined(heaptracker):
++  const heaptrackLib =
++    when defined(heaptracker_inject):
++      "libheaptrack_inject.so"
++    else:
++      "libheaptrack_preload.so"
++  proc heaptrack_malloc(a: pointer, size: int) {.cdecl, importc, dynlib: heaptrackLib.}
++  proc heaptrack_free(a: pointer) {.cdecl, importc, dynlib: heaptrackLib.}
++
+ proc rawAlloc(a: var MemRegion, requestedSize: int): pointer =
+   when defined(nimTypeNames):
+     inc(a.allocCounter)
+@@ -984,6 +993,8 @@ proc rawAlloc(a: var MemRegion, requestedSize: int): pointer =
+   sysAssert(isAccessible(a, result), "rawAlloc 14")
+   sysAssert(allocInv(a), "rawAlloc: end")
+   when logAlloc: cprintf("var pointer_%p = alloc(%ld) # %p\n", result, requestedSize, addr a)
++  when defined(heaptracker):
++    heaptrack_malloc(result, requestedSize)
+ 
+ proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
+   result = rawAlloc(a, requestedSize)
+@@ -992,6 +1003,8 @@ proc rawAlloc0(a: var MemRegion, requestedSize: int): pointer =
+ proc rawDealloc(a: var MemRegion, p: pointer) =
+   when defined(nimTypeNames):
+     inc(a.deallocCounter)
++  when defined(heaptracker):
++    heaptrack_free(p)
+   #sysAssert(isAllocatedPtr(a, p), "rawDealloc: no allocated pointer")
+   sysAssert(allocInv(a), "rawDealloc: begin")
+   var c = pageAddr(p)


### PR DESCRIPTION
# Description

With the latest nimbus-build-system we started using along with Nim 2.2.4
The breaking change coming with nimbus-build-system is that we moved away Status's fork of Nim but now use the main repository, thus we can not push our patched branch.

# Changes

To circumvent the new situation with patching Nim:

- added patch file that can be easily used to make Nim core library heaptrack supporting.
- Updated heatrack.md description
- Updated Dockerfile to apply the patch on the fly when needed.
- Updated Makefile: removed un-necessary NIM_COMMIT and adapted arguments for docker builds.

# How to test

- checkout nwaku
- issue `make HEAPTRACKER=1 docker-image` or `make HEAPTRACKER=1 docker-quick-image`
- run as described in heaptracker.md document

# issue
- https://github.com/waku-org/nwaku/issues/3483
