### PR TITLE
canary exits with error if ping fails

### DIFF
--- a/apps/wakucanary/wakucanary.nim
+++ b/apps/wakucanary/wakucanary.nim
@@ -289,10 +289,6 @@ proc main(rng: ref HmacDrbgContext): Future[int] {.async.} =
       error "Not all protocols are supported",
         expected = conf.protocols, supported = nodeProtocols
       quit(QuitFailure)
-
-    if not pingSuccess:
-      error "Node is reachable and supports protocols but ping failed - connection may be unstable"
-      quit(QuitFailure)
   elif conStatus == CannotConnect:
     error "Could not connect", peerId = peer.peerId
     quit(QuitFailure)


### PR DESCRIPTION
This is aimed to make `wakucanary` app more strict about ping, i.e., if ping fails, then `wakucanary` exits with error too.

We want to avoid the following behaviour:

<img width="928" height="106" alt="image" src="https://github.com/user-attachments/assets/2542821f-a83e-47bb-8094-950540878542" />

## Issue

- https://github.com/logos-messaging/logos-messaging-nim/issues/3686
