### PR TITLE
chore: update js-waku repo reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/prepare_beta_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_beta_release.md
@@ -22,7 +22,7 @@ All items below are to be completed by the owner of the given release.
 - [ ] Generate and edit release notes in CHANGELOG.md.
 
 - [ ] **Waku test and fleets validation**
-  - [ ] Ensure all the unit tests (specifically js-waku tests) are green against the release candidate.
+  - [ ] Ensure all the unit tests (specifically logos-messaging-js tests) are green against the release candidate.
   - [ ] Deploy the release candidate to `waku.test` only through [deploy-waku-test job](https://ci.infra.status.im/job/nim-waku/job/deploy-waku-test/) and wait for it to finish (Jenkins access required; ask the infra team if you don't have it).
     - After completion, disable [deployment job](https://ci.infra.status.im/job/nim-waku/) so that its version is not updated on every merge to master.
     - Verify the deployed version at https://fleets.waku.org/.

--- a/.github/ISSUE_TEMPLATE/prepare_full_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_full_release.md
@@ -24,7 +24,7 @@ All items below are to be completed by the owner of the given release.
 - [ ] **Validation of release candidate**
 
   - [ ] **Automated testing**
-    - [ ] Ensure all the unit tests (specifically js-waku tests) are green against the release candidate.
+    - [ ] Ensure all the unit tests (specifically logos-messaging-js tests) are green against the release candidate.
     - [ ] Ask Vac-QA and Vac-DST to perform the available tests against the release candidate.
     - [ ] Vac-DST (an additional report is needed; see [this](https://www.notion.so/DST-Reports-1228f96fb65c80729cd1d98a7496fe6f))
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,14 +151,14 @@ jobs:
 
   js-waku-node:
     needs: build-docker-image
-    uses: logos-messaging/js-waku/.github/workflows/test-node.yml@master
+    uses: logos-messaging/logos-messaging-js/.github/workflows/test-node.yml@master
     with:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node
 
   js-waku-node-optional:
     needs: build-docker-image
-    uses: logos-messaging/js-waku/.github/workflows/test-node.yml@master
+    uses: logos-messaging/logos-messaging-js/.github/workflows/test-node.yml@master
     with:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node-optional

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -98,7 +98,7 @@ jobs:
 
   js-waku-node:
     needs: build-docker-image
-    uses: logos-messaging/js-waku/.github/workflows/test-node.yml@master
+    uses: logos-messaging/logos-messaging-js/.github/workflows/test-node.yml@master
     with:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node
@@ -106,7 +106,7 @@ jobs:
 
   js-waku-node-optional:
     needs: build-docker-image
-    uses: logos-messaging/js-waku/.github/workflows/test-node.yml@master
+    uses: logos-messaging/logos-messaging-js/.github/workflows/test-node.yml@master
     with:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node-optional


### PR DESCRIPTION
## Description
This PR renames `js-waku` repo reference to new name of `logos-messaging-js`.

## Changes
Updated reference.
To reflect following changes in `js-waku` repo - https://github.com/logos-messaging/logos-messaging-js/pull/2757

## Issue

closes https://github.com/logos-messaging/logos-messaging-js/issues/2756
