### PR TITLE
ci: pass -d:disableMarchNative to avoid secp256k1 build failures

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -8,7 +8,8 @@ on:
 env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none"
+  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
+  NIM_PARAMS: "-d:disableMarchNative"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none"
+  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
   NIM_VERSION: '2.2.4'
   NIMBLE_VERSION: '0.22.3'
 
@@ -157,7 +157,7 @@ jobs:
           fi
 
           export MAKEFLAGS="-j1"
-          export NIMFLAGS="--colors:off -d:chronicles_colors:none"
+          export NIMFLAGS="--colors:off -d:chronicles_colors:none -d:disableMarchNative"
           export USE_LIBBACKTRACE=0
 
           make V=1 POSTGRES=$postgres_enabled test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
 
           export MAKEFLAGS="-j1"
           export NIMFLAGS="--colors:off -d:chronicles_colors:none -d:disableMarchNative"
+          export NIM_PARAMS="-d:disableMarchNative"
           export USE_LIBBACKTRACE=0
 
           make V=1 POSTGRES=$postgres_enabled test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
   NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
+  NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.4'
   NIMBLE_VERSION: '0.22.3'
 
@@ -158,7 +159,6 @@ jobs:
 
           export MAKEFLAGS="-j1"
           export NIMFLAGS="--colors:off -d:chronicles_colors:none -d:disableMarchNative"
-          export NIM_PARAMS="-d:disableMarchNative"
           export USE_LIBBACKTRACE=0
 
           make V=1 POSTGRES=$postgres_enabled test


### PR DESCRIPTION
## Summary
- GitHub-hosted runners pick up host-specific CPU features via `-march=native`, which combined with `-Og -O3` (emitted when `--debugger:native` and `--opt:speed` are both active) exhausts the register constraints in secp256k1's `scalar_4x64_impl.h` inline assembly and breaks the build with `'asm' operand has impossible constraints`.
- This PR enables the existing `disableMarchNative` escape hatch in `config.nims` for CI, which falls back to `-mssse3` and keeps register allocation predictable across the heterogeneous runner pool.

Observed failure (e.g. job [78254955293](https://github.com/logos-messaging/logos-delivery/actions/runs/26564318538/job/78254955293)):
```
secp256k1/../vendor/secp256k1/src/scalar_4x64_impl.h:356:5: error: 'asm' operand has impossible constraints
secp256k1/../vendor/secp256k1/src/scalar_4x64_impl.h:470:5: error: 'asm' operand has impossible constraints
```

## Test plan
- [ ] `test-ubuntu-22.04` passes on this branch
- [ ] `x86_64-linux / liblogosdelivery` passes on this branch
- [ ] Other downstream build jobs that consume `NIMFLAGS` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)