### PR TITLE
chore: update ci container-image.yml ref to a commit in master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
   build-docker-image:
     needs: changes
     if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' || needs.changes.outputs.docker == 'true' }}
-    uses: logos-messaging/logos-messaging-nim/.github/workflows/container-image.yml@4139681df984de008069e86e8ce695f1518f1c0b
+    uses: logos-messaging/logos-messaging-nim/.github/workflows/container-image.yml@10dc3d3eb4b6a3d4313f7b2cc4a85a925e9ce039
     secrets: inherit
 
   nwaku-nwaku-interop-tests:


### PR DESCRIPTION
## Description

Update the `@<ref>` in ci.yml to container-image.yml to a better commit that's in master history to try and fix [this error](https://github.com/logos-messaging/logos-messaging-nim/actions/runs/20231831689) during merge of the ci-misc-fixes branch.

Note that Github's manual on reusable workflows says that `@<commit-hash>` is preferred over e.g. `@master`: https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#calling-a-reusable-workflow

## Changes

From:

`uses: logos-messaging/logos-messaging-nim/.github/workflows/container-image.yml@4139681df984de008069e86e8ce695f1518f1c0b` (commit in the ci-misc-fixes PR/branch)

to:

`uses: logos-messaging/logos-messaging-nim/.github/workflows/container-image.yml@10dc3d3eb4b6a3d4313f7b2cc4a85a925e9ce039` (merge commit in master of the ci-misc-fixes PR/branch)

## Issue

Maintenance Y2025H2 #3483