### PR TITLE
chore: extend RequestBroker with supporting native and external types  and added possibility to define non-async (aka sync) requests for simplicity and performance

### DIFF
--- a/tests/common/test_request_broker.nim
+++ b/tests/common/test_request_broker.nim
@@ -59,7 +59,7 @@ suite "RequestBroker macro (async mode)":
 
   test "zero-argument request errors when unset":
     let res = waitFor SimpleResponse.request()
-    check res.isErr
+    check res.isErr()
     check res.error.contains("no zero-arg provider")
 
   test "serves input-based providers":
@@ -96,7 +96,7 @@ suite "RequestBroker macro (async mode)":
 
   test "input request errors when unset":
     let res = waitFor KeyedResponse.request("foo", 2)
-    check res.isErr
+    check res.isErr()
     check res.error.contains("input signature")
 
   test "supports both provider types simultaneously":
@@ -115,11 +115,11 @@ suite "RequestBroker macro (async mode)":
     .isOk()
 
     let noInput = waitFor DualResponse.request()
-    check noInput.isOk
+    check noInput.isOk()
     check noInput.value.note == "base"
 
     let withInput = waitFor DualResponse.request("-extra")
-    check withInput.isOk
+    check withInput.isOk()
     check withInput.value.note == "base-extra"
     check withInput.value.count == 6
 
@@ -135,7 +135,7 @@ suite "RequestBroker macro (async mode)":
     DualResponse.clearProvider()
 
     let res = waitFor DualResponse.request()
-    check res.isErr
+    check res.isErr()
 
   test "implicit zero-argument provider works by default":
     check ImplicitResponse
@@ -146,14 +146,14 @@ suite "RequestBroker macro (async mode)":
     .isOk()
 
     let res = waitFor ImplicitResponse.request()
-    check res.isOk
+    check res.isOk()
 
     ImplicitResponse.clearProvider()
     check res.value.note == "auto"
 
   test "implicit zero-argument request errors when unset":
     let res = waitFor ImplicitResponse.request()
-    check res.isErr
+    check res.isErr()
     check res.error.contains("no zero-arg provider")
 
   test "no provider override":
@@ -177,7 +177,7 @@ suite "RequestBroker macro (async mode)":
     check DualResponse.setProvider(overrideProc).isErr()
 
     let noInput = waitFor DualResponse.request()
-    check noInput.isOk
+    check noInput.isOk()
     check noInput.value.note == "base"
 
     let stillResponse = waitFor DualResponse.request(" still works")
@@ -197,7 +197,7 @@ suite "RequestBroker macro (async mode)":
     check DualResponse.setProvider(overrideProc).isOk()
 
     let nowSuccWithOverride = waitFor DualResponse.request()
-    check nowSuccWithOverride.isOk
+    check nowSuccWithOverride.isOk()
     check nowSuccWithOverride.value.note == "something else"
     check nowSuccWithOverride.value.count == 1
 
@@ -259,7 +259,7 @@ suite "RequestBroker macro (sync mode)":
 
   test "zero-argument request errors when unset (sync)":
     let res = SimpleResponseSync.request()
-    check res.isErr
+    check res.isErr()
     check res.error.contains("no zero-arg provider")
 
   test "serves input-based providers (sync)":
@@ -296,7 +296,7 @@ suite "RequestBroker macro (sync mode)":
 
   test "input request errors when unset (sync)":
     let res = KeyedResponseSync.request("foo", 2)
-    check res.isErr
+    check res.isErr()
     check res.error.contains("input signature")
 
   test "supports both provider types simultaneously (sync)":
@@ -315,11 +315,11 @@ suite "RequestBroker macro (sync mode)":
     .isOk()
 
     let noInput = DualResponseSync.request()
-    check noInput.isOk
+    check noInput.isOk()
     check noInput.value.note == "base"
 
     let withInput = DualResponseSync.request("-extra")
-    check withInput.isOk
+    check withInput.isOk()
     check withInput.value.note == "base-extra"
     check withInput.value.count == 6
 
