### PR TITLE
fix: make test <nim source file>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,9 +259,9 @@ build/%: | build deps librln
 		$(ENV_SCRIPT) nim buildone $(NIM_PARAMS) waku.nims $*
 
 compile-test: | build deps librln
-	echo -e $(BUILD_MSG) "$(TEST_FILE)" && \
+	echo -e $(BUILD_MSG) "$(TEST_FILE)" "\"$(TEST_NAME)\"" && \
 		$(ENV_SCRIPT) nim buildTest $(NIM_PARAMS) waku.nims $(TEST_FILE) && \
-		$(ENV_SCRIPT) nim execTest $(NIM_PARAMS) waku.nims $(TEST_FILE) "$(TEST_NAME)"
+		$(ENV_SCRIPT) nim execTest $(NIM_PARAMS) waku.nims $(TEST_FILE) "\"$(TEST_NAME)\""; \
 
 ################
 ## Waku tools ##

--- a/waku.nimble
+++ b/waku.nimble
@@ -165,9 +165,17 @@ task buildTest, "Test custom target":
   let filepath = paramStr(paramCount())
   discard buildModule(filepath)
 
+import std/strutils
+
 task execTest, "Run test":
+  # Expects to be parameterized with test case name in quotes
+  # preceded with the nim source file name and path
+  # If no test case name is given still it requires empty quotes `""`
   let filepath = paramStr(paramCount() - 1)
-  exec "build/" & filepath & ".bin" & " test \"" & paramStr(paramCount()) & "\""
+  var testSuite = paramStr(paramCount()).strip(chars = {'\"'})
+  if testSuite != "":
+    testSuite = " \"" & testSuite & "\""
+  exec "build/" & filepath & ".bin " & testSuite
 
 ### C Bindings
 let chroniclesParams =


### PR DESCRIPTION
## Description
I noticed that I cannot run a single file test with `make test <nim source file>` command without specifying test case name or pattern

## Changes

This PR fixes the argument passing from Makefile to nimble `executeTest` task.
It will always pass at least empty quotes when no test case specified. Also `executeTest` task will take care of handling that situation properly.

This way it should be possible to run:
`make test`
`make test tests/<test file name>.nim`
and `make test tests/<test file name>.nim "<test case name>"`
