### PR TITLE
Chore/make nix build phase configurable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,13 +56,14 @@
       packages = forAllSystems (system:
         let
           pkgs = pkgsFor system;
-          mkPkg = zerokitRln: import ./nix/default.nix {
-            inherit pkgs zerokitRln;
+          liblogosdelivery = pkgs.callPackage ./nix/default.nix {
+            inherit pkgs;
             src = ./.;
+            zerokitRln = zerokit.packages.${system}.rln;
           };
-        in rec {
-          liblogosdelivery = mkPkg zerokit.packages.${system}.rln;
-          default          = liblogosdelivery;
+        in {
+          inherit liblogosdelivery;
+          default = liblogosdelivery;
         }
       );
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -46,7 +46,8 @@ pkgs.stdenv.mkDerivation {
     which
   ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.cctools ];
 
-  buildInputs = [ zerokitRln ];
+  buildInputs = [ zerokitRln ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
 
   buildPhase = ''
     export HOME=$TMPDIR
@@ -74,7 +75,7 @@ pkgs.stdenv.mkDerivation {
       ${pathArgs} \
       --path:$NAT_TRAV \
       --path:$NAT_TRAV/src \
-      --passL:"-L${zerokitRln}/lib -lrln" \
+      --passL:"-L${zerokitRln}/lib -lrln${pkgs.lib.optionalString pkgs.stdenv.isLinux " -lstdc++"}" \
       ${nimDefineArgs} \
       --out:build/liblogosdelivery.${libExt} \
       --app:lib \
@@ -93,7 +94,7 @@ pkgs.stdenv.mkDerivation {
       ${pathArgs} \
       --path:$NAT_TRAV \
       --path:$NAT_TRAV/src \
-      --passL:"-L${zerokitRln}/lib -lrln" \
+      --passL:"-L${zerokitRln}/lib -lrln${pkgs.lib.optionalString pkgs.stdenv.isLinux " -lstdc++"}" \
       ${nimDefineArgs} \
       --out:build/liblogosdelivery.a \
       --app:staticlib \

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,21 @@
-{ pkgs, src, zerokitRln }:
+{ pkgs
+, src
+, zerokitRln
+, enablePostgres       ? true
+, enableNimDebugDlOpen ? true
+, chroniclesLogLevel   ? null
+}:
 
 let
   deps      = import ./deps.nix    { inherit pkgs; };
+
+  nimDefineArgs = pkgs.lib.concatStringsSep " \\\n      " (
+       [ "--define:disable_libbacktrace" ]
+    ++ pkgs.lib.optional enablePostgres       "--define:postgres"
+    ++ pkgs.lib.optional enableNimDebugDlOpen "--define:nimDebugDlOpen"
+    ++ pkgs.lib.optional (chroniclesLogLevel != null)
+         "--define:chronicles_log_level=${toString chroniclesLogLevel}"
+  );
 
   # nat_traversal is excluded from the static pathArgs; it is handled
   # separately in buildPhase (its bundled C libs must be compiled first).
@@ -61,9 +75,7 @@ pkgs.stdenv.mkDerivation {
       --path:$NAT_TRAV \
       --path:$NAT_TRAV/src \
       --passL:"-L${zerokitRln}/lib -lrln" \
-      --define:disable_libbacktrace \
-      --define:postgres \
-      --define:nimDebugDlOpen \
+      ${nimDefineArgs} \
       --out:build/liblogosdelivery.${libExt} \
       --app:lib \
       --threads:on \
@@ -82,9 +94,7 @@ pkgs.stdenv.mkDerivation {
       --path:$NAT_TRAV \
       --path:$NAT_TRAV/src \
       --passL:"-L${zerokitRln}/lib -lrln" \
-      --define:disable_libbacktrace \
-      --define:postgres \
-      --define:nimDebugDlOpen \
+      ${nimDefineArgs} \
       --out:build/liblogosdelivery.a \
       --app:staticlib \
       --threads:on \

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -108,9 +108,29 @@ pkgs.stdenv.mkDerivation {
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/lib $out/include
     cp build/liblogosdelivery.${libExt} $out/lib/ 2>/dev/null || true
     cp build/liblogosdelivery.a         $out/lib/ 2>/dev/null || true
     cp liblogosdelivery/liblogosdelivery.h $out/include/ 2>/dev/null || true
+    runHook postInstall
   '';
+
+  # Bundle librln alongside liblogosdelivery so the output is self-contained.
+  # Use --add-rpath (not --set-rpath) so fixupPhase's stdenv RUNPATH injection
+  # for libstdc++ is preserved.
+  postInstall =
+    pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+      cp ${zerokitRln}/lib/librln.dylib $out/lib/
+      chmod +w $out/lib/librln.dylib $out/lib/liblogosdelivery.dylib
+      install_name_tool -id @rpath/liblogosdelivery.dylib $out/lib/liblogosdelivery.dylib
+      install_name_tool -id @rpath/librln.dylib $out/lib/librln.dylib
+      old=$(otool -L $out/lib/liblogosdelivery.dylib | awk 'NR>1{print $1}' | grep librln)
+      install_name_tool -change "$old" @rpath/librln.dylib $out/lib/liblogosdelivery.dylib
+      install_name_tool -add_rpath @loader_path $out/lib/liblogosdelivery.dylib
+    ''
+    + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+      cp ${zerokitRln}/lib/librln.so $out/lib/
+      patchelf --add-rpath '$ORIGIN' $out/lib/liblogosdelivery.so
+    '';
 }


### PR DESCRIPTION
## Description

nix improvements needed by chat cli client: https://github.com/logos-messaging/libchat/pull/91

## Changes

[nix: parameterize build flags with named args](https://github.com/logos-messaging/logos-delivery/commit/f8e7b2d92df70b0dbba0371c3753e245d5a413ee) 

Expose `enablePostgres`, `enableNimDebugDlOpen`, and `chroniclesLogLevel`
as arguments on `nix/default.nix`. Defaults preserve today's hardcoded
behavior, so `nix build .#liblogosdelivery` with no overrides is a
no-op change.

Consume the package via `callPackage` in `flake.nix` so consumers can
use `.override { ... }` without extra wrapping.

[nix: link libstdc++ on Linux so consumers don't need patchelf](https://github.com/logos-messaging/logos-delivery/commit/6d3e15fb94e97063552760bbf60c8549d3716d2c) 

Append `stdenv.cc.cc.lib` to `buildInputs` on Linux and add `-lstdc++`
to the Nim `--passL` flags. Nix stdenv's fixupPhase will auto-inject
`${stdenv.cc.cc.lib}/lib` into the output's RUNPATH, so downstream
consumers can drop their patchelf step.

macOS resolves the C++ stdlib via dyld/libc++ and is unaffected.

[nix: bundle librln into the output for a self-contained package](https://github.com/logos-messaging/logos-delivery/commit/7b81122b0d94a4821465fa548a1defd471c2cc2a) 

Copy the librln shared library (`librln.so` / `librln.dylib`) from the
zerokit input into `$out/lib` and rewrite the internal reference in
`liblogosdelivery`:

- Darwin: set librln's install name to `@rpath/librln.dylib`, change the
  consumer's reference to match, and add `@loader_path` as an rpath.
- Linux: add `$ORIGIN` to the rpath so `librln.so` resolves from the
  sibling directory, preserving the gcc-lib entry injected by the stdenv
  fixupPhase for libstdc++.

The installed `liblogosdelivery` no longer carries a `/nix/store/...`
absolute path to zerokit, so downstream consumers can ship the bundle
as-is.

## Issue

closes #
