### PR TITLE
feat: accept CLI option names in JSON config

### DIFF
--- a/tests/api/test_node_conf.nim
+++ b/tests/api/test_node_conf.nim
@@ -155,6 +155,36 @@ suite "WakuNodeConf - JSON parsing with fieldPairs":
     ## Then - the parser rejects unrecognized config keys
     check confRes.isErr()
 
+  test "JSON config keys accepts cli_args pragma names":
+    ## Given / When
+    let confRes = parseNodeConfFromJson(
+      """{"cluster-id": 7, "reliability": true, "staticnode": ["/ip4/127.0.0.1/tcp/60000"]}"""
+    )
+
+    ## Then
+    require confRes.isOk()
+    let conf = confRes.get()
+    check:
+      conf.clusterId == some(7'u16)
+      conf.reliabilityEnabled == some(true)
+      conf.staticNodes == @["/ip4/127.0.0.1/tcp/60000"]
+
+  test "JSON config accepts field-name form":
+    ## Given / When
+    let confRes = parseNodeConfFromJson("""{"reliabilityEnabled": true}""")
+
+    ## Then
+    require confRes.isOk()
+    check confRes.get().reliabilityEnabled == some(true)
+
+  test "JSON config rejects option set via both field name and cli name":
+    ## Given / When
+    let confRes = parseNodeConfFromJson("""{"clusterId": 5, "cluster-id": 5}""")
+
+    ## Then
+    require confRes.isErr()
+    check "set twice" in confRes.error
+
   test "Invalid JSON syntax returns error":
     ## Given / When
     let confRes = parseNodeConfFromJson("{ not valid json }")

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -216,7 +216,8 @@ type WakuNodeConf* = object
       desc:
         "Specify method to use for determining public address. " &
         "Must be one of: any, none, upnp, pmp, extip:<IP>.",
-      defaultValue: DefaultCLINat
+      defaultValue: DefaultCLINat,
+      name: "nat"
     .}: string
 
     extMultiAddrs* {.

--- a/tools/confutils/conf_from_json.nim
+++ b/tools/confutils/conf_from_json.nim
@@ -1,5 +1,5 @@
-import std/[json, strutils, tables]
-import confutils, confutils/std/net, results
+import std/[json, macros, strutils, tables]
+import confutils, confutils/defs, confutils/std/net, results
 import ./cli_args
 
 proc collectJsonFields*(
@@ -55,9 +55,22 @@ proc applyJsonFieldsToConf(
   ## `jsonFields`. seq fields take a JArray (full replace); scalar fields
   ## take any scalar JSON kind. Errors on leftover unknown keys.
   for confField, confValue in fieldPairs(conf):
+    # Match a field by its name or by its CLI name: pragma; case-insensitive.
+    var matchKey = ""
     let lowerField = confField.toLowerAscii()
     if jsonFields.hasKey(lowerField):
-      let (jsonKey, jsonValue) = jsonFields[lowerField]
+      matchKey = lowerField
+    when confValue.hasCustomPragma(defs.name):
+      let lowerCliName = confValue.getCustomPragmaVal(defs.name).toLowerAscii()
+      if lowerCliName != lowerField and jsonFields.hasKey(lowerCliName):
+        if matchKey != "": # field-name form already present: set twice
+          return err(
+            "config option '" & confField & "' was set twice, via '" &
+              jsonFields[matchKey][0] & "' and '" & jsonFields[lowerCliName][0] & "'"
+          )
+        matchKey = lowerCliName
+    if matchKey != "":
+      let (jsonKey, jsonValue) = jsonFields[matchKey]
       when confValue is seq:
         if jsonValue.kind != JArray:
           return err(
@@ -93,7 +106,7 @@ proc applyJsonFieldsToConf(
             parseErrPrefix & " '" & confField & "' from JSON key '" & jsonKey & "': " &
               e.msg & ". Value: " & formattedString
           )
-      jsonFields.del(lowerField)
+      jsonFields.del(matchKey)
   if jsonFields.len > 0:
     return err(unknownKeysError(jsonFields, unknownErrPrefix))
   return ok()
@@ -101,7 +114,8 @@ proc applyJsonFieldsToConf(
 proc assembleFullConf*(
     jsonFields: Table[string, (string, JsonNode)]
 ): Result[WakuNodeConf, string] =
-  ## Build a WakuNodeConf from a flat JSON object whose keys are WakuNodeConf field names.
+  ## Build a WakuNodeConf from a flat JSON object whose keys are WakuNodeConf field
+  ## names or their CLI `name:` pragma equivalents.
   var conf = ?defaultWakuNodeConf()
   var fields = jsonFields
   ?applyJsonFieldsToConf(
@@ -110,7 +124,8 @@ proc assembleFullConf*(
   return ok(conf)
 
 proc parseNodeConfFromJson*(jsonStr: string): Result[WakuNodeConf, string] =
-  ## Parse a flat JSON config whose keys are WakuNodeConf field names.
+  ## Parse a flat JSON config whose keys are WakuNodeConf field names or their CLI
+  ## `name:` pragma equivalents.
   var jsonNode: JsonNode
   try:
     jsonNode = parseJson(jsonStr)


### PR DESCRIPTION
## Description

This PR makes the JSON config parser accept CLI option names (e.g. cluster-id, reliability, staticnode) in addition to the WakuNodeConf field names (e.g. clusterId, reliabilityEnabled, staticNodes).

## Changes

* conf_from_json: match by field name or CLI name: pragma, case-insensitive
* conf_from_json: error if an option is set via both forms
* cli_args: add name: "nat" pragma
* add tests

## Issue

closes #3827
