### PR TITLE
chore: Add pre-check of options used in config Json for liblogosdelivery pre-createNode, treat unrecognized options as error

### DIFF
--- a/liblogosdelivery/logos_delivery_api/node_api.nim
+++ b/liblogosdelivery/logos_delivery_api/node_api.nim
@@ -33,10 +33,13 @@ registerReqFFI(CreateNodeRequest, ctx: ptr FFIContext[Waku]):
     for confField, _ in fieldPairs(conf):
       knownFields.incl(confField)
     # Check for unknown keys
+    var unknownKeys = newSeq[string]()
     for key in jsonNode.keys:
       if key notin knownFields:
-        error "Invalid configuration option found.", option = key
-        return err("Invalid configuration option found: " & key)
+        unknownKeys.add(key)
+    if unknownKeys.len > 0:
+      error "Unrecognized configuration option(s) found.", option = unknownKeys
+      return err("Unrecognized configuration option(s) found: " & $unknownKeys)
 
     for confField, confValue in fieldPairs(conf):
       if jsonNode.contains(confField):

--- a/liblogosdelivery/logos_delivery_api/node_api.nim
+++ b/liblogosdelivery/logos_delivery_api/node_api.nim
@@ -23,17 +23,21 @@ registerReqFFI(CreateNodeRequest, ctx: ptr FFIContext[Waku]):
     try:
       jsonNode = parseJson($configJson)
     except Exception:
+      let exceptionMsg = getCurrentExceptionMsg()
+      error "Failed to parse config JSON",
+        error = exceptionMsg, configJson = $configJson
       return err(
-        "Failed to parse config JSON: " & getCurrentExceptionMsg() &
-          " configJson string: " & $configJson
+        "Failed to parse config JSON: " & exceptionMsg & " configJson string: " &
+          $configJson
       )
 
-    var jsonFields = initTable[string, (string, JsonNode)]()
+    var jsonFields: Table[string, (string, JsonNode)]
     for key, value in jsonNode:
       let lowerKey = key.toLowerAscii()
 
       if jsonFields.hasKey(lowerKey):
-        error "Duplicate configuration option found when normalized to lowercase.", key = key
+        error "Duplicate configuration option found when normalized to lowercase",
+          key = key
         return err(
           "Duplicate configuration option found when normalized to lowercase: '" & key &
             "'"
@@ -43,24 +47,24 @@ registerReqFFI(CreateNodeRequest, ctx: ptr FFIContext[Waku]):
 
     for confField, confValue in fieldPairs(conf):
       let lowerField = confField.toLowerAscii()
-      if not jsonFields.hasKey(lowerField):
-        continue
+      if jsonFields.hasKey(lowerField):
+        let (jsonKey, jsonValue) = jsonFields[lowerField]
+        let formattedString = ($jsonValue).strip(chars = {'\"'})
+        try:
+          confValue = parseCmdArg(typeof(confValue), formattedString)
+        except Exception:
+          return err(
+            "Failed to parse field '" & confField & "' from JSON key '" & jsonKey & "': " &
+              getCurrentExceptionMsg() & ". Value: " & formattedString
+          )
 
-      let (jsonKey, jsonValue) = jsonFields[lowerField]
-      let formattedString = ($jsonValue).strip(chars = {'\"'})
-      try:
-        confValue = parseCmdArg(typeof(confValue), formattedString)
-      except Exception:
-        return err(
-          "Failed to parse field '" & confField & "' from JSON key '" & jsonKey & "': " &
-            getCurrentExceptionMsg() & ". Value: " & formattedString
-        )
-
-      jsonFields.del(lowerField)
+        jsonFields.del(lowerField)
 
     if jsonFields.len > 0:
-      let unknownKeys = toSeq(jsonFields.values()).mapIt(it[0])
-      error "Unrecognized configuration option(s) found.", option = unknownKeys
+      var unknownKeys = newSeq[string]()
+      for _, (jsonKey, _) in pairs(jsonFields):
+        unknownKeys.add(jsonKey)
+      error "Unrecognized configuration option(s) found", option = unknownKeys
       return err("Unrecognized configuration option(s) found: " & $unknownKeys)
 
     # Create the node

--- a/liblogosdelivery/logos_delivery_api/node_api.nim
+++ b/liblogosdelivery/logos_delivery_api/node_api.nim
@@ -1,4 +1,4 @@
-import std/[json, strutils, sets]
+import std/[json, strutils, tables]
 import chronos, chronicles, results, confutils, confutils/std/net, ffi
 import
   waku/factory/waku,
@@ -28,29 +28,40 @@ registerReqFFI(CreateNodeRequest, ctx: ptr FFIContext[Waku]):
           " configJson string: " & $configJson
       )
 
