### PR TITLE
Release : patch release v0.37.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Remove ENR cache from peer exchange ([#3652](https://github.com/logos-messaging/logos-messaging-nim/pull/3652)) ([7920368a](https://github.com/logos-messaging/logos-messaging-nim/commit/7920368a36687cd5f12afa52d59866792d8457ca))
 
-## v0.37.0 (2025-10-01)
+## v0.37.0-beta (2025-10-01)
 
 ### Notes
 


### PR DESCRIPTION
This PR merges the v0.37.1-beta patch release back to master.

## Changes
- Cherry-picked fix: Remove ENR cache from peer exchange (#3652)
- Updated CHANGELOG for v0.37.1-beta

## Tag
Created tag: v0.37.1-beta