### PR TITLE
fix: relay validator registration and sync filter

### DIFF
--- a/tests/waku_store_sync/test_protocol.nim
+++ b/tests/waku_store_sync/test_protocol.nim
@@ -372,7 +372,7 @@ suite "Waku Sync: reconciliation":
     const
       msgCount = 400_000
       diffCount = 100_000
-      tol = 1000
+      tol = 10_000
 
     var diffMsgHashes: HashSet[WakuMessageHash]
     var missingIdx: HashSet[int]

--- a/waku/waku_relay/protocol.nim
+++ b/waku/waku_relay/protocol.nim
@@ -618,7 +618,7 @@ proc subscribe*(w: WakuRelay, pubsubTopic: PubsubTopic, handler: WakuRelayHandle
   # Otherwise this might lead to unintended behaviour.
   if not w.topicValidator.hasKey(pubSubTopic):
     let newValidator = w.generateOrderedValidator()
-    procCall GossipSub(w).addValidator(pubSubTopic, w.generateOrderedValidator())
+    procCall GossipSub(w).addValidator(pubSubTopic, newValidator)
     w.topicValidator[pubSubTopic] = newValidator
 
   # set this topic parameters for scoring

--- a/waku/waku_store_sync/reconciliation.nim
+++ b/waku/waku_store_sync/reconciliation.nim
@@ -145,7 +145,7 @@ proc preProcessPayload(
   # convert to skip range before processing
   for i in 0 ..< payload.ranges.len:
     let rangeType = payload.ranges[i][1]
-    if rangeType != RangeType.Skip:
+    if rangeType == RangeType.Skip:
       continue
 
     let upperBound = payload.ranges[i][0].b.time


### PR DESCRIPTION
## Description

Fixes two issues raised by Joo on the `delivery-studio` Discord channel (thanks!)

* The instance handed to gossipsub is not the one stored in topicValidator -- in waku_relay/protocol.nim
* Should be "if rangeType == RangeType.Skip:" -- was "!=" in waku_store_sync/reconciliation.nim

## Changes

* reuse stored validator in relay
* fix skip check in store sync
* increase sync tolerance in test (matches similar test)

## Issue

Maintenance Y2026H1 #3686 