@@ -335,7 +335,7 @@ suite "RequestBroker macro (sync mode)":
     DualResponseSync.clearProvider()
 
     let res = DualResponseSync.request()
-    check res.isErr
+    check res.isErr()
 
   test "implicit zero-argument provider works by default (sync)":
     check ImplicitResponseSync
@@ -346,14 +346,14 @@ suite "RequestBroker macro (sync mode)":
     .isOk()
 
     let res = ImplicitResponseSync.request()
-    check res.isOk
+    check res.isOk()
 
     ImplicitResponseSync.clearProvider()
     check res.value.note == "auto"
 
   test "implicit zero-argument request errors when unset (sync)":
     let res = ImplicitResponseSync.request()
-    check res.isErr
+    check res.isErr()
     check res.error.contains("no zero-arg provider")
 
   test "implicit zero-argument provider raises error (sync)":
@@ -365,7 +365,7 @@ suite "RequestBroker macro (sync mode)":
     .isOk()
 
     let res = ImplicitResponseSync.request()
-    check res.isErr
+    check res.isErr()
     check res.error.contains("simulated failure")
 
     ImplicitResponseSync.clearProvider()
@@ -484,15 +484,15 @@ suite "RequestBroker macro (POD/external types)":
 
     let resA = DistinctStringResponseA.request()
     let resB = DistinctStringResponseB.request()
-    check resA.isOk
-    check resB.isOk
+    check resA.isOk()
+    check resB.isOk()
     check string(resA.value) == "a"
     check string(resB.value) == "b"
 
     let resEA = ExternalDistinctResponseA.request()
     let resEB = ExternalDistinctResponseB.request()
-    check resEA.isOk
-    check resEB.isOk
+    check resEA.isOk()
+    check resEB.isOk()
     check ExternalDefinedTypeShared(resEA.value).label == "ea"
     check ExternalDefinedTypeShared(resEB.value).label == "eb"
 


### PR DESCRIPTION
## Description

During development of SendAPI https://github.com/logos-messaging/logos-messaging-nim/issues/3432
It's been made clear that RequestBrokers are useful beasts but with limited to async operations can make them inconvenient and adds unnecessary overhead for cases where only a simple answer with a string or bool is needed.

Due, such requests could simplify the code hugely and can remove the needs to spread callbacks or information through chain of ownerships or constructurs.

For example: Currently almost all component must know peerManager for the sake of getting a random peer for a certain protocol. Or, from whome I need to get actual connectivity info? I would need to register a callback to PeerManager's onConnectionChange handlers.

While with simple sync request we don't need to introduce such dependencies, just able to "throw in" our information request into the void and can truely hope the right answer without knowing the component it has the info.
This also avoids adding more and more interfaces to WakuNode that currently tightly coupled with everything because of being the center of all information. 

Also found that for many cases it would be easier just define request types as native types or user types without the additional overhead of bundle it into a Request object.
Eg.:
```nim
RequestBroker(sync):
  SelectPeerRequest = PeerId
  proc signature(proto: string): Result[SelectPeerRequest, string]
```
This is also needed as without async and withouth the object bundle more performant code can be generated that eliminates deep copies. It means `sync` mode RequestBrokers can be an a real alternatives of callbacks and direct class interfaces.

## Changes

- Added parameter for `RequestBroker` macro. Now it can be used with `sync` or `async` mode. Default kept for `async`.
- `sync` mode has only effect of the provider/request signature used. 
- Added support for native POD types and user types for definition of request's type for simplicity.
   - It comes with a limitation as it would be easy to define ambigous requests of strings for example and could lead to anoying compilation errors. To circumvent this code generates as `= distinct <type>` thus creating a distinguishable new type without object bundle.
- As more tests added it become very dense, it needed to be reorganized into a structured form. 

## Notice

For now I think MultiRequestBroker must stay with async approach only, due to the nature of undefined number of providers and data to collect. But in the near future it also can be extended with support for native and user types. 