### PR TITLE
update rendezvous to use callbacks to get updated info 

### DIFF
--- a/tests/test_waku_rendezvous.nim
+++ b/tests/test_waku_rendezvous.nim
@@ -33,7 +33,11 @@ procSuite "Waku Rendezvous":
       )
 
     await allFutures(
-      [node1.mountRendezvous(), node2.mountRendezvous(), node3.mountRendezvous()]
+      [
+        node1.mountRendezvous(clusterId),
+        node2.mountRendezvous(clusterId),
+        node3.mountRendezvous(clusterId),
+      ]
     )
     await allFutures([node1.start(), node2.start(), node3.start()])
 

--- a/tests/waku_discv5/test_waku_discv5.nim
+++ b/tests/waku_discv5/test_waku_discv5.nim
@@ -450,7 +450,7 @@ suite "Waku Discovery v5":
         raiseAssert error
 
       await waku1.node.mountPeerExchange()
-      await waku1.node.mountRendezvous()
+      await waku1.node.mountRendezvous(conf.clusterId)
 
       confBuilder.discv5Conf.withBootstrapNodes(@[waku1.node.enr.toURI()])
       confBuilder.withP2pTcpPort(60003.Port)

--- a/waku/common/callbacks.nim
+++ b/waku/common/callbacks.nim
@@ -1,1 +1,5 @@
+import ../waku_enr/capabilities
+
 type GetShards* = proc(): seq[uint16] {.closure, gcsafe, raises: [].}
+
+type GetCapabilities* = proc(): seq[Capabilities] {.closure, gcsafe, raises: [].}

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -338,7 +338,7 @@ proc setupProtocols(
 
     # Only relay nodes should be rendezvous points.
     if conf.rendezvous:
-      await node.mountRendezvous()
+      await node.mountRendezvous(conf.clusterId)
 
   # Keepalive mounted on all nodes
   try:


### PR DESCRIPTION
## Description

Similar to https://github.com/waku-org/nwaku/pull/3545 , implement a callback for capabilities so that rendezvous doesn't need to depend on ENR.

Updated rendezvous to also use shards based on callback so that it always uses updated shards.  

