### PR TITLE
Adapt makefile for libwaku windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ ifeq ($(detected_OS),Windows)
 
   LIBS = -lws2_32 -lbcrypt -liphlpapi -luserenv -lntdll -lminiupnpc -lnatpmp -lpq
   NIM_PARAMS += $(foreach lib,$(LIBS),--passL:"$(lib)")
+
+  export PATH := /c/msys64/usr/bin:/c/msys64/mingw64/bin:/c/msys64/usr/lib:/c/msys64/mingw64/lib:$(PATH)
+
 endif
 
 ##########
@@ -421,13 +424,13 @@ docker-liteprotocoltester-push:
 
 STATIC ?= 0
 
-
 libwaku: | build deps librln
 	rm -f build/libwaku*
 
 ifeq ($(STATIC), 1)
 	echo -e $(BUILD_MSG) "build/$@.a" && $(ENV_SCRIPT) nim libwakuStatic $(NIM_PARAMS) waku.nims
 else ifeq ($(detected_OS),Windows)
+	make -f scripts/libwaku_windows_setup.mk windows-setup
 	echo -e $(BUILD_MSG) "build/$@.dll" && $(ENV_SCRIPT) nim libwakuDynamic $(NIM_PARAMS) waku.nims
 else
 	echo -e $(BUILD_MSG) "build/$@.so" && $(ENV_SCRIPT) nim libwakuDynamic $(NIM_PARAMS) waku.nims
@@ -543,3 +546,4 @@ release-notes:
 			sed -E 's@#([0-9]+)@[#\1](https://github.com/waku-org/nwaku/issues/\1)@g'
 # I could not get the tool to replace issue ids with links, so using sed for now,
 # asked here: https://github.com/bvieira/sv4git/discussions/101
+

--- a/scripts/libwaku_windows_setup.mk
+++ b/scripts/libwaku_windows_setup.mk
@@ -1,0 +1,53 @@
+# ---------------------------------------------------------
+# Windows Setup Makefile
+# ---------------------------------------------------------
+
+# Extend PATH (Make preserves environment variables)
+export PATH := /c/msys64/usr/bin:/c/msys64/mingw64/bin:/c/msys64/usr/lib:/c/msys64/mingw64/lib:$(PATH)
+
+# Tools required
+DEPS = gcc g++ make cmake cargo upx rustc python
+
+# Default target
+.PHONY: windows-setup
+windows-setup: check-deps update-submodules create-tmp libunwind miniupnpc libnatpmp
+	@echo "Windows setup completed successfully!"
+
+.PHONY: check-deps
+check-deps:
+	@echo "Checking libwaku build dependencies..."
+	@for dep in $(DEPS); do \
+		if ! which $$dep >/dev/null 2>&1; then \
+			echo "✗ Missing dependency: $$dep"; \
+			exit 1; \
+		else \
+			echo "✓ Found: $$dep"; \
+		fi; \
+	done
+
+.PHONY: update-submodules
+update-submodules:
+	@echo "Updating libwaku git submodules..."
+	git submodule update --init --recursive
+
+.PHONY: create-tmp
+create-tmp:
+	@echo "Creating tmp directory..."
+	mkdir -p tmp
+
+.PHONY: libunwind
+libunwind:
+	@echo "Building libunwind..."
+	cd vendor/nim-libbacktrace && make all V=1
+
+.PHONY: miniupnpc
+miniupnpc:
+	@echo "Building miniupnpc..."
+	cd vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc && \
+		make -f Makefile.mingw CC=gcc CXX=g++ libminiupnpc.a V=1
+
+.PHONY: libnatpmp
+libnatpmp:
+	@echo "Building libnatpmp..."
+	cd vendor/nim-nat-traversal/vendor/libnatpmp-upstream && \
+		make CC="gcc -fPIC -D_WIN32_WINNT=0x0600 -DNATPMP_STATICLIB" libnatpmp.a V=1


### PR DESCRIPTION
## Description
This aims to allow building _StatusDesktop_ on Windows
We already can build libwaku manually.
This PR merely embeds the existing building logic into a Makefile so that it can be consumed easily by _StatusDesktop_

## Changes
- Adapt current Makefile
- Create new `scripts/libwaku_windows_setup.mk` based on the exisint sh scripts for building libwaku

## Issue
- https://github.com/waku-org/nwaku/issues/3194



