### PR TITLE
use nightly docker rust image to allow release creation

### DIFF
--- a/scripts/build_rln.sh
+++ b/scripts/build_rln.sh
@@ -48,9 +48,6 @@ else
         echo "Please update the submodule to ${rln_version}"
         exit 1
     fi
-    # update dependencies
-    rustup update
-    cargo update --manifest-path "${build_dir}/rln/Cargo.toml"
     # if submodule version = version in Makefile, build rln
     cargo build --release -p rln --manifest-path "${build_dir}/rln/Cargo.toml" 
     cp "${build_dir}/target/release/librln.a" "${output_filename}"


### PR DESCRIPTION
This fixes Jenkins release job, to avoid the following error:

<img width="1439" height="646" alt="image" src="https://github.com/user-attachments/assets/cc15a82b-3257-4602-aad5-be51bf483c41" />
