### PR TITLE
chore: fix node break issue when RLN is unregistered

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -202,8 +202,10 @@ proc trackRootChanges*(g: OnchainGroupManager) {.async: (raises: [CatchableError
       let rootUpdated = await g.updateRoots()
 
       if rootUpdated:
+        ## The membership set on-chain has changed (some new members have joined or some members have left)
         if g.membershipIndex.isSome():
-          # merkleProofElements is only needed for rln registered nodes
+          ## A membership index exists only if the node has registered with RLN.
+          ## Non-registered nodes cannot have Merkle proof elements.
           let proofResult = await g.fetchMerkleProofElements()
           if proofResult.isErr():
             error "Failed to fetch Merkle proof", error = proofResult.error

--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -201,23 +201,24 @@ proc trackRootChanges*(g: OnchainGroupManager) {.async: (raises: [CatchableError
       await sleepAsync(rpcDelay)
       let rootUpdated = await g.updateRoots()
 
-      # merkleProofElements is only needed for rln registered nodes
-      if rootUpdated and g.membershipIndex.isSome():
-        let proofResult = await g.fetchMerkleProofElements()
-        if proofResult.isErr():
-          error "Failed to fetch Merkle proof", error = proofResult.error
-        else:
-          g.merkleProofCache = proofResult.get()
+      if rootUpdated:
+        if g.membershipIndex.isSome():
+          # merkleProofElements is only needed for rln registered nodes
+          let proofResult = await g.fetchMerkleProofElements()
+          if proofResult.isErr():
+            error "Failed to fetch Merkle proof", error = proofResult.error
+          else:
+            g.merkleProofCache = proofResult.get()
 
-      let nextFreeIndex = await g.fetchNextFreeIndex()
-      if nextFreeIndex.isErr():
-        error "Failed to fetch next free index", error = nextFreeIndex.error
-        raise newException(
-          CatchableError, "Failed to fetch next free index: " & nextFreeIndex.error
-        )
+        let nextFreeIndex = await g.fetchNextFreeIndex()
+        if nextFreeIndex.isErr():
+          error "Failed to fetch next free index", error = nextFreeIndex.error
+          raise newException(
+            CatchableError, "Failed to fetch next free index: " & nextFreeIndex.error
+          )
 
-      let memberCount = cast[int64](nextFreeIndex.get())
-      waku_rln_number_registered_memberships.set(float64(memberCount))
+        let memberCount = cast[int64](nextFreeIndex.get())
+        waku_rln_number_registered_memberships.set(float64(memberCount))
   except CatchableError:
     error "Fatal error in trackRootChanges", error = getCurrentExceptionMsg()
 


### PR DESCRIPTION
Merkle proof elements are not needed when a node is not registered for RLN. However, the current trackRootChanges function still requires the merkle proof, causing the node to break. This change resolves the issue. 