### PR TITLE
start basic reliable channel folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - 'tools/**'
           - 'tests/all_tests_v2.nim'
           - 'tests/**'
+          - 'channels/**'
           docker:
           - 'docker/**'
 

--- a/channels/encryption/encryption.nim
+++ b/channels/encryption/encryption.nim
@@ -17,5 +17,11 @@ type
     encrypt*: EncryptFn
     decrypt*: DecryptFn
 
-proc isConfigured*(h: EncryptionHook): bool =
-  not h.encrypt.isNil() and not h.decrypt.isNil()
+proc isConfigured*(self: EncryptionHook): bool =
+  not self.encrypt.isNil() and not self.decrypt.isNil()
+
+proc send*(self: EncryptionHook, payload: seq[byte]): seq[byte] =
+  ## Stage 4 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
+  ## For now: passthrough — return the payload unencrypted.
+  ## TODO: invoke `self.encrypt` when configured and surface errors.
+  return payload

--- a/channels/encryption/encryption.nim
+++ b/channels/encryption/encryption.nim
@@ -1,0 +1,21 @@
+## Optional encryption hook for the Reliable Channel API.
+##
+## Applied per-segment after SDS processing on outgoing, and before
+## SDS processing on incoming. No specific scheme is mandated.
+##
+## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
+
+import results
+
+type
+  EncryptionError* = object of CatchableError
+
+  EncryptFn* = proc(payload: seq[byte]): Result[seq[byte], string] {.gcsafe, raises: [].}
+  DecryptFn* = proc(payload: seq[byte]): Result[seq[byte], string] {.gcsafe, raises: [].}
+
+  EncryptionHook* = object
+    encrypt*: EncryptFn
+    decrypt*: DecryptFn
+
+proc isConfigured*(h: EncryptionHook): bool =
+  not h.encrypt.isNil() and not h.decrypt.isNil()

--- a/channels/encryption/encryption.nim
+++ b/channels/encryption/encryption.nim
@@ -20,8 +20,14 @@ type
 proc isConfigured*(self: EncryptionHook): bool =
   not self.encrypt.isNil() and not self.decrypt.isNil()
 
-proc send*(self: EncryptionHook, payload: seq[byte]): seq[byte] =
+proc encrypt*(self: EncryptionHook, payload: seq[byte]): seq[byte] =
   ## Stage 4 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
   ## For now: passthrough — return the payload unencrypted.
-  ## TODO: invoke `self.encrypt` when configured and surface errors.
+  ## TODO: invoke the configured `EncryptFn` when present and surface errors.
+  return payload
+
+proc decrypt*(self: EncryptionHook, payload: seq[byte]): seq[byte] =
+  ## Stage 1 of the incoming pipeline (decryption -> sds -> reassemble -> emit).
+  ## For now: passthrough — return the payload as-is.
+  ## TODO: invoke the configured `DecryptFn` when present and surface errors.
   return payload

--- a/channels/encryption/encryption.nim
+++ b/channels/encryption/encryption.nim
@@ -1,33 +1,25 @@
-## Optional encryption hook for the Reliable Channel API.
+## Optional encryption hooks for the Reliable Channel API.
+##
+## Modelled as `RequestBroker`s: the broker pattern lets the channel
+## delegate work to a provider that may live in any module without
+## introducing a direct dependency. If no provider is registered the
+## broker returns an error, so installing the noop providers from
+## `noop_encryption` is required when the application does not want
+## actual encryption.
 ##
 ## Applied per-segment after SDS processing on outgoing, and before
 ## SDS processing on incoming. No specific scheme is mandated.
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import results
+import waku/common/broker/request_broker
 
-type
-  EncryptionError* = object of CatchableError
+export request_broker
 
-  EncryptFn* = proc(payload: seq[byte]): Result[seq[byte], string] {.gcsafe, raises: [].}
-  DecryptFn* = proc(payload: seq[byte]): Result[seq[byte], string] {.gcsafe, raises: [].}
+RequestBroker:
+  type Encrypt* = seq[byte]
+  proc signature*(payload: seq[byte]): Future[Result[Encrypt, string]] {.async.}
 
-  EncryptionHook* = object
-    encrypt*: EncryptFn
-    decrypt*: DecryptFn
-
-proc isConfigured*(self: EncryptionHook): bool =
-  not self.encrypt.isNil() and not self.decrypt.isNil()
-
-proc encrypt*(self: EncryptionHook, payload: seq[byte]): seq[byte] =
-  ## Stage 4 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
-  ## For now: passthrough — return the payload unencrypted.
-  ## TODO: invoke the configured `EncryptFn` when present and surface errors.
-  return payload
-
-proc decrypt*(self: EncryptionHook, payload: seq[byte]): seq[byte] =
-  ## Stage 1 of the incoming pipeline (decryption -> sds -> reassemble -> emit).
-  ## For now: passthrough — return the payload as-is.
-  ## TODO: invoke the configured `DecryptFn` when present and surface errors.
-  return payload
+RequestBroker:
+  type Decrypt* = seq[byte]
+  proc signature*(payload: seq[byte]): Future[Result[Decrypt, string]] {.async.}

--- a/channels/encryption/encryption.nim
+++ b/channels/encryption/encryption.nim
@@ -12,7 +12,7 @@
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import waku/common/broker/request_broker
+import brokers/request_broker
 
 export request_broker
 

--- a/channels/encryption/noop_encryption.nim
+++ b/channels/encryption/noop_encryption.nim
@@ -1,14 +1,18 @@
-## No-op encryption hook. Useful as the default when no encryption is
-## configured by the application.
+## No-op encryption providers. Install these when the application does
+## not want actual encryption so the `Encrypt` / `Decrypt` brokers have
+## something to dispatch to.
 
 import results
+import chronos
 import ./encryption
 
-proc noopEncrypt(payload: seq[byte]): Result[seq[byte], string] {.gcsafe, raises: [].} =
-  return ok(payload)
+proc setNoopEncryption*() =
+  discard Encrypt.setProvider(
+    proc(payload: seq[byte]): Future[Result[Encrypt, string]] {.async.} =
+      return ok(Encrypt(payload))
+  )
 
-proc noopDecrypt(payload: seq[byte]): Result[seq[byte], string] {.gcsafe, raises: [].} =
-  return ok(payload)
-
-proc init*(T: typedesc[EncryptionHook]): T =
-  return T(encrypt: noopEncrypt, decrypt: noopDecrypt)
+  discard Decrypt.setProvider(
+    proc(payload: seq[byte]): Future[Result[Decrypt, string]] {.async.} =
+      return ok(Decrypt(payload))
+  )

--- a/channels/encryption/noop_encryption.nim
+++ b/channels/encryption/noop_encryption.nim
@@ -1,0 +1,14 @@
+## No-op encryption hook. Useful as the default when no encryption is
+## configured by the application.
+
+import results
+import ./encryption
+
+proc noopEncrypt(payload: seq[byte]): Result[seq[byte], string] {.gcsafe, raises: [].} =
+  return ok(payload)
+
+proc noopDecrypt(payload: seq[byte]): Result[seq[byte], string] {.gcsafe, raises: [].} =
+  return ok(payload)
+
+proc init*(T: typedesc[EncryptionHook]): T =
+  return T(encrypt: noopEncrypt, decrypt: noopDecrypt)

--- a/channels/events.nim
+++ b/channels/events.nim
@@ -1,27 +1,23 @@
 ## Reliable Channel event types emitted to API consumers.
+##
+## Lifecycle events for individual segments (sent / propagated / errored)
+## are the same as the network-level ones the DeliveryService already
+## emits — `requestId` is shared across layers — so we just re-export
+## `waku/events/message_events` and avoid declaring duplicates.
+##
+## Only the channel-level `MessageReceivedEvent` carries data that has
+## no analogue in the lower layer (reassembled application payload,
+## senderId, channelId), so it lives here.
 
-import waku/api/types
+import waku/events/message_events as waku_message_events
+import waku/common/broker/event_broker
 
 import ./types as channel_types
 
-export types, channel_types
+export waku_message_events, channel_types, event_broker
 
-type
-  MessageReceivedEvent* = object
+EventBroker:
+  type ChannelMessageReceivedEvent* = object
     channelId*: ChannelId
     senderId*: SdsParticipantID
     payload*: seq[byte]
-
-  MessageSentEvent* = object
-    requestId*: RequestId
-
-  MessageDeliveredEvent* = object
-    requestId*: RequestId
-
-  MessageSendErrorEvent* = object
-    requestId*: RequestId
-    reason*: string
-
-  MessageDeliveryErrorEvent* = object
-    requestId*: RequestId
-    reason*: string

--- a/channels/events.nim
+++ b/channels/events.nim
@@ -10,7 +10,7 @@
 ## senderId, channelId), so it lives here.
 
 import waku/events/message_events as waku_message_events
-import waku/common/broker/event_broker
+import brokers/event_broker
 
 import ./types as channel_types
 

--- a/channels/events.nim
+++ b/channels/events.nim
@@ -13,15 +13,15 @@ type
     payload*: seq[byte]
 
   MessageSentEvent* = object
-    requestId*: ReliableRequestId
+    requestId*: RequestId
 
   MessageDeliveredEvent* = object
-    requestId*: ReliableRequestId
+    requestId*: RequestId
 
   MessageSendErrorEvent* = object
-    requestId*: ReliableRequestId
+    requestId*: RequestId
     reason*: string
 
   MessageDeliveryErrorEvent* = object
-    requestId*: ReliableRequestId
+    requestId*: RequestId
     reason*: string

--- a/channels/events.nim
+++ b/channels/events.nim
@@ -1,0 +1,26 @@
+## Reliable Channel event types emitted to API consumers.
+
+import ./scalable_data_sync/scalable_data_sync
+
+type
+  ChannelId* = SdsChannelID
+  RequestId* = string
+
+  MessageReceivedEvent* = object
+    channelId*: ChannelId
+    senderId*: SdsParticipantID
+    payload*: seq[byte]
+
+  MessageSentEvent* = object
+    requestId*: RequestId
+
+  MessageDeliveredEvent* = object
+    requestId*: RequestId
+
+  MessageSendErrorEvent* = object
+    requestId*: RequestId
+    reason*: string
+
+  MessageDeliveryErrorEvent* = object
+    requestId*: RequestId
+    reason*: string

--- a/channels/events.nim
+++ b/channels/events.nim
@@ -1,26 +1,27 @@
 ## Reliable Channel event types emitted to API consumers.
 
-import ./scalable_data_sync/scalable_data_sync
+import waku/api/types
+
+import ./types as channel_types
+
+export types, channel_types
 
 type
-  ChannelId* = SdsChannelID
-  RequestId* = string
-
   MessageReceivedEvent* = object
     channelId*: ChannelId
     senderId*: SdsParticipantID
     payload*: seq[byte]
 
   MessageSentEvent* = object
-    requestId*: RequestId
+    requestId*: ReliableRequestId
 
   MessageDeliveredEvent* = object
-    requestId*: RequestId
+    requestId*: ReliableRequestId
 
   MessageSendErrorEvent* = object
-    requestId*: RequestId
+    requestId*: ReliableRequestId
     reason*: string
 
   MessageDeliveryErrorEvent* = object
-    requestId*: RequestId
+    requestId*: ReliableRequestId
     reason*: string

--- a/channels/rate_limit_manager/rate_limit_manager.nim
+++ b/channels/rate_limit_manager/rate_limit_manager.nim
@@ -9,22 +9,25 @@ import std/times
 import sds/message
 import waku/common/broker/event_broker
 
-export message, event_broker
+export event_broker, broker_context
+export message.SdsChannelID
 
 const
   DefaultEpochPeriodSec* = 600
   DefaultMessagesPerEpoch* = 1
 
 EventBroker:
-  ## Emitted by `enqueueToSend` carrying the batch of SDS messages that
-  ## may now leave the rate limiter and continue down the outgoing
-  ## pipeline (encryption -> dispatch).
+  ## Emitted by `enqueueToSend` carrying the batch of opaque message
+  ## blobs that may now leave the rate limiter and continue down the
+  ## outgoing pipeline (encryption -> dispatch). Bytes only: the rate
+  ## limiter is intentionally agnostic of SDS, so anything serialisable
+  ## can flow through it.
   ##
   ## `channelId` lets listeners filter to their own channel, since all
   ## reliable channels share the underlying Waku node's broker context.
   type ReadyToSendEvent* = object
     channelId*: SdsChannelID
-    msgs*: seq[SdsMessage]
+    msgs*: seq[seq[byte]]
 
 type
   RateLimitConfig* = object
@@ -33,13 +36,17 @@ type
 
   RateLimitManager* = ref object
     config*: RateLimitConfig
-    queue*: seq[SdsMessage]
+    queue*: seq[seq[byte]]
     currentEpochStart*: Time
     sentInCurrentEpoch*: int
     channelId*: SdsChannelID ## tag for the emitted `ReadyToSendEvent`
