### PR TITLE
fix: detach partition

### DIFF
--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1348,7 +1348,11 @@ proc removePartition(
     "ALTER TABLE messages DETACH PARTITION " & partitionName & " CONCURRENTLY;"
   debug "removeOldestPartition", query = detachPartitionQuery
   (await self.performWriteQuery(detachPartitionQuery)).isOkOr:
-    if ($error).contains("FINALIZE"):
+    debug "detected error when trying to detach partition",
+      query = detachPartitionFinalizeQuery
+
+    if ($error).contains("FINALIZE") or
+        ($error).contains("already pending detach in part"):
       ## We assume the database is suggesting to use FINALIZE when detaching a partition
       let detachPartitionFinalizeQuery =
         "ALTER TABLE messages DETACH PARTITION " & partitionName & " FINALIZE;"

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1348,8 +1348,7 @@ proc removePartition(
     "ALTER TABLE messages DETACH PARTITION " & partitionName & " CONCURRENTLY;"
   debug "removeOldestPartition", query = detachPartitionQuery
   (await self.performWriteQuery(detachPartitionQuery)).isOkOr:
-    debug "detected error when trying to detach partition",
-      query = detachPartitionFinalizeQuery
+    debug "detected error when trying to detach partition", error
 
     if ($error).contains("FINALIZE") or
         ($error).contains("already pending detach in part"):


### PR DESCRIPTION
## Description
The fleet nodes in waku.sandbox cannot properly reduce the database size. See the related issue for further details.

## Suggested solution
Consider another possible error from the database `already pending detach in part` for performing a `ALTER TABLE messages DETACH PARTITION ... FINALIZE;`

## Issue
closes https://github.com/waku-org/nwaku/issues/3534
