### PR TITLE
Fix redundant start/stop calls (#3785)

### DIFF
--- a/tests/waku_store_sync/sync_utils.nim
+++ b/tests/waku_store_sync/sync_utils.nim
@@ -45,7 +45,7 @@ proc newTestWakuRecon*(
 
   let proto = res.get()
 
-  proto.start()
+  await proto.start()
   switch.mount(proto)
 
   return proto
@@ -55,7 +55,7 @@ proc newTestWakuTransfer*(
     idsTx: AsyncQueue[(SyncID, PubsubTopic, ContentTopic)],
     wantsRx: AsyncQueue[PeerId],
     needsRx: AsyncQueue[(PeerId, WakuMessageHash)],
-): SyncTransfer =
+): Future[SyncTransfer] {.async.} =
   let peerManager = PeerManager.new(switch)
 
   let proto = SyncTransfer.new(
@@ -66,7 +66,7 @@ proc newTestWakuTransfer*(
     remoteNeedsRx = needsRx,
   )
 
-  proto.start()
+  await proto.start()
   switch.mount(proto)
 
   return proto

--- a/tests/waku_store_sync/test_protocol.nim
+++ b/tests/waku_store_sync/test_protocol.nim
@@ -63,8 +63,8 @@ suite "Waku Sync: reconciliation":
     clientPeerInfo = clientSwitch.peerInfo.toRemotePeerInfo()
 
   asyncTeardown:
-    server.stop()
-    client.stop()
+    await server.stop()
+    await client.stop()
 
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
 
@@ -561,8 +561,8 @@ suite "Waku Sync: reconciliation":
     )
 
     defer:
-      server.stop()
-      client.stop()
+      await server.stop()
+      await client.stop()
 
     let res = await client.storeSynchronization(some(serverPeerInfo))
     assert res.isOk(), $res.error
@@ -610,8 +610,8 @@ suite "Waku Sync: reconciliation":
     )
 
     defer:
-      server.stop()
-      client.stop()
+      await server.stop()
+      await client.stop()
 
     let res = await client.storeSynchronization(some(serverPeerInfo))
     assert res.isOk(), $res.error
@@ -657,8 +657,8 @@ suite "Waku Sync: reconciliation":
     )
 
     defer:
-      server.stop()
-      client.stop()
+      await server.stop()
+      await client.stop()
 
     let res = await client.storeSynchronization(some(serverPeerInfo))
     assert res.isOk(), $res.error
@@ -701,8 +701,8 @@ suite "Waku Sync: reconciliation":
     )
 
     defer:
-      server.stop()
-      client.stop()
+      await server.stop()
+      await client.stop()
 
     let res = await client.storeSynchronization(some(serverPeerInfo))
     assert res.isOk(), $res.error
@@ -736,8 +736,8 @@ suite "Waku Sync: reconciliation":
     )
 
     defer:
-      server.stop()
-      client.stop()
+      await server.stop()
+      await client.stop()
 
     let res = await client.storeSynchronization(some(serverPeerInfo))
     assert res.isOk(), $res.error
@@ -773,8 +773,8 @@ suite "Waku Sync: reconciliation":
     )
 
     defer:
-      server.stop()
-      client.stop()
+      await server.stop()
+      await client.stop()
 
     let res = await client.storeSynchronization(some(serverPeerInfo))
     assert res.isOk(), $res.error
@@ -848,8 +848,8 @@ suite "Waku Sync: transfer":
       remoteNeedsRx = clientRemoteNeeds,
     )
 
-    server.start()
-    client.start()
+    await server.start()
+    await client.start()
 
     serverSwitch.mount(server)
     clientSwitch.mount(client)
@@ -861,8 +861,8 @@ suite "Waku Sync: transfer":
     clientPeermanager.addPeer(serverPeerInfo)
 
   asyncTeardown:
-    server.stop()
-    client.stop()
+    await server.stop()
+    await client.stop()
 
     await allFutures(serverSwitch.stop(), clientSwitch.stop())
 

