### PR TITLE
chore: full release v0.38.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,54 @@
+## v0.38.0 (2026-01-27)
+
+### Notes
+
+- **libwaku**: Major improvements to libwaku distribution and iOS compilation support.
+- REST Store API now defaults to page size 20 with max 100.
+- Lightpush no longer mounts without relay enabled.
+- Context-aware and event-driven broker architecture introduced.
+
+### Features
+
+- iOS compilation support (WIP) ([#3668](https://github.com/logos-messaging/logos-messaging-nim/pull/3668)) ([96196ab8](https://github.com/logos-messaging/logos-messaging-nim/commit/96196ab8))
+- Rendezvous: broadcast and discover WakuPeerRecords ([#3617](https://github.com/logos-messaging/logos-messaging-nim/pull/3617)) ([b0cd75f4](https://github.com/logos-messaging/logos-messaging-nim/commit/b0cd75f4))
+- Distribute libwaku binaries ([#3612](https://github.com/logos-messaging/logos-messaging-nim/pull/3612)) ([9e2b3830](https://github.com/logos-messaging/logos-messaging-nim/commit/9e2b3830))
+- Implement libwaku using nim-ffi ([#3656](https://github.com/logos-messaging/logos-messaging-nim/pull/3656)) ([e3dd6203](https://github.com/logos-messaging/logos-messaging-nim/commit/e3dd6203))
+- New postgres metric to estimate payload stats ([#3596](https://github.com/logos-messaging/logos-messaging-nim/pull/3596)) ([454b098a](https://github.com/logos-messaging/logos-messaging-nim/commit/454b098a))
+
+### Bug Fixes
+
+- Store protocol issue in v0.37.0 ([#3657](https://github.com/logos-messaging/logos-messaging-nim/pull/3657)) ([91b4c5f5](https://github.com/logos-messaging/logos-messaging-nim/commit/91b4c5f5))
+- Hash inputs for external nullifier, remove length prefix for sha256 ([#3660](https://github.com/logos-messaging/logos-messaging-nim/pull/3660)) ([2d40cb9d](https://github.com/logos-messaging/logos-messaging-nim/commit/2d40cb9d))
+- Admin API peer shards field from metadata protocol ([#3594](https://github.com/logos-messaging/logos-messaging-nim/pull/3594)) ([e54851d9](https://github.com/logos-messaging/logos-messaging-nim/commit/e54851d9))
+- Wakucanary now fails correctly when ping fails ([#3595](https://github.com/logos-messaging/logos-messaging-nim/pull/3595)) ([adeb1a92](https://github.com/logos-messaging/logos-messaging-nim/commit/adeb1a92))
+
+### Changes
+
+- Context aware brokers architecture ([#3674](https://github.com/logos-messaging/logos-messaging-nim/pull/3674)) ([c27405b1](https://github.com/logos-messaging/logos-messaging-nim/commit/c27405b1))
+- Introduce EventBroker, RequestBroker and MultiRequestBroker ([#3644](https://github.com/logos-messaging/logos-messaging-nim/pull/3644)) ([ae74b901](https://github.com/logos-messaging/logos-messaging-nim/commit/ae74b901))
+- Use chronos' TokenBucket ([#3670](https://github.com/logos-messaging/logos-messaging-nim/pull/3670)) ([284a0816](https://github.com/logos-messaging/logos-messaging-nim/commit/284a0816))
+- REST Store API constraints: default page size 20, max 100 ([#3602](https://github.com/logos-messaging/logos-messaging-nim/pull/3602)) ([8c30a8e1](https://github.com/logos-messaging/logos-messaging-nim/commit/8c30a8e1))
+- Do not mount lightpush without relay ([#3540](https://github.com/logos-messaging/logos-messaging-nim/pull/3540)) ([7d1c6aba](https://github.com/logos-messaging/logos-messaging-nim/commit/7d1c6aba))
+- Mix: use exit==dest approach ([#3642](https://github.com/logos-messaging/logos-messaging-nim/pull/3642)) ([088e3108](https://github.com/logos-messaging/logos-messaging-nim/commit/088e3108))
+- Bump nim-ffi to v0.1.3 ([#3696](https://github.com/logos-messaging/logos-messaging-nim/pull/3696)) ([a02aaab5](https://github.com/logos-messaging/logos-messaging-nim/commit/a02aaab5))
+- Lightpush minor refactor ([#3538](https://github.com/logos-messaging/logos-messaging-nim/pull/3538)) ([1e73213a](https://github.com/logos-messaging/logos-messaging-nim/commit/1e73213a))
+- Pin RLN dependencies to specific version ([#3649](https://github.com/logos-messaging/logos-messaging-nim/pull/3649)) ([834eea94](https://github.com/logos-messaging/logos-messaging-nim/commit/834eea94))
+- Nix: add libwaku target and wakucanary Flake package ([#3599](https://github.com/logos-messaging/logos-messaging-nim/pull/3599), [a561ec3a](https://github.com/logos-messaging/logos-messaging-nim/commit/a561ec3a))
+- Add gasprice overflow check ([#3636](https://github.com/logos-messaging/logos-messaging-nim/pull/3636)) ([a8590a0a](https://github.com/logos-messaging/logos-messaging-nim/commit/a8590a0a))
+- Various CI/CD updates and fixes ([#3664](https://github.com/logos-messaging/logos-messaging-nim/pull/3664), [#3666](https://github.com/logos-messaging/logos-messaging-nim/pull/3666), [#3667](https://github.com/logos-messaging/logos-messaging-nim/pull/3667))
+
+### This release supports the following [libp2p protocols](https://docs.libp2p.io/concepts/protocols/):
+
+| Protocol | Spec status | Protocol id |
+| ---: | :---: | :--- |
+| [`11/WAKU2-RELAY`](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/11/relay.md) | `stable` | `/vac/waku/relay/2.0.0` |
+| [`12/WAKU2-FILTER`](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/12/filter.md) | `draft` | `/vac/waku/filter/2.0.0-beta1` <br />`/vac/waku/filter-subscribe/2.0.0-beta1` <br />`/vac/waku/filter-push/2.0.0-beta1` |
+| [`13/WAKU2-STORE`](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/13/store.md) | `draft` | `/vac/waku/store/2.0.0-beta4` |
+| [`19/WAKU2-LIGHTPUSH`](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/19/lightpush.md) | `draft` | `/vac/waku/lightpush/2.0.0-beta1` |
+| [`WAKU2-LIGHTPUSH v3`](https://github.com/waku-org/specs/blob/master/standards/core/lightpush.md) | `draft` | `/vac/waku/lightpush/3.0.0` |
+| [`66/WAKU2-METADATA`](https://github.com/waku-org/specs/blob/master/standards/core/metadata.md) | `raw` | `/vac/waku/metadata/1.0.0` |
+| [`WAKU-SYNC`](https://github.com/waku-org/specs/blob/master/standards/core/sync.md) | `draft` | `/vac/waku/sync/1.0.0` |
+
 ## v0.37.1-beta (2025-12-10)
 
 ### Bug Fixes


### PR DESCRIPTION
### Items to complete

All items below are to be completed by the owner of the given release.

- [x] Create release branch with major and minor only ( e.g. release/v0.X ) if it doesn't exist.
- [x] Assign release candidate tag to the release branch HEAD (e.g. `v0.X.0-rc.0`, `v0.X.0-rc.1`, ... `v0.X.0-rc.N`).
- [x] Generate and edit release notes in CHANGELOG.md.

- [ ] **Validation of release candidate**

  - [ ] **Automated testing**
    - [ ] Ensure all the unit tests (specifically logos-messaging-js tests) are green against the release candidate.
    - [ ] Ask Vac-QA and Vac-DST to perform the available tests against the release candidate.
    - [ ] Vac-DST (an additional report is needed; see [this](https://www.notion.so/DST-Reports-1228f96fb65c80729cd1d98a7496fe6f))

  - [ ] **Waku fleet testing**
    - [ ] Deploy the release candidate to `waku.test` and `waku.sandbox` fleets.
      - Start the [deployment job](https://ci.infra.status.im/job/nim-waku/) for both fleets and wait for it to finish (Jenkins access required; ask the infra team if you don't have it).
      - After completion, disable [deployment job](https://ci.infra.status.im/job/nim-waku/) so that its version is not updated on every merge to `master`.
      - Verify the deployed version at https://fleets.waku.org/.
      - Confirm the container image exists on [Harbor](https://harbor.status.im/harbor/projects/9/repositories/nwaku/artifacts-tab).
    - [ ] Search _Kibana_ logs from the previous month (since the last release was deployed) for possible crashes or errors in `waku.test` and `waku.sandbox`.
      - Most relevant logs are `(fleet: "waku.test" AND message: "SIGSEGV")` OR `(fleet: "waku.sandbox" AND message: "SIGSEGV")`.
    - [ ] Enable again the `waku.test` fleet to resume auto-deployment of the latest `master` commit.

- [ ] **Status fleet testing**
  - [ ] Deploy release candidate to `status.staging`
  - [ ] Perform [sanity check](https://www.notion.so/How-to-test-Nwaku-on-Status-12c6e4b9bf06420ca868bd199129b425) and log results as comments in this issue.
    - [ ] Connect 2 instances to `status.staging` fleet, one in relay mode, the other one in light client.
      - 1:1 Chats with each other
      - Send and receive messages in a community
      - Close one instance, send messages with second instance, reopen first instance and confirm messages sent while offline are retrieved from store
    - [ ] Perform checks based on _end user impact_
    - [ ] Inform other (Waku and Status) CCs to point their instances to `status.staging` for a few days. Ping Status colleagues on their Discord server or in the [Status community](https://status.app/c/G3kAAMSQtb05kog3aGbr3kiaxN4tF5xy4BAGEkkLwILk2z3GcoYlm5hSJXGn7J3laft-tnTwDWmYJ18dP_3bgX96dqr_8E3qKAvxDf3NrrCMUBp4R9EYkQez9XSM4486mXoC3mIln2zc-TNdvjdfL9eHVZ-mGgs=#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) (this is not a blocking point.)
    - [ ] Ask Status-QA to perform sanity checks (as described above) and checks based on _end user impact_; specify the version being tested
    - [ ] Ask Status-QA or infra to run the automated Status e2e tests against `status.staging`
    - [ ] Get other CCs' sign-off: they should comment on this PR, e.g., "Used the app for a week, no problem." If problems are reported, resolve them and create a new RC.
    - [ ] **Get Status-QA sign-off**, ensuring that the `status.test` update will not disturb ongoing activities.

- [ ] **Proceed with release**

  - [ ] Assign a final release tag (`v0.X.0`) to the same commit that contains the validated release-candidate tag (e.g. `v0.X.0`).
  - [ ] Update [nwaku-compose](https://github.com/logos-messaging/nwaku-compose) and [waku-simulator](https://github.com/logos-messaging/waku-simulator) according to the new release.
  - [ ] Bump nwaku dependency in [waku-rust-bindings](https://github.com/logos-messaging/waku-rust-bindings) and make sure all examples and tests work.
  - [ ] Bump nwaku dependency in [waku-go-bindings](https://github.com/logos-messaging/waku-go-bindings) and make sure all tests work.
  - [ ] Create GitHub release (https://github.com/logos-messaging/nwaku/releases).
  - [ ] Submit a PR to merge the release branch back to `master`. Make sure you use the option "Merge pull request (Create a merge commit)" to perform the merge. Ping repo admin if this option is not available.

- [ ] **Promote release to fleets**
  - [ ] Ask the PM lead to announce the release.
  - [ ] Update infra config with any deprecated arguments or changed options.