### PR TITLE
fix: accept port 0 in JSON config (ephemeral port support)

### DIFF
--- a/library/kernel_api/node_lifecycle_api.nim
+++ b/library/kernel_api/node_lifecycle_api.nim
@@ -33,17 +33,7 @@ proc createWaku(
       let formattedString = ($jsonNode[confField]).strip(chars = {'\"'})
       # Override conf field with the value set in the json-string
       try:
-        when typeof(confValue) is Port:
-          # Accept port 0 so callers can request an OS-assigned ephemeral port.
-          # confutils's parseCmdArg(Port, ...) rejects 0, so parse directly here.
-          let intVal = parseInt(formattedString)
-          if intVal < 0 or intVal > 65535:
-            raise newException(ValueError,
-              "Port must be an integer in the range 0-65535. Value: " &
-                formattedString)
-          confValue = Port(intVal)
-        else:
-          confValue = parseCmdArg(typeof(confValue), formattedString)
+        confValue = parseCmdArg(typeof(confValue), formattedString)
       except Exception:
         return err(
           "exception in createWaku when parsing configuration. exc: " &

--- a/library/kernel_api/node_lifecycle_api.nim
+++ b/library/kernel_api/node_lifecycle_api.nim
@@ -33,7 +33,17 @@ proc createWaku(
       let formattedString = ($jsonNode[confField]).strip(chars = {'\"'})
       # Override conf field with the value set in the json-string
       try:
-        confValue = parseCmdArg(typeof(confValue), formattedString)
+        when typeof(confValue) is Port:
+          # Accept port 0 so callers can request an OS-assigned ephemeral port.
+          # confutils's parseCmdArg(Port, ...) rejects 0, so parse directly here.
+          let intVal = parseInt(formattedString)
+          if intVal < 0 or intVal > 65535:
+            raise newException(ValueError,
+              "Port must be an integer in the range 0-65535. Value: " &
+                formattedString)
+          confValue = Port(intVal)
+        else:
+          confValue = parseCmdArg(typeof(confValue), formattedString)
       except Exception:
         return err(
           "exception in createWaku when parsing configuration. exc: " &

--- a/nimble.lock
+++ b/nimble.lock
@@ -250,8 +250,8 @@
     },
     "confutils": {
       "version": "0.1.0",
-      "vcsRevision": "7728f6bd81a1eedcfe277d02ea85fdb805bcc05a",
-      "url": "https://github.com/status-im/nim-confutils",
+      "vcsRevision": "0292f00d981f29a6c18648be8ee9d4f2ce268df9",
+      "url": "https://github.com/igor-sirotin/nim-confutils",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
@@ -260,7 +260,7 @@
         "results"
       ],
       "checksums": {
-        "sha1": "8bc8c30b107fdba73b677e5f257c6c42ae1cdc8e"
+        "sha1": "2fbe6418ddd9f79fb11a0addd7666a3e787adbe0"
       }
     },
     "cbor_serialization": {

--- a/nimble.lock
+++ b/nimble.lock
@@ -250,8 +250,8 @@
     },
     "confutils": {
       "version": "0.1.0",
-      "vcsRevision": "0292f00d981f29a6c18648be8ee9d4f2ce268df9",
-      "url": "https://github.com/igor-sirotin/nim-confutils",
+      "vcsRevision": "36f3115ca350f40841ac0eecc7dfa5fe7790c864",
+      "url": "https://github.com/status-im/nim-confutils",
       "downloadMethod": "git",
       "dependencies": [
         "nim",

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -123,8 +123,8 @@
   };
 
   confutils = pkgs.fetchgit {
-    url = "https://github.com/igor-sirotin/nim-confutils";
-    rev = "0292f00d981f29a6c18648be8ee9d4f2ce268df9";
+    url = "https://github.com/status-im/nim-confutils";
+    rev = "36f3115ca350f40841ac0eecc7dfa5fe7790c864";
     sha256 = "1vppqplwlpl7a61r8iki5hlzvhd8lnq41ixpqslv35dnm482c55j";
     fetchSubmodules = true;
   };

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -123,9 +123,9 @@
   };
 
   confutils = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-confutils";
-    rev = "7728f6bd81a1eedcfe277d02ea85fdb805bcc05a";
-    sha256 = "18bj1ilx10jm2vmqx2wy2xl9rzy7alymi2m4n9jgpa4sbxnfh0x3";
+    url = "https://github.com/igor-sirotin/nim-confutils";
+    rev = "0292f00d981f29a6c18648be8ee9d4f2ce268df9";
+    sha256 = "1vppqplwlpl7a61r8iki5hlzvhd8lnq41ixpqslv35dnm482c55j";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Summary

Bump `confutils` to include:
- status-im/nim-confutils#146

Needed to run multiple module instances on one host (logos-co/logos-delivery-module#18).
