### PR TITLE
force FINALIZE partition detach after detecting shorter error

### DIFF
--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1347,8 +1347,7 @@ proc removePartition(
   (await self.performWriteQuery(detachPartitionQuery)).isOkOr:
     info "detected error when trying to detach partition", error
 
-    if ($error).contains("FINALIZE") or
-        ($error).contains("already pending"):
+    if ($error).contains("FINALIZE") or ($error).contains("already pending"):
       ## We assume "already pending detach in partitioned table ..." as possible error
       debug "enforce detach with FINALIZE because of detected error", error
 


### PR DESCRIPTION
Enforce partition detach with `FINALIZE` in postgres.

The issue happened the error message returned by the DB was one char shorter (dunno why.)

In this PR we are reducing the error message to consider that we need to force "detach FINALIZE".

See an screnshot of the new error message which we didn't detect properly and hence the node didn't try to force "detach FINALIZE".

<img width="680" height="29" alt="image" src="https://github.com/user-attachments/assets/accd4414-c65c-4040-80a0-dcb54d5de8c2" />


## Related issue

- https://github.com/logos-messaging/logos-messaging-nim/issues/3686