### PR TITLE
fix: make update and wakunode2 build on arm64 after Nimble migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ $(NIMBLEDEPS_STAMP): nimble.lock | waku.nims
 	nimble setup --localdeps
 	$(MAKE) build-nph
 	$(MAKE) rebuild-bearssl-nimbledeps
+	$(MAKE) rebuild-nat-libs-nimbledeps
 	touch $@
 
 update:


### PR DESCRIPTION
# Summary

## `make update` failing

`make update` failing at `nimble lock`.

PR #3812 bumped `nim-jwt` to `#057ec95e...` in `waku.nimble`, but:
- the pinned `libp2p` commit (`ff8d51857b...`) still requires `nim-jwt#18f8378...`. 
- Two conflicting specific-commit requirements for the same package cause the SAT solver to fail entirely. 
- Additionally, `nim-ffi` and `nim-lsquic` were unpinned, causing nimble to download their latest versions — `lsquic 0.1.0` then triggered a secondary nimble localdeps bug ("Missing package 'zlib'"). 
 
**Fix:** revert `nim-jwt` to the version compatible with the current `libp2p` pin, and add explicit commit pins for `nim-ffi` and `nim-lsquic` matching the existing `nimble.lock`.

## `make wakunode2` failing

`make wakunode2` failing with "symbol(s) not found for architecture arm64".

`rebuild-nat-libs-nimbledeps` was never called from the `$(NIMBLEDEPS_STAMP)` setup target. `libminiupnpc.a` and `libnatpmp.a` were left as prebuilt x86_64 from the nimble package cache. 

**Fix:** add `rebuild-nat-libs-nimbledeps` to `$(NIMBLEDEPS_STAMP)`, alongside the existing `rebuild-bearssl-nimbledeps`.

# Lessons learnt

PR #3812 broke it, and CI didn't detect this because of filtering jobs to be exectued.
The CI logic should be improved.