### PR TITLE
fix: restore -d:postgres in nimble task and propagate NIMFLAGS

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -83,7 +83,7 @@ jobs:
         id: build
         if: ${{ steps.secrets.outcome == 'success' }}
         run: |
-          make -j${NPROC} V=1 NIMFLAGS="-d:disableMarchNative -d:postgres -d:chronicles_colors:none" wakunode2
+          make -j${NPROC} V=1 POSTGRES=1 NIMFLAGS="-d:disableMarchNative -d:chronicles_colors:none" wakunode2
 
           SHORT_REF=$(git rev-parse --short HEAD)
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -66,8 +66,8 @@ jobs:
           make V=1 CI=false NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" \
             update
 
-          make V=1 CI=false\
-            NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}} -d:postgres" \
+          make V=1 CI=false POSTGRES=1\
+            NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" \
             wakunode2\
             chat2\
             tools

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -86,15 +86,15 @@ jobs:
           OS=$([[ "${{runner.os}}" == "macOS" ]] && echo "macosx" || echo "linux")
 
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" V=1 update
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}} -d:postgres" CI=false wakunode2
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false wakunode2
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" CI=false chat2
           tar -cvzf ${{steps.vars.outputs.waku}} ./build/
 
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}} -d:postgres" CI=false libwaku
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}} -d:postgres" CI=false STATIC=1 libwaku
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false libwaku
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false STATIC=1 libwaku
 
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}} -d:postgres" CI=false liblogosdelivery
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}} -d:postgres" CI=false STATIC=1 liblogosdelivery
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false liblogosdelivery
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false STATIC=1 liblogosdelivery
 
       - name: Create distributable libwaku package
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2
 ARG NIM_COMMIT
 ARG HEAPTRACK_BUILD=0
+ARG POSTGRES=1
 
 # Get build tools and required header files
 RUN apk add --no-cache bash git build-base openssl-dev linux-headers curl jq libbsd-dev
@@ -26,7 +27,7 @@ RUN if [ "$HEAPTRACK_BUILD" = "1" ]; then \
 RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1 ${NIM_COMMIT}
 
 # Build the final node binary
-RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET NIMFLAGS="${NIMFLAGS}"
+RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET NIMFLAGS="${NIMFLAGS}" POSTGRES=${POSTGRES}
 
 
 # PRODUCTION IMAGE -------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG NIMFLAGS
 ARG MAKE_TARGET=wakunode2
 ARG NIM_COMMIT
 ARG HEAPTRACK_BUILD=0
-ARG POSTGRES=1
+ARG POSTGRES=0
 
 # Get build tools and required header files
 RUN apk add --no-cache bash git build-base openssl-dev linux-headers curl jq libbsd-dev

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -85,7 +85,8 @@ pipeline {
             "--label=commit='${git.commit()}' " +
             "--label=version='${git.describe('--tags')}' " +
             "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
-            "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres -d:heaptracker ' " +
+            "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:heaptracker ' " +
+            "--build-arg=POSTGRES='1' " +
             "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
             "--build-arg=DEBUG='${params.DEBUG ? "1" : "0"} ' " +
             "--build-arg=NIM_COMMIT='NIM_COMMIT=heaptrack_support_v2.0.12' " +
@@ -98,7 +99,8 @@ pipeline {
             "--label=commit='${git.commit()}' " +
             "--label=version='${git.describe('--tags')}' " +
             "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
-            "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:postgres ' " +
+            "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
+            "--build-arg=POSTGRES='1' " +
             "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
             "--build-arg=DEBUG='${params.DEBUG ? "1" : "0"} ' " +
             "--target='prod' ."

--- a/waku.nimble
+++ b/waku.nimble
@@ -76,7 +76,7 @@ proc getMyCPU(): string =
     return " --cpu:amd64 "
 
 proc getNimParams(): string =
-  return " " & getEnv("NIM_PARAMS") & " "
+  return " " & getEnv("NIM_PARAMS") & " " & getEnv("NIMFLAGS") & " "
 
 ### Helper functions
 proc buildModule(filePath, params = ""): bool =
@@ -379,7 +379,7 @@ task testcommon, "Build & run common tests":
 ### Waku tasks
 task wakunode2, "Build Waku v2 cli node":
   let name = "wakunode2"
-  buildBinary name, "apps/wakunode2/", " -d:chronicles_log_level=TRACE "
+  buildBinary name, "apps/wakunode2/", " -d:chronicles_log_level=TRACE -d:postgres "
 
 task benchmarks, "Some benchmarks":
   let name = "benchmarks"

--- a/waku.nimble
+++ b/waku.nimble
@@ -76,7 +76,7 @@ proc getMyCPU(): string =
     return " --cpu:amd64 "
 
 proc getNimParams(): string =
-  return " " & getEnv("NIM_PARAMS") & " " & getEnv("NIMFLAGS") & " "
+  return " " & getEnv("NIM_PARAMS") & " "
 
 ### Helper functions
 proc buildModule(filePath, params = ""): bool =
@@ -105,11 +105,11 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
 
   if `type` == "static":
     exec "nim c" & " --out:build/" & lib_name &
-      " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
+      " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics -d:postgres --nimMainPrefix:" & mainPrefix & " --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
       getMyCPU() & getNimParams() & srcDir & "/" & srcFile
   else:
     exec "nim c" & " --out:build/" & lib_name &
-      " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
+      " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics -d:postgres --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
       getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
 
 proc buildLibDynamicWindows(libName: string, folderName: string) =

--- a/waku.nimble
+++ b/waku.nimble
@@ -105,11 +105,11 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
 
   if `type` == "static":
     exec "nim c" & " --out:build/" & lib_name &
-      " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics -d:postgres --nimMainPrefix:" & mainPrefix & " --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
+      " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
       getMyCPU() & getNimParams() & srcDir & "/" & srcFile
   else:
     exec "nim c" & " --out:build/" & lib_name &
-      " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics -d:postgres --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
+      " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
       getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
 
 proc buildLibDynamicWindows(libName: string, folderName: string) =
@@ -379,7 +379,7 @@ task testcommon, "Build & run common tests":
 ### Waku tasks
 task wakunode2, "Build Waku v2 cli node":
   let name = "wakunode2"
-  buildBinary name, "apps/wakunode2/", " -d:chronicles_log_level=TRACE -d:postgres "
+  buildBinary name, "apps/wakunode2/", " -d:chronicles_log_level=TRACE "
 
 task benchmarks, "Some benchmarks":
   let name = "benchmarks"


### PR DESCRIPTION
Regression from #3798 ( nimble migration ):
- make wakunode2 target now delegates to 'nimble wakunode2'
- nimble task hard-codes only -d:chronicles_log_level=TRACE; -d:postgres was lost
- getNimParams() only read NIM_PARAMS env var, so NIMFLAGS passed via Dockerfile/Jenkinsfile.release was silently dropped