### PR TITLE
fix: remove pcre dependency as it is not used anymore and causing random CI docker build failures

### DIFF
--- a/Dockerfile.lightpushWithMix.compile
+++ b/Dockerfile.lightpushWithMix.compile
@@ -7,7 +7,7 @@ ARG NIM_COMMIT
 ARG LOG_LEVEL=TRACE
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git build-base openssl-dev pcre-dev linux-headers curl jq
+RUN apk add --no-cache bash git build-base openssl-dev linux-headers curl jq
 
 WORKDIR /app
 COPY . .
@@ -40,14 +40,12 @@ LABEL version="unknown"
 EXPOSE 30303 60000 8545
 
 # Referenced in the binary
-RUN apk add --no-cache libgcc pcre-dev libpq-dev \
+RUN apk add --no-cache libgcc libpq-dev \
   wget \
   iproute2 \
   python3 \
   jq
 
-# Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
-RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
 COPY --from=nim-build /app/build/lightpush_publisher_mix /usr/bin/
 RUN chmod +x /usr/bin/lightpush_publisher_mix

--- a/apps/liteprotocoltester/Dockerfile.liteprotocoltester
+++ b/apps/liteprotocoltester/Dockerfile.liteprotocoltester
@@ -1,37 +1,33 @@
-  # TESTING IMAGE --------------------------------------------------------------
+# TESTING IMAGE --------------------------------------------------------------
 
-    ## NOTICE: This is a short cut build file for ubuntu users who compiles nwaku in ubuntu distro.
-    ##         This is used for faster turnaround time for testing the compiled binary.
-    ##         Prerequisites: compiled liteprotocoltester binary in build/ directory
+## NOTICE: This is a short cut build file for ubuntu users who compiles nwaku in ubuntu distro.
+##         This is used for faster turnaround time for testing the compiled binary.
+##         Prerequisites: compiled liteprotocoltester binary in build/ directory
 
-  FROM ubuntu:noble AS prod
+FROM ubuntu:noble AS prod
 
-  LABEL maintainer="zoltan@status.im"
-  LABEL source="https://github.com/waku-org/nwaku"
-  LABEL description="Lite Protocol Tester: Waku light-client"
-  LABEL commit="unknown"
-  LABEL version="unknown"
+LABEL maintainer="zoltan@status.im"
+LABEL source="https://github.com/waku-org/nwaku"
+LABEL description="Lite Protocol Tester: Waku light-client"
+LABEL commit="unknown"
+LABEL version="unknown"
 
-  # DevP2P, LibP2P, and JSON RPC ports
-  EXPOSE 30303 60000 8545
+# DevP2P, LibP2P, and JSON RPC ports
+EXPOSE 30303 60000 8545
 
-  # Referenced in the binary
-  RUN apt-get update && apt-get install -y --no-install-recommends \
-      libgcc1 \
-      libpcre3 \
-      libpq-dev \
-      wget \
-      iproute2 \
-      && rm -rf /var/lib/apt/lists/*
+# Referenced in the binary
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgcc1 \
+  libpq-dev \
+  wget \
+  iproute2 \
+  && rm -rf /var/lib/apt/lists/*
 
-  # Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
-  RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
+COPY build/liteprotocoltester /usr/bin/
+COPY apps/liteprotocoltester/run_tester_node.sh /usr/bin/
+COPY apps/liteprotocoltester/run_tester_node_on_fleet.sh /usr/bin/
 
-  COPY build/liteprotocoltester /usr/bin/
-  COPY apps/liteprotocoltester/run_tester_node.sh /usr/bin/
-  COPY apps/liteprotocoltester/run_tester_node_on_fleet.sh /usr/bin/
+ENTRYPOINT ["/usr/bin/run_tester_node.sh", "/usr/bin/liteprotocoltester"]
 
-  ENTRYPOINT ["/usr/bin/run_tester_node.sh", "/usr/bin/liteprotocoltester"]
-
-  # # By default just show help if called without arguments
-  CMD ["--help"]
+# # By default just show help if called without arguments
+CMD ["--help"]

--- a/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
+++ b/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
@@ -45,9 +45,6 @@ RUN apk add --no-cache libgcc libpq-dev \
   iproute2 \
   python3
 
-# Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
-RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
-
 COPY --from=nim-build /app/build/liteprotocoltester /usr/bin/
 RUN chmod +x /usr/bin/liteprotocoltester
 

--- a/docker/binaries/Dockerfile.bn.local
+++ b/docker/binaries/Dockerfile.bn.local
@@ -14,11 +14,8 @@ EXPOSE 30303 60000 8545
 
 # Referenced in the binary
 RUN apt-get update &&\
-    apt-get install -y libpcre3=2:8.39-13ubuntu0.22.04.1 libpq-dev curl iproute2 wget jq dnsutils &&\
+    apt-get install -y libpq-dev curl iproute2 wget jq dnsutils &&\
     apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
-RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
 # Copy to separate location to accomodate different MAKE_TARGET values
 ADD ./build/$MAKE_TARGET /usr/local/bin/


### PR DESCRIPTION
## Description

docker builds on ubuntu keep failing in CI with below error. It has happened for many PR's in nwaku. here is [one](https://github.com/waku-org/nwaku/actions/runs/17584171183/job/50015646473?pr=3561)

```
#7 2.432 E: Unable to locate package libpcre3
#7 ERROR: process "/bin/sh -c apt-get update &&    apt-get install -y libpcre3 libpq-dev curl iproute2 wget dnsutils &&    apt-get clean && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100

```
Picking a version as mentioned [here](https://github.com/TablePlus/TablePlus-Linux/issues/164#issuecomment-1289405845) which matches ubuntu version.

