### PR TITLE
chore: do not mount lightpush without relay (fixes #2808)

### DIFF
--- a/tests/node/test_wakunode_sharding.nim
+++ b/tests/node/test_wakunode_sharding.nim
@@ -281,7 +281,7 @@ suite "Sharding":
       asyncTest "lightpush":
         # Given a connected server and client subscribed to the same pubsub topic
         client.mountLegacyLightPushClient()
-        await server.mountLightpush()
+        check (await server.mountLightpush()).isOk()
 
         let
           topic = "/waku/2/rs/0/1"
@@ -404,7 +404,7 @@ suite "Sharding":
       asyncTest "lightpush (automatic sharding filtering)":
         # Given a connected server and client using the same content topic (with two different formats)
         client.mountLegacyLightPushClient()
-        await server.mountLightpush()
+        check (await server.mountLightpush()).isOk()
 
         let
           contentTopicShort = "/toychat/2/huilong/proto"
@@ -562,7 +562,7 @@ suite "Sharding":
       asyncTest "lightpush - exclusion (automatic sharding filtering)":
         # Given a connected server and client using different content topics
         client.mountLegacyLightPushClient()
-        await server.mountLightpush()
+        check (await server.mountLightpush()).isOk()
 
         let
           contentTopic1 = "/toychat/2/huilong/proto"
@@ -873,7 +873,7 @@ suite "Sharding":
     asyncTest "Waku LightPush Sharding (Static Sharding)":
       # Given a connected server and client using two different pubsub topics
       client.mountLegacyLightPushClient()
-      await server.mountLightpush()
+      check (await server.mountLightpush()).isOk()
 
       # Given a connected server and client subscribed to multiple pubsub topics
       let

--- a/tests/wakunode_rest/test_rest_lightpush.nim
+++ b/tests/wakunode_rest/test_rest_lightpush.nim
@@ -61,7 +61,7 @@ proc init(
     assert false, "Failed to mount relay: " & $error
   (await testSetup.serviceNode.mountRelay()).isOkOr:
     assert false, "Failed to mount relay: " & $error
-  await testSetup.serviceNode.mountLightPush(rateLimit)
+  check (await testSetup.serviceNode.mountLightPush(rateLimit)).isOk()
   testSetup.pushNode.mountLightPushClient()
 
   testSetup.serviceNode.peerManager.addServicePeer(

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -369,7 +369,10 @@ proc setupProtocols(
   # NOTE Must be mounted after relay
   if conf.lightPush:
     try:
-      await mountLightPush(node, node.rateLimitSettings.getSetting(LIGHTPUSH))
+      let lpRes =
+        await mountLightPush(node, node.rateLimitSettings.getSetting(LIGHTPUSH))
+      if lpRes.isErr():
+        return err("failed to mount waku lightpush protocol: " & $lpRes.error)
       await mountLegacyLightPush(node, node.rateLimitSettings.getSetting(LIGHTPUSH))
     except CatchableError:
       return err("failed to mount waku lightpush protocol: " & getCurrentExceptionMsg())


### PR DESCRIPTION
# Description

Previously, when mounting Lightpush, if Relay was not mounted, a nil Lightpush protocol handler was used. This PR changes node setup logic: mounting Lightpush without Relay mounted results in an error. The rationale behind this change is that a node cannot serve a Lightpush request without Relay. Fixes #2808.

# Changes

<!-- List of detailed changes -->

- [x] change node setup logic to return error if Lightpush is mounted without Relay
- [x] add test for this behavior
- [x] adapt other usages of Lightpush mounting procedure (its signature was changed to return a `Result`-type value)
<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->