### PR TITLE
feat(nix): expose cargoHash-corrected librln as packages.rln

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,11 @@
           };
         in {
           inherit liblogosdelivery;
+          # Expose the cargoHash-corrected librln so downstream consumers
+          # (e.g. logos-delivery-module) bundle the exact same librln this
+          # build links, instead of pulling zerokit's rln directly — whose
+          # committed cargoHash is stale for v2.0.2 (see zerokitRln above).
+          rln = zerokitRln;
           default = liblogosdelivery;
         }
       );


### PR DESCRIPTION
## Description

Expose the cargoHash-corrected `librln` (`zerokitRln`, added in #3899) as `packages.<system>.rln`.

Exposing the corrected derivation lets those consumers bundle the **exact same** librln this build links, instead of duplicating the cargoHash override.

Required for `logos-delivery-module`. Validated in:
- https://github.com/logos-co/logos-delivery-module/pull/42

🤖 Generated with [Claude Code](https://claude.com/claude-code)