### PR TITLE
fix remove libpcre lib dependency used for docker builds 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,6 @@ EXPOSE 30303 60000 8545
 # Referenced in the binary
 RUN apk add --no-cache libgcc libpq-dev bind-tools
 
-# Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
-# RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
-
 # Copy to separate location to accomodate different MAKE_TARGET values
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG NIM_COMMIT
 ARG LOG_LEVEL=TRACE
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git build-base openssl-dev pcre-dev linux-headers curl jq
+RUN apk add --no-cache bash git build-base openssl-dev linux-headers curl jq
 
 WORKDIR /app
 COPY . .
@@ -41,10 +41,10 @@ LABEL version="unknown"
 EXPOSE 30303 60000 8545
 
 # Referenced in the binary
-RUN apk add --no-cache libgcc pcre-dev libpq-dev bind-tools
+RUN apk add --no-cache libgcc libpq-dev bind-tools
 
 # Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
-RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
+# RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
 # Copy to separate location to accomodate different MAKE_TARGET values
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/

--- a/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
+++ b/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
@@ -7,7 +7,7 @@ ARG NIM_COMMIT
 ARG LOG_LEVEL=TRACE
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git build-base openssl-dev pcre-dev linux-headers curl jq
+RUN apk add --no-cache bash git build-base openssl-dev linux-headers curl jq
 
 WORKDIR /app
 COPY . .
@@ -40,7 +40,7 @@ LABEL version="unknown"
 EXPOSE 30303 60000 8545
 
 # Referenced in the binary
-RUN apk add --no-cache libgcc pcre-dev libpq-dev \
+RUN apk add --no-cache libgcc libpq-dev \
   wget \
   iproute2 \
   python3

--- a/docker/binaries/Dockerfile.bn.amd64
+++ b/docker/binaries/Dockerfile.bn.amd64
@@ -13,7 +13,7 @@ EXPOSE 30303 60000 8545
 
 # Referenced in the binary
 RUN apt-get update &&\
-    apt-get install -y libpcre3 libpq-dev curl iproute2 wget dnsutils &&\
+    apt-get install -y libpcre2-8-0 libpq-dev curl iproute2 wget dnsutils &&\
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Fix for 'Error loading shared library libpcre.so.3: No such file or directory'

--- a/docker/binaries/Dockerfile.bn.amd64
+++ b/docker/binaries/Dockerfile.bn.amd64
@@ -13,11 +13,8 @@ EXPOSE 30303 60000 8545
 
 # Referenced in the binary
 RUN apt-get update &&\
-    apt-get install -y libpcre2-8-0 libpq-dev curl iproute2 wget dnsutils &&\
+    apt-get install -y libpq-dev curl iproute2 wget dnsutils &&\
     apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
-RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
 # Copy to separate location to accomodate different MAKE_TARGET values
 ADD ./build/$MAKE_TARGET /usr/local/bin/

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-{ 
+{
   pkgs ? import <nixpkgs> { },
 }:
 let
@@ -20,7 +20,4 @@ pkgs.mkShell {
     nim-unwrapped-2_0
   ];
 
-  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
-    pkgs.pcre
-  ];
 }


### PR DESCRIPTION
## Description
Seems with debian:stable-slim now points to Debian Bookworm and that made libpcre3 deprecated we have a failing docker build

## Changes

As we already removed std/re dependencies and moved to using nim-regex lib that does not depend on pcre external lib.
As libpcre3 is reported to be vulnerable, it is betterto  completely remove it.

## Issue

- https://github.com/waku-org/nwaku/issues/3483
