### PR TITLE
chore: Update RLN contract address to new one with restricted token minting

### DIFF
--- a/apps/sonda/docker-compose.yml
+++ b/apps/sonda/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging: &logging
 x-rln-relay-eth-client-address: &rln_relay_eth_client_address ${RLN_RELAY_ETH_CLIENT_ADDRESS:-} # Add your RLN_RELAY_ETH_CLIENT_ADDRESS after the "-"
 
 x-rln-environment: &rln_env
-  RLN_RELAY_CONTRACT_ADDRESS: ${RLN_RELAY_CONTRACT_ADDRESS:-0xB9cd878C90E49F797B4431fBF4fb333108CB90e6}
+  RLN_RELAY_CONTRACT_ADDRESS: ${RLN_RELAY_CONTRACT_ADDRESS:-0x313a4a4dcf95da8e020b5375c0f8f732b7b4f15b}
   RLN_RELAY_CRED_PATH: ${RLN_RELAY_CRED_PATH:-} # Optional: Add your RLN_RELAY_CRED_PATH after the "-"
   RLN_RELAY_CRED_PASSWORD: ${RLN_RELAY_CRED_PASSWORD:-} # Optional: Add your RLN_RELAY_CRED_PASSWORD after the "-"
 

--- a/apps/sonda/register_rln.sh
+++ b/apps/sonda/register_rln.sh
@@ -21,10 +21,10 @@ if test -n "${ETH_CLIENT_ADDRESS}"; then
   exit 1
 fi
 
-docker run -v $(pwd)/keystore:/keystore/:Z harbor.status.im/wakuorg/nwaku:v0.30.1 generateRlnKeystore \
+docker run -v $(pwd)/keystore:/keystore/:Z harbor.status.im/wakuorg/nwaku:v0.36.1 generateRlnKeystore \
 --rln-relay-eth-client-address=${RLN_RELAY_ETH_CLIENT_ADDRESS} \
 --rln-relay-eth-private-key=${ETH_TESTNET_KEY} \
---rln-relay-eth-contract-address=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6 \
+--rln-relay-eth-contract-address=0x313a4a4dcf95da8e020b5375c0f8f732b7b4f15b \
 --rln-relay-cred-path=/keystore/keystore.json \
 --rln-relay-cred-password="${RLN_RELAY_CRED_PASSWORD}" \
 --rln-relay-user-message-limit=20 \

--- a/tests/waku_rln_relay/utils_onchain.nim
+++ b/tests/waku_rln_relay/utils_onchain.nim
@@ -113,7 +113,7 @@ proc sendMintCall(
 
   # Create mint transaction
   # Method ID for mint(address,uint256) is 0x40c10f19 which is part of the openzeppelin ERC20 standard
-  # The method ID for a deployed test token can be viewed here https://sepolia.lineascan.build/address/0x185A0015aC462a0aECb81beCc0497b649a64B9ea#writeContract
+  # The method ID for a deployed test token can be viewed here https://sepolia.lineascan.build/address/0xd17e184e3c1941585a3edcb3a10367da6326d844#writeContract
   let mintSelector = "0x40c10f19"
   let addressHex = recipientAddress.toHex()
   # Pad the address and amount to 32 bytes each

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -35,7 +35,7 @@ proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
     maxMessageSize: "150KiB",
     clusterId: 1,
     rlnRelay: true,
-    rlnRelayEthContractAddress: "0xB9cd878C90E49F797B4431fBF4fb333108CB90e6",
+    rlnRelayEthContractAddress: "0x313a4a4dcf95da8e020b5375c0f8f732b7b4f15b",
     rlnRelayDynamic: true,
     rlnRelayChainId: RelayChainId,
     rlnEpochSizeSec: 600,


### PR DESCRIPTION
# Description
The WakuRlnV2 contract has been redeployed and the address needs to be updated.
The redeployment is required because the current contract has been spammed and there are no more memberships left.

# Changes

All instances of the old contract address have been replaced with the new one.


## How to test

1. Test with this PR image and nwaku-compose branch: https://github.com/waku-org/nwaku-compose/tree/update-to-contract-with-restricted-mint


