### PR TITLE
chore: Add gasprice  flag for RLN membership registration

### DIFF
--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -436,3 +436,26 @@ suite "Onchain group manager":
 
     check:
       isReady == true
+
+  test "register: should use max gas price when useMaxGasPrice flag is set":
+    (waitFor manager.init()).isOkOr:
+      raiseAssert $error
+
+    manager.useMaxGasPrice = true
+
+    let idCredentials = generateCredentials()
+    let merkleRootBefore = waitFor manager.fetchMerkleRoot()
+
+    try:
+      waitFor manager.register(idCredentials, UserMessageLimit(20))
+    except Exception, CatchableError:
+      assert false,
+        "exception raised when calling register with useMaxGasPrice: " &
+        getCurrentExceptionMsg()
+
+    let merkleRootAfter = waitFor manager.fetchMerkleRoot()
+
+    check:
+      merkleRootAfter != merkleRootBefore
+      manager.latestIndex == 1
+      manager.useMaxGasPrice == true

--- a/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
+++ b/tests/waku_rln_relay/test_rln_group_manager_onchain.nim
@@ -451,7 +451,7 @@ suite "Onchain group manager":
     except Exception, CatchableError:
       assert false,
         "exception raised when calling register with useMaxGasPrice: " &
-        getCurrentExceptionMsg()
+          getCurrentExceptionMsg()
 
     let merkleRootAfter = waitFor manager.fetchMerkleRoot()
 

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -138,6 +138,13 @@ type WakuNodeConf* = object
       defaultValue: false,
       name: "execute"
     .}: bool
+
+    rlnRelayMaxGasPrice* {.
+      desc:
+        "Use fixed large gas price (1000 Gwei) for the registration transaction. If not set, will use 2x current gas price.",
+      defaultValue: false,
+      name: "rln-relay-max-gas-price"
+    .}: bool
   of noCommand:
     ##  Application-level configuration
     protectedShards* {.
@@ -885,6 +892,7 @@ proc toKeystoreGeneratorConf*(n: WakuNodeConf): RlnKeystoreGeneratorConf =
     ethPrivateKey: n.rlnRelayEthPrivateKey,
     credPath: n.rlnRelayCredPath,
     credPassword: n.rlnRelayCredPassword,
+    useMaxGasPrice: n.rlnRelayMaxGasPrice,
   )
 
 proc toNetworkConf(

--- a/tools/rln_keystore_generator/rln_keystore_generator.nim
+++ b/tools/rln_keystore_generator/rln_keystore_generator.nim
@@ -25,6 +25,7 @@ type RlnKeystoreGeneratorConf* = object
   credPassword*: string
   userMessageLimit*: uint64
   ethPrivateKey*: string
+  useMaxGasPrice*: bool
 
 proc doRlnKeystoreGenerator*(conf: RlnKeystoreGeneratorConf) =
   # 1. load configuration
@@ -59,6 +60,7 @@ proc doRlnKeystoreGenerator*(conf: RlnKeystoreGeneratorConf) =
     keystorePath: none(string),
     keystorePassword: none(string),
     ethPrivateKey: some(conf.ethPrivateKey),
+    useMaxGasPrice: conf.useMaxGasPrice,
     onFatalErrorAction: onFatalErrorAction,
   )
   try:


### PR DESCRIPTION
## Description
This is related to an issue observed by DST when trying to register multiple RLN memberships consecutively with the `generateRlnKeystore` command.
An overflow error was observed for the gasprice.
I doubt we need to make this a permanent change, but it could help us understand the issue seen by DST and allow them to complete testing.

## Changes
Add a flag to the `generateRlnKeystore` command to use a much larger gasprice than should ever be needed which will mainly be used for testing purposes
Registration method in group_manager updated to recognise this flag

relates to https://github.com/waku-org/nwaku/issues/3643
