### PR TITLE
fix(discovery): prune stale discv5 peers from peer store so PX stops serving dead ENRs (#3933)

### DIFF
--- a/logos_delivery/waku/discovery/waku_discv5.nim
+++ b/logos_delivery/waku/discovery/waku_discv5.nim
@@ -12,7 +12,8 @@ import
   libp2p/multiaddress,
   eth/keys as eth_keys,
   eth/p2p/discoveryv5/node,
-  eth/p2p/discoveryv5/protocol
+  eth/p2p/discoveryv5/protocol,
+  eth/p2p/discoveryv5/routing_table
 import
   logos_delivery/waku/
     [net/auto_port, node/peer_manager/peer_manager, waku_core, waku_enr]
@@ -254,6 +255,40 @@ proc findRandomPeers*(
 
   return discoveredRecords
 
+proc reconcilePeerStoreWithRoutingTable(
+    wd: WakuDiscoveryV5, pm: PeerManager, justDiscovered: seq[RemotePeerInfo]
+) =
+  ## discv5 revalidates its routing table and evicts unreachable nodes, but those
+  ## evictions were never propagated to the peer store. As a result peer-exchange
+  ## kept advertising stale ENRs of dead Discv5-origin peers (see #3933), and
+  ## clients (e.g. light clients) repeatedly tried to dial unreachable peers.
+  ##
+  ## Here we drop Discv5-origin, non-connected peers that discv5 no longer knows
+  ## about. Peers discovered this round are preserved (they were just learned and
+  ## may not be in a routing-table bucket yet).
+  let peerStore = pm.switch.peerStore
+
+  var liveIds = initHashSet[PeerId]()
+  for peer in justDiscovered:
+    liveIds.incl(peer.peerId)
+  for node in wd.protocol.routingTable.randomNodes(int.high):
+    let info = node.record.toRemotePeerInfo().valueOr:
+      continue
+    liveIds.incl(info.peerId)
+
+  var stalePeers: seq[PeerId]
+  for peer in peerStore.peers():
+    if peer.origin == PeerOrigin.Discv5 and peer.connectedness != Connectedness.Connected and
+        peer.peerId notin liveIds:
+      stalePeers.add(peer.peerId)
+
+  for peerId in stalePeers:
+    peerStore.delete(peerId)
+
+  if stalePeers.len > 0:
+    debug "discv5: pruned stale peers no longer in routing table from peer store",
+      count = stalePeers.len
+
 proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
   ## Continuously add newly discovered nodes
 
@@ -290,6 +325,11 @@ proc searchLoop(wd: WakuDiscoveryV5) {.async.} =
     for peer in discoveredPeers:
       # Peers added are filtered by the peer manager
       peerManager.addPeer(peer, PeerOrigin.Discv5)
+
+    # Reconcile the peer store with discv5's revalidated routing table so that
+    # peer-exchange stops advertising ENRs of nodes discv5 has already evicted
+    # (#3933).
+    wd.reconcilePeerStoreWithRoutingTable(peerManager, discoveredPeers)
 
     # Discovery `queryRandom` can have a synchronous fast path for example
     # when no peers are in the routing table. Don't run it in continuous loop.


### PR DESCRIPTION
Fixes #3933

## Note (human-written)

> [!WARNING]
> I'm not sure if this is a good solution, look more like a workaround to me.
> So please review carefully.

## Description

Peer-exchange responds with ENRs read from the **PeerStore `ENRBook`**, which is populated *add-only* by the discv5 search loop and only pruned on **capacity**, never on staleness. discv5 revalidates its own routing table and evicts unreachable nodes within seconds, but those evictions were never propagated to the peer store — so PX kept advertising ENRs of dead peers indefinitely (under capacity).

The only liveness gate in `getEnrsFromStore` skips `CannotConnect`, which is set **only** when *we* personally failed to dial a peer. A peer that merely disconnected is `CanConnect`, and a discv5-discovered-but-never-connected peer is `NotConnected` — both were still served by PX.

## Change

At the end of each discv5 search iteration, reconcile the peer store against the live (revalidated) routing table: drop `Discv5`-origin, non-connected peers that discv5 no longer knows about. Peers discovered in the same round are preserved (they may not be in a bucket yet).

- `reconcilePeerStoreWithRoutingTable` in `waku/discovery/waku_discv5.nim`, called from `searchLoop` after adding discovered peers.

This keeps PX responses tied to discv5's liveness without changing the PX protocol or its peer-store-backed read path.

## Notes / open questions

- Scope is intentionally minimal. Alternatives considered: serving PX directly from the routing table, or adding a last-seen TTL to the `ENRBook`. Happy to take direction if maintainers prefer one of those.
- `randomNodes(int.high)` is used to enumerate the routing table each iteration (every ~5s); fine for typical table sizes, can be optimized if needed.
- Verified with `nim check` (compiles clean) and `nph`-formatted. Functional verification against the status-go light-client flake is in progress — see status-im/status-go#7513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
