### PR TITLE
avoid keeping delivery tasks in propagated state when check store is disabled

### DIFF
--- a/waku/node/delivery_service/send_service/send_service.nim
+++ b/waku/node/delivery_service/send_service/send_service.nim
@@ -225,9 +225,10 @@ proc evaluateAndCleanUp(self: SendService) =
       it.state != DeliveryState.FailedToDeliver
   )
 
-  # remove propagated ephemeral messages as no store check is possible
+  # remove propagated messages when no store confirmation will follow
   self.taskCache.keepItIf(
-    not (it.isEphemeral() and it.state == DeliveryState.SuccessfullyPropagated)
+    not (it.state == DeliveryState.SuccessfullyPropagated and
+      (it.isEphemeral() or not self.checkStoreForMessages))
   )
 
 proc trySendMessages(self: SendService) {.async.} =

--- a/waku/node/delivery_service/send_service/send_service.nim
+++ b/waku/node/delivery_service/send_service/send_service.nim
@@ -227,8 +227,10 @@ proc evaluateAndCleanUp(self: SendService) =
 
   # remove propagated messages when no store confirmation will follow
   self.taskCache.keepItIf(
-    not (it.state == DeliveryState.SuccessfullyPropagated and
-      (it.isEphemeral() or not self.checkStoreForMessages))
+    not (
+      it.state == DeliveryState.SuccessfullyPropagated and
+      (it.isEphemeral() or not self.checkStoreForMessages)
+    )
   )
 
 proc trySendMessages(self: SendService) {.async.} =


### PR DESCRIPTION
## Issue

- https://github.com/logos-messaging/logos-delivery/issues/3686
