### PR TITLE
chore: fix issues found when using waku as a nimble lib

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -27,8 +27,7 @@ requires "nim >= 2.2.4",
   "regex",
   "results",
   "db_connector",
-  "minilru",
-  "quic"
+  "minilru"
 
 ### Helper functions
 proc buildModule(filePath, params = "", lang = "c"): bool =

--- a/waku/node/peer_manager/peer_manager.nim
+++ b/waku/node/peer_manager/peer_manager.nim
@@ -1,7 +1,8 @@
 {.push raises: [].}
 
 import
-  std/[options, sets, sequtils, times, strformat, strutils, math, random, tables],
+  std/
+    [options, sets, sequtils, tables, times, strformat, strutils, math, random, tables],
   chronos,
   chronicles,
   metrics,


### PR DESCRIPTION
## Description

When installing Waku as a `nimble` library I found a couple of issues.

## Changes

- `quic` is not a direct dependency, but a transient one, and is never used in nwaku code
- `std/tables` import missing in a file where we do use `Table`.