-    # Collect known fields
-    var knownFields = initHashSet[string]()
-    for confField, _ in fieldPairs(conf):
-      knownFields.incl(confField)
-    # Check for unknown keys
-    var unknownKeys = newSeq[string]()
-    for key in jsonNode.keys:
-      if key notin knownFields:
-        unknownKeys.add(key)
-    if unknownKeys.len > 0:
-      error "Unrecognized configuration option(s) found.", option = unknownKeys
-      return err("Unrecognized configuration option(s) found: " & $unknownKeys)
+    var jsonFields = initTable[string, (string, JsonNode)]()
+    for key, value in jsonNode:
+      let lowerKey = key.toLowerAscii()
+
+      if jsonFields.hasKey(lowerKey):
+        error "Duplicate configuration option found when normalized to lowercase.", key = key
+        return err(
+          "Duplicate configuration option found when normalized to lowercase: '" & key &
+            "'"
+        )
+
+      jsonFields[lowerKey] = (key, value)
 
     for confField, confValue in fieldPairs(conf):
-      if jsonNode.contains(confField):
-        let formattedString = ($jsonNode[confField]).strip(chars = {'\"'})
-        try:
-          confValue = parseCmdArg(typeof(confValue), formattedString)
-        except Exception:
-          return err(
-            "Failed to parse field '" & confField & "': " & getCurrentExceptionMsg() &
-              ". Value: " & formattedString
-          )
+      let lowerField = confField.toLowerAscii()
+      if not jsonFields.hasKey(lowerField):
+        continue
+
+      let (jsonKey, jsonValue) = jsonFields[lowerField]
+      let formattedString = ($jsonValue).strip(chars = {'\"'})
+      try:
+        confValue = parseCmdArg(typeof(confValue), formattedString)
+      except Exception:
+        return err(
+          "Failed to parse field '" & confField & "' from JSON key '" & jsonKey & "': " &
+            getCurrentExceptionMsg() & ". Value: " & formattedString
+        )
+
+      jsonFields.del(lowerField)
+
+    if jsonFields.len > 0:
+      let unknownKeys = toSeq(jsonFields.values()).mapIt(it[0])
+      error "Unrecognized configuration option(s) found.", option = unknownKeys
+      return err("Unrecognized configuration option(s) found: " & $unknownKeys)
 
     # Create the node
     ctx.myLib[] = (await api.createNode(conf)).valueOr:

--- a/liblogosdelivery/logos_delivery_api/node_api.nim
+++ b/liblogosdelivery/logos_delivery_api/node_api.nim
@@ -1,4 +1,4 @@
-import std/[json, strutils]
+import std/[json, strutils, sets]
 import chronos, chronicles, results, confutils, confutils/std/net, ffi
 import
   waku/factory/waku,
@@ -27,6 +27,16 @@ registerReqFFI(CreateNodeRequest, ctx: ptr FFIContext[Waku]):
         "Failed to parse config JSON: " & getCurrentExceptionMsg() &
           " configJson string: " & $configJson
       )
+
+    # Collect known fields
+    var knownFields = initHashSet[string]()
+    for confField, _ in fieldPairs(conf):
+      knownFields.incl(confField)
+    # Check for unknown keys
+    for key in jsonNode.keys:
+      if key notin knownFields:
+        error "Invalid configuration option found.", option = key
+        return err("Invalid configuration option found: " & key)
 
     for confField, confValue in fieldPairs(conf):
       if jsonNode.contains(confField):


### PR DESCRIPTION
## Description

liblogosdelivey silently ignores uncrecognized options given through json string config.

## Changes

- For liblogosdelivery pre calling createNode we parse the given json string configuration. Now we cross check json keys with known options and treat unrecognized options as error.

## Issue

https://github.com/logos-messaging/logos-delivery/issues/3800
closes #
https://github.com/logos-messaging/logos-delivery/issues/3800