### PR TITLE
fix: docker failure in fleets 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG LOG_LEVEL=TRACE
 ARG HEAPTRACK_BUILD=0
 
 # Get build tools and required header files
-RUN apk add --no-cache bash git build-base openssl-dev linux-headers curl jq
+RUN apk add --no-cache bash git build-base openssl-dev linux-headers curl jq bsd-compat-headers
 
 WORKDIR /app
 COPY . .
@@ -46,7 +46,7 @@ LABEL version="unknown"
 EXPOSE 30303 60000 8545
 
 # Referenced in the binary
-RUN apk add --no-cache libgcc libpq-dev bind-tools
+RUN apk add --no-cache libgcc libstdc++ libpq-dev bind-tools
 
 # Copy to separate location to accomodate different MAKE_TARGET values
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/


### PR DESCRIPTION
  Add `bsd-compat-headers` to the build stage to provide sys/queue.h required by lsquic C sources on Alpine (musl libc).       
  Add `libstdc++` to the production image for the C++ runtime dependency introduced by lsquic/boringssl linkage.