### PR TITLE
chore: peer-exchange client separation

### DIFF
--- a/tests/node/test_wakunode_peer_exchange.nim
+++ b/tests/node/test_wakunode_peer_exchange.nim
@@ -78,11 +78,11 @@ suite "Waku Peer Exchange":
       check:
         node.peerManager.switch.peerStore.peers.len == 0
         res.error.status_code == SERVICE_UNAVAILABLE
-        res.error.status_desc == some("PeerExchange is not mounted")
+        res.error.status_desc == some("PeerExchangeClient is not mounted")
 
     asyncTest "Node fetches with mounted peer exchange, but no peers":
       # Given a node with peer exchange mounted
-      await node.mountPeerExchange()
+      await node.mountPeerExchangeClient()
 
       # When a node fetches peers
       let res = await node.fetchPeerExchangePeers(1)
@@ -95,7 +95,7 @@ suite "Waku Peer Exchange":
 
     asyncTest "Node succesfully exchanges px peers with faked discv5":
       # Given both nodes mount peer exchange
-      await allFutures([node.mountPeerExchange(), node2.mountPeerExchange()])
+      await allFutures([node.mountPeerExchangeClient(), node2.mountPeerExchange()])
       check node.peerManager.switch.peerStore.peers.len == 0
 
       # Mock that we discovered a node (to avoid running discv5)
@@ -271,6 +271,7 @@ suite "Waku Peer Exchange with discv5":
     # Mount peer exchange
     await node1.mountPeerExchange()
     await node3.mountPeerExchange()
+    await node3.mountPeerExchangeClient()
 
     let dialResponse =
       await node3.dialForPeerExchange(node1.switch.peerInfo.toRemotePeerInfo())

--- a/tests/waku_peer_exchange/utils.nim
+++ b/tests/waku_peer_exchange/utils.nim
@@ -17,6 +17,7 @@ import
     waku_peer_exchange,
     waku_peer_exchange/rpc,
     waku_peer_exchange/protocol,
+    waku_peer_exchange/client,
     node/peer_manager,
     waku_core,
   ],
