### PR TITLE
fix: prefer --num-shards-in-network over preset (#3795)

### DIFF
--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -213,6 +213,54 @@ suite "Waku Conf - build with cluster conf":
       check rlnRelayConf.epochSizeSec == networkConf.rlnEpochSizeSec
       check rlnRelayConf.userMessageLimit == userMessageLimit.uint
 
+  test "num-shards-in-network > 0 overrides preset":
+    ## Setup
+    let networkConf = NetworkConf.LogosDevConf()
+    var builder = WakuConfBuilder.init()
+
+    # Sanity check
+    check networkConf.shardingConf.kind == AutoSharding
+    check networkConf.shardingConf.numShardsInCluster > 1
+
+    ## Given: preset says >1 shards but user explicitly sets 1
+    builder.withNetworkConf(networkConf)
+    builder.withNumShardsInCluster(1)
+    builder.withShardingConf(AutoSharding)
+
+    ## When
+    let conf = builder.build().expect("build should succeed")
+
+    ## Then: user value wins, not preset
+    conf.validate().expect("conf should validate")
+    check conf.shardingConf.kind == AutoSharding
+    check conf.shardingConf.numShardsInCluster == 1
+
+  test "num-shards-in-network == 0 does not override preset":
+    ## Passing an AutoSharding preset and trying to override with
+    ## --num-shards-in-network=0 (which is StaticSharding) doesn't work.
+    ## Note that --num-shards-in-network=0 and omitting the switch are
+    ## internally the same. Promoting the config to an Option[uint16] is
+    ## probably not worth it since overriding an AutoSharding preset with
+    ## StaticSharding shouldn't make any sense (that is, no use case).
+
+    ## Given: emulate --preset=logos.dev --num-shards-in-network=0
+    let networkConf = NetworkConf.LogosDevConf()
+    var builder = WakuConfBuilder.init()
+    builder.withNetworkConf(networkConf)
+    # Note: builder.withNumShardsInCluster() is not called when the
+    # value that comes from the CLI path is 0 (which means it was
+    # either set to 0 or was left unset).
+    builder.withShardingConf(StaticSharding)
+
+    ## When
+    let conf = builder.build().expect("build should succeed")
+
+    ## Then: preset wins and StaticSharding user intent is lost
+    conf.validate().expect("conf should validate")
+    check conf.shardingConf.kind == networkConf.shardingConf.kind
+    check conf.shardingConf.numShardsInCluster ==
+      networkConf.shardingConf.numShardsInCluster
+
 suite "Waku Conf - node key":
   test "Node key is generated":
     ## Setup

--- a/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/waku/factory/conf_builder/waku_conf_builder.nim
@@ -299,7 +299,6 @@ proc buildShardingConf(
     bNumShardsInCluster: Option[uint16],
     bSubscribeShards: Option[seq[uint16]],
 ): (ShardingConf, seq[uint16]) =
-  echo "bSubscribeShards: ", bSubscribeShards
   case bShardingConfKind.get(AutoSharding)
   of StaticSharding:
     (ShardingConf(kind: StaticSharding), bSubscribeShards.get(@[]))
@@ -374,17 +373,17 @@ proc applyNetworkConf(builder: var WakuConfBuilder) =
     warn "Sharding Conf was provided alongside a network conf",
       used = networkConf.shardingConf.kind, discarded = builder.shardingConf
 
-  if builder.numShardsInCluster.isSome():
-    warn "Num Shards In Cluster was provided alongside a network conf",
-      used = networkConf.shardingConf.numShardsInCluster,
-      discarded = builder.numShardsInCluster
-
   case networkConf.shardingConf.kind
   of StaticSharding:
     builder.shardingConf = some(StaticSharding)
   of AutoSharding:
     builder.shardingConf = some(AutoSharding)
-    builder.numShardsInCluster = some(networkConf.shardingConf.numShardsInCluster)
+    if builder.numShardsInCluster.isSome():
+      warn "Num Shards In Cluster overrides network conf preset",
+        used = builder.numShardsInCluster.get(),
+        ignored = networkConf.shardingConf.numShardsInCluster
+    else:
+      builder.numShardsInCluster = some(networkConf.shardingConf.numShardsInCluster)
 
   if networkConf.discv5Discovery:
     if builder.discv5Conf.enabled.isNone:


### PR DESCRIPTION
## Description

In applyNetworkConf, the AutoSharding branch unconditionally applied:

```
builder.numShardsInCluster = some(networkConf.shardingConf.numShardsInCluster)
```

... which ignore any value the user set via withNumShardsInCluster, so--num-shards-in-network=N (N > 0) was overwritten by the network preset.

Now if in AutoSharding, check builder.numShardsInCluster.isSome() first, and if that is set, keep it and warn that the preset value is overriden. Otherwise, fill it from networkConf.shardingConf.numShardsInCluster.

Added two regression tests to cover --num-shards-in-network being set to zero and to non-zero. If it is zero, the override is not applied: cli_args.nim leaves builder.numShardsInCluster as none in both the explicit flag = 0 case and flag omitted case (zero is the default value), so applyNetworkConf can't tell them apart. We don't fix this because it's not a bug; overriding an AutoSharding preset with StaticSharding has no meaningful use case.

## Changes

* fill numShardsInCluster from preset when builder slot is none
* add regression tests

## Issue

closes #3795 