### PR TITLE
chore(liblogosdelivery): node_api destroy move + security/resource fixes

### DIFF
--- a/liblogosdelivery/declare_lib.nim
+++ b/liblogosdelivery/declare_lib.nim
@@ -1,7 +1,11 @@
 import ffi
+import std/locks
 import waku/factory/waku
 
 declareLibrary("logosdelivery")
+
+var eventCallbackLock: Lock
+initLock(eventCallbackLock)
 
 template requireInitializedNode*(
     ctx: ptr FFIContext[Waku], opName: string, onError: untyped
@@ -19,6 +23,11 @@ proc logosdelivery_set_event_callback(
   if isNil(ctx):
     echo "error: invalid context in logosdelivery_set_event_callback"
     return
+
+  # prevent race conditions that might happen due incorrect usage.
+  eventCallbackLock.acquire()
+  defer:
+    eventCallbackLock.release()
 
   ctx[].eventCallback = cast[pointer](callback)
   ctx[].eventUserData = userData

--- a/liblogosdelivery/liblogosdelivery.nim
+++ b/liblogosdelivery/liblogosdelivery.nim
@@ -5,25 +5,3 @@ import waku/factory/waku, waku/node/waku_node, ./declare_lib
 ################################################################################
 ## Include different APIs, i.e. all procs with {.ffi.} pragma
 include ./logos_delivery_api/node_api, ./logos_delivery_api/messaging_api
-
-################################################################################
-### Exported procs
-
-proc logosdelivery_destroy(
-    ctx: ptr FFIContext[Waku], callback: FFICallBack, userData: pointer
-): cint {.dynlib, exportc, cdecl.} =
-  initializeLibrary()
-  checkParams(ctx, callback, userData)
-
-  ffi.destroyFFIContext(ctx).isOkOr:
-    let msg = "liblogosdelivery error: " & $error
-    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
-    return RET_ERR
-
-  ## always need to invoke the callback although we don't retrieve value to the caller
-  callback(RET_OK, nil, 0, userData)
-
-  return RET_OK
-
-# ### End of exported procs
-# ################################################################################

--- a/liblogosdelivery/logos_delivery_api/node_api.nim
+++ b/liblogosdelivery/logos_delivery_api/node_api.nim
@@ -29,6 +29,22 @@ registerReqFFI(CreateNodeRequest, ctx: ptr FFIContext[Waku]):
 
     return ok("")
 
+proc logosdelivery_destroy(
+    ctx: ptr FFIContext[Waku], callback: FFICallBack, userData: pointer
+): cint {.dynlib, exportc, cdecl.} =
+  initializeLibrary()
+  checkParams(ctx, callback, userData)
+
+  ffi.destroyFFIContext(ctx).isOkOr:
+    let msg = "liblogosdelivery error: " & $error
+    callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    return RET_ERR
+
+  ## always need to invoke the callback although we don't retrieve value to the caller
+  callback(RET_OK, nil, 0, userData)
+
+  return RET_OK
+
 proc logosdelivery_create_node(
     configJson: cstring, callback: FFICallback, userData: pointer
 ): pointer {.dynlib, exportc, cdecl.} =
@@ -50,6 +66,9 @@ proc logosdelivery_create_node(
   ).isOkOr:
     let msg = "error in sendRequestToFFIThread: " & $error
     callback(RET_ERR, unsafeAddr msg[0], cast[csize_t](len(msg)), userData)
+    # free allocated resources as they won't be available
+    ffi.destroyFFIContext(ctx).isOkOr:
+      chronicles.error "Error in destroyFFIContext after sendRequestToFFIThread during creation", err = $error
     return nil
 
   return ctx


### PR DESCRIPTION
## Summary
- move destroy api to node_api
- add security checks
- fix possible resource leak

## Scope after split
- this PR now intentionally excludes health-status event support
- health-status event support was extracted to: https://github.com/logos-messaging/logos-delivery/pull/3737
