### PR TITLE
fix: Do not allow invalid pubsub topic subscription via relay REST api

### DIFF
--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -44,6 +44,7 @@ suite "Waku v2 Rest API - Relay":
       assert false, "Failed to mount relay"
 
     var restPort = Port(0)
+
     let restAddress = parseIpAddress("0.0.0.0")
     let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
 
@@ -74,7 +75,8 @@ suite "Waku v2 Rest API - Relay":
     check:
       errorResponse.status == 400
       $errorResponse.contentType == $MIMETYPE_TEXT
-      errorResponse.data == "Invalid pubsub topic(s): @[\"/test/2/this/is/a/content/topic/1\"]"
+      errorResponse.data ==
+        "Invalid pubsub topic(s): @[\"/test/2/this/is/a/content/topic/1\"]"
 
     # when all pubsub topics are correct, subscribe shall succeed
     let response = await client.relayPostSubscriptionsV1(shards)

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -61,8 +61,22 @@ suite "Waku v2 Rest API - Relay":
 
     let shards = @[$shard0, $shard1, $shard2]
 
-    # When
+    let invalidTopic = "/test/2/this/is/a/content/topic/1"
+
+    var containsIncorrect = shards
+    containsIncorrect.add(invalidTopic)
+
+    # When contains incorrect pubsub topics, subscribe shall fail
     let client = newRestHttpClient(initTAddress(restAddress, restPort))
+    let errorResponse = await client.relayPostSubscriptionsV1(containsIncorrect)
+
+    # Then
+    check:
+      errorResponse.status == 400
+      $errorResponse.contentType == $MIMETYPE_TEXT
+      errorResponse.data == "Invalid pubsub topic(s): @[\"/test/2/this/is/a/content/topic/1\"]"
+
+    # when all pubsub topics are correct, subscribe shall succeed
     let response = await client.relayPostSubscriptionsV1(shards)
 
     # Then

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -131,7 +131,8 @@ proc getShardsGetter(node: WakuNode): GetShards =
       return @[]
     let subscribedTopics = node.wakuRelay.subscribedTopics()
     let relayShards = topicsToRelayShards(subscribedTopics).valueOr:
-      error "could not convert relay topics to shards", error = $error, topics = subscribedTopics
+      error "could not convert relay topics to shards",
+        error = $error, topics = subscribedTopics
       return @[]
     if relayShards.isSome():
       let shards = relayShards.get().shardIds

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -129,9 +129,9 @@ proc getShardsGetter(node: WakuNode): GetShards =
     # fetch pubsubTopics subscribed to relay and convert them to shards
     if node.wakuRelay.isNil():
       return @[]
-    let subTopics = node.wakuRelay.subscribedTopics()
-    let relayShards = topicsToRelayShards(subTopics).valueOr:
-      error "could not convert relay topics to shards", error = $error
+    let subscribedTopics = node.wakuRelay.subscribedTopics()
+    let relayShards = topicsToRelayShards(subscribedTopics).valueOr:
+      error "could not convert relay topics to shards", error = $error, topics = subscribedTopics
       return @[]
     if relayShards.isSome():
       let shards = relayShards.get().shardIds

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -45,9 +45,9 @@ proc validatePubSubTopics(topics: seq[PubsubTopic]): Result[void, RestApiRespons
   let badPubSubTopics = topics.filterIt(RelayShard.parseStaticSharding(it).isErr())
   if badPubSubTopics.len > 0:
     error "Invalid pubsub topic(s)", PubSubTopics = $badPubSubTopics
-    return err(RestApiResponse.badRequest(
-      "Invalid pubsub topic(s): " & $badPubSubTopics
-    ))
+    return
+      err(RestApiResponse.badRequest("Invalid pubsub topic(s): " & $badPubSubTopics))
+
   return ok()
 
 proc installRelayApiHandlers*(

--- a/waku/waku_api/rest/relay/handlers.nim
+++ b/waku/waku_api/rest/relay/handlers.nim
@@ -41,6 +41,15 @@ const ROUTE_RELAY_AUTO_SUBSCRIPTIONSV1* = "/relay/v1/auto/subscriptions"
 const ROUTE_RELAY_AUTO_MESSAGESV1* = "/relay/v1/auto/messages/{contentTopic}"
 const ROUTE_RELAY_AUTO_MESSAGESV1_NO_TOPIC* = "/relay/v1/auto/messages"
 
+proc validatePubSubTopics(topics: seq[PubsubTopic]): Result[void, RestApiResponse] =
+  let badPubSubTopics = topics.filterIt(RelayShard.parseStaticSharding(it).isErr())
+  if badPubSubTopics.len > 0:
+    error "Invalid pubsub topic(s)", PubSubTopics = $badPubSubTopics
+    return err(RestApiResponse.badRequest(
+      "Invalid pubsub topic(s): " & $badPubSubTopics
+    ))
+  return ok()
+
 proc installRelayApiHandlers*(
     router: var RestRouter, node: WakuNode, cache: MessageCache
 ) =
@@ -59,6 +68,9 @@ proc installRelayApiHandlers*(
       return RestApiResponse.badRequest()
 
     let req: seq[PubsubTopic] = decodeRequestBody[seq[PubsubTopic]](contentBody).valueOr:
+      return error
+
+    validatePubSubTopics(req).isOkOr:
       return error
 
     # Only subscribe to topics for which we have no subscribed topic handlers yet
@@ -85,6 +97,9 @@ proc installRelayApiHandlers*(
       return RestApiResponse.badRequest()
 
     let req: seq[PubsubTopic] = decodeRequestBody[seq[PubsubTopic]](contentBody).valueOr:
+      return error
+
+    validatePubSubTopics(req).isOkOr:
       return error
 
     # Unsubscribe all handlers from requested topics


### PR DESCRIPTION
## Description
https://discord.com/channels/1110799176264056863/1412567451333562498
Recently reported js-waku autosharding tests were failing with latest master.

Finally it is revealed that https://github.com/waku-org/nwaku/pull/3545 changed the shard management with using Relay's subscripbed topics.

That turned out js-waku was using wrong REST api endpoint for Auto sharding relay subscribe.
--> https://github.com/waku-org/js-waku/pull/2625

It's made possible to subscribe with content topics as pubsub topics on Gossipsub level also. 

## Changes

This PR intends to forbid such case by validating pubsub topic inputs on REST endpoint level.

## Issue

- https://github.com/waku-org/nwaku/issues/3483
