### PR TITLE
feat: override ports with values supplied via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,11 @@ and any supplied configuration for that port.
 | `--metrics-server-port` | `LOGOS_DELIVERY_METRICS_PORT`    |
 | `--websocket-port`      | `LOGOS_DELIVERY_WEBSOCKET_PORT`  |
 
-The override just replaces the configured port value, so any subsequent transform
-such as `--ports-shift` still applies on top.
+Effective port is determined in this order:
+
+1. Config parameter (CLI flag or library API)
+2. Environment variable
+3. Any post-processing (e.g. `--ports-shift`)
 
 ## Formatting
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ make test/tests/common/test_enr_builder.nim
 ### Testing against `js-waku`
 Refer to [js-waku repo](https://github.com/waku-org/js-waku/tree/master/packages/tests) for instructions.
 
+## Port override environment variables
+
+Every listening port can be overridden with an environment variable. When the
+variable is set to a valid `uint16`, it takes precedence over both the default
+and any supplied configuration for that port.
+
+| Port config             | Env variable                     |
+| ----------------------- | -------------------------------- |
+| `--tcp-port`            | `LOGOS_DELIVERY_P2P_TCP_PORT`    |
+| `--discv5-udp-port`     | `LOGOS_DELIVERY_DISCV5_UDP_PORT` |
+| `--rest-port`           | `LOGOS_DELIVERY_REST_PORT`       |
+| `--metrics-server-port` | `LOGOS_DELIVERY_METRICS_PORT`    |
+| `--websocket-port`      | `LOGOS_DELIVERY_WEBSOCKET_PORT`  |
+
+The override just replaces the configured port value, so any subsequent transform
+such as `--ports-shift` still applies on top.
+
 ## Formatting
 
 Nim files are expected to be formatted using the [`nph`](https://github.com/arnetheduck/nph) version present in `vendor/nph`.

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -350,8 +350,7 @@ suite "Waku Conf Builder - rate limits":
 suite "Waku Conf Builder - env port overrides":
   proc clearPortEnv() =
     for name in [
-      EnvP2pTcpPort, EnvDiscv5UdpPort, EnvRestPort, EnvMetricsPort,
-      EnvWebSocketPort,
+      EnvP2pTcpPort, EnvDiscv5UdpPort, EnvRestPort, EnvMetricsPort, EnvWebSocketPort
     ]:
       delEnv(name)
 

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -4,7 +4,7 @@ import
   libp2p/crypto/[crypto, secp],
   libp2p/multiaddress,
   nimcrypto/utils,
-  std/[options, random, sequtils],
+  std/[net, options, os, random, sequtils],
   results,
   testutils/unittests
 import
@@ -346,3 +346,100 @@ suite "Waku Conf Builder - rate limits":
 
     ## Then
     assert res.isOk(), $res.error
+
+suite "Waku Conf Builder - env port overrides":
+  proc clearPortEnv() =
+    for name in [
+      EnvP2pTcpPort, EnvDiscv5UdpPort, EnvRestPort, EnvMetricsPort,
+      EnvWebSocketPort,
+    ]:
+      delEnv(name)
+
+  test "non-numeric env is ignored":
+    clearPortEnv()
+    putEnv(EnvP2pTcpPort, "notanumber")
+    defer:
+      delEnv(EnvP2pTcpPort)
+
+    var builder = WakuConfBuilder.init()
+    builder.withClusterId(1)
+    builder.withP2pTcpPort(60000.uint16)
+
+    let conf = builder.build().expect("build should succeed")
+
+    check conf.endpointConf.p2pTcpPort == 60000.Port
+
+  test "out-of-range env is ignored":
+    clearPortEnv()
+    putEnv(EnvP2pTcpPort, "999999")
+    defer:
+      delEnv(EnvP2pTcpPort)
+
+    var builder = WakuConfBuilder.init()
+    builder.withClusterId(1)
+    builder.withP2pTcpPort(60000.uint16)
+
+    let conf = builder.build().expect("build should succeed")
+
+    check conf.endpointConf.p2pTcpPort == 60000.Port
+
+  test "env=0 is accepted":
+    clearPortEnv()
+    putEnv(EnvP2pTcpPort, "0")
+    defer:
+      delEnv(EnvP2pTcpPort)
+
+    var builder = WakuConfBuilder.init()
+    builder.withClusterId(1)
+    builder.withP2pTcpPort(60000.uint16)
+
+    let conf = builder.build().expect("build should succeed")
+
+    check conf.endpointConf.p2pTcpPort == 0.Port
+
+  test "env overrides every configured port":
+    clearPortEnv()
+    putEnv(EnvP2pTcpPort, "60001")
+    putEnv(EnvDiscv5UdpPort, "60002")
+    putEnv(EnvRestPort, "60003")
+    putEnv(EnvMetricsPort, "60004")
+    putEnv(EnvWebSocketPort, "60005")
+    defer:
+      clearPortEnv()
+
+    var builder = WakuConfBuilder.init()
+    builder.withP2pTcpPort(50000.uint16)
+    builder.discv5Conf.withEnabled(true)
+    builder.discv5Conf.withUdpPort(50001.uint)
+    builder.restServerConf.withEnabled(true)
+    builder.restServerConf.withListenAddress(parseIpAddress("127.0.0.1"))
+    builder.restServerConf.withPort(50002.uint16)
+    builder.restServerConf.withRelayCacheCapacity(0.uint32)
+    builder.metricsServerConf.withEnabled(true)
+    builder.metricsServerConf.withHttpPort(50003.uint16)
+    builder.webSocketConf.withEnabled(true)
+    builder.webSocketConf.withWebSocketPort(50004.uint16)
+
+    let conf = builder.build().expect("build should succeed")
+
+    check conf.endpointConf.p2pTcpPort == 60001.Port
+    check conf.discv5Conf.get().udpPort == 60002.Port
+    check conf.restServerConf.get().port == 60003.Port
+    check conf.metricsServerConf.get().httpPort == 60004.Port
+    check conf.webSocketConf.get().port == 60005.Port
+
+  test "env override preserves portsShift":
+    clearPortEnv()
+    putEnv(EnvP2pTcpPort, "61234")
+    defer:
+      delEnv(EnvP2pTcpPort)
+
+    var builder = WakuConfBuilder.init()
+    builder.withClusterId(1)
+    builder.withP2pTcpPort(60000.uint16)
+    builder.withPortsShift(5.uint16)
+
+    let conf = builder.build().expect("build should succeed")
+
+    check conf.endpointConf.p2pTcpPort == 61234.Port
+    check conf.portsShift == 5.uint16

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -192,8 +192,11 @@ type WakuNodeConf* = object
       name: "listen-address"
     .}: IpAddress
 
-    tcpPort* {.desc: "TCP listening port.", defaultValue: 60000, name: "tcp-port".}:
-      Port
+    tcpPort* {.
+      desc: "TCP listening port. (env var override: " & EnvP2pTcpPort & ")",
+      defaultValue: 60000,
+      name: "tcp-port"
+    .}: Port
 
     portsShift* {.
       desc: "Add a shift to all port numbers.", defaultValue: 0, name: "ports-shift"
@@ -489,7 +492,8 @@ with the drawback of consuming some more bandwidth.""",
     .}: IpAddress
 
     restPort* {.
-      desc: "Listening port of the REST HTTP server.",
+      desc:
+        "Listening port of the REST HTTP server. (env var override: " & EnvRestPort & ")",
       defaultValue: 8645,
       name: "rest-port"
     .}: uint16
@@ -530,7 +534,9 @@ with the drawback of consuming some more bandwidth.""",
     .}: IpAddress
 
     metricsServerPort* {.
-      desc: "Listening HTTP port of the metrics server.",
+      desc:
+        "Listening HTTP port of the metrics server. (env var override: " & EnvMetricsPort &
+        ")",
       defaultValue: 8008,
       name: "metrics-server-port"
     .}: uint16
@@ -564,7 +570,9 @@ with the drawback of consuming some more bandwidth.""",
     .}: Option[bool]
 
     discv5UdpPort* {.
-      desc: "Listening UDP port for Node Discovery v5.",
+      desc:
+        "Listening UDP port for Node Discovery v5. (env var override: " &
+        EnvDiscv5UdpPort & ")",
       defaultValue: 9000,
       name: "discv5-udp-port"
     .}: Port
@@ -664,7 +672,9 @@ with the drawback of consuming some more bandwidth.""",
     .}: bool
 
     websocketPort* {.
-      desc: "WebSocket listening port.", defaultValue: 8000, name: "websocket-port"
+      desc: "WebSocket listening port. (env var override: " & EnvWebSocketPort & ")",
+      defaultValue: 8000,
+      name: "websocket-port"
     .}: Port
 
     websocketSecureSupport* {.

--- a/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/waku/factory/conf_builder/waku_conf_builder.nim
@@ -1,7 +1,7 @@
 import
   libp2p/crypto/crypto,
   libp2p/multiaddress,
-  std/[net, options, sequtils],
+  std/[net, options, os, sequtils, strutils],
   stint,
   chronicles,
   chronos,
@@ -33,6 +33,14 @@ logScope:
   topics = "waku conf builder"
 
 const DefaultMaxConnections* = 150
+
+## Port override env-var names.
+const
+  EnvP2pTcpPort* = "LOGOS_DELIVERY_P2P_TCP_PORT"
+  EnvDiscv5UdpPort* = "LOGOS_DELIVERY_DISCV5_UDP_PORT"
+  EnvRestPort* = "LOGOS_DELIVERY_REST_PORT"
+  EnvMetricsPort* = "LOGOS_DELIVERY_METRICS_PORT"
+  EnvWebSocketPort* = "LOGOS_DELIVERY_WEBSOCKET_PORT"
 
 type MaxMessageSizeKind* = enum
   mmskNone
@@ -309,6 +317,50 @@ proc buildShardingConf(
     let upperShard = uint16(numShardsInCluster - 1)
     (shardingConf, bSubscribeShards.get(toSeq(0.uint16 .. upperShard)))
 
+proc envOverridePort(envName: string): Option[Port] =
+  let raw = os.getEnv(envName, "").strip()
+
+  if raw.len == 0:
+    return none(Port)
+
+  let parsed =
+    try:
+      parseInt(raw)
+    except ValueError:
+      warn "env port override is not a number, ignoring",
+        envVar = envName, value = raw
+      return none(Port)
+
+  if parsed < 0 or parsed > uint16.high.int:
+    warn "env port override is out of uint16 range, ignoring",
+      envVar = envName, value = raw
+    return none(Port)
+
+  info "applying env port override", envVar = envName, port = parsed
+  return some(Port(parsed.uint16))
+
+proc applyEnvironmentOverrides(b: var WakuConfBuilder) =
+  ## Applies env-var overrides to the builder.
+  let p2p = envOverridePort(EnvP2pTcpPort)
+  if p2p.isSome():
+    b.withP2pTcpPort(p2p.get())
+
+  let discv5 = envOverridePort(EnvDiscv5UdpPort)
+  if discv5.isSome():
+    b.discv5Conf.withUdpPort(discv5.get())
+
+  let rest = envOverridePort(EnvRestPort)
+  if rest.isSome():
+    b.restServerConf.withPort(rest.get())
+
+  let metrics = envOverridePort(EnvMetricsPort)
+  if metrics.isSome():
+    b.metricsServerConf.withHttpPort(metrics.get())
+
+  let ws = envOverridePort(EnvWebSocketPort)
+  if ws.isSome():
+    b.webSocketConf.withWebSocketPort(ws.get())
+
 proc applyNetworkConf(builder: var WakuConfBuilder) =
   # Apply network conf, overrides most values passed individually
   # If you want to tweak values, don't use networkConf
@@ -441,6 +493,7 @@ proc build*(
   ## default when it is opinionated.
 
   applyNetworkConf(builder)
+  applyEnvironmentOverrides(builder)
 
   let relay =
     if builder.relay.isSome():

--- a/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/waku/factory/conf_builder/waku_conf_builder.nim
@@ -327,8 +327,7 @@ proc envOverridePort(envName: string): Option[Port] =
     try:
       parseInt(raw)
     except ValueError:
-      warn "env port override is not a number, ignoring",
-        envVar = envName, value = raw
+      warn "env port override is not a number, ignoring", envVar = envName, value = raw
       return none(Port)
 
   if parsed < 0 or parsed > uint16.high.int:


### PR DESCRIPTION
## Description

Allows overriding any port value in the config with an (optional) environment-variable-supplied value.

NOTE: This just changes the base configured value. Transforms like --ports-shift still apply on top of it, just like it does with default values or explicit port values given via switches.

## Changes

* Add checks for environment variable overrides for each configurable port
* Add tests
* Update README.md with instructions

## Issue

closes #3819

Should also close: https://github.com/logos-co/logos-delivery-module/issues/18