### PR TITLE
setting num-shards-in-network to 0 by default

### DIFF
--- a/tests/wakunode2/test_cli_args.nim
+++ b/tests/wakunode2/test_cli_args.nim
@@ -23,9 +23,8 @@ import
 suite "Waku external config - default values":
   test "Default sharding value":
     ## Setup
-    let defaultShardingMode = AutoSharding
-    let defaultNumShardsInCluster = 1.uint16
-    let defaultSubscribeShards = @[0.uint16]
+    let defaultShardingMode = StaticSharding
+    let defaultSubscribeShards: seq[uint16] = @[]
 
     ## Given
     let preConfig = defaultWakuNodeConf().get()
@@ -37,7 +36,6 @@ suite "Waku external config - default values":
     ## Then
     let conf = res.get()
     check conf.shardingConf.kind == defaultShardingMode
-    check conf.shardingConf.numShardsInCluster == defaultNumShardsInCluster
     check conf.subscribeShards == defaultSubscribeShards
 
   test "Default shards value in static sharding":
@@ -212,7 +210,7 @@ suite "Waku external config - Shards":
     let vRes = wakuConf.validate()
     assert vRes.isOk(), $vRes.error
 
-  test "Imvalid shard is passed without num shards":
+  test "Any shard is valid without num shards in static sharding mode":
     ## Setup
 
     ## Given
@@ -222,7 +220,9 @@ suite "Waku external config - Shards":
     let res = wakuNodeConf.toWakuConf()
 
     ## Then
-    assert res.isErr(), "Invalid shard was accepted"
+    let wakuConf = res.get()
+    let vRes = wakuConf.validate()
+    assert vRes.isOk(), $vRes.error
 
 suite "Waku external config - store retention policy":
   test "Default retention policy":

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -328,7 +328,7 @@ hence would have reachability issues.""",
     numShardsInNetwork* {.
       desc:
         "Enables autosharding and set number of shards in the cluster, set to `0` to use static sharding",
-      defaultValue: 1,
+      defaultValue: 0,
       name: "num-shards-in-network"
     .}: uint16
 


### PR DESCRIPTION
## Description

Setting num shards in network to zero by default, which implies that static sharding is considered by default.

This is needed to avoid having to set weird configuration settings in a node that is currently configuring static shards.

For example, this current config:
```nim
cluster-id = 16
shard = [
  1,
  32,
  64,
  128,
  256,
]
```
Doesn't allow a node to run properly with v0.37.0-beta, showing the following error:
```nim
nim-waku-store  | ERR 2026-03-05 15:17:13.794+00:00 Waku configuration failed                  topics="wakunode main" tid=1 file=wakunode2.nim:52 error="validateShards invalid shard: 1 when numShardsInCluster: 1"
```

Then, with the current implementation, we need to provide this weird configuration to make the node start, which doesn't look nice:
```nim
cluster-id = 16
num-shards-in-network = 257
shard = [
  1,
  32,
  64,
  128,
  256,
]
```