--- a/waku/node/kernel_api/relay.nim
+++ b/waku/node/kernel_api/relay.nim
@@ -263,7 +263,8 @@ proc mountRelay*(
     node.wakuRelay.routingRecordsHandler.add(peerExchangeHandler.get())
 
   if node.started:
-    await node.startRelay()
+    await node.wakuRelay.start()
+    await node.reconnectRelayPeers()
 
   node.switch.mount(node.wakuRelay, protocolMatcher(WakuRelayCodec))
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -369,37 +369,16 @@ proc mountStoreSync*(
 
   return ok()
 
-proc startRelay*(node: WakuNode) {.async.} =
-  ## Setup and start relay protocol
-  ## This proc has two roles
-  ## 1. Reconnect relay peer connections at the switch.
-  ## 2. In case the switch is started and *then* the relay protocol is mounted, this proc
-  ##    catches that and starts it late (the switch won't do that because it has already started).
-  ##    Relevant for apps or tests that have that workflow, for whatever reason.
-
-  info "starting relay protocol"
-
+proc reconnectRelayPeers*(node: WakuNode) {.async.} =
+  ## Reconnect to previously-seen WakuRelay peers.
   if node.wakuRelay.isNil():
-    error "Failed to start relay. Not mounted."
     return
-
-  ## Setup relay protocol
-
-  # Resume previous relay connections
-  if node.peerManager.switch.peerStore.hasPeers(protocolMatcher(WakuRelayCodec)):
-    info "Found previous WakuRelay peers. Reconnecting."
-
-    # Reconnect to previous relay peers. This will respect a backoff period, if necessary
-    let backoffPeriod =
-      node.wakuRelay.parameters.pruneBackoff + chronos.seconds(BackoffSlackTime)
-
-    await node.peerManager.reconnectPeers(WakuRelayCodec, backoffPeriod)
-
-  if node.started:
-    # if switch.start() already finished before this wakuRelay was mounted, then start the relay now.
-    await node.wakuRelay.start()
-
-  info "relay started successfully"
+  if not node.peerManager.switch.peerStore.hasPeers(protocolMatcher(WakuRelayCodec)):
+    return
+  info "Found previous WakuRelay peers. Reconnecting."
+  let backoffPeriod =
+    node.wakuRelay.parameters.pruneBackoff + chronos.seconds(BackoffSlackTime)
+  await node.peerManager.reconnectPeers(WakuRelayCodec, backoffPeriod)
 
 proc selectRandomPeers*(peers: seq[PeerId], numRandomPeers: int): seq[PeerId] =
   var randomPeers = peers
@@ -607,8 +586,7 @@ proc start*(node: WakuNode) {.async.} =
   await node.switch.start()
 
   # After switch.start, run custom Logos Delivery relay start logic
-  if not node.wakuRelay.isNil():
-    await node.startRelay()
+  await node.reconnectRelayPeers()
 
   node.started = true
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -371,6 +371,12 @@ proc mountStoreSync*(
 
 proc startRelay*(node: WakuNode) {.async.} =
   ## Setup and start relay protocol
+  ## This proc has two roles
+  ## 1. Reconnect relay peer connections at the switch.
+  ## 2. In case the switch is started and *then* the relay protocol is mounted, this proc
+  ##    catches that and starts it late (the switch won't do that because it has already started).
+  ##    Relevant for apps or tests that have that workflow, for whatever reason.
+
   info "starting relay protocol"
 
   if node.wakuRelay.isNil():
@@ -389,8 +395,9 @@ proc startRelay*(node: WakuNode) {.async.} =
 
     await node.peerManager.reconnectPeers(WakuRelayCodec, backoffPeriod)
 
-  # Start the WakuRelay protocol
-  await node.wakuRelay.start()
+  if node.started:
+    # if switch.start() already finished before this wakuRelay was mounted, then start the relay now.
+    await node.wakuRelay.start()
 
   info "relay started successfully"
 
@@ -430,7 +437,10 @@ proc mountRendezvous*(
     return
 
   if node.started:
-    await node.wakuRendezvous.start()
+    try:
+      await node.wakuRendezvous.start()
+    except CancelledError as exc:
+      error "failed to start wakuRendezvous", error = exc.msg
 
   try:
     node.switch.mount(node.wakuRendezvous, protocolMatcher(WakuRendezVousCodec))
@@ -578,30 +588,11 @@ proc start*(node: WakuNode) {.async.} =
     if isBindIpWithZeroPort(address):
       zeroPortPresent = true
 
-  # Perform relay-specific startup tasks TODO: this should be rethought
-  if not node.wakuRelay.isNil():
-    await node.startRelay()
-
-  if not node.wakuMix.isNil():
-    node.wakuMix.start()
-
-  if not node.wakuMetadata.isNil():
-    node.wakuMetadata.start()
-
   if not node.wakuStoreResume.isNil():
     await node.wakuStoreResume.start()
 
-  if not node.wakuRendezvous.isNil():
-    await node.wakuRendezvous.start()
-
   if not node.wakuRendezvousClient.isNil():
     await node.wakuRendezvousClient.start()
-
-  if not node.wakuStoreReconciliation.isNil():
-    node.wakuStoreReconciliation.start()
-
-  if not node.wakuStoreTransfer.isNil():
-    node.wakuStoreTransfer.start()
 
   ## The switch uses this mapper to update peer info addrs
   ## with announced addrs after start
@@ -612,7 +603,12 @@ proc start*(node: WakuNode) {.async.} =
   node.switch.peerInfo.addressMappers.add(addressMapper)
 
   ## The switch will update addresses after start using the addressMapper
+  ## NOTE: This will dispatch gossipsub start to the WakuRelay.start method override
   await node.switch.start()
+
+  # After switch.start, run custom Logos Delivery relay start logic
+  if not node.wakuRelay.isNil():
+    await node.startRelay()
 
   node.started = true
 
@@ -637,6 +633,7 @@ proc stop*(node: WakuNode) {.async.} =
 
   node.stopProvidersAndListeners()
 
+  ## NOTE: This will dispatch gossipsub stop to the WakuRelay.stop method override
   await node.switch.stop()
 
   node.peerManager.stop()
@@ -653,21 +650,12 @@ proc stop*(node: WakuNode) {.async.} =
   if not node.wakuStoreResume.isNil():
     await node.wakuStoreResume.stopWait()
 
-  if not node.wakuStoreReconciliation.isNil():
-    node.wakuStoreReconciliation.stop()
-
-  if not node.wakuStoreTransfer.isNil():
-    node.wakuStoreTransfer.stop()
-
   if not node.wakuPeerExchangeClient.isNil() and
       not node.wakuPeerExchangeClient.pxLoopHandle.isNil():
     await node.wakuPeerExchangeClient.pxLoopHandle.cancelAndWait()
 
   if not node.wakuKademlia.isNil():
     await node.wakuKademlia.stop()
-
-  if not node.wakuRendezvous.isNil():
-    await node.wakuRendezvous.stopWait()
 
   if not node.wakuRendezvousClient.isNil():
     await node.wakuRendezvousClient.stopWait()

--- a/waku/waku_metadata/protocol.nim
+++ b/waku/waku_metadata/protocol.nim
@@ -109,8 +109,3 @@ proc new*(T: type WakuMetadata, clusterId: uint32, getShards: GetShards): T =
 
   return wm
 
-proc start*(wm: WakuMetadata) =
-  wm.started = true
-
-proc stop*(wm: WakuMetadata) =
-  wm.started = false

--- a/waku/waku_metadata/protocol.nim
+++ b/waku/waku_metadata/protocol.nim
@@ -108,4 +108,3 @@ proc new*(T: type WakuMetadata, clusterId: uint32, getShards: GetShards): T =
     clusterId = wm.clusterId, shards = wm.getShards()
 
   return wm
-

--- a/waku/waku_mix/protocol.nim
+++ b/waku/waku_mix/protocol.nim
@@ -104,10 +104,4 @@ proc new*(
 proc poolSize*(mix: WakuMix): int =
   mix.nodePool.len
 
-method start*(mix: WakuMix) =
-  info "starting waku mix protocol"
-
-method stop*(mix: WakuMix) {.async.} =
-  discard
-
 # Mix Protocol

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -515,12 +515,12 @@ proc topicsHealthLoop(w: WakuRelay) {.async.} =
     # safety cooldown to protect from edge cases
     await sleepAsync(100.milliseconds)
 
-method start*(w: WakuRelay) {.async, base.} =
+method start*(w: WakuRelay) {.async: (raises: [CancelledError]).} =
   info "start"
   await procCall GossipSub(w).start()
   w.topicHealthLoopHandle = w.topicsHealthLoop()
 
-method stop*(w: WakuRelay) {.async, base.} =
+method stop*(w: WakuRelay) {.async: (raises: []).} =
   info "stop"
   await procCall GossipSub(w).stop()
 

--- a/waku/waku_rendezvous/protocol.nim
+++ b/waku/waku_rendezvous/protocol.nim
@@ -211,29 +211,22 @@ proc new*(
 
   return ok(wrv)
 
-proc start*(self: WakuRendezVous) {.async: (raises: []).} =
+method start*(self: WakuRendezVous) {.async: (raises: [CancelledError]).} =
   # Start the parent GenericRendezVous (starts the register deletion loop)
   if self.started:
     warn "waku rendezvous already started"
     return
-  try:
-    await procCall GenericRendezVous[WakuPeerRecord](self).start()
-  except CancelledError as exc:
-    error "failed to start GenericRendezVous", cause = exc.msg
-    return
+  await procCall GenericRendezVous[WakuPeerRecord](self).start()
   # start registering forever
   self.periodicRegistrationFut = self.periodicRegistration()
 
   info "waku rendezvous discovery started"
 
-proc stopWait*(self: WakuRendezVous) {.async: (raises: []).} =
+method stop*(self: WakuRendezVous) {.async: (raises: []).} =
   if not self.periodicRegistrationFut.isNil():
     await self.periodicRegistrationFut.cancelAndWait()
 
   # Stop the parent GenericRendezVous (stops the register deletion loop)
-  await GenericRendezVous[WakuPeerRecord](self).stop()
-
-  # Stop the parent GenericRendezVous (stops the register deletion loop)
-  await GenericRendezVous[WakuPeerRecord](self).stop()
+  await procCall GenericRendezVous[WakuPeerRecord](self).stop()
 
   info "waku rendezvous discovery stopped"

--- a/waku/waku_store_sync/reconciliation.nim
+++ b/waku/waku_store_sync/reconciliation.nim
@@ -468,7 +468,7 @@ proc idsReceiverLoop(self: SyncReconciliation) {.async.} =
 
     self.messageIngress(id, pubsub, content)
 
-proc start*(self: SyncReconciliation) =
+method start*(self: SyncReconciliation) {.async: (raises: [CancelledError]).} =
   if self.started:
     return
 
@@ -484,13 +484,15 @@ proc start*(self: SyncReconciliation) =
 
   info "Store Sync Reconciliation protocol started"
 
-proc stop*(self: SyncReconciliation) =
-  if self.syncInterval > ZeroDuration:
-    self.periodicSyncFut.cancelSoon()
+method stop*(self: SyncReconciliation) {.async: (raises: []).} =
+  self.started = false
 
   if self.syncInterval > ZeroDuration:
-    self.periodicPruneFut.cancelSoon()
+    await self.periodicSyncFut.cancelAndWait()
 
-  self.idsReceiverFut.cancelSoon()
+  if self.syncInterval > ZeroDuration:
+    await self.periodicPruneFut.cancelAndWait()
+
+  await self.idsReceiverFut.cancelAndWait()
 
   info "Store Sync Reconciliation protocol stopped"

--- a/waku/waku_store_sync/reconciliation.nim
+++ b/waku/waku_store_sync/reconciliation.nim
@@ -485,7 +485,8 @@ method start*(self: SyncReconciliation) {.async: (raises: [CancelledError]).} =
   info "Store Sync Reconciliation protocol started"
 
 method stop*(self: SyncReconciliation) {.async: (raises: []).} =
-  self.started = false
+  defer:
+    self.started = false
 
   if self.syncInterval > ZeroDuration:
     await self.periodicSyncFut.cancelAndWait()

--- a/waku/waku_store_sync/transfer.nim
+++ b/waku/waku_store_sync/transfer.nim
@@ -217,7 +217,7 @@ proc new*(
 
   return transfer
 
-proc start*(self: SyncTransfer) =
+method start*(self: SyncTransfer) {.async: (raises: [CancelledError]).} =
   if self.started:
     return
 
@@ -228,10 +228,10 @@ proc start*(self: SyncTransfer) =
 
   info "Store Sync Transfer protocol started"
 
-proc stop*(self: SyncTransfer) =
+method stop*(self: SyncTransfer) {.async: (raises: []).} =
   self.started = false
 
-  self.localWantsRxFut.cancelSoon()
-  self.remoteNeedsRxFut.cancelSoon()
+  await self.localWantsRxFut.cancelAndWait()
+  await self.remoteNeedsRxFut.cancelAndWait()
 
   info "Store Sync Transfer protocol stopped"

--- a/waku/waku_store_sync/transfer.nim
+++ b/waku/waku_store_sync/transfer.nim
@@ -229,7 +229,8 @@ method start*(self: SyncTransfer) {.async: (raises: [CancelledError]).} =
   info "Store Sync Transfer protocol started"
 
 method stop*(self: SyncTransfer) {.async: (raises: []).} =
-  self.started = false
+  defer:
+    self.started = false
 
   await self.localWantsRxFut.cancelAndWait()
   await self.remoteNeedsRxFut.cancelAndWait()


### PR DESCRIPTION
## Description

Fixes life-cycle (start/stop) issues with node, wakurelay, gossipsub, and other protos.

## Changes

* remove redundant proto start/stop calls from node start/stop
* fix WakuRelay start/stop not overriding GossipSub start/stop (remove {.base.})
* fix most duplicate "relay already started" warnings
* delete startRelay
* add reconnectRelayPeers
* wire custom handling to kernel API relay start

## Issue

closes #3785 