@@ -40,7 +41,8 @@ proc dialForPeerExchange*(
     require connOpt.isSome()
     await sleepAsync(FUTURE_TIMEOUT_SHORT)
 
-    let response = await client.wakuPeerExchange.request(requestedPeers, connOpt.get())
+    let response =
+      await client.wakuPeerExchangeClient.request(requestedPeers, connOpt.get())
     assertResultOk(response)
 
     if uint64(response.get().peerInfos.len) > minimumPeers:

--- a/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/waku/factory/conf_builder/waku_conf_builder.nim
@@ -615,8 +615,10 @@ proc build*(
     protectedShards: protectedShards,
     relay: relay,
     lightPush: lightPush,
-    peerExchange: peerExchange,
+    peerExchangeService: peerExchange,
     rendezvous: rendezvous,
+    peerExchangeDiscovery: true,
+      # enabling peer exchange client by default for quicker bootstrapping
     remoteStoreNode: builder.remoteStoreNode,
     remoteLightPushNode: builder.remoteLightPushNode,
     remoteFilterNode: builder.remoteFilterNode,

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -411,7 +411,7 @@ proc setupProtocols(
       return err("failed to set node waku filter peer: " & filterNode.error)
 
   # waku peer exchange setup
-  if conf.peerExchange:
+  if conf.peerExchangeService:
     try:
       await mountPeerExchange(
         node, some(conf.clusterId), node.rateLimitSettings.getSetting(PEEREXCHG)
@@ -428,6 +428,8 @@ proc setupProtocols(
       return
         err("failed to set node waku peer-exchange peer: " & peerExchangeNode.error)
 
+  if conf.peerExchangeDiscovery:
+    await node.mountPeerExchangeClient()
   return ok()
 
 ## Start node
@@ -472,7 +474,7 @@ proc startNode*(
   # 
   # Use px to periodically get peers if discv5 is disabled, as discv5 nodes have their own
   # periodic loop to find peers and px returned peers actually come from discv5
-  if conf.peerExchange and not conf.discv5Conf.isSome():
+  if conf.peerExchangeDiscovery and not conf.discv5Conf.isSome():
     node.startPeerExchangeLoop()
 
   # Maintain relay connections

--- a/waku/factory/waku_conf.nim
+++ b/waku/factory/waku_conf.nim
@@ -85,7 +85,8 @@ type WakuConf* {.requiresInit.} = ref object
 
   relay*: bool
   lightPush*: bool
-  peerExchange*: bool
+  peerExchangeService*: bool
+  peerExchangeDiscovery*: bool
 
   # TODO: remove relay peer exchange
   relayPeerExchange*: bool
@@ -145,7 +146,7 @@ proc logConf*(conf: WakuConf) =
     store = conf.storeServiceConf.isSome(),
     filter = conf.filterServiceConf.isSome(),
     lightPush = conf.lightPush,
-    peerExchange = conf.peerExchange
+    peerExchange = conf.peerExchangeService
 
   info "Configuration. Network", cluster = conf.clusterId
 

--- a/waku/waku_peer_exchange.nim
+++ b/waku/waku_peer_exchange.nim
@@ -1,5 +1,5 @@
 {.push raises: [].}
 
-import ./waku_peer_exchange/[protocol, rpc]
+import ./waku_peer_exchange/[protocol, rpc, common, client]
 
-export protocol, rpc
+export protocol, rpc, common, client

--- a/waku/waku_peer_exchange/client.nim
+++ b/waku/waku_peer_exchange/client.nim
@@ -1,0 +1,102 @@
+import std/options, results, chronicles, chronos, metrics
+
+import ./common, ./rpc, ./rpc_codec, ../node/peer_manager
+
+from ../waku_core/codecs import WakuPeerExchangeCodec
+
+declarePublicGauge waku_px_peers_received_total,
+  "number of ENRs received via peer exchange"
+declarePublicCounter waku_px_client_errors, "number of peer exchange errors", ["type"]
+
+logScope:
+  topics = "waku peer_exchange client"
+
+type WakuPeerExchangeClient* = ref object
+  peerManager*: PeerManager
+  pxLoopHandle*: Future[void]
+
+proc new*(T: type WakuPeerExchangeClient, peerManager: PeerManager): T =
+  WakuPeerExchangeClient(peerManager: peerManager)
+
+proc request*(
+    wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, conn: Connection
+): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
+  let rpc = PeerExchangeRpc.makeRequest(numPeers)
+
+  var buffer: seq[byte]
+  var callResult =
+    (status_code: PeerExchangeResponseStatusCode.SUCCESS, status_desc: none(string))
+  try:
+    await conn.writeLP(rpc.encode().buffer)
+    buffer = await conn.readLp(DefaultMaxRpcSize.int)
+  except CatchableError as exc:
+    error "exception when handling peer exchange request", error = exc.msg
+    waku_px_client_errors.inc(labelValues = ["error_sending_or_receiving_px_req"])
+    callResult = (
+      status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+      status_desc: some($exc.msg),
+    )
+  finally:
+    # close, no more data is expected
+    await conn.closeWithEof()
+
+  if callResult.status_code != PeerExchangeResponseStatusCode.SUCCESS:
+    error "peer exchange request failed", status_code = callResult.status_code
+    return err(callResult)
+
+  let decoded = PeerExchangeRpc.decode(buffer).valueOr:
+    error "peer exchange request error decoding buffer", error = $error
+    return err(
+      (
+        status_code: PeerExchangeResponseStatusCode.BAD_RESPONSE,
+        status_desc: some($error),
+      )
+    )
+  if decoded.response.status_code != PeerExchangeResponseStatusCode.SUCCESS:
+    error "peer exchange request error", status_code = decoded.response.status_code
+    return err(
+      (
+        status_code: decoded.response.status_code,
+        status_desc: decoded.response.status_desc,
+      )
+    )
+
+  return ok(decoded.response)
+
+proc request*(
+    wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, peer: RemotePeerInfo
+): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
+  try:
+    let connOpt = await wpx.peerManager.dialPeer(peer, WakuPeerExchangeCodec)
+    if connOpt.isNone():
+      error "error in request connOpt is none"
+      return err(
+        (
+          status_code: PeerExchangeResponseStatusCode.DIAL_FAILURE,
+          status_desc: some(dialFailure),
+        )
+      )
+    return await wpx.request(numPeers, connOpt.get())
+  except CatchableError:
+    error "peer exchange request exception", error = getCurrentExceptionMsg()
+    return err(
+      (
+        status_code: PeerExchangeResponseStatusCode.BAD_RESPONSE,
+        status_desc: some("exception dialing peer: " & getCurrentExceptionMsg()),
+      )
+    )
+
+proc request*(
+    wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq
+): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
+  let peerOpt = wpx.peerManager.selectPeer(WakuPeerExchangeCodec)
+  if peerOpt.isNone():
+    waku_px_client_errors.inc(labelValues = [peerNotFoundFailure])
+    error "peer exchange error peerOpt is none"
+    return err(
+      (
+        status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+        status_desc: some(peerNotFoundFailure),
+      )
+    )
+  return await wpx.request(numPeers, peerOpt.get())

--- a/waku/waku_peer_exchange/common.nim
+++ b/waku/waku_peer_exchange/common.nim
@@ -1,0 +1,21 @@
+import results, metrics, chronos
+import ./rpc, ../waku_core
+
+const
+  # We add a 64kB safety buffer for protocol overhead.
+  # 10x-multiplier also for safety
+  DefaultMaxRpcSize* = 10 * DefaultMaxWakuMessageSize + 64 * 1024
+    # TODO what is the expected size of a PX message? As currently specified, it can contain an arbitrary number of ENRs...
+  MaxPeersCacheSize* = 60
+  CacheRefreshInterval* = 10.minutes
+  DefaultPXNumPeersReq* = 5.uint64()
+
+# Error types (metric label values)
+const
+  dialFailure* = "dial_failure"
+  peerNotFoundFailure* = "peer_not_found_failure"
+  decodeRpcFailure* = "decode_rpc_failure"
+  retrievePeersDiscv5Error* = "retrieve_peers_discv5_failure"
+  pxFailure* = "px_failure"
+
+type WakuPeerExchangeResult*[T] = Result[T, PeerExchangeResponseStatus]


### PR DESCRIPTION
# Description
As of now peer-exchange implementation requires mounting of the peer-exchange protocol even if only the client side functionality is required. This PR address this and separates the implementation for client side and service side of the protocol.

Noticed while working on chat2 app for mix.
But opened the PR on master as this PR doesn't have dependency on any other PR.
<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->