### PR TITLE
chore: Add gasprice overflow check

### DIFF
--- a/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
+++ b/waku/waku_rln_relay/group_manager/on_chain/group_manager.nim
@@ -233,12 +233,12 @@ method register*(
     ## Multiply by 2 to speed up the transaction
     ## Check for overflow when casting to int
     if fetchedGasPrice > uint64(high(int) div 2):
-      trace "Gas price overflow detected, capping at maximum int value",
+      warn "Gas price overflow detected, capping at maximum int value",
         fetchedGasPrice = fetchedGasPrice, maxInt = high(int)
       high(int)
     else:
       let calculatedGasPrice = int(fetchedGasPrice) * 2
-      trace "Gas price calculated",
+      debug "Gas price calculated",
         fetchedGasPrice = fetchedGasPrice, gasPrice = calculatedGasPrice
       calculatedGasPrice
   let idCommitmentHex = identityCredential.idCommitment.inHex()


### PR DESCRIPTION
## Description
Casting from uint64 to int may cause overflow error.
The register proc in the on_chain groupmanager makes an rpc call to get the gas price (which is uint64), multiplies it by 2 and casts to int to be used in the web3 send method.

## Changes
Check for overflow before casting and use max int value if there is an overflow.


relates to https://github.com/waku-org/nwaku/issues/3643
