### PR TITLE
patch release v0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-<<<<<<< update-changelog-v0.37.1-master
 ## v0.37.1 (2026-03-12)
 
 ### Bug Fixes
@@ -6,10 +5,7 @@
 - Avoid IndexDefect if DB error message is short ([#3725](https://github.com/logos-messaging/logos-delivery/pull/3725))
 - Remove ENR cache from peer exchange ([#3652](https://github.com/logos-messaging/logos-messaging-nim/pull/3652)) ([7920368a](https://github.com/logos-messaging/logos-messaging-nim/commit/7920368a36687cd5f12afa52d59866792d8457ca))
 
-## v0.37.0-beta (2025-10-01)
-=======
 ## v0.37.0 (2025-10-01)
->>>>>>> master
 
 ### Notes
 


### PR DESCRIPTION
## Description

This aims to merge a release patch v0.37.1 into master. Mostly to update the CHANGELOG.md

- We no longer use the `beta` concept.
- This PR doesn't show the code fix change because it is actually in `master`, in this commit: 8f29070dcfc7c621fdcd3941369fd2cdc81b69e7



