### PR TITLE
Fix peer stats endpoint

### DIFF
--- a/waku/rest_api/endpoint/admin/handlers.nim
+++ b/waku/rest_api/endpoint/admin/handlers.nim
@@ -344,7 +344,7 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
       for ps in relayPeers:
         totalRelayPeers += ps.peers.len
         stat[$ps.shard] = ps.peers.len
-      stat["Total relay peers"] = relayPeers.len
+      stat["Total relay peers"] = totalRelayPeers
       stat
 
     # stats of mesh peers
@@ -355,7 +355,7 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
       for ps in meshPeers:
         totalMeshPeers += ps.peers.len
         stat[$ps.shard] = ps.peers.len
-      stat["Total mesh peers"] = meshPeers.len
+      stat["Total mesh peers"] = totalMeshPeers
       stat
 
     var protoStats = initOrderedTable[string, int]()


### PR DESCRIPTION
## Description

handlers.nim used .len on intermediary data structures instead of using the actual counts that were already there. 

## Changes

* Fix total relay peers stat (return totalRelayPeers instead of relayPeers.len)
* Fix total mesh peers stat (return totalMeshPeers instead of meshPeers.len)

## Issue

closes #3541 