### PR TITLE
Fix log libwaku

### DIFF
--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -298,6 +298,7 @@ int main(int argc, char** argv) {
     snprintf(jsonConfig, 5000, "{ \
                                     \"clusterId\": 16, \
                                     \"shards\": [ 1, 32, 64, 128, 256 ], \
+                                    \"numShardsInNetwork\": 257, \
                                     \"listenAddress\": \"%s\",    \
                                     \"tcpPort\": %d,        \
                                     \"relay\": %s,       \

--- a/library/waku_context.nim
+++ b/library/waku_context.nim
@@ -5,6 +5,7 @@
 import std/[options, atomics, os, net, locks]
 import chronicles, chronos, chronos/threadsync, taskpools/channels_spsc_single, results
 import
+  waku/common/logging,
   waku/factory/waku,
   waku/node/peer_manager,
   waku/waku_relay/[protocol, topic_health],
@@ -154,6 +155,8 @@ proc watchdogThreadBody(ctx: ptr WakuContext) {.thread.} =
 
 proc wakuThreadBody(ctx: ptr WakuContext) {.thread.} =
   ## Waku thread that attends library user requests (stop, connect_to, etc.)
+
+  logging.setupLog(logging.LogLevel.DEBUG, logging.LogFormat.TEXT)
 
   let wakuRun = proc(ctx: ptr WakuContext) {.async.} =
     var waku: Waku


### PR DESCRIPTION
## Description

Avoid crash in cwaku_example, and any other app using libwaku, due to not having chronicles log properly set up.
That issue started to happen ever since we started to use nim-chronicles `v0.12.1` and I assume is because it got more strict.

## Issue

- https://github.com/waku-org/nwaku/issues/3483
