### PR TITLE
fix: only stop health monitor components if not nil

### DIFF
--- a/waku/node/health_monitor/node_health_monitor.nim
+++ b/waku/node/health_monitor/node_health_monitor.nim
@@ -408,8 +408,11 @@ proc startHealthMonitor*(hm: NodeHealthMonitor): Result[void, string] =
   return ok()
 
 proc stopHealthMonitor*(hm: NodeHealthMonitor) {.async.} =
-  await hm.onlineMonitor.stopOnlineMonitor()
-  await hm.keepAliveFut.cancelAndWait()
+  if not hm.onlineMonitor.isNil():
+    await hm.onlineMonitor.stopOnlineMonitor()
+
+  if not hm.keepAliveFut.isNil():
+    await hm.keepAliveFut.cancelAndWait()
 
 proc new*(
     T: type NodeHealthMonitor,


### PR DESCRIPTION
# Description
Only stopping health monitor components that aren't nil

## Issue

#3483 