### PR TITLE
chore: use a callback to get latest shards for metadata

### DIFF
--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -625,6 +625,15 @@ procSuite "Peer Manager":
     await allFutures(nodes.mapIt(it.mountRelay()))
     await allFutures(nodes.mapIt(it.start()))
 
+    proc simpleHandler(
+        topic: PubsubTopic, msg: WakuMessage
+    ): Future[void] {.async, gcsafe.} =
+      await sleepAsync(0.millis)
+
+    let topic = "/waku/2/rs/0/0"
+    for node in nodes:
+      node.wakuRelay.subscribe(topic, simpleHandler)
+
     # Get all peer infos
     let peerInfos = collect:
       for i in 0 .. nodes.high:

--- a/waku/common/callbacks.nim
+++ b/waku/common/callbacks.nim
@@ -1,0 +1,1 @@
+type GetShards* = proc(): seq[uint16] {.closure, gcsafe, raises: [].}


### PR DESCRIPTION
# Description
An attempt to address #3539. Comments/suggestions are welcome :)

# Changes

<!-- List of detailed changes -->

- [x] A callback that provides current subscribed shards
- [x] Metadata always uses shards available with the Monitor via a Getter API

Rendezvous changes would be taken up in a separate PR.


<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->