### PR TITLE
chore: enable postgres support in nix liblogosdelivery build

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -62,6 +62,8 @@ pkgs.stdenv.mkDerivation {
       --path:$NAT_TRAV/src \
       --passL:"-L${zerokitRln}/lib -lrln" \
       --define:disable_libbacktrace \
+      --define:postgres \
+      --define:nimDebugDlOpen \
       --out:build/liblogosdelivery.${libExt} \
       --app:lib \
       --threads:on \
@@ -81,6 +83,8 @@ pkgs.stdenv.mkDerivation {
       --path:$NAT_TRAV/src \
       --passL:"-L${zerokitRln}/lib -lrln" \
       --define:disable_libbacktrace \
+      --define:postgres \
+      --define:nimDebugDlOpen \
       --out:build/liblogosdelivery.a \
       --app:staticlib \
       --threads:on \


### PR DESCRIPTION
## Notice

It is important for fleet node support vie logos-delivery-module and headless logos-core!

## Summary

Add `-d:postgres` and `-d:nimDebugDlOpen` to both the dynamic and static `nim c` invocations in `nix/default.nix`.

## Motivation

The Make-based build path already passes `POSTGRES=1` (which injects `-d:postgres -d:nimDebugDlOpen` via `NIM_PARAMS`) when building liblogosdelivery. The nix build path was missing these flags, creating an inconsistency between the two build methods.

## Changes

- `nix/default.nix`: added `--define:postgres` and `--define:nimDebugDlOpen` to both the dynamic (`.dylib/.so`) and static (`.a`) nim compilation invocations.