### PR TITLE
disable js-waku from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,20 +177,6 @@ jobs:
 
     secrets: inherit
 
-  js-waku-node:
-    needs: build-docker-image
-    uses: logos-messaging/logos-delivery-js/.github/workflows/test-node.yml@master
-    with:
-      nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
-      test_type: node
-
-  js-waku-node-optional:
-    needs: build-docker-image
-    uses: logos-messaging/logos-delivery-js/.github/workflows/test-node.yml@master
-    with:
-      nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
-      test_type: node-optional
-
   lint:
     name: "Lint"
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Pause interaction with js-waku in CI.
Stop running js-waku interop tests in CI because they are failing.
The reason why fail is because the js-waku node need to operate with at least two relay peers because now, with one single relay peer in the js-waku interop tests, the lightpush service always returns "NO_PEERS_TO_RELAY".