### PR TITLE
chore(refactoring): replace some `isOk` usage with better alternatives

### DIFF
--- a/apps/benchmarks/benchmarks.nim
+++ b/apps/benchmarks/benchmarks.nim
@@ -28,10 +28,9 @@ proc benchmark(
       iter = i, elapsed_ms = (getTime() - start_time).inMilliseconds
 
   discard await manager.updateRoots()
-  let proofResult = await manager.fetchMerkleProofElements()
-  if proofResult.isErr():
-    error "Failed to fetch Merkle proof", error = proofResult.error
-  manager.merkleProofCache = proofResult.get()
+  manager.merkleProofCache = (await manager.fetchMerkleProofElements()).valueOr:
+    error "Failed to fetch Merkle proof", error = error
+    quit(QuitFailure)
 
   let epoch = default(Epoch)
   debug "epoch in bytes", epochHex = epoch.inHex()

--- a/apps/chat2bridge/chat2bridge.nim
+++ b/apps/chat2bridge/chat2bridge.nim
@@ -136,9 +136,7 @@ proc toMatterbridge(
 
 proc pollMatterbridge(cmb: Chat2MatterBridge, handler: MbMessageHandler) {.async.} =
   while cmb.running:
-    let getRes = cmb.mbClient.getMessages()
-
-    if getRes.isOk():
+    if (let getRes = cmb.mbClient.getMessages(); getRes.isOk()):
       for jsonNode in getRes[]:
         await handler(jsonNode)
     else:
@@ -169,9 +167,7 @@ proc new*(
   let mbClient = MatterbridgeClient.new(mbHostUri, mbGateway)
 
   # Let's verify the Matterbridge configuration before continuing
-  let clientHealth = mbClient.isHealthy()
-
-  if clientHealth.isOk() and clientHealth[]:
+  if mbClient.isHealthy().valueOr(false):
     info "Reached Matterbridge host", host = mbClient.host
   else:
     raise newException(ValueError, "Matterbridge client not reachable/healthy")

--- a/apps/chat2bridge/config_chat2bridge.nim
+++ b/apps/chat2bridge/config_chat2bridge.nim
@@ -91,7 +91,7 @@ type Chat2MatterbridgeConf* = object
     name: "filternode"
   .}: string
 
-  # Matterbridge options    
+  # Matterbridge options
   mbHostAddress* {.
     desc: "Listening address of the Matterbridge host",
     defaultValue: parseIpAddress("127.0.0.1"),
@@ -126,11 +126,9 @@ proc completeCmdArg*(T: type keys.KeyPair, val: string): seq[string] =
   return @[]
 
 proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
-  let key = SkPrivateKey.init(p)
-  if key.isOk():
-    crypto.PrivateKey(scheme: Secp256k1, skkey: key.get())
-  else:
+  let key = SkPrivateKey.init(p).valueOr:
     raise newException(ValueError, "Invalid private key")
+  return crypto.PrivateKey(scheme: Secp256k1, skkey: key)
 
 proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]

--- a/examples/lightpush_publisher.nim
+++ b/examples/lightpush_publisher.nim
@@ -86,7 +86,9 @@ proc setupAndPublish(rng: ref HmacDrbgContext) {.async.} =
       timestamp: now(),
     ) # current timestamp
 
-    let lightpushPeer = parsePeerInfo(LightpushPeer).get()
+    let lightpushPeer = parsePeerInfo(LightpushPeer).valueOr:
+      error "failed to parse LightpushPeer", error = error
+      quit(QuitFailure)
 
     let res = await node.legacyLightpushPublish(
       some(LightpushPubsubTopic), message, lightpushPeer

--- a/waku/discovery/waku_discv5.nim
+++ b/waku/discovery/waku_discv5.nim
@@ -421,13 +421,11 @@ proc setupDiscoveryV5*(
     addBootstrapNode(enrUri, discv5BootstrapEnrs)
 
   for enr in discv5BootstrapEnrs:
-    let peerInfoRes = enr.toRemotePeerInfo()
-    if peerInfoRes.isOk():
-      nodePeerManager.addPeer(peerInfoRes.get(), PeerOrigin.Discv5)
-    else:
+    let peerInfo = enr.toRemotePeerInfo().valueOr:
       debug "could not convert discv5 bootstrap node to peerInfo, not adding peer to Peer Store",
-        enr = enr.toUri(), error = peerInfoRes.error
-
+        enr = enr.toUri(), error = error
+      continue
+    nodePeerManager.addPeer(peerInfo, PeerOrigin.Discv5)
   discv5BootstrapEnrs.add(dynamicBootstrapEnrs)
 
   let discv5Config =

--- a/waku/factory/validator_signed.nim
+++ b/waku/factory/validator_signed.nim
@@ -67,9 +67,8 @@ proc addSignedShardsValidator*(
         if msg.timestamp != 0:
           if msg.withinTimeWindow():
             let msgHash = SkMessage(topic.msgHash(msg))
-            let recoveredSignature = SkSignature.fromRaw(msg.meta)
-            if recoveredSignature.isOk():
-              if recoveredSignature.get.verify(msgHash, protectedShard.key):
+            SkSignature.fromRaw(msg.meta).isErrOr:
+              if value.verify(msgHash, protectedShard.key):
                 outcome = errors.ValidationResult.Accept
 
         if outcome != errors.ValidationResult.Accept:

--- a/waku/utils/noise.nim
+++ b/waku/utils/noise.nim
@@ -12,11 +12,9 @@ proc decodePayloadV2*(
   case message.version
   of 2:
     # We attempt to decode the WakuMessage payload
-    let deserializedPayload2 = deserializePayloadV2(message.payload)
-    if deserializedPayload2.isOk():
-      return ok(deserializedPayload2.get())
-    else:
+    let deserializedPayload2 = deserializePayloadV2(message.payload).valueOr:
       return err("Failed to decode WakuMessage")
+    return ok(deserializedPayload2)
   else:
     return err("Wrong message version while decoding payload")
 
@@ -28,13 +26,11 @@ proc encodePayloadV2*(
     raises: [NoiseMalformedHandshake, NoisePublicKeyError]
 .} =
   # We attempt to encode the PayloadV2
-  let serializedPayload2 = serializePayloadV2(payload2)
-  if not serializedPayload2.isOk():
+  let serializedPayload2 = serializePayloadV2(payload2).valueOr:
     return err("Failed to encode PayloadV2")
 
   # If successful, we create and return a WakuMessage
-  let msg = WakuMessage(
-    payload: serializedPayload2.get(), version: 2, contentTopic: contentTopic
-  )
+  let msg =
+    WakuMessage(payload: serializedPayload2, version: 2, contentTopic: contentTopic)
 
   return ok(msg)

--- a/waku/waku_api/rest/legacy_store/types.nim
+++ b/waku/waku_api/rest/legacy_store/types.nim
@@ -60,13 +60,11 @@ proc parseMsgDigest*(
     return ok(none(waku_store_common.MessageDigest))
 
   let decodedUrl = decodeUrl(input.get())
-  let base64Decoded = base64.decode(Base64String(decodedUrl))
+  let base64DecodedArr = base64.decode(Base64String(decodedUrl)).valueOr:
+    return err(error)
+
   var messageDigest = waku_store_common.MessageDigest()
 
-  if not base64Decoded.isOk():
-    return err(base64Decoded.error)
-
-  let base64DecodedArr = base64Decoded.get()
   # Next snippet inspired by "nwaku/waku/waku_archive/archive.nim"
   # TODO: Improve coherence of MessageDigest type
   messageDigest = block:
@@ -220,10 +218,9 @@ proc readValue*(
     of "data":
       if data.isSome():
         reader.raiseUnexpectedField("Multiple `data` fields found", "MessageDigest")
-      let decoded = base64.decode(reader.readValue(Base64String))
-      if not decoded.isOk():
+      let decoded = base64.decode(reader.readValue(Base64String)).valueOr:
         reader.raiseUnexpectedField("Failed decoding data", "MessageDigest")
-      data = some(decoded.get())
+      data = some(decoded)
     else:
       reader.raiseUnexpectedField("Unrecognided field", cstring(fieldName))
 

--- a/waku/waku_api/rest/server.nim
+++ b/waku/waku_api/rest/server.nim
@@ -91,7 +91,7 @@ proc new*(
   ): Future[HttpResponseRef] {.async: (raises: [CancelledError]).} =
     discard
 
-  let sres = HttpServerRef.new(
+  server.httpServer = HttpServerRef.new(
     address,
     defaultProcessCallback,
     serverFlags,
@@ -106,12 +106,9 @@ proc new*(
     maxRequestBodySize,
     dualstack = dualstack,
     middlewares = middlewares,
-  )
-  if sres.isOk():
-    server.httpServer = sres.get()
-    ok(server)
-  else:
-    err(sres.error)
+  ).valueOr:
+    return err(error)
+  return ok(server)
 
 proc getRouter(): RestRouter =
   # TODO: Review this `validate` method. Check in nim-presto what is this used for.

--- a/waku/waku_archive/driver/postgres_driver/postgres_healthcheck.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_healthcheck.nim
@@ -24,8 +24,7 @@ proc checkConnectivity*(
 
         var numTrial = 0
         while numTrial < MaxNumTrials:
-          let res = await connPool.pgQuery(HealthCheckQuery)
-          if res.isOk():
+          (await connPool.pgQuery(HealthCheckQuery)).isErrOr:
             ## Connection resumed. Let's go back to the normal healthcheck.
             break errorBlock
 

--- a/waku/waku_archive_legacy/driver/postgres_driver/postgres_healthcheck.nim
+++ b/waku/waku_archive_legacy/driver/postgres_driver/postgres_healthcheck.nim
@@ -24,8 +24,7 @@ proc checkConnectivity*(
 
         var numTrial = 0
         while numTrial < MaxNumTrials:
-          let res = await connPool.pgQuery(HealthCheckQuery)
-          if res.isOk():
+          (await connPool.pgQuery(HealthCheckQuery)).isErrOr:
             ## Connection resumed. Let's go back to the normal healthcheck.
             break errorBlock
 


### PR DESCRIPTION
## Description

This PR refactors various patterns that use `isOk` across nwaku with less verbose and more idiomatic alternatives.

## Changes

This PR changes varied usage of `isOk` into better patterns with e.g. `valueOr` , `isOkOr`, `isErrOr`, etc. There are a few other non-isOk, miscellaneous refactors included.

There should not be any behavior (semantics) changes in this PR.

## Issue

This PR will address `isOk` refactors for #1969. A follow-up PR will address `isErr` refactors separately to merge less code at a time and minimize potential conflicts.