### PR TITLE
fix: apply modulus in sharding

### DIFF
--- a/waku/waku_core/topics/sharding.nim
+++ b/waku/waku_core/topics/sharding.nim
@@ -25,8 +25,7 @@ proc getGenZeroShard*(s: Sharding, topic: NsContentTopic, count: int): RelayShar
   # We only use the last 64 bits of the hash as having more shards is unlikely.
   let hashValue = uint64.fromBytesBE(hash.data[24 .. 31])
 
-  # This is equilavent to modulo shard count but faster
-  let shard = hashValue and uint64((count - 1))
+  let shard = hashValue mod uint64(count)
 
   RelayShard(clusterId: s.clusterId, shardId: uint16(shard))
 


### PR DESCRIPTION
## Description
It seems that the suggested operation is not equivalent for all cases.

For example, the following don't give the same results:
```nim
  echo "25 mod 7 == " & $(25.uint64 mod 7.uint64)
  echo "25 and (7 - 1) == " & $(25.uint64 and uint64(7 - 1))
```

## Issue

- https://github.com/waku-org/nwaku/issues/3483