+    brokerCtx: BrokerContext
 
 proc new*(
-    T: type RateLimitManager, config: RateLimitConfig, channelId: SdsChannelID
+    T: type RateLimitManager,
+    config: RateLimitConfig,
+    channelId: SdsChannelID,
+    brokerCtx: BrokerContext = globalBrokerContext(),
 ): T =
   return T(
     config: config,
@@ -47,9 +54,10 @@ proc new*(
     currentEpochStart: getTime(),
     sentInCurrentEpoch: 0,
     channelId: channelId,
+    brokerCtx: brokerCtx,
   )
 
-proc enqueueToSend*(self: RateLimitManager, msg: SdsMessage) =
+proc enqueueToSend*(self: RateLimitManager, msg: seq[byte]) =
   ## Stage 3 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
   ##
   ## For now: enqueue the message and immediately dequeue the full
@@ -62,10 +70,10 @@ proc enqueueToSend*(self: RateLimitManager, msg: SdsMessage) =
   self.queue = @[]
 
   ReadyToSendEvent.emit(
-    globalBrokerContext(), ReadyToSendEvent(channelId: self.channelId, msgs: ready)
+    self.brokerCtx, ReadyToSendEvent(channelId: self.channelId, msgs: ready)
   )
 
-proc dequeueReady*(self: RateLimitManager): seq[SdsMessage] =
+proc dequeueReady*(self: RateLimitManager): seq[seq[byte]] =
   ## Returns the set of queued messages that may be dispatched now
   ## without exceeding the configured rate limit. Advances epoch
   ## bookkeeping as needed.

--- a/channels/rate_limit_manager/rate_limit_manager.nim
+++ b/channels/rate_limit_manager/rate_limit_manager.nim
@@ -3,11 +3,15 @@
 ## Tracks messages sent per RLN epoch and delays dispatch when the
 ## limit is approached, ensuring RLN compliance on enforcing relays.
 ##
+## For the skeleton this is a pass-through: messages are immediately
+## released as ready-to-send. Real epoch budgeting will be added later.
+##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
 import std/times
-import sds/message
-import waku/common/broker/event_broker
+import message
+import brokers/event_broker
+import brokers/broker_context
 
 export event_broker, broker_context
 export message.SdsChannelID
@@ -31,6 +35,7 @@ EventBroker:
 
 type
   RateLimitConfig* = object
+    enabled*: bool ## spec: rate limiting opt-in; SHOULD be true when RLN active
     epochPeriodSec*: int
     messagesPerEpoch*: int
 
@@ -58,25 +63,16 @@ proc new*(
   )
 
 proc enqueueToSend*(self: RateLimitManager, msg: seq[byte]) =
-  ## Stage 3 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
-  ##
-  ## For now: enqueue the message and immediately dequeue the full
-  ## queue, emitting `ReadyToSendEvent` with the batch ready to be sent.
-  ## TODO: park `msg` on `self.queue` and only emit when the RLN-epoch
-  ## budget allows; advance epoch bookkeeping on `dequeueReady`.
-  self.queue.add(msg)
-
-  let ready = self.queue
-  self.queue = @[]
-
+  ## Skeleton behaviour: enqueue and immediately release as a single
+  ## ready batch. Real per-epoch budgeting will park messages on
+  ## `self.queue` and emit only when the budget allows.
   ReadyToSendEvent.emit(
-    self.brokerCtx, ReadyToSendEvent(channelId: self.channelId, msgs: ready)
+    self.brokerCtx, ReadyToSendEvent(channelId: self.channelId, msgs: @[msg])
   )
 
 proc dequeueReady*(self: RateLimitManager): seq[seq[byte]] =
   ## Returns the set of queued messages that may be dispatched now
-  ## without exceeding the configured rate limit. Advances epoch
-  ## bookkeeping as needed.
+  ## without exceeding the configured rate limit.
   discard
 
 proc resetEpoch*(self: RateLimitManager) =

--- a/channels/rate_limit_manager/rate_limit_manager.nim
+++ b/channels/rate_limit_manager/rate_limit_manager.nim
@@ -1,0 +1,43 @@
+## Rate Limit Manager for the Reliable Channel API.
+##
+## Tracks messages sent per RLN epoch and delays dispatch when the
+## limit is approached, ensuring RLN compliance on enforcing relays.
+##
+## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
+
+import std/times
+import sds/message
+
+export message
+
+const
+  DefaultEpochPeriodSec* = 600
+  DefaultMessagesPerEpoch* = 1
+
+type
+  RateLimitConfig* = object
+    epochPeriodSec*: int
+    messagesPerEpoch*: int
+
+  RateLimitManager* = ref object
+    config*: RateLimitConfig
+    queue*: seq[SdsMessage]
+    currentEpochStart*: Time
+    sentInCurrentEpoch*: int
+
+proc new*(T: type RateLimitManager, config: RateLimitConfig): T =
+  return T(config: config, queue: @[], currentEpochStart: getTime(), sentInCurrentEpoch: 0)
+
+proc enqueue*(mgr: RateLimitManager, msg: SdsMessage) =
+  ## Append an SDS message to the pending dispatch queue.
+  mgr.queue.add(msg)
+
+proc dequeueReady*(mgr: RateLimitManager): seq[SdsMessage] =
+  ## Returns the set of queued messages that may be dispatched now
+  ## without exceeding the configured rate limit. Advances epoch
+  ## bookkeeping as needed.
+  discard
+
+proc resetEpoch*(mgr: RateLimitManager) =
+  mgr.currentEpochStart = getTime()
+  mgr.sentInCurrentEpoch = 0

--- a/channels/rate_limit_manager/rate_limit_manager.nim
+++ b/channels/rate_limit_manager/rate_limit_manager.nim
@@ -7,12 +7,24 @@
 
 import std/times
 import sds/message
+import waku/common/broker/event_broker
 
-export message
+export message, event_broker
 
 const
   DefaultEpochPeriodSec* = 600
   DefaultMessagesPerEpoch* = 1
+
+EventBroker:
+  ## Emitted by `enqueueToSend` carrying the batch of SDS messages that
+  ## may now leave the rate limiter and continue down the outgoing
+  ## pipeline (encryption -> dispatch).
+  ##
+  ## `channelId` lets listeners filter to their own channel, since all
+  ## reliable channels share the underlying Waku node's broker context.
+  type ReadyToSendEvent* = object
+    channelId*: SdsChannelID
+    msgs*: seq[SdsMessage]
 
 type
   RateLimitConfig* = object
@@ -24,20 +36,41 @@ type
     queue*: seq[SdsMessage]
     currentEpochStart*: Time
     sentInCurrentEpoch*: int
+    channelId*: SdsChannelID ## tag for the emitted `ReadyToSendEvent`
 
-proc new*(T: type RateLimitManager, config: RateLimitConfig): T =
-  return T(config: config, queue: @[], currentEpochStart: getTime(), sentInCurrentEpoch: 0)
+proc new*(
+    T: type RateLimitManager, config: RateLimitConfig, channelId: SdsChannelID
+): T =
+  return T(
+    config: config,
+    queue: @[],
+    currentEpochStart: getTime(),
+    sentInCurrentEpoch: 0,
+    channelId: channelId,
+  )
 
-proc enqueue*(mgr: RateLimitManager, msg: SdsMessage) =
-  ## Append an SDS message to the pending dispatch queue.
-  mgr.queue.add(msg)
+proc enqueueToSend*(self: RateLimitManager, msg: SdsMessage) =
+  ## Stage 3 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
+  ##
+  ## For now: enqueue the message and immediately dequeue the full
+  ## queue, emitting `ReadyToSendEvent` with the batch ready to be sent.
+  ## TODO: park `msg` on `self.queue` and only emit when the RLN-epoch
+  ## budget allows; advance epoch bookkeeping on `dequeueReady`.
+  self.queue.add(msg)
 
-proc dequeueReady*(mgr: RateLimitManager): seq[SdsMessage] =
+  let ready = self.queue
+  self.queue = @[]
+
+  ReadyToSendEvent.emit(
+    globalBrokerContext(), ReadyToSendEvent(channelId: self.channelId, msgs: ready)
+  )
+
+proc dequeueReady*(self: RateLimitManager): seq[SdsMessage] =
   ## Returns the set of queued messages that may be dispatched now
   ## without exceeding the configured rate limit. Advances epoch
   ## bookkeeping as needed.
   discard
 
-proc resetEpoch*(mgr: RateLimitManager) =
-  mgr.currentEpochStart = getTime()
-  mgr.sentInCurrentEpoch = 0
+proc resetEpoch*(self: RateLimitManager) =
+  self.currentEpochStart = getTime()
+  self.sentInCurrentEpoch = 0

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -39,36 +39,35 @@ const Lip173Meta* = "LIP173"
   ## this layer and is silently dropped on ingress.
 
 type
-  ReliablePayload* = object
+  ReliableChannelPayload* = object
     channelId*: ChannelId
     payload*: seq[byte]
 
   ReliableChannel* = ref object
-    deliveryService*: DeliveryService
-    channelId*: ChannelId
-    contentTopic*: ContentTopic
-    senderId*: SdsParticipantID
+    ## Spec-defined public type. Fields are private so callers cannot
+    ## mutate internals and break invariants (e.g. rewriting the
+    ## delivery service mid-flight, or corrupting `requestIds`).
+    ## Getters are added below for the few values consumers may need.
+    deliveryService: DeliveryService
+    channelId: ChannelId
+    contentTopic: ContentTopic
+    senderId: SdsParticipantID
     rng: ref HmacDrbgContext
-      ## Private. Each channel owns its own RNG, created locally at
-      ## construction. Used to mint `RequestId`s and
-      ## delivery-service `RequestId`s.
-    segmentation*: SegmentationHandler
-    sdsHandler*: SdsHandler
-    rateLimit*: RateLimitManager
-    encryption*: EncryptionHook
+    segmentation: SegmentationHandler
+    sdsHandler: SdsHandler
+    rateLimit: RateLimitManager
 
-    requestIds*: Table[RequestId, seq[RequestId]]
-      ## Maps each reliable-channel-level (parent) `RequestId`
-      ## returned to the caller of `send` to the set of delivery-service
-      ## `RequestId`s it fanned out into (one per dispatched segment).
-    pendingRequests*: seq[tuple[parent: RequestId, ephemeral: bool]]
-      ## FIFO of pending dispatches awaiting release by the rate limiter.
-      ## Each entry pairs a parent `RequestId` with the caller's
-      ## `ephemeral` flag so the corresponding `MessageEnvelope` can be
-      ## stamped correctly when the rate limiter releases the batch.
-      ## One entry is pushed per segment enqueued and popped per segment
-      ## handed to the delivery service. Relies on FIFO release from
-      ## `rate_limit_manager`, which is the case in this skeleton.
+    requestIds: Table[RequestId, seq[RequestId]]
+    pendingRequests: seq[tuple[parent: RequestId, ephemeral: bool]]
+
+func getChannelId*(self: ReliableChannel): ChannelId {.inline.} =
+  self.channelId
+
+func getContentTopic*(self: ReliableChannel): ContentTopic {.inline.} =
+  self.contentTopic
+
+func getSenderId*(self: ReliableChannel): SdsParticipantID {.inline.} =
+  self.senderId
 
 proc new*(
     T: type ReliableChannel,
@@ -76,28 +75,36 @@ proc new*(
     channelId: ChannelId,
     contentTopic: ContentTopic,
     senderId: SdsParticipantID,
-    segmentation: SegmentationHandler,
-    sdsHandler: SdsHandler,
-    rateLimit: RateLimitManager,
-    encryption: EncryptionHook,
+    segConfig: SegmentationConfig,
+    sdsConfig: SdsConfig,
+    rateConfig: RateLimitConfig,
+    brokerCtx: BrokerContext = globalBrokerContext(),
 ): T =
+  ## Pipeline handlers (segmentation/SDS/rate-limit) are constructed
+  ## inside the channel rather than handed in by the caller — they are
+  ## implementation details of the channel, not knobs the API consumer
+  ## should be wiring up. Encryption is delegated to the `Encrypt`/
+  ## `Decrypt` request brokers, so the channel keeps no per-instance
+  ## encryption state either.
   return T(
     deliveryService: deliveryService,
     channelId: channelId,
     contentTopic: contentTopic,
     senderId: senderId,
     rng: libp2p_crypto.newRng(),
-    segmentation: segmentation,
-    sdsHandler: sdsHandler,
-    rateLimit: rateLimit,
-    encryption: encryption,
+    segmentation: SegmentationHandler.new(segConfig),
+    sdsHandler: SdsHandler.new(sdsConfig),
+    rateLimit: RateLimitManager.new(rateConfig, channelId, brokerCtx),
     requestIds: initTable[RequestId, seq[RequestId]](),
     pendingRequests: @[],
   )
 
-proc onReadyToSend*(self: ReliableChannel, msgs: seq[SdsMessage]) =
+proc onReadyToSend*(
+    self: ReliableChannel, msgs: seq[seq[byte]]
+) {.async: (raises: []).} =
   ## Tail of the outgoing pipeline. Invoked from the `ReadyToSendEvent`
-  ## listener once `rate_limit_manager` releases a batch of SDS messages:
+  ## listener once `rate_limit_manager` releases a batch of opaque
+  ## blobs (already-encoded SDS messages):
   ##
   ##   ... -> rate_limit_manager -> [encryption] -> dispatch
   for m in msgs:
@@ -111,7 +118,9 @@ proc onReadyToSend*(self: ReliableChannel, msgs: seq[SdsMessage]) =
     ## decryption before it can route, which breaks selective dispatch.
     ## Leave routing metadata (channelId, causal-history references) in
     ## clear and encrypt only the application payload.
-    let wireBytes = self.encryption.encrypt(m.encode())
+    let encRes = await Encrypt.request(m)
+    let wireBytes =
+      if encRes.isOk(): seq[byte](encRes.get()) else: m
     let envelope = MessageEnvelope(
       contentTopic: self.contentTopic,
       payload: wireBytes,
@@ -148,16 +157,21 @@ proc send*(
   self.requestIds[parentReqId] = @[]
 
   for segment in self.segmentation.performSegmentation(payload):
-    let sdsMsg = self.sdsHandler.wrapOutgoing(self.channelId, self.senderId, segment)
+    ## Encode the segment to bytes here so SDS stays agnostic of the
+    ## segmentation wire format.
+    let sdsMsg =
+      self.sdsHandler.wrapOutgoing(self.channelId, self.senderId, segment.encode())
     self.pendingRequests.add((parent: parentReqId, ephemeral: ephemeral))
-    self.rateLimit.enqueueToSend(sdsMsg)
+    self.rateLimit.enqueueToSend(sdsMsg.encode())
 
   return ok(parentReqId)
 
-proc onMessageReceived*(self: ReliableChannel, wakuMsg: WakuMessage) =
+proc onMessageReceived*(
+    self: ReliableChannel, wakuMsg: WakuMessage
+) {.async: (raises: []).} =
   ## Ingress pipeline made visible:
   ##
-  ##   WakuMessage -> ReliablePayload -> decrypt -> sds -> reassemble -> emit
+  ##   WakuMessage -> ReliableChannelPayload -> decrypt -> sds -> reassemble -> emit
   ##
   ## Invoked from the waku `MessageReceivedEvent` listener after the
   ## inbound `WakuMessage` has been filtered to this channel's
@@ -168,12 +182,14 @@ proc onMessageReceived*(self: ReliableChannel, wakuMsg: WakuMessage) =
     ## Not a Reliable Channel message — silently drop it.
     return
 
-  ## TODO: decode the `ReliablePayload` wrapper out of `inWakuMsg.payload`
+  ## TODO: decode the `ReliableChannelPayload` wrapper out of `inWakuMsg.payload`
   ## properly (currently treated as the raw SDS bytes).
-  let reliablePayload: ReliablePayload =
-    ReliablePayload(channelId: self.channelId, payload: inWakuMsg.payload)
+  let reliablePayload: ReliableChannelPayload =
+    ReliableChannelPayload(channelId: self.channelId, payload: inWakuMsg.payload)
 
-  let plaintext: seq[byte] = self.encryption.decrypt(reliablePayload.payload)
+  let decRes = await Decrypt.request(reliablePayload.payload)
+  let plaintext: seq[byte] =
+    if decRes.isOk(): seq[byte](decRes.get()) else: reliablePayload.payload
 
   let sdsMsg: SdsMessage = SdsMessage.decode(plaintext)
   let processedSds: SdsMessage = self.sdsHandler.handleIncoming(sdsMsg)

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -55,6 +55,12 @@ type
 
     requestIds: Table[RequestId, seq[RequestId]]
     pendingRequests: seq[tuple[parent: RequestId, ephemeral: bool]]
+    brokerCtx: BrokerContext
+      ## Captured here so the channel emits `ChannelMessageReceivedEvent`
+      ## on the same broker context the owning manager registered its
+      ## listeners on. Without this, an emit via `globalBrokerContext()`
+      ## would land on whatever context happens to be thread-local at
+      ## emit time, which is not necessarily the manager's.
 
 func getChannelId*(self: ReliableChannel): ChannelId {.inline.} =
   self.channelId
@@ -93,6 +99,7 @@ proc new*(
     rateLimit: RateLimitManager.new(rateConfig, channelId, brokerCtx),
     requestIds: initTable[RequestId, seq[RequestId]](),
     pendingRequests: @[],
+    brokerCtx: brokerCtx,
   )
 
 proc onReadyToSend*(
@@ -198,7 +205,14 @@ proc onMessageReceived*(
   let segment = SegmentMessageProto.decode(unwrapped.get().content)
   let reassembled = self.segmentation.handleIncomingSegment(segment)
   if reassembled.isSome():
-    ## TODO: emit `ChannelMessageReceivedEvent` carrying
-    ## `reassembled.get().payload` once the channel-level event surface
-    ## is wired into the EventBroker.
-    discard reassembled
+    ## Emit on the captured `brokerCtx` (the manager's), so the
+    ## application listener that the manager has set up on that same
+    ## context picks the event up.
+    ChannelMessageReceivedEvent.emit(
+      self.brokerCtx,
+      ChannelMessageReceivedEvent(
+        channelId: self.channelId,
+        senderId: self.senderId,
+        payload: reassembled.get().payload,
+      ),
+    )

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -50,20 +50,20 @@ type
     senderId*: SdsParticipantID
     rng: ref HmacDrbgContext
       ## Private. Each channel owns its own RNG, created locally at
-      ## construction. Used to mint `ReliableRequestId`s and
+      ## construction. Used to mint `RequestId`s and
       ## delivery-service `RequestId`s.
     segmentation*: SegmentationHandler
     sdsHandler*: SdsHandler
     rateLimit*: RateLimitManager
     encryption*: EncryptionHook
 
-    requestIds*: Table[ReliableRequestId, seq[RequestId]]
-      ## Maps each reliable-channel-level (parent) `ReliableRequestId`
+    requestIds*: Table[RequestId, seq[RequestId]]
+      ## Maps each reliable-channel-level (parent) `RequestId`
       ## returned to the caller of `send` to the set of delivery-service
       ## `RequestId`s it fanned out into (one per dispatched segment).
-    pendingRequests*: seq[tuple[parent: ReliableRequestId, ephemeral: bool]]
+    pendingRequests*: seq[tuple[parent: RequestId, ephemeral: bool]]
       ## FIFO of pending dispatches awaiting release by the rate limiter.
-      ## Each entry pairs a parent `ReliableRequestId` with the caller's
+      ## Each entry pairs a parent `RequestId` with the caller's
       ## `ephemeral` flag so the corresponding `MessageEnvelope` can be
       ## stamped correctly when the rate limiter releases the batch.
       ## One entry is pushed per segment enqueued and popped per segment
@@ -91,7 +91,7 @@ proc new*(
     sdsHandler: sdsHandler,
     rateLimit: rateLimit,
     encryption: encryption,
-    requestIds: initTable[ReliableRequestId, seq[RequestId]](),
+    requestIds: initTable[RequestId, seq[RequestId]](),
     pendingRequests: @[],
   )
 
@@ -128,7 +128,7 @@ proc onReadyToSend*(self: ReliableChannel, msgs: seq[SdsMessage]) =
 
 proc send*(
     self: ReliableChannel, payload: seq[byte], ephemeral: bool = false
-): Result[ReliableRequestId, string] =
+): Result[RequestId, string] =
   ## Single application-level send. The first three stages of the
   ## outgoing pipeline are chained explicitly so the flow is visible
   ## at a glance:
@@ -141,10 +141,10 @@ proc send*(
   ## flag is carried alongside each segment in `pendingRequests` and
   ## stamped onto the eventual `MessageEnvelope`.
   ##
-  ## The returned `ReliableRequestId` is the parent of one-or-more
+  ## The returned `RequestId` is the parent of one-or-more
   ## delivery-service `RequestId`s; the mapping is recorded in
   ## `self.requestIds`.
-  let parentReqId = ReliableRequestId.new(self.rng)
+  let parentReqId = RequestId.new(self.rng)
   self.requestIds[parentReqId] = @[]
 
   for segment in self.segmentation.performSegmentation(payload):

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -39,28 +39,27 @@ const Lip173Meta* = "LIP173"
   ## whose `meta` field does not equal these bytes is not addressed to
   ## this layer and is silently dropped on ingress.
 
-type
-  ReliableChannel* = ref object
-    ## Spec-defined public type. Fields are private so callers cannot
-    ## mutate internals and break invariants. Getters are added below
-    ## for the few values consumers may need.
-    deliveryService: DeliveryService
-    channelId: ChannelId
-    contentTopic: ContentTopic
-    senderId: SdsParticipantID
-    rng: ref HmacDrbgContext
-    segmentation: SegmentationHandler
-    sdsHandler: SdsHandler
-    rateLimit: RateLimitManager
+type ReliableChannel* = ref object
+  ## Spec-defined public type. Fields are private so callers cannot
+  ## mutate internals and break invariants. Getters are added below
+  ## for the few values consumers may need.
+  deliveryService: DeliveryService
+  channelId: ChannelId
+  contentTopic: ContentTopic
+  senderId: SdsParticipantID
+  rng: ref HmacDrbgContext
+  segmentation: SegmentationHandler
+  sdsHandler: SdsHandler
+  rateLimit: RateLimitManager
 
-    requestIds: Table[RequestId, seq[RequestId]]
-    pendingRequests: seq[tuple[parent: RequestId, ephemeral: bool]]
-    brokerCtx: BrokerContext
-      ## Captured here so the channel emits `ChannelMessageReceivedEvent`
-      ## on the same broker context the owning manager registered its
-      ## listeners on. Without this, an emit via `globalBrokerContext()`
-      ## would land on whatever context happens to be thread-local at
-      ## emit time, which is not necessarily the manager's.
+  requestIds: Table[RequestId, seq[RequestId]]
+  pendingRequests: seq[tuple[parent: RequestId, ephemeral: bool]]
+  brokerCtx: BrokerContext
+    ## Captured here so the channel emits `ChannelMessageReceivedEvent`
+    ## on the same broker context the owning manager registered its
+    ## listeners on. Without this, an emit via `globalBrokerContext()`
+    ## would land on whatever context happens to be thread-local at
+    ## emit time, which is not necessarily the manager's.
 
 func getChannelId*(self: ReliableChannel): ChannelId {.inline.} =
   self.channelId
@@ -123,12 +122,13 @@ proc onReadyToSend*(
     ## clear and encrypt only the application payload.
     let encRes = await Encrypt.request(m)
     let wireBytes =
-      if encRes.isOk(): seq[byte](encRes.get()) else: m
+      if encRes.isOk():
+        seq[byte](encRes.get())
+      else:
+        m
 
     let envelope = MessageEnvelope(
-      contentTopic: self.contentTopic,
-      payload: wireBytes,
-      ephemeral: pending.ephemeral,
+      contentTopic: self.contentTopic, payload: wireBytes, ephemeral: pending.ephemeral
     )
 
     let deliveryReqId = RequestId.new(self.rng)
@@ -172,10 +172,10 @@ proc send*(
   for segment in self.segmentation.performSegmentation(payload):
     ## Encode the segment to bytes here so SDS stays agnostic of the
     ## segmentation wire format.
-    let sdsBytes = self.sdsHandler
-      .wrapOutgoing(self.channelId, self.senderId, segment.encode())
-      .valueOr:
-        return err("SDS wrap failed: " & error)
+    let sdsBytes = self.sdsHandler.wrapOutgoing(
+      self.channelId, self.senderId, segment.encode()
+    ).valueOr:
+      return err("SDS wrap failed: " & error)
     self.pendingRequests.add((parent: parentReqId, ephemeral: ephemeral))
     self.rateLimit.enqueueToSend(sdsBytes)
 
@@ -191,12 +191,15 @@ proc onMessageReceived*(
   ## The ReliableChannelManager already validated LIP173 on the WakuMessage and
   ## stripped the wire framing, so the channel only sees the raw
   ## payload bytes for itself.
-  
+
   ## Notice that the following "request" is implemented implicitly as a broker call to
   ## the `Decrypt` request broker.
   let decRes = await Decrypt.request(payload)
   let plaintext: seq[byte] =
-    if decRes.isOk(): seq[byte](decRes.get()) else: payload
+    if decRes.isOk():
+      seq[byte](decRes.get())
+    else:
+      payload
 
   let unwrapped = self.sdsHandler.handleIncoming(plaintext)
   if unwrapped.isErr():

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -13,41 +13,128 @@
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
+import std/tables
+import results
+import chronos
+import bearssl/rand
+import libp2p/crypto/crypto as libp2p_crypto
+
+import waku/node/delivery_service/delivery_service
+import waku/node/delivery_service/send_service
+
 import ./events
 import ./segmentation/segmentation
 import ./scalable_data_sync/scalable_data_sync
 import ./rate_limit_manager/rate_limit_manager
 import ./encryption/encryption
 
-export events, segmentation, scalable_data_sync, rate_limit_manager, encryption
+export
+  delivery_service, send_service, events, segmentation, scalable_data_sync,
+  rate_limit_manager, encryption
 
 type
-  ContentTopic* = string
-
-  WakuNode* = ref object
-    ## Opaque handle to the underlying messaging node. The node's
-    ## NodeConfig carries `segmentation_config`, `sds_config` and
-    ## `rate_limit_config` consumed by the Reliable Channel layer.
-    ## TODO: replace with `waku/node/waku_node.WakuNode` once wired up.
-    segmentationConfig*: SegmentationConfig
-    sdsConfig*: SdsConfig
-    rateLimitConfig*: RateLimitConfig
-
   ReliablePayload* = object
     channelId*: ChannelId
     payload*: seq[byte]
 
-  MessageEnvelope* = object
-    contentTopic*: ContentTopic
-    payload*: seq[byte]
-    ephemeral*: bool
-
   ReliableChannel* = ref object
-    node*: WakuNode
+    deliveryService*: DeliveryService
     channelId*: ChannelId
     contentTopic*: ContentTopic
     senderId*: SdsParticipantID
+    rng: ref HmacDrbgContext
+      ## Private. Each channel owns its own RNG, created locally at
+      ## construction. Used to mint `ReliableRequestId`s and
+      ## delivery-service `RequestId`s.
     segmentation*: SegmentationHandler
     sds*: SdsHandler
     rateLimit*: RateLimitManager
     encryption*: EncryptionHook
+
+    requestIds*: Table[ReliableRequestId, seq[RequestId]]
+      ## Maps each reliable-channel-level (parent) `ReliableRequestId`
+      ## returned to the caller of `send` to the set of delivery-service
+      ## `RequestId`s it fanned out into (one per dispatched segment).
+    pendingRequests*: seq[ReliableRequestId]
+      ## FIFO of parent `ReliableRequestId`s awaiting release by the rate
+      ## limiter. One entry is pushed per segment enqueued and popped per
+      ## segment handed to the delivery service. Relies on FIFO release
+      ## from `rate_limit_manager`, which is the case in this skeleton.
+
+proc new*(
+    T: type ReliableChannel,
+    deliveryService: DeliveryService,
+    channelId: ChannelId,
+    contentTopic: ContentTopic,
+    senderId: SdsParticipantID,
+    segmentation: SegmentationHandler,
+    sds: SdsHandler,
+    rateLimit: RateLimitManager,
+    encryption: EncryptionHook,
+): T =
+  return T(
+    deliveryService: deliveryService,
+    channelId: channelId,
+    contentTopic: contentTopic,
+    senderId: senderId,
+    rng: libp2p_crypto.newRng(),
+    segmentation: segmentation,
+    sds: sds,
+    rateLimit: rateLimit,
+    encryption: encryption,
+    requestIds: initTable[ReliableRequestId, seq[RequestId]](),
+    pendingRequests: @[],
+  )
+
+proc onReadyToSend*(self: ReliableChannel, msgs: seq[SdsMessage]) =
+  ## Tail of the outgoing pipeline. Invoked from the `ReadyToSendEvent`
+  ## listener once `rate_limit_manager` releases a batch of SDS messages:
+  ##
+  ##   ... -> rate_limit_manager -> [encryption] -> dispatch
+  for m in msgs:
+    let wireBytes = self.encryption.send(m.encode())
+    let envelope = MessageEnvelope(
+      contentTopic: self.contentTopic, payload: wireBytes, ephemeral: false
+    )
+
+    let deliveryReqId = RequestId.new(self.rng)
+    let deliveryTask = DeliveryTask.new(deliveryReqId, envelope, globalBrokerContext()).valueOr:
+      ## TODO: emit MessageSendErrorEvent for the parent request id.
+      if self.pendingRequests.len > 0:
+        self.pendingRequests.delete(0)
+      continue
+
+    asyncSpawn self.deliveryService.sendService.send(deliveryTask)
+
+    if self.pendingRequests.len == 0:
+      ## TODO: log/track unparented dispatch — shouldn't happen in skeleton.
+      continue
+    let parent = self.pendingRequests[0]
+    self.pendingRequests.delete(0)
+    self.requestIds.mgetOrPut(parent, @[]).add(deliveryReqId)
+
+proc send*(
+    self: ReliableChannel, payload: seq[byte]
+): Result[ReliableRequestId, string] =
+  ## Single application-level send. The first three stages of the
+  ## outgoing pipeline are chained explicitly so the flow is visible
+  ## at a glance:
+  ##
+  ##   segmentation -> sds -> rate_limit_manager
+  ##
+  ## `rate_limit_manager.enqueueToSend` emits a `ReadyToSendEvent` with
+  ## the SDS messages cleared for transmission; the channel's listener
+  ## then runs the final stage (encryption -> dispatch).
+  ##
+  ## The returned `ReliableRequestId` is the parent of one-or-more
+  ## delivery-service `RequestId`s; the mapping is recorded in
+  ## `self.requestIds`.
+  let parentReqId = ReliableRequestId.new(self.rng)
+  self.requestIds[parentReqId] = @[]
+
+  for segment in self.segmentation.performSegmentation(payload):
+    let sdsMsg = self.sds.wrapOutgoing(self.channelId, self.senderId, segment)
+    self.pendingRequests.add(parentReqId)
+    self.rateLimit.enqueueToSend(sdsMsg)
+
+  return ok(parentReqId)

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -161,7 +161,7 @@ proc send*(
   return ok(parentReqId)
 
 proc onMessageReceived(
-    self: ReliableChannel, payload: seq[byte]
+    self: ReliableChannel, messageHash: string, payload: seq[byte]
 ) {.async: (raises: []).} =
   ## Ingress pipeline made visible:
   ##
@@ -174,13 +174,19 @@ proc onMessageReceived(
   ## Notice that the following "request" is implemented implicitly as a broker call to
   ## the `Decrypt` request broker.
   let decRes = await Decrypt.request(payload)
-  let plaintext: seq[byte] =
-    if decRes.isOk():
-      seq[byte](decRes.get())
-    else:
-      payload
+  let plaintext = decRes.valueOr:
+    MessageErrorEvent.emit(
+      self.brokerCtx,
+      MessageErrorEvent(
+        requestId: RequestId(""),
+        messageHash: messageHash,
+        error: "decryption failed: " & error,
+      ),
+    )
+    return
+  let plaintextBytes = seq[byte](plaintext)
 
-  let unwrapped = self.sdsHandler.handleIncoming(plaintext)
+  let unwrapped = self.sdsHandler.handleIncoming(plaintextBytes)
   if unwrapped.isErr():
     return
 
@@ -252,7 +258,7 @@ proc new*(
         return
       if evt.message.contentTopic != chn.contentTopic:
         return
-      await chn.onMessageReceived(evt.message.payload)
+      await chn.onMessageReceived(evt.messageHash, evt.message.payload)
     ,
   )
 

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -22,6 +22,7 @@ import libp2p/crypto/crypto as libp2p_crypto
 
 import waku/node/delivery_service/delivery_service
 import waku/node/delivery_service/send_service
+import waku/waku_core/topics
 
 import ./events
 import ./segmentation/segmentation
@@ -41,9 +42,8 @@ const Lip173Meta* = "LIP173"
 type
   ReliableChannel* = ref object
     ## Spec-defined public type. Fields are private so callers cannot
-    ## mutate internals and break invariants (e.g. rewriting the
-    ## delivery service mid-flight, or corrupting `requestIds`).
-    ## Getters are added below for the few values consumers may need.
+    ## mutate internals and break invariants. Getters are added below
+    ## for the few values consumers may need.
     deliveryService: DeliveryService
     channelId: ChannelId
     contentTopic: ContentTopic
@@ -89,7 +89,7 @@ proc new*(
     senderId: senderId,
     rng: libp2p_crypto.newRng(),
     segmentation: SegmentationHandler.new(segConfig),
-    sdsHandler: SdsHandler.new(sdsConfig),
+    sdsHandler: SdsHandler.new(sdsConfig, senderId),
     rateLimit: RateLimitManager.new(rateConfig, channelId, brokerCtx),
     requestIds: initTable[RequestId, seq[RequestId]](),
     pendingRequests: @[],
@@ -117,6 +117,7 @@ proc onReadyToSend*(
     let encRes = await Encrypt.request(m)
     let wireBytes =
       if encRes.isOk(): seq[byte](encRes.get()) else: m
+
     let envelope = MessageEnvelope(
       contentTopic: self.contentTopic,
       payload: wireBytes,
@@ -125,8 +126,14 @@ proc onReadyToSend*(
 
     let deliveryReqId = RequestId.new(self.rng)
     let deliveryTask = DeliveryTask.new(deliveryReqId, envelope, globalBrokerContext()).valueOr:
-      ## TODO: emit MessageSendErrorEvent for the parent request id.
+      ## TODO: emit waku `MessageErrorEvent` for the parent request id.
       continue
+
+    ## Stamp the LIP173 wire-level marker so the ingress side of any
+    ## peer can route this WakuMessage to its Reliable Channel layer.
+    ## Done on the constructed WakuMessage rather than via the envelope
+    ## because `MessageEnvelope` does not expose a `meta` field.
+    deliveryTask.msg.meta = Lip173Meta.toBytes()
 
     asyncSpawn self.deliveryService.sendService.send(deliveryTask)
     self.requestIds.mgetOrPut(pending.parent, @[]).add(deliveryReqId)
@@ -149,16 +156,21 @@ proc send*(
   ## The returned `RequestId` is the parent of one-or-more
   ## delivery-service `RequestId`s; the mapping is recorded in
   ## `self.requestIds`.
+  if payload.len == 0:
+    return err("empty payload")
+
   let parentReqId = RequestId.new(self.rng)
   self.requestIds[parentReqId] = @[]
 
   for segment in self.segmentation.performSegmentation(payload):
     ## Encode the segment to bytes here so SDS stays agnostic of the
     ## segmentation wire format.
-    let sdsMsg =
-      self.sdsHandler.wrapOutgoing(self.channelId, self.senderId, segment.encode())
+    let sdsBytes = self.sdsHandler
+      .wrapOutgoing(self.channelId, self.senderId, segment.encode())
+      .valueOr:
+        return err("SDS wrap failed: " & error)
     self.pendingRequests.add((parent: parentReqId, ephemeral: ephemeral))
-    self.rateLimit.enqueueToSend(sdsMsg.encode())
+    self.rateLimit.enqueueToSend(sdsBytes)
 
   return ok(parentReqId)
 
@@ -171,22 +183,19 @@ proc onMessageReceived*(
   ##
   ## The ReliableChannelManager already validated LIP173 on the WakuMessage and
   ## stripped the wire framing, so the channel only sees the raw
-  ## payload bytes for itself. Each stage below is a minimal stub for
-  ## now.
+  ## payload bytes for itself.
   let decRes = await Decrypt.request(payload)
   let plaintext: seq[byte] =
     if decRes.isOk(): seq[byte](decRes.get()) else: payload
 
-  let sdsMsg: SdsMessage = SdsMessage.decode(plaintext)
-  let processedSds: SdsMessage = self.sdsHandler.handleIncoming(sdsMsg)
+  let unwrapped = self.sdsHandler.handleIncoming(plaintext)
+  if unwrapped.isErr():
+    return
 
-  let segment: SegmentMessageProto =
-    SegmentMessageProto.decode(processedSds.content)
-  let reassembled: Option[ReassemblyResult] =
-    self.segmentation.handleIncomingSegment(segment)
-
+  let segment = SegmentMessageProto.decode(unwrapped.get().content)
+  let reassembled = self.segmentation.handleIncomingSegment(segment)
   if reassembled.isSome():
-    ## TODO: emit the channel-level `ChannelMessageReceivedEvent` carrying
-    ## `reassembled.get().payload` once the event is wired into the
-    ## EventBroker.
+    ## TODO: emit `ChannelMessageReceivedEvent` carrying
+    ## `reassembled.get().payload` once the channel-level event surface
+    ## is wired into the EventBroker.
     discard reassembled

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -148,11 +148,11 @@ proc send*(
   let parentReqId = RequestId.new(self.rng)
   self.requestIds[parentReqId] = @[]
 
-  for segment in self.segmentation.performSegmentation(payload):
-    ## Encode the segment to bytes here so SDS stays agnostic of the
-    ## segmentation wire format.
+  for segmentBytes in self.segmentation.performSegmentation(payload):
+    ## Segments arrive already encoded; the segmentation module owns
+    ## the wire format so SDS only ever sees opaque bytes.
     let sdsBytes = self.sdsHandler.wrapOutgoing(
-      self.channelId, self.senderId, segment.encode()
+      self.channelId, self.senderId, segmentBytes
     ).valueOr:
       return err("SDS wrap failed: " & error)
     self.pendingRequests.add((parent: parentReqId, ephemeral: ephemeral))
@@ -190,8 +190,7 @@ proc onMessageReceived(
   if unwrapped.isErr():
     return
 
-  let segment = SegmentMessageProto.decode(unwrapped.get().content)
-  let reassembled = self.segmentation.handleIncomingSegment(segment)
+  let reassembled = self.segmentation.handleIncomingSegment(unwrapped.get().content)
   if reassembled.isSome():
     ## Emit on the captured `brokerCtx` (the manager's), so the
     ## application listener that the manager has set up on that same

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -34,10 +34,13 @@ export
   delivery_service, send_service, events, segmentation, scalable_data_sync,
   rate_limit_manager, encryption
 
-const Lip173Meta* = "LIP173"
-  ## Wire-level marker for the Reliable Channel layer. A `WakuMessage`
-  ## whose `meta` field does not equal these bytes is not addressed to
-  ## this layer and is silently dropped on ingress.
+const LipWireReliableChannelVersion* = "RELIABLE-CHANNEL-API/1"
+  ## Wire-format spec marker for the Reliable Channel layer, as defined
+  ## in the reliable-channel-api LIP (`Wire Format / Spec Marker`).
+  ## A `WakuMessage` whose `meta` field does not equal these bytes is
+  ## not addressed to this layer and is silently dropped on ingress.
+  ## The trailing `/N` is the wire-format version and is bumped only
+  ## on breaking on-the-wire changes; implementations pin one version.
 
 type ReliableChannel* = ref object
   ## Spec-defined public type. Fields are private so callers cannot
@@ -136,11 +139,12 @@ proc onReadyToSend*(
       ## TODO: emit waku `MessageErrorEvent` for the parent request id.
       continue
 
-    ## Stamp the LIP173 wire-level marker so the ingress side of any
-    ## peer can route this WakuMessage to its Reliable Channel layer.
-    ## Done on the constructed WakuMessage rather than via the envelope
-    ## because `MessageEnvelope` does not expose a `meta` field.
-    deliveryTask.msg.meta = Lip173Meta.toBytes()
+    ## Stamp the Reliable Channel wire-format spec marker so the ingress
+    ## side of any peer can route this WakuMessage to its Reliable
+    ## Channel layer. Done on the constructed WakuMessage rather than
+    ## via the envelope because `MessageEnvelope` does not expose a
+    ## `meta` field.
+    deliveryTask.msg.meta = LipWireReliableChannelVersion.toBytes()
 
     asyncSpawn self.deliveryService.sendService.send(deliveryTask)
     self.requestIds.mgetOrPut(pending.parent, @[]).add(deliveryReqId)
@@ -188,7 +192,7 @@ proc onMessageReceived*(
   ##
   ##   payload -> decrypt -> sds -> reassemble -> emit
   ##
-  ## The ReliableChannelManager already validated LIP173 on the WakuMessage and
+  ## The ReliableChannelManager already validated the spec marker on the WakuMessage and
   ## stripped the wire framing, so the channel only sees the raw
   ## payload bytes for itself.
 

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -93,11 +93,17 @@ proc onReadyToSend(
     ## Leave routing metadata (channelId, causal-history references) in
     ## clear and encrypt only the application payload.
     let encRes = await Encrypt.request(m)
-    let wireBytes =
-      if encRes.isOk():
-        seq[byte](encRes.get())
-      else:
-        m
+    let encrypted = encRes.valueOr:
+      MessageErrorEvent.emit(
+        self.brokerCtx,
+        MessageErrorEvent(
+          requestId: pending.parent,
+          messageHash: "",
+          error: "encryption failed: " & error,
+        ),
+      )
+      continue
+    let wireBytes = seq[byte](encrypted)
 
     let envelope = MessageEnvelope(
       contentTopic: self.contentTopic, payload: wireBytes, ephemeral: pending.ephemeral

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -39,10 +39,6 @@ const Lip173Meta* = "LIP173"
   ## this layer and is silently dropped on ingress.
 
 type
-  ReliableChannelPayload* = object
-    channelId*: ChannelId
-    payload*: seq[byte]
-
   ReliableChannel* = ref object
     ## Spec-defined public type. Fields are private so callers cannot
     ## mutate internals and break invariants (e.g. rewriting the
@@ -167,29 +163,19 @@ proc send*(
   return ok(parentReqId)
 
 proc onMessageReceived*(
-    self: ReliableChannel, wakuMsg: WakuMessage
+    self: ReliableChannel, payload: seq[byte]
 ) {.async: (raises: []).} =
   ## Ingress pipeline made visible:
   ##
-  ##   WakuMessage -> ReliableChannelPayload -> decrypt -> sds -> reassemble -> emit
+  ##   payload -> decrypt -> sds -> reassemble -> emit
   ##
-  ## Invoked from the waku `MessageReceivedEvent` listener after the
-  ## inbound `WakuMessage` has been filtered to this channel's
-  ## `contentTopic`. Each stage is a minimal stub for now.
-  let inWakuMsg: WakuMessage = wakuMsg
-
-  if string.fromBytes(inWakuMsg.meta) != Lip173Meta:
-    ## Not a Reliable Channel message — silently drop it.
-    return
-
-  ## TODO: decode the `ReliableChannelPayload` wrapper out of `inWakuMsg.payload`
-  ## properly (currently treated as the raw SDS bytes).
-  let reliablePayload: ReliableChannelPayload =
-    ReliableChannelPayload(channelId: self.channelId, payload: inWakuMsg.payload)
-
-  let decRes = await Decrypt.request(reliablePayload.payload)
+  ## The ReliableChannelManager already validated LIP173 on the WakuMessage and
+  ## stripped the wire framing, so the channel only sees the raw
+  ## payload bytes for itself. Each stage below is a minimal stub for
+  ## now.
+  let decRes = await Decrypt.request(payload)
   let plaintext: seq[byte] =
-    if decRes.isOk(): seq[byte](decRes.get()) else: reliablePayload.payload
+    if decRes.isOk(): seq[byte](decRes.get()) else: payload
 
   let sdsMsg: SdsMessage = SdsMessage.decode(plaintext)
   let processedSds: SdsMessage = self.sdsHandler.handleIncoming(sdsMsg)
@@ -200,7 +186,7 @@ proc onMessageReceived*(
     self.segmentation.handleIncomingSegment(segment)
 
   if reassembled.isSome():
-    ## TODO: emit the channel-level `MessageReceivedEvent` carrying
+    ## TODO: emit the channel-level `ChannelMessageReceivedEvent` carrying
     ## `reassembled.get().payload` once the event is wired into the
     ## EventBroker.
     discard reassembled

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -53,7 +53,7 @@ type
       ## construction. Used to mint `ReliableRequestId`s and
       ## delivery-service `RequestId`s.
     segmentation*: SegmentationHandler
-    sds*: SdsHandler
+    sdsHandler*: SdsHandler
     rateLimit*: RateLimitManager
     encryption*: EncryptionHook
 
@@ -61,11 +61,14 @@ type
       ## Maps each reliable-channel-level (parent) `ReliableRequestId`
       ## returned to the caller of `send` to the set of delivery-service
       ## `RequestId`s it fanned out into (one per dispatched segment).
-    pendingRequests*: seq[ReliableRequestId]
-      ## FIFO of parent `ReliableRequestId`s awaiting release by the rate
-      ## limiter. One entry is pushed per segment enqueued and popped per
-      ## segment handed to the delivery service. Relies on FIFO release
-      ## from `rate_limit_manager`, which is the case in this skeleton.
+    pendingRequests*: seq[tuple[parent: ReliableRequestId, ephemeral: bool]]
+      ## FIFO of pending dispatches awaiting release by the rate limiter.
+      ## Each entry pairs a parent `ReliableRequestId` with the caller's
+      ## `ephemeral` flag so the corresponding `MessageEnvelope` can be
+      ## stamped correctly when the rate limiter releases the batch.
+      ## One entry is pushed per segment enqueued and popped per segment
+      ## handed to the delivery service. Relies on FIFO release from
+      ## `rate_limit_manager`, which is the case in this skeleton.
 
 proc new*(
     T: type ReliableChannel,
@@ -74,7 +77,7 @@ proc new*(
     contentTopic: ContentTopic,
     senderId: SdsParticipantID,
     segmentation: SegmentationHandler,
-    sds: SdsHandler,
+    sdsHandler: SdsHandler,
     rateLimit: RateLimitManager,
     encryption: EncryptionHook,
 ): T =
@@ -85,7 +88,7 @@ proc new*(
     senderId: senderId,
     rng: libp2p_crypto.newRng(),
     segmentation: segmentation,
-    sds: sds,
+    sdsHandler: sdsHandler,
     rateLimit: rateLimit,
     encryption: encryption,
     requestIds: initTable[ReliableRequestId, seq[RequestId]](),
@@ -98,29 +101,28 @@ proc onReadyToSend*(self: ReliableChannel, msgs: seq[SdsMessage]) =
   ##
   ##   ... -> rate_limit_manager -> [encryption] -> dispatch
   for m in msgs:
+    ## Each `m` was preceded by exactly one push onto `pendingRequests`
+    ## in `send`, so this pop is always safe in the current skeleton.
+    let pending = self.pendingRequests[0]
+    self.pendingRequests.delete(0)
+
     let wireBytes = self.encryption.encrypt(m.encode())
     let envelope = MessageEnvelope(
-      contentTopic: self.contentTopic, payload: wireBytes, ephemeral: false
+      contentTopic: self.contentTopic,
+      payload: wireBytes,
+      ephemeral: pending.ephemeral,
     )
 
     let deliveryReqId = RequestId.new(self.rng)
     let deliveryTask = DeliveryTask.new(deliveryReqId, envelope, globalBrokerContext()).valueOr:
       ## TODO: emit MessageSendErrorEvent for the parent request id.
-      if self.pendingRequests.len > 0:
-        self.pendingRequests.delete(0)
       continue
 
     asyncSpawn self.deliveryService.sendService.send(deliveryTask)
-
-    if self.pendingRequests.len == 0:
-      ## TODO: log/track unparented dispatch — shouldn't happen in skeleton.
-      continue
-    let parent = self.pendingRequests[0]
-    self.pendingRequests.delete(0)
-    self.requestIds.mgetOrPut(parent, @[]).add(deliveryReqId)
+    self.requestIds.mgetOrPut(pending.parent, @[]).add(deliveryReqId)
 
 proc send*(
-    self: ReliableChannel, payload: seq[byte]
+    self: ReliableChannel, payload: seq[byte], ephemeral: bool = false
 ): Result[ReliableRequestId, string] =
   ## Single application-level send. The first three stages of the
   ## outgoing pipeline are chained explicitly so the flow is visible
@@ -130,7 +132,9 @@ proc send*(
   ##
   ## `rate_limit_manager.enqueueToSend` emits a `ReadyToSendEvent` with
   ## the SDS messages cleared for transmission; the channel's listener
-  ## then runs the final stage (encryption -> dispatch).
+  ## then runs the final stage (encryption -> dispatch). The `ephemeral`
+  ## flag is carried alongside each segment in `pendingRequests` and
+  ## stamped onto the eventual `MessageEnvelope`.
   ##
   ## The returned `ReliableRequestId` is the parent of one-or-more
   ## delivery-service `RequestId`s; the mapping is recorded in
@@ -139,8 +143,8 @@ proc send*(
   self.requestIds[parentReqId] = @[]
 
   for segment in self.segmentation.performSegmentation(payload):
-    let sdsMsg = self.sds.wrapOutgoing(self.channelId, self.senderId, segment)
-    self.pendingRequests.add(parentReqId)
+    let sdsMsg = self.sdsHandler.wrapOutgoing(self.channelId, self.senderId, segment)
+    self.pendingRequests.add((parent: parentReqId, ephemeral: ephemeral))
     self.rateLimit.enqueueToSend(sdsMsg)
 
   return ok(parentReqId)
@@ -167,7 +171,7 @@ proc onMessageReceived*(self: ReliableChannel, wakuMsg: WakuMessage) =
   let plaintext: seq[byte] = self.encryption.decrypt(reliablePayload.payload)
 
   let sdsMsg: SdsMessage = SdsMessage.decode(plaintext)
-  let processedSds: SdsMessage = self.sds.handleIncoming(sdsMsg)
+  let processedSds: SdsMessage = self.sdsHandler.handleIncoming(sdsMsg)
 
   let segment: SegmentMessageProto =
     SegmentMessageProto.decode(processedSds.content)

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -73,38 +73,7 @@ func getContentTopic*(self: ReliableChannel): ContentTopic {.inline.} =
 func getSenderId*(self: ReliableChannel): SdsParticipantID {.inline.} =
   self.senderId
 
-proc new*(
-    T: type ReliableChannel,
-    deliveryService: DeliveryService,
-    channelId: ChannelId,
-    contentTopic: ContentTopic,
-    senderId: SdsParticipantID,
-    segConfig: SegmentationConfig,
-    sdsConfig: SdsConfig,
-    rateConfig: RateLimitConfig,
-    brokerCtx: BrokerContext = globalBrokerContext(),
-): T =
-  ## Pipeline handlers (segmentation/SDS/rate-limit) are constructed
-  ## inside the channel rather than handed in by the caller — they are
-  ## implementation details of the channel, not knobs the API consumer
-  ## should be wiring up. Encryption is delegated to the `Encrypt`/
-  ## `Decrypt` request brokers, so the channel keeps no per-instance
-  ## encryption state either.
-  return T(
-    deliveryService: deliveryService,
-    channelId: channelId,
-    contentTopic: contentTopic,
-    senderId: senderId,
-    rng: libp2p_crypto.newRng(),
-    segmentation: SegmentationHandler.new(segConfig),
-    sdsHandler: SdsHandler.new(sdsConfig, senderId),
-    rateLimit: RateLimitManager.new(rateConfig, channelId, brokerCtx),
-    requestIds: initTable[RequestId, seq[RequestId]](),
-    pendingRequests: @[],
-    brokerCtx: brokerCtx,
-  )
-
-proc onReadyToSend*(
+proc onReadyToSend(
     self: ReliableChannel, msgs: seq[seq[byte]]
 ) {.async: (raises: []).} =
   ## Tail of the outgoing pipeline. Invoked from the `ReadyToSendEvent`
@@ -185,16 +154,16 @@ proc send*(
 
   return ok(parentReqId)
 
-proc onMessageReceived*(
+proc onMessageReceived(
     self: ReliableChannel, payload: seq[byte]
 ) {.async: (raises: []).} =
   ## Ingress pipeline made visible:
   ##
   ##   payload -> decrypt -> sds -> reassemble -> emit
   ##
-  ## The ReliableChannelManager already validated the spec marker on the WakuMessage and
-  ## stripped the wire framing, so the channel only sees the raw
-  ## payload bytes for itself.
+  ## Invoked from this channel's `MessageReceivedEvent` listener, which
+  ## already filtered on the spec marker and on `contentTopic`. The
+  ## channel only sees the raw payload bytes for itself.
 
   ## Notice that the following "request" is implemented implicitly as a broker call to
   ## the `Decrypt` request broker.
@@ -223,3 +192,62 @@ proc onMessageReceived*(
         payload: reassembled.get().payload,
       ),
     )
+
+proc new*(
+    T: type ReliableChannel,
+    deliveryService: DeliveryService,
+    channelId: ChannelId,
+    contentTopic: ContentTopic,
+    senderId: SdsParticipantID,
+    segConfig: SegmentationConfig,
+    sdsConfig: SdsConfig,
+    rateConfig: RateLimitConfig,
+    brokerCtx: BrokerContext = globalBrokerContext(),
+): T =
+  ## Pipeline handlers (segmentation/SDS/rate-limit) are constructed
+  ## inside the channel rather than handed in by the caller — they are
+  ## implementation details of the channel, not knobs the API consumer
+  ## should be wiring up. Encryption is delegated to the `Encrypt`/
+  ## `Decrypt` request brokers, so the channel keeps no per-instance
+  ## encryption state either.
+  let chn = T(
+    deliveryService: deliveryService,
+    channelId: channelId,
+    contentTopic: contentTopic,
+    senderId: senderId,
+    rng: libp2p_crypto.newRng(),
+    segmentation: SegmentationHandler.new(segConfig),
+    sdsHandler: SdsHandler.new(sdsConfig, senderId),
+    rateLimit: RateLimitManager.new(rateConfig, channelId, brokerCtx),
+    requestIds: initTable[RequestId, seq[RequestId]](),
+    pendingRequests: @[],
+    brokerCtx: brokerCtx,
+  )
+
+  ## Each channel owns its own egress + ingress listeners on
+  ## `chn.brokerCtx`, filtered to traffic addressed to this channel.
+  ## Keeping the listeners (and the procs they call) inside the
+  ## channel lets `onReadyToSend` and `onMessageReceived` stay private
+  ## — the manager doesn't need to know about them.
+  discard ReadyToSendEvent.listen(
+    chn.brokerCtx,
+    proc(evt: ReadyToSendEvent): Future[void] {.async: (raises: []).} =
+      if evt.channelId == chn.channelId:
+        await chn.onReadyToSend(evt.msgs)
+    ,
+  )
+
+  discard MessageReceivedEvent.listen(
+    chn.brokerCtx,
+    proc(evt: MessageReceivedEvent): Future[void] {.async: (raises: []).} =
+      ## Drop foreign traffic (non-Reliable-Channel `meta`) and traffic
+      ## for other channels before doing any decode work.
+      if string.fromBytes(evt.message.meta) != LipWireReliableChannelVersion:
+        return
+      if evt.message.contentTopic != chn.contentTopic:
+        return
+      await chn.onMessageReceived(evt.message.payload)
+    ,
+  )
+
+  return chn

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -1,0 +1,53 @@
+## Reliable Channel type.
+##
+## A `ReliableChannel` orchestrates segmentation, SDS (end-to-end
+## reliability), optional encryption, and rate-limited dispatch on top
+## of the Messaging API for a single channel.
+##
+## Outgoing pipeline: Segment -> SDS -> Rate Limit -> Encrypt -> Dispatch
+## Incoming pipeline: Decrypt -> SDS -> Reassemble -> Emit event
+##
+## Channels are owned by a `ReliableChannelManager`. Lifecycle and send
+## operations are addressed by `ChannelId`, so callers only need to keep
+## an opaque handle around.
+##
+## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
+
+import ./events
+import ./segmentation/segmentation
+import ./scalable_data_sync/scalable_data_sync
+import ./rate_limit_manager/rate_limit_manager
+import ./encryption/encryption
+
+export events, segmentation, scalable_data_sync, rate_limit_manager, encryption
+
+type
+  ContentTopic* = string
+
+  WakuNode* = ref object
+    ## Opaque handle to the underlying messaging node. The node's
+    ## NodeConfig carries `segmentation_config`, `sds_config` and
+    ## `rate_limit_config` consumed by the Reliable Channel layer.
+    ## TODO: replace with `waku/node/waku_node.WakuNode` once wired up.
+    segmentationConfig*: SegmentationConfig
+    sdsConfig*: SdsConfig
+    rateLimitConfig*: RateLimitConfig
+
+  ReliablePayload* = object
+    channelId*: ChannelId
+    payload*: seq[byte]
+
+  MessageEnvelope* = object
+    contentTopic*: ContentTopic
+    payload*: seq[byte]
+    ephemeral*: bool
+
+  ReliableChannel* = ref object
+    node*: WakuNode
+    channelId*: ChannelId
+    contentTopic*: ContentTopic
+    senderId*: SdsParticipantID
+    segmentation*: SegmentationHandler
+    sds*: SdsHandler
+    rateLimit*: RateLimitManager
+    encryption*: EncryptionHook

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -184,6 +184,9 @@ proc onMessageReceived*(
   ## The ReliableChannelManager already validated LIP173 on the WakuMessage and
   ## stripped the wire framing, so the channel only sees the raw
   ## payload bytes for itself.
+  
+  ## Notice that the following "request" is implemented implicitly as a broker call to
+  ## the `Decrypt` request broker.
   let decRes = await Decrypt.request(payload)
   let plaintext: seq[byte] =
     if decRes.isOk(): seq[byte](decRes.get()) else: payload

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -106,6 +106,11 @@ proc onReadyToSend*(self: ReliableChannel, msgs: seq[SdsMessage]) =
     let pending = self.pendingRequests[0]
     self.pendingRequests.delete(0)
 
+    ## TODO: revisit which fields of the SDS message must be encrypted.
+    ## Encrypting the whole encoded blob forces every receiver to attempt
+    ## decryption before it can route, which breaks selective dispatch.
+    ## Leave routing metadata (channelId, causal-history references) in
+    ## clear and encrypt only the application payload.
     let wireBytes = self.encryption.encrypt(m.encode())
     let envelope = MessageEnvelope(
       contentTopic: self.contentTopic,

--- a/channels/reliable_channel.nim
+++ b/channels/reliable_channel.nim
@@ -13,10 +13,11 @@
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import std/tables
+import std/[options, tables]
 import results
 import chronos
 import bearssl/rand
+import stew/byteutils
 import libp2p/crypto/crypto as libp2p_crypto
 
 import waku/node/delivery_service/delivery_service
@@ -31,6 +32,11 @@ import ./encryption/encryption
 export
   delivery_service, send_service, events, segmentation, scalable_data_sync,
   rate_limit_manager, encryption
+
+const Lip173Meta* = "LIP173"
+  ## Wire-level marker for the Reliable Channel layer. A `WakuMessage`
+  ## whose `meta` field does not equal these bytes is not addressed to
+  ## this layer and is silently dropped on ingress.
 
 type
   ReliablePayload* = object
@@ -92,7 +98,7 @@ proc onReadyToSend*(self: ReliableChannel, msgs: seq[SdsMessage]) =
   ##
   ##   ... -> rate_limit_manager -> [encryption] -> dispatch
   for m in msgs:
-    let wireBytes = self.encryption.send(m.encode())
+    let wireBytes = self.encryption.encrypt(m.encode())
     let envelope = MessageEnvelope(
       contentTopic: self.contentTopic, payload: wireBytes, ephemeral: false
     )
@@ -138,3 +144,38 @@ proc send*(
     self.rateLimit.enqueueToSend(sdsMsg)
 
   return ok(parentReqId)
+
+proc onMessageReceived*(self: ReliableChannel, wakuMsg: WakuMessage) =
+  ## Ingress pipeline made visible:
+  ##
+  ##   WakuMessage -> ReliablePayload -> decrypt -> sds -> reassemble -> emit
+  ##
+  ## Invoked from the waku `MessageReceivedEvent` listener after the
+  ## inbound `WakuMessage` has been filtered to this channel's
+  ## `contentTopic`. Each stage is a minimal stub for now.
+  let inWakuMsg: WakuMessage = wakuMsg
+
+  if string.fromBytes(inWakuMsg.meta) != Lip173Meta:
+    ## Not a Reliable Channel message — silently drop it.
+    return
+
+  ## TODO: decode the `ReliablePayload` wrapper out of `inWakuMsg.payload`
+  ## properly (currently treated as the raw SDS bytes).
+  let reliablePayload: ReliablePayload =
+    ReliablePayload(channelId: self.channelId, payload: inWakuMsg.payload)
+
+  let plaintext: seq[byte] = self.encryption.decrypt(reliablePayload.payload)
+
+  let sdsMsg: SdsMessage = SdsMessage.decode(plaintext)
+  let processedSds: SdsMessage = self.sds.handleIncoming(sdsMsg)
+
+  let segment: SegmentMessageProto =
+    SegmentMessageProto.decode(processedSds.content)
+  let reassembled: Option[ReassemblyResult] =
+    self.segmentation.handleIncomingSegment(segment)
+
+  if reassembled.isSome():
+    ## TODO: emit the channel-level `MessageReceivedEvent` carrying
+    ## `reassembled.get().payload` once the event is wired into the
+    ## EventBroker.
+    discard reassembled

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -117,7 +117,7 @@ proc send*(
     channelId: ChannelId,
     appPayload: seq[byte],
     ephemeral: bool = false,
-): Result[ReliableRequestId, string] =
+): Result[RequestId, string] =
   ## Spec-level entry point. Looks the channel up by id and delegates
   ## to `ReliableChannel.send`, which exposes the visible pipeline
   ## segmentation -> sds -> rate_limit_manager -> encryption.

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -7,9 +7,13 @@
 
 import std/tables
 import results
+import chronos
 import stew/byteutils
 
+import waku/api/api
+import waku/api/api_conf
 import waku/events/message_events as waku_message_events
+import waku/factory/waku as waku_factory
 
 import ./reliable_channel
 import ./encryption/noop_encryption
@@ -18,18 +22,30 @@ export reliable_channel
 
 type ReliableChannelManager* = ref object
   channels: Table[ChannelId, ReliableChannel]
-  deliveryService*: DeliveryService
-    ## The single send/receive surface all owned channels dispatch through.
+  deliveryService: DeliveryService
+    ## Owned by the manager. The ownership chain is
+    ##   ReliableChannelManager -> DeliveryService -> Waku -> WakuNode.
+    ## Hidden so callers can't substitute their own and bypass the
+    ## manager's pipeline.
   brokerCtx: BrokerContext
 
 proc new*(
     T: type ReliableChannelManager,
-    deliveryService: DeliveryService,
+    conf: WakuNodeConf,
     brokerCtx: BrokerContext = globalBrokerContext(),
-): T =
+): Future[Result[T, string]] {.async.} =
+
+  ## TODO !! The proper ownership chain is:
+  ## ReliableChannelManager -> DeliveryService (MessagingClient) -> Waku (Kernel/Protocols) -> WakuNode,
+  ## and this will be implemented in the future. For now, `createNode`
+  ## is called here to get a DeliveryService instance, and the WakuNode is immediately discarded.
+  ## This is a temporary workaround to get the API
+
+  let waku = ?(await createNode(conf))
+
   let manager = T(
     channels: initTable[ChannelId, ReliableChannel](),
-    deliveryService: deliveryService,
+    deliveryService: waku.deliveryService,
     brokerCtx: brokerCtx,
   )
 
@@ -70,7 +86,17 @@ proc new*(
     ,
   )
 
-  return manager
+  return ok(manager)
+
+proc start*(self: ReliableChannelManager): Result[void, string] =
+  ## Bring the owned DeliveryService up. Separated from `new` so callers
+  ## can register encryption providers / create channels before traffic
+  ## starts flowing.
+  self.deliveryService.startDeliveryService()
+
+proc stop*(self: ReliableChannelManager) {.async.} =
+  if not self.deliveryService.isNil():
+    await self.deliveryService.stopDeliveryService()
 
 proc createReliableChannel*(
     self: ReliableChannelManager,

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -35,7 +35,6 @@ proc new*(
     conf: WakuNodeConf,
     brokerCtx: BrokerContext = globalBrokerContext(),
 ): Future[Result[T, string]] {.async.} =
-
   ## TODO !! The proper ownership chain is:
   ## ReliableChannelManager -> DeliveryService (MessagingClient) -> Waku (Kernel/Protocols) -> WakuNode,
   ## and this will be implemented in the future. For now, `createNode`

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -72,6 +72,7 @@ proc new*(
       for chn in manager.channels.values:
         if chn.getContentTopic() == evt.message.contentTopic:
           await chn.onMessageReceived(evt.message.payload)
+          break
     ,
   )
 

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -16,20 +16,30 @@ export reliable_channel
 
 type ReliableChannelManager* = ref object
   channels: Table[ChannelId, ReliableChannel]
+  deliveryService*: DeliveryService
+    ## The single send/receive surface all owned channels dispatch through.
 
-proc new*(T: type ReliableChannelManager): T =
-  T(channels: initTable[ChannelId, ReliableChannel]())
+proc new*(
+    T: type ReliableChannelManager, deliveryService: DeliveryService
+): T =
+  return T(
+    channels: initTable[ChannelId, ReliableChannel](),
+    deliveryService: deliveryService,
+  )
 
 proc createReliableChannel*(
     manager: ReliableChannelManager,
-    node: WakuNode,
     channelId: ChannelId,
     contentTopic: ContentTopic,
     senderId: SdsParticipantID,
     encryption: Option[EncryptionHook] = none(EncryptionHook),
 ): Result[ChannelId, string] =
-  ## Spec: createReliableChannel(node, channelId, contentTopic, senderId, encryption?)
-  ## Segmentation, SDS and rate-limit configs are taken from the node's NodeConfig.
+  ## Spec entry point. The `DeliveryService` and `rng` the channel needs
+  ## are sourced from the owning `ReliableChannelManager` rather than
+  ## passed per call.
+  ##
+  ## Segmentation, SDS and rate-limit configs will eventually be read
+  ## from the node's `NodeConfig`. Defaults for now.
   if manager.channels.hasKey(channelId):
     return err("channel already exists: " & channelId)
 
@@ -38,16 +48,43 @@ proc createReliableChannel*(
       encryption.get
     else:
       newNoopEncryptionHook()
-  let chn = ReliableChannel(
-    node: node,
-    channelId: channelId,
-    contentTopic: contentTopic,
-    senderId: senderId,
-    segmentation: SegmentationHandler.new(node.segmentationConfig),
-    sds: SdsHandler.new(node.sdsConfig),
-    rateLimit: RateLimitManager.new(node.rateLimitConfig),
-    encryption: enc,
+  let segConfig = SegmentationConfig(
+    segmentSizeBytes: DefaultSegmentSizeBytes,
+    enableReedSolomon: false,
+    persistence: nil,
   )
+  let sdsConfig = SdsConfig(
+    acknowledgementTimeoutMs: DefaultAcknowledgementTimeoutMs,
+    maxRetransmissions: DefaultMaxRetransmissions,
+    causalHistorySize: DefaultCausalHistorySize,
+    persistence: nil,
+  )
+  let rateConfig = RateLimitConfig(
+    epochPeriodSec: DefaultEpochPeriodSec, messagesPerEpoch: DefaultMessagesPerEpoch
+  )
+
+  let chn = ReliableChannel.new(
+    deliveryService = manager.deliveryService,
+    channelId = channelId,
+    contentTopic = contentTopic,
+    senderId = senderId,
+    segmentation = SegmentationHandler.new(segConfig),
+    sds = SdsHandler.new(sdsConfig),
+    rateLimit = RateLimitManager.new(rateConfig, channelId),
+    encryption = enc,
+  )
+  ## Continue the outgoing pipeline once the rate limiter releases a
+  ## batch of SDS messages: rate_limit_manager -> encryption -> dispatch.
+  ## The listener filters on `channelId` since all reliable channels
+  ## share the global broker context.
+  discard ReadyToSendEvent.listen(
+    globalBrokerContext(),
+    proc(evt: ReadyToSendEvent): Future[void] {.async: (raises: []).} =
+      if evt.channelId == chn.channelId:
+        chn.onReadyToSend(evt.msgs)
+    ,
+  )
+
   manager.channels[channelId] = chn
   return ok(channelId)
 
@@ -65,30 +102,14 @@ proc send*(
     channelId: ChannelId,
     appPayload: seq[byte],
     ephemeral: bool = false,
-): Result[RequestId, string] =
-  ## Single application-level send. Internally produces one or more
-  ## segment-level dispatches; the returned RequestId maps to all of them.
+): Result[ReliableRequestId, string] =
+  ## Spec-level entry point. Looks the channel up by id and delegates
+  ## to `ReliableChannel.send`, which exposes the visible pipeline
+  ## segmentation -> sds -> rate_limit_manager -> encryption.
   let chn = manager.channels.getOrDefault(channelId)
   if chn.isNil():
     return err("unknown channel: " & channelId)
-
-  let segments = chn.segmentation.segmentMessage(appPayload)
-  for segment in segments:
-    let sdsMsg = chn.sds.wrapOutgoing(chn.channelId, chn.senderId, segment.payload)
-    chn.rateLimit.enqueue(sdsMsg)
-
-  return ok()
-
-proc processSendQueue*(manager: ReliableChannelManager, channelId: ChannelId) =
-  ## Drain ready messages from the rate limiter and dispatch them via
-  ## the underlying Messaging API.
-  let chn = manager.channels.getOrDefault(channelId)
-  if chn.isNil():
-    return
-  let ready = chn.rateLimit.dequeueReady()
-  for sdsMsg in ready:
-    discard sdsMsg
-    ## TODO: encrypt(sdsMsg payload) -> wrap as ReliablePayload -> WakuMessage
+  return chn.send(appPayload)
 
 proc processInboundMessage*(
     manager: ReliableChannelManager, channelId: ChannelId, inMsg: MessageEnvelope

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -14,6 +14,7 @@ import waku/api/api
 import waku/api/api_conf
 import waku/events/message_events as waku_message_events
 import waku/factory/waku as waku_factory
+import waku/waku_core/topics
 
 import ./reliable_channel
 import ./encryption/noop_encryption

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -5,13 +5,12 @@
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import std/[options, tables]
+import std/tables
 import results
 
 import waku/events/message_events as waku_message_events
 
 import ./reliable_channel
-import ./encryption/encryption
 import ./encryption/noop_encryption
 
 export reliable_channel
@@ -20,13 +19,17 @@ type ReliableChannelManager* = ref object
   channels: Table[ChannelId, ReliableChannel]
   deliveryService*: DeliveryService
     ## The single send/receive surface all owned channels dispatch through.
+  brokerCtx: BrokerContext
 
 proc new*(
-    T: type ReliableChannelManager, deliveryService: DeliveryService
+    T: type ReliableChannelManager,
+    deliveryService: DeliveryService,
+    brokerCtx: BrokerContext = globalBrokerContext(),
 ): T =
   return T(
     channels: initTable[ChannelId, ReliableChannel](),
     deliveryService: deliveryService,
+    brokerCtx: brokerCtx,
   )
 
 proc createReliableChannel*(
@@ -34,22 +37,18 @@ proc createReliableChannel*(
     channelId: ChannelId,
     contentTopic: ContentTopic,
     senderId: SdsParticipantID,
-    encryption: Option[EncryptionHook] = none(EncryptionHook),
 ): Result[ChannelId, string] =
   ## Spec entry point. The `DeliveryService` and `rng` the channel needs
   ## are sourced from the owning `ReliableChannelManager` rather than
-  ## passed per call.
+  ## passed per call. Encryption is wired up through the `Encrypt`/
+  ## `Decrypt` request brokers — the application installs its own
+  ## providers (or `setNoopEncryption()`) before traffic flows.
   ##
   ## Segmentation, SDS and rate-limit configs will eventually be read
   ## from the node's `NodeConfig`. Defaults for now.
   if manager.channels.hasKey(channelId):
     return err("channel already exists: " & channelId)
 
-  let enc =
-    if encryption.isSome and encryption.get.isConfigured():
-      encryption.get
-    else:
-      newNoopEncryptionHook()
   let segConfig = SegmentationConfig(
     segmentSizeBytes: DefaultSegmentSizeBytes,
     enableReedSolomon: false,
@@ -70,20 +69,20 @@ proc createReliableChannel*(
     channelId = channelId,
     contentTopic = contentTopic,
     senderId = senderId,
-    segmentation = SegmentationHandler.new(segConfig),
-    sdsHandler = SdsHandler.new(sdsConfig),
-    rateLimit = RateLimitManager.new(rateConfig, channelId),
-    encryption = enc,
+    segConfig = segConfig,
+    sdsConfig = sdsConfig,
+    rateConfig = rateConfig,
+    brokerCtx = manager.brokerCtx,
   )
   ## Continue the outgoing pipeline once the rate limiter releases a
   ## batch of SDS messages: rate_limit_manager -> encryption -> dispatch.
   ## The listener filters on `channelId` since all reliable channels
-  ## share the global broker context.
+  ## owned by the same manager share the same broker context.
   discard ReadyToSendEvent.listen(
-    globalBrokerContext(),
+    manager.brokerCtx,
     proc(evt: ReadyToSendEvent): Future[void] {.async: (raises: []).} =
-      if evt.channelId == chn.channelId:
-        chn.onReadyToSend(evt.msgs)
+      if evt.channelId == chn.getChannelId:
+        await chn.onReadyToSend(evt.msgs)
     ,
   )
 
@@ -91,12 +90,12 @@ proc createReliableChannel*(
   ## message on this channel's content topic:
   ##   decryption -> sds -> segmentation reassembly -> emit.
   discard waku_message_events.MessageReceivedEvent.listen(
-    globalBrokerContext(),
+    manager.brokerCtx,
     proc(
         evt: waku_message_events.MessageReceivedEvent
     ): Future[void] {.async: (raises: []).} =
-      if evt.message.contentTopic == chn.contentTopic:
-        chn.onMessageReceived(evt.message)
+      if evt.message.contentTopic == chn.getContentTopic:
+        await chn.onMessageReceived(evt.message)
     ,
   )
 
@@ -126,16 +125,8 @@ proc send*(
     return err("unknown channel: " & channelId)
   return chn.send(appPayload, ephemeral)
 
-proc processInboundMessage*(
-    manager: ReliableChannelManager, channelId: ChannelId, inMsg: MessageEnvelope
-) =
-  ## Entry point for messages delivered by the Messaging API.
-  ##
-  ## TODO:
-  ## - validate LIP173 meta on the WakuMessage
-  ## - decode `ReliablePayload`
-  ## - decrypt via chn.encryption
-  ## - feed into chn.sdsHandler.handleIncoming
-  ## - feed resulting segment into chn.segmentation.handleIncomingSegment
-  ## - on reassembly completion, emit MessageReceivedEvent
-  discard
+## Inbound messages are not handed to the manager by direct call: the
+## listener registered in `createReliableChannel` for
+## `waku_message_events.MessageReceivedEvent` invokes
+## `chn.onMessageReceived` itself. This keeps the lower layer
+## (MessagingAPI/Waku) unaware of the existence of ReliableChannel.

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -52,7 +52,8 @@ proc new*(
   ## Single ingress listener for the whole manager. The DeliveryService
   ## recv path emits `MessageReceivedEvent` for every WakuMessage it
   ## sees; the manager:
-  ##   1. drops anything whose `meta` is not LIP173 (foreign traffic);
+  ##   1. drops anything whose `meta` is not the Reliable Channel
+  ##      spec marker (foreign traffic);
   ##   2. decodes the `ReliableChannelPayload` wrapper once;
   ##   3. dispatches the typed payload to every channel whose
   ##      `contentTopic` matches (multiple channels may subscribe to
@@ -65,7 +66,7 @@ proc new*(
     proc(
         evt: waku_message_events.MessageReceivedEvent
     ): Future[void] {.async: (raises: []).} =
-      if string.fromBytes(evt.message.meta) != Lip173Meta:
+      if string.fromBytes(evt.message.meta) != LipWireReliableChannelVersion:
         return
 
       for chn in manager.channels.values:

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -49,45 +49,6 @@ proc new*(
     brokerCtx: brokerCtx,
   )
 
-  ## Single ingress listener for the whole manager. The DeliveryService
-  ## recv path emits `MessageReceivedEvent` for every WakuMessage it
-  ## sees; the manager:
-  ##   1. drops anything whose `meta` is not the Reliable Channel
-  ##      spec marker (foreign traffic);
-  ##   2. decodes the `ReliableChannelPayload` wrapper once;
-  ##   3. dispatches the typed payload to every channel whose
-  ##      `contentTopic` matches (multiple channels may subscribe to
-  ##      the same topic).
-  ## Doing the wrapper decode here keeps the channels free of
-  ## wire-format concerns, and keeps the DeliveryService unaware of
-  ## ReliableChannel altogether.
-  discard waku_message_events.MessageReceivedEvent.listen(
-    manager.brokerCtx,
-    proc(
-        evt: waku_message_events.MessageReceivedEvent
-    ): Future[void] {.async: (raises: []).} =
-      if string.fromBytes(evt.message.meta) != LipWireReliableChannelVersion:
-        return
-
-      for chn in manager.channels.values:
-        if chn.getContentTopic() == evt.message.contentTopic:
-          await chn.onMessageReceived(evt.message.payload)
-          break
-    ,
-  )
-
-  ## Single egress listener: rate_limit_manager emits a
-  ## `ReadyToSendEvent` tagged with `channelId`, so the dispatch here
-  ## is a direct table lookup.
-  discard ReadyToSendEvent.listen(
-    manager.brokerCtx,
-    proc(evt: ReadyToSendEvent): Future[void] {.async: (raises: []).} =
-      let chn = manager.channels.getOrDefault(evt.channelId)
-      if not chn.isNil():
-        await chn.onReadyToSend(evt.msgs)
-    ,
-  )
-
   return ok(manager)
 
 proc start*(self: ReliableChannelManager): Result[void, string] =
@@ -169,8 +130,9 @@ proc send*(
     return err("unknown channel: " & channelId)
   return chn.send(appPayload, ephemeral)
 
-## Inbound messages are not handed to the manager by direct call: the
-## single `MessageReceivedEvent` listener registered in `new` looks the
-## owning channel up by `contentTopic` and invokes its
-## `onMessageReceived`. This keeps the lower layer (MessagingAPI/Waku)
-## unaware of the existence of ReliableChannel.
+## Inbound messages are not handed to the manager by direct call. Each
+## `ReliableChannel` installs its own `MessageReceivedEvent` listener
+## in `ReliableChannel.new`, filters by spec marker and `contentTopic`,
+## and routes to its private `onMessageReceived`. This keeps the lower
+## layer (MessagingAPI/Waku) unaware of the existence of ReliableChannel
+## and keeps the manager out of per-channel event dispatch.

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -8,6 +8,8 @@
 import std/[options, tables]
 import results
 
+import waku/events/message_events as waku_message_events
+
 import ./reliable_channel
 import ./encryption/encryption
 import ./encryption/noop_encryption
@@ -82,6 +84,19 @@ proc createReliableChannel*(
     proc(evt: ReadyToSendEvent): Future[void] {.async: (raises: []).} =
       if evt.channelId == chn.channelId:
         chn.onReadyToSend(evt.msgs)
+    ,
+  )
+
+  ## Run the incoming pipeline whenever waku reports a received
+  ## message on this channel's content topic:
+  ##   decryption -> sds -> segmentation reassembly -> emit.
+  discard waku_message_events.MessageReceivedEvent.listen(
+    globalBrokerContext(),
+    proc(
+        evt: waku_message_events.MessageReceivedEvent
+    ): Future[void] {.async: (raises: []).} =
+      if evt.message.contentTopic == chn.contentTopic:
+        chn.onMessageReceived(evt.message)
     ,
   )
 

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -71,7 +71,7 @@ proc createReliableChannel*(
     contentTopic = contentTopic,
     senderId = senderId,
     segmentation = SegmentationHandler.new(segConfig),
-    sds = SdsHandler.new(sdsConfig),
+    sdsHandler = SdsHandler.new(sdsConfig),
     rateLimit = RateLimitManager.new(rateConfig, channelId),
     encryption = enc,
   )
@@ -124,7 +124,7 @@ proc send*(
   let chn = manager.channels.getOrDefault(channelId)
   if chn.isNil():
     return err("unknown channel: " & channelId)
-  return chn.send(appPayload)
+  return chn.send(appPayload, ephemeral)
 
 proc processInboundMessage*(
     manager: ReliableChannelManager, channelId: ChannelId, inMsg: MessageEnvelope
@@ -135,7 +135,7 @@ proc processInboundMessage*(
   ## - validate LIP173 meta on the WakuMessage
   ## - decode `ReliablePayload`
   ## - decrypt via chn.encryption
-  ## - feed into chn.sds.handleIncoming
+  ## - feed into chn.sdsHandler.handleIncoming
   ## - feed resulting segment into chn.segmentation.handleIncomingSegment
   ## - on reassembly completion, emit MessageReceivedEvent
   discard

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -1,0 +1,105 @@
+## Reliable Channel API entry point.
+##
+## Owns the set of `ReliableChannel` instances and exposes lifecycle and
+## send/receive operations addressed by `ChannelId`.
+##
+## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
+
+import std/[options, tables]
+import results
+
+import ./reliable_channel
+import ./encryption/encryption
+import ./encryption/noop_encryption
+
+export reliable_channel
+
+type ReliableChannelManager* = ref object
+  channels: Table[ChannelId, ReliableChannel]
+
+proc new*(T: type ReliableChannelManager): T =
+  T(channels: initTable[ChannelId, ReliableChannel]())
+
+proc createReliableChannel*(
+    manager: ReliableChannelManager,
+    node: WakuNode,
+    channelId: ChannelId,
+    contentTopic: ContentTopic,
+    senderId: SdsParticipantID,
+    encryption: Option[EncryptionHook] = none(EncryptionHook),
+): Result[ChannelId, string] =
+  ## Spec: createReliableChannel(node, channelId, contentTopic, senderId, encryption?)
+  ## Segmentation, SDS and rate-limit configs are taken from the node's NodeConfig.
+  if manager.channels.hasKey(channelId):
+    return err("channel already exists: " & channelId)
+
+  let enc =
+    if encryption.isSome and encryption.get.isConfigured():
+      encryption.get
+    else:
+      newNoopEncryptionHook()
+  let chn = ReliableChannel(
+    node: node,
+    channelId: channelId,
+    contentTopic: contentTopic,
+    senderId: senderId,
+    segmentation: SegmentationHandler.new(node.segmentationConfig),
+    sds: SdsHandler.new(node.sdsConfig),
+    rateLimit: RateLimitManager.new(node.rateLimitConfig),
+    encryption: enc,
+  )
+  manager.channels[channelId] = chn
+  return ok(channelId)
+
+proc closeChannel*(
+    manager: ReliableChannelManager, channelId: ChannelId
+): Result[void, string] =
+  ## Flush state, persist outstanding SDS buffers, release resources.
+  if not manager.channels.hasKey(channelId):
+    return err("unknown channel: " & channelId)
+  manager.channels.del(channelId)
+  return ok()
+
+proc send*(
+    manager: ReliableChannelManager,
+    channelId: ChannelId,
+    appPayload: seq[byte],
+    ephemeral: bool = false,
+): Result[RequestId, string] =
+  ## Single application-level send. Internally produces one or more
+  ## segment-level dispatches; the returned RequestId maps to all of them.
+  let chn = manager.channels.getOrDefault(channelId)
+  if chn.isNil():
+    return err("unknown channel: " & channelId)
+
+  let segments = chn.segmentation.segmentMessage(appPayload)
+  for segment in segments:
+    let sdsMsg = chn.sds.wrapOutgoing(chn.channelId, chn.senderId, segment.payload)
+    chn.rateLimit.enqueue(sdsMsg)
+
+  return ok()
+
+proc processSendQueue*(manager: ReliableChannelManager, channelId: ChannelId) =
+  ## Drain ready messages from the rate limiter and dispatch them via
+  ## the underlying Messaging API.
+  let chn = manager.channels.getOrDefault(channelId)
+  if chn.isNil():
+    return
+  let ready = chn.rateLimit.dequeueReady()
+  for sdsMsg in ready:
+    discard sdsMsg
+    ## TODO: encrypt(sdsMsg payload) -> wrap as ReliablePayload -> WakuMessage
+
+proc processInboundMessage*(
+    manager: ReliableChannelManager, channelId: ChannelId, inMsg: MessageEnvelope
+) =
+  ## Entry point for messages delivered by the Messaging API.
+  ##
+  ## TODO:
+  ## - validate LIP173 meta on the WakuMessage
+  ## - decode `ReliablePayload`
+  ## - decrypt via chn.encryption
+  ## - feed into chn.sds.handleIncoming
+  ## - feed resulting segment into chn.segmentation.handleIncomingSegment
+  ## - on reassembly completion, emit MessageReceivedEvent
+  discard

--- a/channels/reliable_channel_manager.nim
+++ b/channels/reliable_channel_manager.nim
@@ -7,6 +7,7 @@
 
 import std/tables
 import results
+import stew/byteutils
 
 import waku/events/message_events as waku_message_events
 
@@ -26,14 +27,53 @@ proc new*(
     deliveryService: DeliveryService,
     brokerCtx: BrokerContext = globalBrokerContext(),
 ): T =
-  return T(
+  let manager = T(
     channels: initTable[ChannelId, ReliableChannel](),
     deliveryService: deliveryService,
     brokerCtx: brokerCtx,
   )
 
+  ## Single ingress listener for the whole manager. The DeliveryService
+  ## recv path emits `MessageReceivedEvent` for every WakuMessage it
+  ## sees; the manager:
+  ##   1. drops anything whose `meta` is not LIP173 (foreign traffic);
+  ##   2. decodes the `ReliableChannelPayload` wrapper once;
+  ##   3. dispatches the typed payload to every channel whose
+  ##      `contentTopic` matches (multiple channels may subscribe to
+  ##      the same topic).
+  ## Doing the wrapper decode here keeps the channels free of
+  ## wire-format concerns, and keeps the DeliveryService unaware of
+  ## ReliableChannel altogether.
+  discard waku_message_events.MessageReceivedEvent.listen(
+    manager.brokerCtx,
+    proc(
+        evt: waku_message_events.MessageReceivedEvent
+    ): Future[void] {.async: (raises: []).} =
+      if string.fromBytes(evt.message.meta) != Lip173Meta:
+        return
+
+      for chn in manager.channels.values:
+        if chn.getContentTopic() == evt.message.contentTopic:
+          await chn.onMessageReceived(evt.message.payload)
+    ,
+  )
+
+  ## Single egress listener: rate_limit_manager emits a
+  ## `ReadyToSendEvent` tagged with `channelId`, so the dispatch here
+  ## is a direct table lookup.
+  discard ReadyToSendEvent.listen(
+    manager.brokerCtx,
+    proc(evt: ReadyToSendEvent): Future[void] {.async: (raises: []).} =
+      let chn = manager.channels.getOrDefault(evt.channelId)
+      if not chn.isNil():
+        await chn.onReadyToSend(evt.msgs)
+    ,
+  )
+
+  return manager
+
 proc createReliableChannel*(
-    manager: ReliableChannelManager,
+    self: ReliableChannelManager,
     channelId: ChannelId,
     contentTopic: ContentTopic,
     senderId: SdsParticipantID,
@@ -46,7 +86,7 @@ proc createReliableChannel*(
   ##
   ## Segmentation, SDS and rate-limit configs will eventually be read
   ## from the node's `NodeConfig`. Defaults for now.
-  if manager.channels.hasKey(channelId):
+  if self.channels.hasKey(channelId):
     return err("channel already exists: " & channelId)
 
   let segConfig = SegmentationConfig(
@@ -65,54 +105,30 @@ proc createReliableChannel*(
   )
 
   let chn = ReliableChannel.new(
-    deliveryService = manager.deliveryService,
+    deliveryService = self.deliveryService,
     channelId = channelId,
     contentTopic = contentTopic,
     senderId = senderId,
     segConfig = segConfig,
     sdsConfig = sdsConfig,
     rateConfig = rateConfig,
-    brokerCtx = manager.brokerCtx,
-  )
-  ## Continue the outgoing pipeline once the rate limiter releases a
-  ## batch of SDS messages: rate_limit_manager -> encryption -> dispatch.
-  ## The listener filters on `channelId` since all reliable channels
-  ## owned by the same manager share the same broker context.
-  discard ReadyToSendEvent.listen(
-    manager.brokerCtx,
-    proc(evt: ReadyToSendEvent): Future[void] {.async: (raises: []).} =
-      if evt.channelId == chn.getChannelId:
-        await chn.onReadyToSend(evt.msgs)
-    ,
+    brokerCtx = self.brokerCtx,
   )
 
-  ## Run the incoming pipeline whenever waku reports a received
-  ## message on this channel's content topic:
-  ##   decryption -> sds -> segmentation reassembly -> emit.
-  discard waku_message_events.MessageReceivedEvent.listen(
-    manager.brokerCtx,
-    proc(
-        evt: waku_message_events.MessageReceivedEvent
-    ): Future[void] {.async: (raises: []).} =
-      if evt.message.contentTopic == chn.getContentTopic:
-        await chn.onMessageReceived(evt.message)
-    ,
-  )
-
-  manager.channels[channelId] = chn
+  self.channels[channelId] = chn
   return ok(channelId)
 
 proc closeChannel*(
-    manager: ReliableChannelManager, channelId: ChannelId
+    self: ReliableChannelManager, channelId: ChannelId
 ): Result[void, string] =
   ## Flush state, persist outstanding SDS buffers, release resources.
-  if not manager.channels.hasKey(channelId):
+  if not self.channels.hasKey(channelId):
     return err("unknown channel: " & channelId)
-  manager.channels.del(channelId)
+  self.channels.del(channelId)
   return ok()
 
 proc send*(
-    manager: ReliableChannelManager,
+    self: ReliableChannelManager,
     channelId: ChannelId,
     appPayload: seq[byte],
     ephemeral: bool = false,
@@ -120,13 +136,13 @@ proc send*(
   ## Spec-level entry point. Looks the channel up by id and delegates
   ## to `ReliableChannel.send`, which exposes the visible pipeline
   ## segmentation -> sds -> rate_limit_manager -> encryption.
-  let chn = manager.channels.getOrDefault(channelId)
+  let chn = self.channels.getOrDefault(channelId)
   if chn.isNil():
     return err("unknown channel: " & channelId)
   return chn.send(appPayload, ephemeral)
 
 ## Inbound messages are not handed to the manager by direct call: the
-## listener registered in `createReliableChannel` for
-## `waku_message_events.MessageReceivedEvent` invokes
-## `chn.onMessageReceived` itself. This keeps the lower layer
-## (MessagingAPI/Waku) unaware of the existence of ReliableChannel.
+## single `MessageReceivedEvent` listener registered in `new` looks the
+## owning channel up by `contentTopic` and invokes its
+## `onMessageReceived`. This keeps the lower layer (MessagingAPI/Waku)
+## unaware of the existence of ReliableChannel.

--- a/channels/scalable_data_sync/scalable_data_sync.nim
+++ b/channels/scalable_data_sync/scalable_data_sync.nim
@@ -1,0 +1,51 @@
+## Scalable Data Sync (SDS) component for the Reliable Channel API.
+##
+## Provides end-to-end delivery guarantees via causal history tracking,
+## acknowledgements, and retransmission of unacknowledged segments.
+##
+## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
+
+import sds/message
+import ./sds_persistence
+
+export message, sds_persistence
+
+const
+  DefaultAcknowledgementTimeoutMs* = 5_000
+  DefaultMaxRetransmissions* = 5
+  DefaultCausalHistorySize* = 2
+
+type
+  SdsConfig* = object
+    acknowledgementTimeoutMs*: int
+    maxRetransmissions*: int
+    causalHistorySize*: int
+    persistence*: SdsPersistence
+
+  SdsHandler* = ref object
+    config*: SdsConfig
+
+proc new*(T: type SdsHandler, config: SdsConfig): T =
+  return T(config: config)
+
+proc wrapOutgoing*(
+    handler: SdsHandler,
+    channelId: SdsChannelID,
+    senderId: SdsParticipantID,
+    content: seq[byte],
+): SdsMessage =
+  ## Wrap an outgoing segment payload into an SdsMessage with causal
+  ## history, lamport timestamp and bloom filter.
+  discard
+
+proc handleIncoming*(
+    handler: SdsHandler, msg: SdsMessage
+): SdsMessage =
+  ## Update local SDS state from an incoming message. May trigger
+  ## repair requests (SDS-R) for missing causal history entries.
+  discard
+
+proc tickRetransmissions*(handler: SdsHandler): seq[SdsMessage] =
+  ## Returns messages whose ack timeout has elapsed and should be
+  ## retransmitted.
+  discard

--- a/channels/scalable_data_sync/scalable_data_sync.nim
+++ b/channels/scalable_data_sync/scalable_data_sync.nim
@@ -7,9 +7,8 @@
 
 import sds/message
 import ./sds_persistence
-import ../segmentation/segment_message_proto
 
-export message, sds_persistence, segment_message_proto
+export message, sds_persistence
 
 const
   DefaultAcknowledgementTimeoutMs* = 5_000
@@ -33,11 +32,11 @@ proc wrapOutgoing*(
     self: SdsHandler,
     channelId: SdsChannelID,
     senderId: SdsParticipantID,
-    segment: SegmentMessageProto,
+    payload: seq[byte],
 ): SdsMessage =
   ## Stage 2 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
-  ## Wraps a single segment from the segmentation stage into an `SdsMessage`,
-  ## populating causal history, lamport timestamp and bloom filter.
+  ## SDS is intentionally segmentation-agnostic: the caller encodes the
+  ## segment to bytes before handing it over here.
   ##
   ## TODO: real causal-history/lamport/bloom-filter population.
   discard

--- a/channels/scalable_data_sync/scalable_data_sync.nim
+++ b/channels/scalable_data_sync/scalable_data_sync.nim
@@ -7,8 +7,9 @@
 
 import sds/message
 import ./sds_persistence
+import ../segmentation/segment_message_proto
 
-export message, sds_persistence
+export message, sds_persistence, segment_message_proto
 
 const
   DefaultAcknowledgementTimeoutMs* = 5_000
@@ -29,23 +30,26 @@ proc new*(T: type SdsHandler, config: SdsConfig): T =
   return T(config: config)
 
 proc wrapOutgoing*(
-    handler: SdsHandler,
+    self: SdsHandler,
     channelId: SdsChannelID,
     senderId: SdsParticipantID,
-    content: seq[byte],
+    segment: SegmentMessageProto,
 ): SdsMessage =
-  ## Wrap an outgoing segment payload into an SdsMessage with causal
-  ## history, lamport timestamp and bloom filter.
+  ## Stage 2 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
+  ## Wraps a single segment from the segmentation stage into an `SdsMessage`,
+  ## populating causal history, lamport timestamp and bloom filter.
+  ##
+  ## TODO: real causal-history/lamport/bloom-filter population.
   discard
 
 proc handleIncoming*(
-    handler: SdsHandler, msg: SdsMessage
+    self: SdsHandler, msg: SdsMessage
 ): SdsMessage =
   ## Update local SDS state from an incoming message. May trigger
   ## repair requests (SDS-R) for missing causal history entries.
   discard
 
-proc tickRetransmissions*(handler: SdsHandler): seq[SdsMessage] =
+proc tickRetransmissions*(self: SdsHandler): seq[SdsMessage] =
   ## Returns messages whose ack timeout has elapsed and should be
   ## retransmitted.
   discard

--- a/channels/scalable_data_sync/scalable_data_sync.nim
+++ b/channels/scalable_data_sync/scalable_data_sync.nim
@@ -3,12 +3,18 @@
 ## Provides end-to-end delivery guarantees via causal history tracking,
 ## acknowledgements, and retransmission of unacknowledged segments.
 ##
+## Skeleton: `wrapOutgoing` and `handleIncoming` are pass-throughs so
+## the send/receive circuit can exercise the surrounding pipeline.
+## Real SDS wrapping will plug in via `nim-sds` later.
+##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import sds/message
+import results
+import message as sds_message
+
 import ./sds_persistence
 
-export message, sds_persistence
+export sds_message, sds_persistence
 
 const
   DefaultAcknowledgementTimeoutMs* = 5_000
@@ -24,31 +30,33 @@ type
 
   SdsHandler* = ref object
     config*: SdsConfig
+    participantId*: SdsParticipantID
 
-proc new*(T: type SdsHandler, config: SdsConfig): T =
-  return T(config: config)
+proc new*(
+    T: type SdsHandler,
+    config: SdsConfig,
+    participantId: SdsParticipantID = SdsParticipantID(""),
+): T =
+  return T(config: config, participantId: participantId)
 
 proc wrapOutgoing*(
     self: SdsHandler,
     channelId: SdsChannelID,
     senderId: SdsParticipantID,
     payload: seq[byte],
-): SdsMessage =
+): Result[seq[byte], string] =
   ## Stage 2 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
-  ## SDS is intentionally segmentation-agnostic: the caller encodes the
-  ## segment to bytes before handing it over here.
-  ##
-  ## TODO: real causal-history/lamport/bloom-filter population.
-  discard
+  ## Skeleton: pass the encoded segment through unchanged. Real causal
+  ## history / lamport / bloom-filter population will replace this.
+  return ok(payload)
 
 proc handleIncoming*(
-    self: SdsHandler, msg: SdsMessage
-): SdsMessage =
-  ## Update local SDS state from an incoming message. May trigger
-  ## repair requests (SDS-R) for missing causal history entries.
-  discard
+    self: SdsHandler, msg: seq[byte]
+): Result[tuple[content: seq[byte], channelId: SdsChannelID], string] =
+  ## Skeleton: pass the bytes through; channel id is left empty until
+  ## the real wire format provides it.
+  return ok((content: msg, channelId: SdsChannelID("")))
 
-proc tickRetransmissions*(self: SdsHandler): seq[SdsMessage] =
-  ## Returns messages whose ack timeout has elapsed and should be
-  ## retransmitted.
+proc tickRetransmissions*(self: SdsHandler) =
+  ## Drives retransmissions of unacknowledged messages.
   discard

--- a/channels/scalable_data_sync/sds_persistence.nim
+++ b/channels/scalable_data_sync/sds_persistence.nim
@@ -1,4 +1,9 @@
 ## Persistence backend for SDS outgoing buffer and causal history.
+##
+## TODO (raised in PR review): this surface is duplicating concerns that
+## should come from the SDS module itself. Once the SDS module exposes a
+## complete persistence contract, drop this file and import that surface
+## instead of re-declaring it here.
 
 import sds/message
 

--- a/channels/scalable_data_sync/sds_persistence.nim
+++ b/channels/scalable_data_sync/sds_persistence.nim
@@ -15,17 +15,11 @@ type
   SdsPersistence* = ref object of RootObj
     kind*: SdsPersistenceKind
 
-method storeOutgoing*(
-    self: SdsPersistence, msg: SdsMessage
-) {.base.} =
+method storeOutgoing*(self: SdsPersistence, msg: SdsMessage) {.base.} =
   discard
 
-method markAcknowledged*(
-    self: SdsPersistence, messageId: SdsMessageID
-) {.base.} =
+method markAcknowledged*(self: SdsPersistence, messageId: SdsMessageID) {.base.} =
   discard
 
-method unackedOlderThan*(
-    self: SdsPersistence, ageMs: int
-): seq[SdsMessage] {.base.} =
+method unackedOlderThan*(self: SdsPersistence, ageMs: int): seq[SdsMessage] {.base.} =
   discard

--- a/channels/scalable_data_sync/sds_persistence.nim
+++ b/channels/scalable_data_sync/sds_persistence.nim
@@ -1,0 +1,26 @@
+## Persistence backend for SDS outgoing buffer and causal history.
+
+import sds/message
+
+type
+  SdsPersistenceKind* {.pure.} = enum
+    InMemory
+    Sqlite
+
+  SdsPersistence* = ref object of RootObj
+    kind*: SdsPersistenceKind
+
+method storeOutgoing*(
+    p: SdsPersistence, msg: SdsMessage
+) {.base.} =
+  discard
+
+method markAcknowledged*(
+    p: SdsPersistence, messageId: SdsMessageID
+) {.base.} =
+  discard
+
+method unackedOlderThan*(
+    p: SdsPersistence, ageMs: int
+): seq[SdsMessage] {.base.} =
+  discard

--- a/channels/scalable_data_sync/sds_persistence.nim
+++ b/channels/scalable_data_sync/sds_persistence.nim
@@ -11,16 +11,16 @@ type
     kind*: SdsPersistenceKind
 
 method storeOutgoing*(
-    p: SdsPersistence, msg: SdsMessage
+    self: SdsPersistence, msg: SdsMessage
 ) {.base.} =
   discard
 
 method markAcknowledged*(
-    p: SdsPersistence, messageId: SdsMessageID
+    self: SdsPersistence, messageId: SdsMessageID
 ) {.base.} =
   discard
 
 method unackedOlderThan*(
-    p: SdsPersistence, ageMs: int
+    self: SdsPersistence, ageMs: int
 ): seq[SdsMessage] {.base.} =
   discard

--- a/channels/scalable_data_sync/sds_persistence.nim
+++ b/channels/scalable_data_sync/sds_persistence.nim
@@ -5,7 +5,7 @@
 ## complete persistence contract, drop this file and import that surface
 ## instead of re-declaring it here.
 
-import sds/message
+import message
 
 type
   SdsPersistenceKind* {.pure.} = enum

--- a/channels/segmentation/segment_message_proto.nim
+++ b/channels/segmentation/segment_message_proto.nim
@@ -9,14 +9,14 @@ type SegmentMessageProto* = object
   paritySegmentCount*: uint32 ## number of parity segments
   isParity*: bool ## true for parity segments, false (default) for data segments
 
-proc isParityMessage*(s: SegmentMessageProto): bool =
-  s.isParity
+proc isParityMessage*(self: SegmentMessageProto): bool =
+  self.isParity
 
-proc isValid*(s: SegmentMessageProto): bool =
+proc isValid*(self: SegmentMessageProto): bool =
   ## Validates hash length (32 bytes), segment indices and counts.
   discard
 
-proc encode*(s: SegmentMessageProto): seq[byte] =
+proc encode*(self: SegmentMessageProto): seq[byte] =
   discard
 
 proc decode*(T: type SegmentMessageProto, buf: seq[byte]): T =

--- a/channels/segmentation/segment_message_proto.nim
+++ b/channels/segmentation/segment_message_proto.nim
@@ -1,4 +1,7 @@
 ## Wire format for a single segment, per the Reliable Channel API spec.
+##
+## Skeleton: encode/decode treat the segment as just its payload bytes,
+## since for now we only ever produce a single segment per send.
 
 type SegmentMessageProto* = object
   entireMessageHash*: seq[byte] ## Keccak256(original payload), 32 bytes
@@ -17,7 +20,15 @@ proc isValid*(self: SegmentMessageProto): bool =
   discard
 
 proc encode*(self: SegmentMessageProto): seq[byte] =
-  discard
+  self.payload
 
 proc decode*(T: type SegmentMessageProto, buf: seq[byte]): T =
-  discard
+  T(
+    entireMessageHash: @[],
+    dataSegmentIndex: 0,
+    dataSegmentCount: 1,
+    payload: buf,
+    paritySegmentIndex: 0,
+    paritySegmentCount: 0,
+    isParity: false,
+  )

--- a/channels/segmentation/segment_message_proto.nim
+++ b/channels/segmentation/segment_message_proto.nim
@@ -1,0 +1,23 @@
+## Wire format for a single segment, per the Reliable Channel API spec.
+
+type SegmentMessageProto* = object
+  entireMessageHash*: seq[byte] ## Keccak256(original payload), 32 bytes
+  dataSegmentIndex*: uint32 ## zero-indexed sequence number for data segments
+  dataSegmentCount*: uint32 ## number of data segments (>= 1)
+  payload*: seq[byte] ## segment payload (data or parity shard)
+  paritySegmentIndex*: uint32 ## zero-based sequence number for parity segments
+  paritySegmentCount*: uint32 ## number of parity segments
+  isParity*: bool ## true for parity segments, false (default) for data segments
+
+proc isParityMessage*(s: SegmentMessageProto): bool =
+  s.isParity
+
+proc isValid*(s: SegmentMessageProto): bool =
+  ## Validates hash length (32 bytes), segment indices and counts.
+  discard
+
+proc encode*(s: SegmentMessageProto): seq[byte] =
+  discard
+
+proc decode*(T: type SegmentMessageProto, buf: seq[byte]): T =
+  discard

--- a/channels/segmentation/segmentation.nim
+++ b/channels/segmentation/segmentation.nim
@@ -38,28 +38,27 @@ proc new*(T: type SegmentationHandler, config: SegmentationConfig): T =
 
 proc performSegmentation*(
     self: SegmentationHandler, payload: seq[byte]
-): seq[SegmentMessageProto] =
-  ## Stage 1 of the outgoing pipeline.
+): seq[seq[byte]] =
   ## Skeleton behaviour: emit exactly one segment carrying the whole
   ## payload. Real chunking and Reed-Solomon parity will replace this.
-  return @[
-    SegmentMessageProto(
-      entireMessageHash: @[],
-      dataSegmentIndex: 0,
-      dataSegmentCount: 1,
-      payload: payload,
-      paritySegmentIndex: 0,
-      paritySegmentCount: 0,
-      isParity: false,
-    )
-  ]
+  let segment = SegmentMessageProto(
+    entireMessageHash: @[],
+    dataSegmentIndex: 0,
+    dataSegmentCount: 1,
+    payload: payload,
+    paritySegmentIndex: 0,
+    paritySegmentCount: 0,
+    isParity: false,
+  )
+  return @[segment.encode()]
 
 proc handleIncomingSegment*(
-    self: SegmentationHandler, segment: SegmentMessageProto
+    self: SegmentationHandler, segmentBytes: seq[byte]
 ): Option[ReassemblyResult] =
   ## Skeleton behaviour: every segment is already a complete message
   ## (since `performSegmentation` always emits one), so just hand the
   ## payload straight back.
+  let segment = SegmentMessageProto.decode(segmentBytes)
   return some(
     ReassemblyResult(
       payload: segment.payload, entireMessageHash: segment.entireMessageHash

--- a/channels/segmentation/segmentation.nim
+++ b/channels/segmentation/segmentation.nim
@@ -1,0 +1,52 @@
+## Segmentation component for the Reliable Channel API.
+##
+## Splits large application payloads into transmittable segments and
+## reassembles them on reception. Supports optional Reed-Solomon parity
+## segments for loss recovery, as per the Reliable Channel API spec.
+##
+## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
+
+import std/options
+import ./segment_message_proto
+import ./segmentation_persistence
+
+export segment_message_proto, segmentation_persistence
+
+const
+  DefaultSegmentSizeBytes* = 102_400
+  SegmentsParityRate* = 0.125
+  SegmentsReedSolomonMaxCount* = 256
+
+type
+  SegmentationConfig* = object
+    segmentSizeBytes*: int
+    enableReedSolomon*: bool
+    persistence*: SegmentationPersistence
+
+  SegmentationHandler* = ref object
+    config*: SegmentationConfig
+
+  ReassemblyResult* = object
+    payload*: seq[byte]
+    entireMessageHash*: seq[byte]
+
+proc new*(T: type SegmentationHandler, config: SegmentationConfig): T =
+  return T(config: config)
+
+proc segmentMessage*(
+    handler: SegmentationHandler, appPayload: seq[byte]
+): seq[SegmentMessageProto] =
+  ## Split `appPayload` into segments according to handler config.
+  ## When `enableReedSolomon` is true, parity segments are appended.
+  return @[]
+
+proc handleIncomingSegment*(
+    handler: SegmentationHandler, segment: SegmentMessageProto
+): Option[ReassemblyResult] =
+  ## Process an incoming segment. Returns Some(ReassemblyResult) when
+  ## the full message has been reassembled (and hash-verified), else None.
+  return none(ReassemblyResult)
+
+proc cleanupSegments*(handler: SegmentationHandler) =
+  ## Drop expired partial-reassembly state.
+  discard

--- a/channels/segmentation/segmentation.nim
+++ b/channels/segmentation/segmentation.nim
@@ -42,18 +42,17 @@ proc performSegmentation*(
   ## Stage 1 of the outgoing pipeline.
   ## Skeleton behaviour: emit exactly one segment carrying the whole
   ## payload. Real chunking and Reed-Solomon parity will replace this.
-  return
-    @[
-      SegmentMessageProto(
-        entireMessageHash: @[],
-        dataSegmentIndex: 0,
-        dataSegmentCount: 1,
-        payload: payload,
-        paritySegmentIndex: 0,
-        paritySegmentCount: 0,
-        isParity: false,
-      )
-    ]
+  return @[
+    SegmentMessageProto(
+      entireMessageHash: @[],
+      dataSegmentIndex: 0,
+      dataSegmentCount: 1,
+      payload: payload,
+      paritySegmentIndex: 0,
+      paritySegmentCount: 0,
+      isParity: false,
+    )
+  ]
 
 proc handleIncomingSegment*(
     self: SegmentationHandler, segment: SegmentMessageProto

--- a/channels/segmentation/segmentation.nim
+++ b/channels/segmentation/segmentation.nim
@@ -33,20 +33,35 @@ type
 proc new*(T: type SegmentationHandler, config: SegmentationConfig): T =
   return T(config: config)
 
-proc segmentMessage*(
-    handler: SegmentationHandler, appPayload: seq[byte]
+proc performSegmentation*(
+    self: SegmentationHandler, payload: seq[byte]
 ): seq[SegmentMessageProto] =
-  ## Split `appPayload` into segments according to handler config.
-  ## When `enableReedSolomon` is true, parity segments are appended.
-  return @[]
+  ## Stage 1 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
+  ## Split `payload` into segments according to handler config; when
+  ## `enableReedSolomon` is true, parity segments are appended.
+  ##
+  ## For now: emit a single segment carrying the entire payload.
+  ## TODO: real chunking + Reed-Solomon parity.
+  return
+    @[
+      SegmentMessageProto(
+        entireMessageHash: @[],
+        dataSegmentIndex: 0,
+        dataSegmentCount: 1,
+        payload: payload,
+        paritySegmentIndex: 0,
+        paritySegmentCount: 0,
+        isParity: false,
+      )
+    ]
 
 proc handleIncomingSegment*(
-    handler: SegmentationHandler, segment: SegmentMessageProto
+    self: SegmentationHandler, segment: SegmentMessageProto
 ): Option[ReassemblyResult] =
   ## Process an incoming segment. Returns Some(ReassemblyResult) when
   ## the full message has been reassembled (and hash-verified), else None.
   return none(ReassemblyResult)
 
-proc cleanupSegments*(handler: SegmentationHandler) =
+proc cleanupSegments*(self: SegmentationHandler) =
   ## Drop expired partial-reassembly state.
   discard

--- a/channels/segmentation/segmentation.nim
+++ b/channels/segmentation/segmentation.nim
@@ -4,6 +4,9 @@
 ## reassembles them on reception. Supports optional Reed-Solomon parity
 ## segments for loss recovery, as per the Reliable Channel API spec.
 ##
+## For the skeleton everything fits in a single segment: real chunking
+## and Reed-Solomon parity will be plugged in later.
+##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
 import std/options
@@ -36,12 +39,9 @@ proc new*(T: type SegmentationHandler, config: SegmentationConfig): T =
 proc performSegmentation*(
     self: SegmentationHandler, payload: seq[byte]
 ): seq[SegmentMessageProto] =
-  ## Stage 1 of the outgoing pipeline (segmentation -> sds -> rate_limit_manager -> encryption).
-  ## Split `payload` into segments according to handler config; when
-  ## `enableReedSolomon` is true, parity segments are appended.
-  ##
-  ## For now: emit a single segment carrying the entire payload.
-  ## TODO: real chunking + Reed-Solomon parity.
+  ## Stage 1 of the outgoing pipeline.
+  ## Skeleton behaviour: emit exactly one segment carrying the whole
+  ## payload. Real chunking and Reed-Solomon parity will replace this.
   return
     @[
       SegmentMessageProto(
@@ -58,9 +58,14 @@ proc performSegmentation*(
 proc handleIncomingSegment*(
     self: SegmentationHandler, segment: SegmentMessageProto
 ): Option[ReassemblyResult] =
-  ## Process an incoming segment. Returns Some(ReassemblyResult) when
-  ## the full message has been reassembled (and hash-verified), else None.
-  return none(ReassemblyResult)
+  ## Skeleton behaviour: every segment is already a complete message
+  ## (since `performSegmentation` always emits one), so just hand the
+  ## payload straight back.
+  return some(
+    ReassemblyResult(
+      payload: segment.payload, entireMessageHash: segment.entireMessageHash
+    )
+  )
 
 proc cleanupSegments*(self: SegmentationHandler) =
   ## Drop expired partial-reassembly state.

--- a/channels/segmentation/segmentation_persistence.nim
+++ b/channels/segmentation/segmentation_persistence.nim
@@ -11,12 +11,12 @@ type
     kind*: SegmentationPersistenceKind
 
 method put*(
-    p: SegmentationPersistence, key: seq[byte], value: seq[byte]
+    self: SegmentationPersistence, key: seq[byte], value: seq[byte]
 ) {.base.} =
   discard
 
-method get*(p: SegmentationPersistence, key: seq[byte]): seq[byte] {.base.} =
+method get*(self: SegmentationPersistence, key: seq[byte]): seq[byte] {.base.} =
   discard
 
-method delete*(p: SegmentationPersistence, key: seq[byte]) {.base.} =
+method delete*(self: SegmentationPersistence, key: seq[byte]) {.base.} =
   discard

--- a/channels/segmentation/segmentation_persistence.nim
+++ b/channels/segmentation/segmentation_persistence.nim
@@ -1,0 +1,22 @@
+## Persistence backend interface for segmentation reassembly state.
+##
+## Allows partial reassembly state to survive process restarts.
+
+type
+  SegmentationPersistenceKind* {.pure.} = enum
+    InMemory
+    Sqlite
+
+  SegmentationPersistence* = ref object of RootObj
+    kind*: SegmentationPersistenceKind
+
+method put*(
+    p: SegmentationPersistence, key: seq[byte], value: seq[byte]
+) {.base.} =
+  discard
+
+method get*(p: SegmentationPersistence, key: seq[byte]): seq[byte] {.base.} =
+  discard
+
+method delete*(p: SegmentationPersistence, key: seq[byte]) {.base.} =
+  discard

--- a/channels/segmentation/segmentation_persistence.nim
+++ b/channels/segmentation/segmentation_persistence.nim
@@ -10,9 +10,7 @@ type
   SegmentationPersistence* = ref object of RootObj
     kind*: SegmentationPersistenceKind
 
-method put*(
-    self: SegmentationPersistence, key: seq[byte], value: seq[byte]
-) {.base.} =
+method put*(self: SegmentationPersistence, key: seq[byte], value: seq[byte]) {.base.} =
   discard
 
 method get*(self: SegmentationPersistence, key: seq[byte]): seq[byte] {.base.} =

--- a/channels/types.nim
+++ b/channels/types.nim
@@ -1,0 +1,33 @@
+## Core identifier types for the Reliable Channel API.
+##
+## Kept separate from `events.nim` so identifier definitions don't
+## travel with event payload definitions.
+
+import std/hashes
+import bearssl/rand
+import waku/utils/requests as request_utils
+
+import ./scalable_data_sync/scalable_data_sync
+
+export scalable_data_sync
+
+type
+  ChannelId* = SdsChannelID
+
+  ReliableRequestId* = distinct string
+    ## Channel-level (parent) request id returned by `ReliableChannel.send`.
+    ## A single `ReliableRequestId` fans out into one-or-more delivery-service
+    ## `RequestId`s — one per dispatched segment.
+
+proc new*(T: typedesc[ReliableRequestId], rng: ref HmacDrbgContext): T =
+  ReliableRequestId(request_utils.generateRequestId(rng))
+
+proc `$`*(r: ReliableRequestId): string {.inline.} =
+  string(r)
+
+proc `==`*(a, b: ReliableRequestId): bool {.inline.} =
+  string(a) == string(b)
+
+proc hash*(r: ReliableRequestId): Hash =
+  ## Allows `ReliableRequestId` to be used as a `Table` key.
+  hash(string(r))

--- a/channels/types.nim
+++ b/channels/types.nim
@@ -1,33 +1,16 @@
 ## Core identifier types for the Reliable Channel API.
-##
-## Kept separate from `events.nim` so identifier definitions don't
-## travel with event payload definitions.
 
 import std/hashes
-import bearssl/rand
-import waku/utils/requests as request_utils
+import waku/api/types as api_types
 
 import ./scalable_data_sync/scalable_data_sync
 
 export scalable_data_sync
+export api_types
 
 type
   ChannelId* = SdsChannelID
 
-  ReliableRequestId* = distinct string
-    ## Channel-level (parent) request id returned by `ReliableChannel.send`.
-    ## A single `ReliableRequestId` fans out into one-or-more delivery-service
-    ## `RequestId`s — one per dispatched segment.
-
-proc new*(T: typedesc[ReliableRequestId], rng: ref HmacDrbgContext): T =
-  ReliableRequestId(request_utils.generateRequestId(rng))
-
-proc `$`*(r: ReliableRequestId): string {.inline.} =
-  string(r)
-
-proc `==`*(a, b: ReliableRequestId): bool {.inline.} =
-  string(a) == string(b)
-
-proc hash*(r: ReliableRequestId): Hash =
-  ## Allows `ReliableRequestId` to be used as a `Table` key.
+proc hash*(r: RequestId): Hash =
+  ## Allows `RequestId` to be used as a `Table` key.
   hash(string(r))

--- a/channels/types.nim
+++ b/channels/types.nim
@@ -8,8 +8,7 @@ import ./scalable_data_sync/scalable_data_sync
 export scalable_data_sync
 export api_types
 
-type
-  ChannelId* = SdsChannelID
+type ChannelId* = SdsChannelID
 
 proc hash*(r: RequestId): Hash =
   ## Allows `RequestId` to be used as a `Table` key.

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -88,3 +88,6 @@ import ./tools/test_all
 
 # Persistency library tests
 import ./persistency/test_all
+
+# Reliable Channel API tests
+import ./channels/test_all

--- a/tests/channels/test_all.nim
+++ b/tests/channels/test_all.nim
@@ -1,0 +1,3 @@
+{.used.}
+
+import ./test_reliable_channel_send_receive

--- a/tests/channels/test_reliable_channel_send_receive.nim
+++ b/tests/channels/test_reliable_channel_send_receive.nim
@@ -87,9 +87,7 @@ suite "Reliable Channel - ingress":
 
     waku_message_events.MessageReceivedEvent.emit(
       brokerCtx,
-      waku_message_events.MessageReceivedEvent(
-        messageHash: "", message: inboundMsg
-      ),
+      waku_message_events.MessageReceivedEvent(messageHash: "", message: inboundMsg),
     )
 
     let arrived = await received.withTimeout(TestTimeout)
@@ -141,9 +139,7 @@ suite "Reliable Channel - ingress":
 
     waku_message_events.MessageReceivedEvent.emit(
       brokerCtx,
-      waku_message_events.MessageReceivedEvent(
-        messageHash: "", message: inboundMsg
-      ),
+      waku_message_events.MessageReceivedEvent(messageHash: "", message: inboundMsg),
     )
 
     ## Give the event broker a chance to fan out.

--- a/tests/channels/test_reliable_channel_send_receive.nim
+++ b/tests/channels/test_reliable_channel_send_receive.nim
@@ -1,0 +1,153 @@
+{.used.}
+
+import std/[net]
+import chronos, testutils/unittests, stew/byteutils
+import brokers/broker_context
+
+import ../testlib/[common, wakucore, wakunode, testasync]
+
+import waku
+import waku/[waku_node, waku_core]
+import waku/factory/waku_conf
+import waku/events/message_events as waku_message_events
+import tools/confutils/cli_args
+
+import channels/reliable_channel_manager
+import channels/encryption/noop_encryption
+
+const TestTimeout = chronos.seconds(15)
+
+proc createApiNodeConf(): WakuNodeConf =
+  var conf = defaultWakuNodeConf().valueOr:
+    raiseAssert error
+  conf.mode = cli_args.WakuMode.Core
+  conf.listenAddress = parseIpAddress("0.0.0.0")
+  conf.tcpPort = Port(0)
+  conf.discv5UdpPort = Port(0)
+  conf.clusterId = 3'u16
+  conf.numShardsInNetwork = 1
+  conf.reliabilityEnabled = true
+  conf.rest = false
+  return conf
+
+suite "Reliable Channel - ingress":
+  asyncTest "manager dispatches LIP173 WakuMessage to the right channel":
+    ## Unit test for the receive side of the API: instead of standing
+    ## up two libp2p nodes and a relay mesh, we drive the manager
+    ## directly by emitting a `MessageReceivedEvent` (the exact event
+    ## the DeliveryService emits when a `WakuMessage` arrives off the
+    ## wire). The manager must:
+    ##   - drop non-LIP173 traffic
+    ##   - dispatch the matching channel's `onMessageReceived`
+    ##   - emit `ChannelMessageReceivedEvent` with the payload
+    const
+      channelId = ChannelId("test-channel")
+      contentTopic = ContentTopic("/reliable-channel/test/proto")
+    let appPayload = "hello reliable channel".toBytes()
+
+    var manager: ReliableChannelManager
+    var brokerCtx: BrokerContext
+    lockNewGlobalBrokerContext:
+      brokerCtx = globalBrokerContext()
+      manager = (await ReliableChannelManager.new(createApiNodeConf())).expect(
+        "Failed to create manager"
+      )
+
+    ## Noop encryption providers so the Encrypt/Decrypt brokers have
+    ## something to dispatch to; without this the channel falls back to
+    ## plaintext anyway, but installing them is the documented setup.
+    setNoopEncryption()
+
+    discard manager
+      .createReliableChannel(channelId, contentTopic, SdsParticipantID("local"))
+      .expect("createReliableChannel")
+
+    let received = newFuture[seq[byte]]("channel-message-received")
+    discard ChannelMessageReceivedEvent
+      .listen(
+        brokerCtx,
+        proc(evt: ChannelMessageReceivedEvent) {.async: (raises: []).} =
+          if not received.finished() and evt.channelId == channelId:
+            received.complete(evt.payload)
+        ,
+      )
+      .expect("listen ChannelMessageReceivedEvent")
+
+    ## Build a `WakuMessage` that looks like one that came in off the
+    ## wire from a peer: the LIP173 meta marker plus the right content
+    ## topic. The manager's ingress listener should pick it up,
+    ## decrypt (noop), unwrap SDS (pass-through), reassemble (one
+    ## segment), and finally emit `ChannelMessageReceivedEvent`.
+    let inboundMsg = WakuMessage(
+      payload: appPayload,
+      contentTopic: contentTopic,
+      version: 0,
+      meta: Lip173Meta.toBytes(),
+    )
+
+    waku_message_events.MessageReceivedEvent.emit(
+      brokerCtx,
+      waku_message_events.MessageReceivedEvent(
+        messageHash: "", message: inboundMsg
+      ),
+    )
+
+    let arrived = await received.withTimeout(TestTimeout)
+    check arrived
+    if arrived:
+      check received.read() == appPayload
+
+    await manager.stop()
+
+  asyncTest "manager drops non-LIP173 WakuMessage":
+    ## Mirror of the above: same content topic, but `meta` is empty
+    ## (i.e. foreign traffic). The channel-level event must NOT fire.
+    const
+      channelId = ChannelId("test-channel-2")
+      contentTopic = ContentTopic("/reliable-channel/test/proto")
+    let appPayload = "foreign payload".toBytes()
+
+    var manager: ReliableChannelManager
+    var brokerCtx: BrokerContext
+    lockNewGlobalBrokerContext:
+      brokerCtx = globalBrokerContext()
+      manager = (await ReliableChannelManager.new(createApiNodeConf())).expect(
+        "Failed to create manager"
+      )
+
+    setNoopEncryption()
+
+    discard manager
+      .createReliableChannel(channelId, contentTopic, SdsParticipantID("local"))
+      .expect("createReliableChannel")
+
+    var fired = false
+    discard ChannelMessageReceivedEvent
+      .listen(
+        brokerCtx,
+        proc(evt: ChannelMessageReceivedEvent) {.async: (raises: []).} =
+          if evt.channelId == channelId:
+            fired = true
+        ,
+      )
+      .expect("listen ChannelMessageReceivedEvent")
+
+    let inboundMsg = WakuMessage(
+      payload: appPayload,
+      contentTopic: contentTopic,
+      version: 0,
+      meta: @[], ## no LIP173 marker
+    )
+
+    waku_message_events.MessageReceivedEvent.emit(
+      brokerCtx,
+      waku_message_events.MessageReceivedEvent(
+        messageHash: "", message: inboundMsg
+      ),
+    )
+
+    ## Give the event broker a chance to fan out.
+    await sleepAsync(100.milliseconds)
+    check not fired
+
+    await manager.stop()

--- a/tests/channels/test_reliable_channel_send_receive.nim
+++ b/tests/channels/test_reliable_channel_send_receive.nim
@@ -31,13 +31,13 @@ proc createApiNodeConf(): WakuNodeConf =
   return conf
 
 suite "Reliable Channel - ingress":
-  asyncTest "manager dispatches LIP173 WakuMessage to the right channel":
+  asyncTest "manager dispatches marked WakuMessage to the right channel":
     ## Unit test for the receive side of the API: instead of standing
     ## up two libp2p nodes and a relay mesh, we drive the manager
     ## directly by emitting a `MessageReceivedEvent` (the exact event
     ## the DeliveryService emits when a `WakuMessage` arrives off the
     ## wire). The manager must:
-    ##   - drop non-LIP173 traffic
+    ##   - drop traffic missing the Reliable Channel spec marker
     ##   - dispatch the matching channel's `onMessageReceived`
     ##   - emit `ChannelMessageReceivedEvent` with the payload
     const
@@ -74,7 +74,7 @@ suite "Reliable Channel - ingress":
       .expect("listen ChannelMessageReceivedEvent")
 
     ## Build a `WakuMessage` that looks like one that came in off the
-    ## wire from a peer: the LIP173 meta marker plus the right content
+    ## wire from a peer: the spec marker on `meta` plus the right content
     ## topic. The manager's ingress listener should pick it up,
     ## decrypt (noop), unwrap SDS (pass-through), reassemble (one
     ## segment), and finally emit `ChannelMessageReceivedEvent`.
@@ -82,7 +82,7 @@ suite "Reliable Channel - ingress":
       payload: appPayload,
       contentTopic: contentTopic,
       version: 0,
-      meta: Lip173Meta.toBytes(),
+      meta: LipWireReliableChannelVersion.toBytes(),
     )
 
     waku_message_events.MessageReceivedEvent.emit(
@@ -97,7 +97,7 @@ suite "Reliable Channel - ingress":
 
     await manager.stop()
 
-  asyncTest "manager drops non-LIP173 WakuMessage":
+  asyncTest "manager drops unmarked WakuMessage":
     ## Mirror of the above: same content topic, but `meta` is empty
     ## (i.e. foreign traffic). The channel-level event must NOT fire.
     const
@@ -134,7 +134,7 @@ suite "Reliable Channel - ingress":
       payload: appPayload,
       contentTopic: contentTopic,
       version: 0,
-      meta: @[], ## no LIP173 marker
+      meta: @[], ## no Reliable Channel spec marker
     )
 
     waku_message_events.MessageReceivedEvent.emit(


### PR DESCRIPTION
This PR:
- Is inspired by pair session with @jazzz , 🙌 !

- Adds a very basic folder structure of reliable channel and its components.
The main suggested new folder is `channels` and inside, it contains `segmentation`, `rate-limit-manager`, `sds`, and `encryption`. This is just structural PR but no functionality is implemented yet.

In separate PRs:
- Properly accommodate all the broker events and properly refactor the MessagingClient/MessagingAPI implementation.
- Properly implement `channels/scalable_data_sync/scalable_data_sync.nim` and `channels/scalable_data_sync/sds_persistence.nim` modules.
- Implement unit tests for reliable channel.

closes https://github.com/logos-messaging/logos-delivery/issues/3853