### PR TITLE
Pin nim-ffi to v0.1.3 in waku.nimble

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -59,7 +59,7 @@ requires "nim >= 2.2.4",
   "unittest2"
 
 # Packages not on nimble (use git URLs)
-requires "https://github.com/logos-messaging/nim-ffi"
+requires "https://github.com/logos-messaging/nim-ffi#v0.1.3"
 
 requires "https://github.com/logos-messaging/nim-sds.git#2e9a7683f0e180bf112135fae3a3803eed8490d4"
 


### PR DESCRIPTION
The `requires` entry for `nim-ffi` has no tag, so the build resolves the **latest** tag — currently **v0.2.0**.

v0.2.0 changed `declareLibrary` to require an extra `libType` argument:
```
macro declareLibrary*(libraryName: static[string], libType: untyped)
```
which breaks `liblogosdelivery/declare_lib.nim`'s single-arg call `declareLibrary("logosdelivery")`, failing `make liblogosdelivery`.

This pins `nim-ffi` to **v0.1.3** (the version already in `nimble.lock`), restoring the build. Pinning also matches the existing convention in this file (e.g. `nim-sds`, `nim-brokers` are pinned by tag/commit). Revert once the typed-FFI (v0.2.0) migration lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)