### PR TITLE
fix: increase time buffer for sync test

### DIFF
--- a/tests/waku_store_sync/test_protocol.nim
+++ b/tests/waku_store_sync/test_protocol.nim
@@ -518,7 +518,7 @@ suite "Waku Sync: reconciliation":
       diffInWin = 18
       diffOutWin = 20
       stepOutNs = 100_000_000'u64
-      outOffsetNs = 2_300_000_000'u64 # for 20 mesg they sent 2 seconds earlier 
+      outOffsetNs = 2_600_000_000'u64 # for 20 mesg they sent 2 seconds earlier 
 
     randomize()
 


### PR DESCRIPTION
Increased the time buffer for this tests in the hope that weaker computer don't run into timing issues.

closes #3584
