### PR TITLE
feat: add logos.test fleet preset

### DIFF
--- a/tests/api/test_node_conf.nim
+++ b/tests/api/test_node_conf.nim
@@ -219,6 +219,22 @@ suite "WakuNodeConf - preset integration":
     check:
       wakuConf.clusterId == 2
 
+  test "LogosTest preset applies LogosTestConf":
+    ## Given
+    var conf = defaultWakuNodeConf().valueOr:
+      raiseAssert error
+    conf.preset = "logostest"
+
+    ## When
+    let wakuConfRes = conf.toWakuConf()
+
+    ## Then
+    require wakuConfRes.isOk()
+    let wakuConf = wakuConfRes.get()
+    require wakuConf.validate().isOk()
+    check:
+      wakuConf.clusterId == 2
+
   test "Invalid preset returns error":
     ## Given
     var conf = defaultWakuNodeConf().valueOr:

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -165,7 +165,7 @@ type WakuNodeConf* = object
 
     preset* {.
       desc:
-        "Network preset to use. 'twn' is The RLN-protected Waku Network (cluster 1). 'logos.dev' is the Logos Dev Network (cluster 2). Overrides other values.",
+        "Network preset to use. 'twn' is The RLN-protected Waku Network (cluster 1). 'logos.dev' is the Logos Dev Network (cluster 2). 'logos.test' is the Logos Test Network (cluster 2). Overrides other values.",
       defaultValue: "",
       name: "preset"
     .}: string
@@ -947,6 +947,8 @@ proc toNetworkConf(
     ok(some(NetworkConf.TheWakuNetworkConf()))
   of "logos.dev", "logosdev":
     ok(some(NetworkConf.LogosDevConf()))
+  of "logos.test", "logostest":
+    ok(some(NetworkConf.LogosTestConf()))
   else:
     err("Invalid --preset value passed: " & lcPreset)
 

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -92,6 +92,35 @@ proc LogosDevConf*(T: type NetworkConf): NetworkConf =
     ],
   )
 
+# cluster-id=2 (Logos Test Network)
+# Cluster configuration for the Logos Test Network.
+proc LogosTestConf*(T: type NetworkConf): NetworkConf =
+  const ZeroChainId = 0'u256
+  return NetworkConf(
+    maxMessageSize: "150KiB",
+    clusterId: 2,
+    rlnRelay: false,
+    rlnRelayEthContractAddress: "",
+    rlnRelayDynamic: false,
+    rlnRelayChainId: ZeroChainId,
+    rlnEpochSizeSec: 0,
+    rlnRelayUserMessageLimit: 0,
+    shardingConf: ShardingConf(kind: AutoSharding, numShardsInCluster: 8),
+    enableKadDiscovery: true,
+    mix: true,
+    p2pReliability: true,
+    discv5Discovery: true,
+    discv5BootstrapNodes: @[],
+    entryNodes: @[
+      "/dns4/node-01.do-ams3.logos.test.status.im/tcp/30303/p2p/16Uiu2HAmQ9X2xDfPG3uL77V9piYDhjq14JhKCtcmNYsTMKNqrKCj",
+      "/dns4/node-02.do-ams3.logos.test.status.im/tcp/30303/p2p/16Uiu2HAmB8NYprrfQrgWVzsJtYWkfjsXbmJEGNMG6othXsQ53BwG",
+      "/dns4/node-01.gc-us-central1-a.logos.test.status.im/tcp/30303/p2p/16Uiu2HAmF8WtwGPmeGHgYAX2277jHgy5cW9F7zsB8EqUjBZQAZQ3",
+      "/dns4/node-02.gc-us-central1-a.logos.test.status.im/tcp/30303/p2p/16Uiu2HAmUuXhUW9bdJpzN1kfDziFiUZo4bszTk66cvr7uuyCHXR7",
+      "/dns4/node-01.ac-cn-hongkong-c.logos.test.status.im/tcp/30303/p2p/16Uiu2HAmL3oU95jh1BZHozn3uNhx8HEneirgr8M1jEAapzXGDqRF",
+      "/dns4/node-02.ac-cn-hongkong-c.logos.test.status.im/tcp/30303/p2p/16Uiu2HAm28CoBZjpyxsanC8tQpbvZ7bZJnVYuB1EgFzb571qpWsV",
+    ],
+  )
+
 proc validateShards*(
     shardingConf: ShardingConf, shards: seq[uint16]
 ): Result[void, string] =


### PR DESCRIPTION
Adds a `logos.test` network preset (cluster 2) with the six `logos.test` delivery entry nodes from fleets.logos.co/data.json.

`logos.test` fleet deployed here: https://github.com/status-im/infra-logos/issues/2

Iterates https://github.com/logos-messaging/pm/issues/386

🤖 Generated with [Claude Code](https://claude.com/claude-code)