### PR TITLE
fixL Add connection closeWithEof for req/resp protocols

### DIFF
--- a/waku/waku_filter_v2/client.nim
+++ b/waku/waku_filter_v2/client.nim
@@ -58,6 +58,9 @@ proc sendSubscribeRequest(
 
   let connection = connOpt.get()
 
+  defer:
+    await connection.closeWithEOF()
+
   try:
     await connection.writeLP(filterSubscribeRequest.encode().buffer)
   except CatchableError:

--- a/waku/waku_filter_v2/protocol.nim
+++ b/waku/waku_filter_v2/protocol.nim
@@ -293,6 +293,9 @@ proc initProtocolHandler(wf: WakuFilter) =
 
     var response: FilterSubscribeResponse
 
+    defer:
+      await conn.closeWithEOF()
+
     wf.peerRequestRateLimiter.checkUsageLimit(WakuFilterSubscribeCodec, conn):
       var buf: seq[byte]
       try:

--- a/waku/waku_lightpush/client.nim
+++ b/waku/waku_lightpush/client.nim
@@ -43,6 +43,9 @@ proc sendPushRequest(
         dialFailure & ": " & $peer & " is not accessible",
       )
 
+  defer:
+    await connection.closeWithEOF()
+
   await connection.writeLP(req.encode().buffer)
 
   var buffer: seq[byte]

--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -107,6 +107,9 @@ proc handleRequest*(
 proc initProtocolHandler(wl: WakuLightPush) =
   proc handler(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     var rpc: LightPushResponse
+    defer:
+      await conn.closeWithEOF()
+
     wl.requestRateLimiter.checkUsageLimit(WakuLightPushCodec, conn):
       var buffer: seq[byte]
       try:

--- a/waku/waku_lightpush_legacy/client.nim
+++ b/waku/waku_lightpush_legacy/client.nim
@@ -40,6 +40,9 @@ proc sendPushRequest(
     return err(dialFailure)
   let connection = connOpt.get()
 
+  defer:
+    await connection.closeWithEOF()
+
   let rpc = PushRPC(requestId: generateRequestId(wl.rng), request: some(req))
   await connection.writeLP(rpc.encode().buffer)
 

--- a/waku/waku_lightpush_legacy/protocol.nim
+++ b/waku/waku_lightpush_legacy/protocol.nim
@@ -67,6 +67,9 @@ proc handleRequest*(
 proc initProtocolHandler(wl: WakuLegacyLightPush) =
   proc handler(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     var rpc: PushRPC
+    defer:
+      await conn.closeWithEOF()
+
     wl.requestRateLimiter.checkUsageLimit(WakuLegacyLightPushCodec, conn):
       var buffer: seq[byte]
       try:


### PR DESCRIPTION

## Description

## Changes

- closeWithEof for protocol handler and client requests sides:
- lightpush
- legacy lightpush
- filter

Exception
- filter push - needs review of reusing streams.

## Issue

closes #
https://github.com/waku-org/nwaku/issues/3582