### PR TITLE
Fix BearSSL and NAT lib build reproducibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           path: |
             nimbledeps/
             nimble.paths
-          key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock') }}
+          key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
 
       - name: Install nimble deps
         if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
@@ -136,7 +136,7 @@ jobs:
           path: |
             nimbledeps/
             nimble.paths
-          key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock') }}
+          key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
 
       - name: Install nimble deps
         if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
@@ -215,7 +215,7 @@ jobs:
           path: |
             nimbledeps/
             nimble.paths
-          key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock') }}
+          key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
 
       - name: Install nimble deps
         if: steps.cache-nimbledeps.outputs.cache-hit != 'true'

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -69,7 +69,7 @@ jobs:
           path: |
             nimbledeps/
             nimble.paths
-          key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock') }}
+          key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
 
       - name: Install nimble deps
         if: ${{ steps.secrets.outcome == 'success' && steps.cache-nimbledeps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -87,7 +87,7 @@ jobs:
         path: |
             nimbledeps/
             nimble.paths
-        key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock') }}
+        key: ${{ runner.os }}-nimbledeps-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
 
     - name: Install nimble deps
       if: steps.cache-nimbledeps.outputs.cache-hit != 'true'

--- a/BearSSL.mk
+++ b/BearSSL.mk
@@ -22,6 +22,13 @@
 BEARSSL_NIMBLEDEPS_DIR := $(shell ls -dt $(CURDIR)/nimbledeps/pkgs2/bearssl-* 2>/dev/null | head -1)
 BEARSSL_CSOURCES_DIR   := $(BEARSSL_NIMBLEDEPS_DIR)/bearssl/csources
 
+BEARSSL_UNAME_M := $(shell uname -m)
+ifeq ($(BEARSSL_UNAME_M),x86_64)
+  PORTABLE_BEARSSL_CFLAGS := -W -Wall -Os -fPIC -mssse3
+else
+  PORTABLE_BEARSSL_CFLAGS := -W -Wall -Os -fPIC
+endif
+
 .PHONY: clean-bearssl-nimbledeps rebuild-bearssl-nimbledeps
 
 clean-bearssl-nimbledeps:
@@ -36,4 +43,4 @@ ifeq ($(BEARSSL_NIMBLEDEPS_DIR),)
 	$(error No bearssl package found under nimbledeps/pkgs2/ — run 'make update' first)
 endif
 	@echo "Rebuilding bearssl from $(BEARSSL_CSOURCES_DIR)"
-	+ "$(MAKE)" -C "$(BEARSSL_CSOURCES_DIR)" lib
+	+ "$(MAKE)" -C "$(BEARSSL_CSOURCES_DIR)" CFLAGS="$(PORTABLE_BEARSSL_CFLAGS)" lib

--- a/Nat.mk
+++ b/Nat.mk
@@ -21,6 +21,13 @@
 
 NAT_TRAVERSAL_NIMBLEDEPS_DIR := $(shell ls -dt $(CURDIR)/nimbledeps/pkgs2/nat_traversal-* 2>/dev/null | head -1)
 
+NAT_UNAME_M := $(shell uname -m)
+ifeq ($(NAT_UNAME_M),x86_64)
+  PORTABLE_NAT_MARCH := -mssse3
+else
+  PORTABLE_NAT_MARCH :=
+endif
+
 .PHONY: clean-cross-nimbledeps rebuild-nat-libs-nimbledeps
 
 clean-cross-nimbledeps:
@@ -47,8 +54,8 @@ ifeq ($(OS), Windows_NT)
 		libnatpmp.a $(HANDLE_OUTPUT)
 else
 	+ "$(MAKE)" -C "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor/miniupnp/miniupnpc" \
-		CC=$(CC) CFLAGS="-Os -fPIC" build/libminiupnpc.a $(HANDLE_OUTPUT)
-	+ "$(MAKE)" CFLAGS="-Wall -Wno-cpp -Os -fPIC -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 $(CFLAGS)" \
+		CC=$(CC) CFLAGS="-Os -fPIC $(PORTABLE_NAT_MARCH)" build/libminiupnpc.a $(HANDLE_OUTPUT)
+	+ "$(MAKE)" CFLAGS="-Wall -Wno-cpp -Os -fPIC $(PORTABLE_NAT_MARCH) -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 $(CFLAGS)" \
 		-C "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor/libnatpmp-upstream" \
 		CC=$(CC) libnatpmp.a $(HANDLE_OUTPUT)
 endif


### PR DESCRIPTION
## Description

BearSSL and the NAT lib dependencies are using native arch by default, so the resulting binary is not portable. This manifests as e.g. interop-tests failures in CI as one CI machine builds the docker image with a larger instruction set and another CI machine runs the interop tests with a reduced instruction set.

Forces -mssse3 for these dependencies.

Also added them to the cache key in nibledeps. (Zerokit uses Cargo so it's not covered by the nimbledeps cache, and it should be fine).

## Changes

* pass -mssse3 on x86_64 to BearSSL and NAT C lib builds
* add BearSSL.mk and Nat.mk to nimbledeps cache key

## Issue

Maintenance Y2026H1 #3686
