### PR TITLE
fix: make docker-image. docker ignore nimbledeps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,6 @@
 /tests
 /metrics
 /nimcache
+/nimbledeps
 librln*
 **/vendor/*


### PR DESCRIPTION

## Description

Fixes `make docker-image`

the `**/vendor/*` ignore pattern removes part of ./nimbledeps that is copied into the image during build.

example error message:
```
229.7 make[2]: *** /app/nimbledeps/pkgs2/nat_traversal-0.0.1-1a376d3e710590ef2c48748a546369755f0a7c97/vendor/miniupnp/miniupnpc: No such file or directory.  Stop.
```

see `...97/7c97/vendor/miniupnp/miniupnpc: No such file or directory.  Stop.`


## Changes

add `/nimbledeps` to .dockerignore

