### PR TITLE
feat: Waku API create node and use it with nimble

### DIFF
--- a/.github/workflows/test-nimble-install.yml
+++ b/.github/workflows/test-nimble-install.yml
@@ -32,7 +32,7 @@ jobs:
       run: cat examples/nimble/example.nimble
 
     - name: Display waku.nimble
-      run: head waku.nimble -n40
+      run: head -n40 waku.nimble
 
     - name: Install waku from head of PR branch
       working-directory: examples/nimble


### PR DESCRIPTION
## Description

Introduce `createNode`, part of the Waku API, as defined in https://github.com/waku-org/specs/pull/65 and ensure it's usable via `nimble`

## Changes

## Notes / TODO

- [x] merge and rebase on https://github.com/status-im/nim-web3/pull/224

## Issue

closes https://github.com/waku-org/nwaku/issues/3493
