### PR TITLE
fix(pr-lint): grant the comment job pull-requests:write

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   labels:
     runs-on: ubuntu-22.04
@@ -44,7 +48,6 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       if: ${{steps.filter.outputs.db_schema == 'true'}}
       with:
-        header: pr-title-lint-error
         message: |
           This PR may contain changes to **database schema** of one of the drivers.
 


### PR DESCRIPTION
## Description

Fix for [this](https://github.com/logos-messaging/logos-delivery/actions/runs/27286257879/job/80594196179?pr=3929) CI failure.

Tested the fix in a temporary logos-delivery fork: [successful run](https://github.com/fcecin/logos-delivery/actions/runs/27290335323), [commit](https://github.com/fcecin/logos-delivery/commit/8f88f64ecdabe9614c22ccda3000fea0b7bb2e8d), [test PR](https://github.com/fcecin/logos-delivery/pull/1), [working bot message](https://github.com/fcecin/logos-delivery/pull/1#issuecomment-4672217720).

The labels job's comment steps need pull-requests: write but never declared it; they relied on the repo's default workflow token, which is now likely read-only for some reason. Adds an explicit permissions: block (and drops a stray, invalid header: input).

## Changes

* Add explicit `permissions:` block (`contents: read`, `pull-requests: write`)
* Drop invalid `header:` input from the db-schema comment step

## Issue

Maintenance Y2026H1 #3686