### PR TITLE
enable peer-exchange by default and fix log on client

### DIFF
--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -603,7 +603,7 @@ with the drawback of consuming some more bandwidth.""",
     ## waku peer exchange config
     peerExchange* {.
       desc: "Enable waku peer exchange protocol (responder side): true|false",
-      defaultValue: false,
+      defaultValue: true,
       name: "peer-exchange"
     .}: bool
 

--- a/waku/waku_peer_exchange/client.nim
+++ b/waku/waku_peer_exchange/client.nim
@@ -92,7 +92,7 @@ proc request*(
   let peerOpt = wpx.peerManager.selectPeer(WakuPeerExchangeCodec)
   if peerOpt.isNone():
     waku_px_client_errors.inc(labelValues = [peerNotFoundFailure])
-    error "peer exchange error peerOpt is none"
+    info "peer exchange request could not be made as no peer exchange peers found"
     return err(
       (
         status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,


### PR DESCRIPTION
## Description

A community node runner faced an issue where the log was noticed for peer-exchange as error when the node was unable to find peers with peer-exchange enabled. 
This log need not be an error log, rather an info log and hence fixing the same.

Also realized that peer-exchange service is not enabled by default when wakunode2 is run, also addressed the same.

