### PR TITLE
Fix websock nimble dependency version restriction to match lock file

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -33,7 +33,7 @@ requires "nim >= 2.2.4",
   "dnsdisc",
   "dnsclient",
   "httputils >= 0.4.1",
-  "websock >= 0.2.1",
+  "websock >= 0.3.0",
   # Cryptography
   "nimcrypto == 0.6.4", # 0.6.4 used in libp2p. Version 0.7.3 makes test to crash on Ubuntu.
   "secp256k1",


### PR DESCRIPTION
This updates the declared `websock` dependency in `waku.nimble` from `>= 0.2.1` to `>= 0.3.0`.

Why:
The lock file already resolves against `websock` 0.3.x, so the previous lower bound was out of sync with the actual pinned dependency set. Aligning the constraint avoids version mismatch during dependency resolution.