### PR TITLE
feat: integrate service discovery

### DIFF
--- a/apps/chat2mix/chat2mix.nim
+++ b/apps/chat2mix/chat2mix.nim
@@ -464,19 +464,17 @@ proc processInput(rfd: AsyncFD, rng: crypto.Rng) {.async.} =
     var kadBootstrapPeers: seq[(PeerId, seq[MultiAddress])]
     for nodeStr in conf.kadBootstrapNodes:
       let (peerId, ma) = block:
-        let r = parseFullAddress(nodeStr)
-        if r.isErr:
-          error "Failed to parse kademlia bootstrap node",
-            node = nodeStr, error = r.error
+        parseFullAddress(nodeStr).isOkOr:
+          error "Failed to parse kademlia bootstrap node", node = nodeStr, error
           continue
-        r.get()
+
       kadBootstrapPeers.add((peerId, @[ma]))
 
     if kadBootstrapPeers.len > 0:
       node.mountKademlia(
         KademliaDiscoveryConf(
           bootstrapNodes: kadBootstrapPeers,
-          servicesToDiscover: @["mix"],
+          servicesToDiscover: @[MixProtocolID],
           randomLookupInterval: chronos.seconds(60),
           serviceLookupInterval: chronos.seconds(60),
           kadDhtConfig: KadDHTConfig.new(),

--- a/apps/chat2mix/chat2mix.nim
+++ b/apps/chat2mix/chat2mix.nim
@@ -28,6 +28,8 @@ import
       # manage the information of a peer, such as peer ID and public / private key
     peerid, # Implement how peers interact
     protobuf/minprotobuf, # message serialisation/deserialisation from and to protobufs
+    protocols/kademlia/types,
+    protocols/service_discovery/types as sd_types,
     nameresolving/dnsresolver,
     protocols/mix/curve25519,
     protocols/mix/mix_protocol,
@@ -35,6 +37,7 @@ import
 import
   logos_delivery/waku/[
     waku_core,
+    waku_core/peers,
     waku_lightpush/common,
     waku_lightpush/rpc,
     waku_enr,
@@ -43,6 +46,7 @@ import
     waku_node,
     node/waku_metrics,
     node/peer_manager,
+    factory/waku_conf,
     factory/builder,
     common/utils/nat,
     waku_store/common,
@@ -459,29 +463,29 @@ proc processInput(rfd: AsyncFD, rng: crypto.Rng) {.async.} =
   if conf.kadBootstrapNodes.len > 0:
     var kadBootstrapPeers: seq[(PeerId, seq[MultiAddress])]
     for nodeStr in conf.kadBootstrapNodes:
-      let (peerId, ma) = parseFullAddress(nodeStr).valueOr:
-        error "Failed to parse kademlia bootstrap node", node = nodeStr, error = error
-        continue
+      let (peerId, ma) = block:
+        let r = parseFullAddress(nodeStr)
+        if r.isErr:
+          error "Failed to parse kademlia bootstrap node",
+            node = nodeStr, error = r.error
+          continue
+        r.get()
       kadBootstrapPeers.add((peerId, @[ma]))
 
     if kadBootstrapPeers.len > 0:
-      node.wakuKademlia = WakuKademlia.new(
-        node.switch,
-        ExtendedKademliaDiscoveryParams(
+      node.mountKademlia(
+        KademliaDiscoveryConf(
           bootstrapNodes: kadBootstrapPeers,
-          mixPubKey: some(mixPubKey),
-          advertiseMix: false,
-        ),
-        node.peerManager,
-        getMixNodePoolSize = proc(): int {.gcsafe, raises: [].} =
-          if node.wakuMix.isNil():
-            0
-          else:
-            node.getMixNodePoolSize(),
-        isNodeStarted = proc(): bool {.gcsafe, raises: [].} =
-          node.started,
-      ).valueOr:
-        error "failed to setup kademlia discovery", error = error
+          servicesToDiscover: @["mix"],
+          randomLookupInterval: chronos.seconds(60),
+          serviceLookupInterval: chronos.seconds(60),
+          kadDhtConfig: KadDHTConfig.new(),
+          discoConfig: sd_types.ServiceDiscoveryConfig.new(),
+          clientMode: false,
+          xprPublishing: true,
+        )
+      ).isOkOr:
+        error "failed to setup service discovery", error = error
         quit(QuitFailure)
 
   #await node.mountRendezvousClient(conf.clusterId)
@@ -489,10 +493,6 @@ proc processInput(rfd: AsyncFD, rng: crypto.Rng) {.async.} =
   await node.start()
 
   node.peerManager.start()
-  if not node.wakuKademlia.isNil():
-    (await node.wakuKademlia.start(minMixPeers = MinMixNodePoolSize)).isOkOr:
-      error "failed to start kademlia discovery", error = error
-      quit(QuitFailure)
 
   await node.mountLibp2pPing()
   #await node.mountPeerExchangeClient()

--- a/logos_delivery/waku/discovery/waku_kademlia.nim
+++ b/logos_delivery/waku/discovery/waku_kademlia.nim
@@ -1,7 +1,7 @@
 import logos_delivery/waku/compat/option_valueor
 {.push raises: [].}
 
-import std/[sequtils, sets]
+import std/[options, sequtils, sets]
 import
   chronos,
   chronicles,
@@ -39,6 +39,17 @@ type WakuKademlia* = ref object
   serviceLookupInterval: Duration
   servicesToDiscover: HashSet[string]
   servicesToAdvertise: HashSet[ServiceInfo]
+
+type KademliaDiscoveryConf* = object
+  bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
+  servicesToAdvertise*: seq[ServiceInfo]
+  servicesToDiscover*: seq[string]
+  randomLookupInterval*: Duration
+  serviceLookupInterval*: Duration
+  kadDhtConfig*: KadDHTConfig
+  discoConfig*: ServiceDiscoveryConfig
+  clientMode*: bool
+  xprPublishing*: bool
 
 proc extractMixPubKey(service: ServiceInfo): Option[Curve25519Key] =
   if service.id != MixProtocolID:

--- a/logos_delivery/waku/discovery/waku_kademlia.nim
+++ b/logos_delivery/waku/discovery/waku_kademlia.nim
@@ -1,7 +1,7 @@
 import logos_delivery/waku/compat/option_valueor
 {.push raises: [].}
 
-import std/[options, sequtils]
+import std/[sequtils, sets]
 import
   chronos,
   chronicles,
@@ -9,275 +9,244 @@ import
   stew/byteutils,
   libp2p/[peerid, multiaddress, switch],
   libp2p/extended_peer_record,
+  libp2p/crypto/crypto,
+  libp2p/crypto/rng,
   libp2p/crypto/curve25519,
-  libp2p/protocols/[kademlia, service_discovery],
-  libp2p/protocols/service_discovery/types as svdisc_types,
-  libp2p_mix/mix_protocol
+  libp2p/protocols/service_discovery,
+  libp2p/protocols/service_discovery/types,
+  libp2p/protocols/kademlia/types,
+  libp2p_mix/mix_protocol,
+  libp2p_mix/curve25519
 
-import logos_delivery/waku/waku_core, logos_delivery/waku/node/peer_manager
+import
+  logos_delivery/waku/waku_core,
+  logos_delivery/waku/node/peer_manager,
+  logos_delivery/waku/events/discovery_events
 
 logScope:
-  topics = "waku extended kademlia discovery"
+  topics = "waku service discovery"
 
 const
-  DefaultExtendedKademliaDiscoveryInterval* = chronos.seconds(5)
-  ExtendedKademliaDiscoveryStartupDelay* = chronos.seconds(5)
+  DefaultServiceDiscoveryInterval* = chronos.seconds(60)
+  DefaultRandomDiscoveryInterval* = chronos.seconds(60)
 
-type
-  MixNodePoolSizeProvider* = proc(): int {.gcsafe, raises: [].}
-  NodeStartedProvider* = proc(): bool {.gcsafe, raises: [].}
-
-  ExtendedKademliaDiscoveryParams* = object
-    bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
-    mixPubKey*: Option[Curve25519Key]
-    advertiseMix*: bool = false
-
-  WakuKademlia* = ref object
-    protocol*: ServiceDiscovery
-    peerManager: PeerManager
-    discoveryLoop: Future[void]
-    running*: bool
-    getMixNodePoolSize: MixNodePoolSizeProvider
-    isNodeStarted: NodeStartedProvider
-
-proc new*(
-    T: type WakuKademlia,
-    switch: Switch,
-    params: ExtendedKademliaDiscoveryParams,
-    peerManager: PeerManager,
-    getMixNodePoolSize: MixNodePoolSizeProvider = nil,
-    isNodeStarted: NodeStartedProvider = nil,
-): Result[T, string] =
-  if params.bootstrapNodes.len == 0:
-    info "creating kademlia discovery as seed node (no bootstrap nodes)"
-
-  let kademlia = ServiceDiscovery.new(
-    switch,
-    bootstrapNodes = params.bootstrapNodes,
-    config = KadDHTConfig.new(
-      validator = svdisc_types.ExtEntryValidator(),
-      selector = svdisc_types.ExtEntrySelector(),
-    ),
-    rng = switch.rng,
-    codec = ExtendedServiceDiscoveryCodec,
-  )
-
-  try:
-    switch.mount(kademlia)
-  except CatchableError:
-    return err("failed to mount kademlia discovery: " & getCurrentExceptionMsg())
-
-  # Register services BEFORE starting kademlia so they are included in the
-  # initial self-signed peer record published to the DHT
-  if params.advertiseMix:
-    if params.mixPubKey.isSome():
-      kademlia.startAdvertising(
-        ServiceInfo(id: MixProtocolID, data: @(params.mixPubKey.get()))
-      )
-      debug "extended kademlia advertising mix service",
-        keyHex = byteutils.toHex(params.mixPubKey.get()),
-        bootstrapNodes = params.bootstrapNodes.len
-    else:
-      warn "mix advertising enabled but no key provided"
-
-  info "kademlia discovery created",
-    bootstrapNodes = params.bootstrapNodes.len, advertiseMix = params.advertiseMix
-
-  return ok(
-    WakuKademlia(
-      protocol: kademlia,
-      peerManager: peerManager,
-      running: false,
-      getMixNodePoolSize: getMixNodePoolSize,
-      isNodeStarted: isNodeStarted,
-    )
-  )
+type WakuKademlia* = ref object
+  protocol*: ServiceDiscovery
+  peerManager: PeerManager
+  randomLookupLoop: Future[void]
+  serviceLookupLoop: Future[void]
+  randomLookupInterval: Duration
+  serviceLookupInterval: Duration
+  servicesToDiscover: HashSet[string]
+  servicesToAdvertise: HashSet[ServiceInfo]
 
 proc extractMixPubKey(service: ServiceInfo): Option[Curve25519Key] =
   if service.id != MixProtocolID:
-    trace "service is not mix protocol",
-      serviceId = service.id, mixProtocolId = MixProtocolID
     return none(Curve25519Key)
 
   if service.data.len != Curve25519KeySize:
-    warn "invalid mix pub key length from kademlia record",
+    error "invalid mix pub key length",
       expected = Curve25519KeySize,
       actual = service.data.len,
       dataHex = byteutils.toHex(service.data)
     return none(Curve25519Key)
 
-  debug "found mix protocol service",
-    dataLen = service.data.len, expectedLen = Curve25519KeySize
-
   let key = intoCurve25519Key(service.data)
-  debug "successfully extracted mix pub key", keyHex = byteutils.toHex(key)
+
   return some(key)
 
 proc remotePeerInfoFrom(record: ExtendedPeerRecord): Option[RemotePeerInfo] =
-  debug "processing kademlia record",
-    peerId = record.peerId,
-    numAddresses = record.addresses.len,
-    numServices = record.services.len,
-    serviceIds = record.services.mapIt(it.id)
-
   if record.addresses.len == 0:
-    trace "kademlia record missing addresses", peerId = record.peerId
+    error "missing addresses", peerId = record.peerId
     return none(RemotePeerInfo)
 
   let addrs = record.addresses.mapIt(it.address)
   if addrs.len == 0:
-    trace "kademlia record produced no dialable addresses", peerId = record.peerId
+    error "no dialable addresses", peerId = record.peerId
     return none(RemotePeerInfo)
 
-  let protocols = record.services.mapIt(it.id)
-
-  var mixPubKey = none(Curve25519Key)
+  var mixPubKey: Option[Curve25519Key] = none(Curve25519Key)
   for service in record.services:
-    debug "checking service",
-      peerId = record.peerId, serviceId = service.id, dataLen = service.data.len
-    mixPubKey = extractMixPubKey(service)
-    if mixPubKey.isSome():
-      debug "extracted mix public key from service", peerId = record.peerId
-      break
+    let key = extractMixPubKey(service).valueOr:
+      continue
+    mixPubKey = some(key)
 
-  if record.services.len > 0 and mixPubKey.isNone():
-    debug "record has services but no valid mix key",
-      peerId = record.peerId, services = record.services.mapIt(it.id)
-    return none(RemotePeerInfo)
+    trace "successfully extracted mix pub key",
+      peerId = record.peerId, keyHex = byteutils.toHex(mixPubKey.get())
+
+    break
+
   return some(
     RemotePeerInfo.init(
-      record.peerId,
-      addrs = addrs,
-      protocols = protocols,
-      origin = PeerOrigin.Kademlia,
-      mixPubKey = mixPubKey,
+      record.peerId, addrs = addrs, origin = PeerOrigin.Kademlia, mixPubKey = mixPubKey
     )
   )
 
-proc lookupMixPeers*(
-    wk: WakuKademlia
-): Future[Result[int, string]] {.async: (raises: []).} =
-  ## Lookup mix peers via kademlia and add them to the peer store.
-  ## Returns the number of mix peers found and added.
-  if wk.protocol.isNil():
-    return err("cannot lookup mix peers: kademlia not mounted")
+proc lookupServicePeers*(
+    self: WakuKademlia, service: string
+): Future[Result[seq[RemotePeerInfo], string]] {.async: (raises: []).} =
+  if self.protocol.isNil():
+    return err("cannot lookup service peers: service discovery not mounted")
 
-  let mixService = ServiceInfo(id: MixProtocolID, data: @[])
-  var records: seq[ExtendedPeerRecord]
-  try:
-    let advertisements = (await wk.protocol.lookup(mixService)).valueOr:
-      return err("mix peer lookup failed: " & $error)
-    records = advertisements.mapIt(it.data)
-  except CatchableError:
-    return err("mix peer lookup failed: " & getCurrentExceptionMsg())
+  let serviceId = service.hashServiceId()
 
-  debug "mix peer lookup returned records", numRecords = records.len
+  let lookupCatch = catch:
+    (await self.protocol.lookup(serviceId))
 
-  var added = 0
-  for record in records:
-    let peerOpt = remotePeerInfoFrom(record)
-    if peerOpt.isNone():
+  let lookupResult = lookupCatch.valueOr:
+    return err("service peer lookup failed: " & error.msg)
+
+  let advertisements = lookupResult.valueOr:
+    return err("service peer lookup failed: " & lookupResult.error)
+
+  var discovered: seq[RemotePeerInfo]
+  for ad in advertisements:
+    let record = ad.data
+    let peerInfo = remotePeerInfoFrom(record).valueOr:
       continue
 
-    let peerInfo = peerOpt.get()
-    if peerInfo.mixPubKey.isNone():
+    self.peerManager.addPeer(peerInfo, PeerOrigin.Kademlia)
+
+    debug "peer added via service discovery",
+      service,
+      peerId = $peerInfo.peerId,
+      addresses = peerInfo.addrs.mapIt($it),
+      protocols = peerInfo.protocols
+
+    discovered.add(peerInfo)
+
+  debug "service lookup complete", service, found = discovered.len
+
+  return ok(discovered)
+
+proc runRandomLookupLoop(self: WakuKademlia) {.async: (raises: [CancelledError]).} =
+  debug "periodic random lookup started", interval = $self.randomLookupInterval
+
+  while true:
+    await sleepAsync(self.randomLookupInterval)
+
+    let recordsRes = catch:
+      (await self.protocol.lookupRandom())
+
+    let records = recordsRes.valueOr:
+      error "random lookup failed", error
       continue
 
-    wk.peerManager.addPeer(peerInfo, PeerOrigin.Kademlia)
-    info "mix peer added via kademlia lookup",
-      peerId = $peerInfo.peerId, mixPubKey = byteutils.toHex(peerInfo.mixPubKey.get())
-    added.inc()
-
-  info "mix peer lookup complete", found = added
-  return ok(added)
-
-proc runDiscoveryLoop(
-    wk: WakuKademlia, interval: Duration, minMixPeers: int
-) {.async: (raises: []).} =
-  info "extended kademlia discovery loop started", interval = interval
-
-  try:
-    while true:
-      # Wait for node to be started
-      if not wk.isNodeStarted.isNil() and not wk.isNodeStarted():
-        await sleepAsync(ExtendedKademliaDiscoveryStartupDelay)
+    var discoveredPeers: seq[RemotePeerInfo]
+    for record in records:
+      let peerInfo = remotePeerInfoFrom(record).valueOr:
         continue
 
-      var records: seq[ExtendedPeerRecord]
-      try:
-        records = await wk.protocol.lookupRandom()
-      except CatchableError as e:
-        warn "extended kademlia discovery failed", error = e.msg
-        await sleepAsync(interval)
+      self.peerManager.addPeer(peerInfo, PeerOrigin.Kademlia)
+
+      debug "peer added via random walk",
+        peerId = $peerInfo.peerId,
+        addresses = peerInfo.addrs.mapIt($it),
+        protocols = peerInfo.protocols
+
+      discoveredPeers.add(peerInfo)
+
+    if discoveredPeers.len > 0:
+      PeersDiscoveredEvent.emit(peers = discoveredPeers)
+
+    debug "random lookup complete", found = discoveredPeers.len
+
+proc runServiceLookupLoop(self: WakuKademlia) {.async: (raises: [CancelledError]).} =
+  debug "periodic service lookup started",
+    interval = $self.serviceLookupInterval, services = self.servicesToDiscover
+
+  while true:
+    await sleepAsync(self.serviceLookupInterval)
+
+    for service in self.servicesToDiscover:
+      let discovered = (await self.lookupServicePeers(service)).valueOr:
+        error "service lookup failed", service, error
         continue
 
-      debug "received random records from kademlia", numRecords = records.len
+      if discovered.len > 0:
+        PeersDiscoveredEvent.emit(peers = discovered)
 
-      var added = 0
-      for record in records:
-        let peerOpt = remotePeerInfoFrom(record)
-        if peerOpt.isNone():
-          continue
+proc new*(
+    T: type WakuKademlia,
+    switch: Switch,
+    peerManager: PeerManager,
+    bootstrapNodes: seq[(PeerId, seq[MultiAddress])],
+    servicesToAdvertise: seq[ServiceInfo],
+    servicesToDiscover: seq[string],
+    randomLookupInterval: Duration = DefaultRandomDiscoveryInterval,
+    serviceLookupInterval: Duration = DefaultServiceDiscoveryInterval,
+    rng: Rng,
+    kadDhtConfig: KadDHTConfig = KadDHTConfig.new(),
+    discoConfig: ServiceDiscoveryConfig = ServiceDiscoveryConfig.new(),
+    clientMode: bool = false,
+    xprPublishing: bool = true,
+): Result[T, string] =
+  if bootstrapNodes.len == 0:
+    debug "creating service discovery as seed node (no bootstrap nodes)"
 
-        let peerInfo = peerOpt.get()
-        wk.peerManager.addPeer(peerInfo, PeerOrigin.Kademlia)
-        debug "peer added via extended kademlia discovery",
-          peerId = $peerInfo.peerId,
-          addresses = peerInfo.addrs.mapIt($it),
-          protocols = peerInfo.protocols,
-          hasMixPubKey = peerInfo.mixPubKey.isSome()
-        added.inc()
+  let protocol = ServiceDiscovery.new(
+    switch,
+    bootstrapNodes = bootstrapNodes,
+    config = kadDhtConfig,
+    rng = rng,
+    client = clientMode,
+    services = servicesToAdvertise,
+    discoConfig = discoConfig,
+    xprPublishing = xprPublishing,
+  )
 
-      if added > 0:
-        info "added peers from extended kademlia discovery", count = added
+  let self = WakuKademlia(
+    protocol: protocol,
+    peerManager: peerManager,
+    randomLookupInterval: randomLookupInterval,
+    serviceLookupInterval: serviceLookupInterval,
+    servicesToDiscover: servicesToDiscover.toHashSet(),
+    servicesToAdvertise: servicesToAdvertise.toHashSet(),
+  )
 
-      # Targeted mix peer lookup when pool is low
-      if minMixPeers > 0 and not wk.getMixNodePoolSize.isNil() and
-          wk.getMixNodePoolSize() < minMixPeers:
-        debug "mix node pool below threshold, performing targeted lookup",
-          currentPoolSize = wk.getMixNodePoolSize(), threshold = minMixPeers
-        let found = (await wk.lookupMixPeers()).valueOr:
-          warn "targeted mix peer lookup failed", error = error
-          0
-        if found > 0:
-          info "found mix peers via targeted kademlia lookup", count = found
+  return ok(self)
 
-      await sleepAsync(interval)
-  except CancelledError as e:
-    debug "extended kademlia discovery loop cancelled", error = e.msg
-  except CatchableError as e:
-    error "extended kademlia discovery loop failed", error = e.msg
+proc start*(self: WakuKademlia) {.async: (raises: []).} =
+  for serviceId in self.servicesToDiscover:
+    discard self.protocol.registerInterest(serviceId)
 
-proc start*(
-    wk: WakuKademlia,
-    interval: Duration = DefaultExtendedKademliaDiscoveryInterval,
-    minMixPeers: int = 0,
-): Future[Result[void, string]] {.async: (raises: []).} =
-  if wk.running:
-    return err("already running")
+  if self.randomLookupLoop.isNil():
+    self.randomLookupLoop = self.runRandomLookupLoop()
 
-  try:
-    await wk.protocol.start()
-  except CatchableError as e:
-    return err("failed to start kademlia discovery: " & e.msg)
-
-  wk.discoveryLoop = wk.runDiscoveryLoop(interval, minMixPeers)
+  if self.serviceLookupLoop.isNil():
+    self.serviceLookupLoop = self.runServiceLookupLoop()
 
   info "kademlia discovery started"
-  return ok()
 
-proc stop*(wk: WakuKademlia) {.async: (raises: []).} =
-  if not wk.running:
-    return
+proc stop*(self: WakuKademlia) {.async: (raises: []).} =
+  if not self.serviceLookupLoop.isNil():
+    await self.serviceLookupLoop.cancelAndWait()
+    self.serviceLookupLoop = nil
 
-  info "Stopping kademlia discovery"
+  if not self.randomLookupLoop.isNil():
+    await self.randomLookupLoop.cancelAndWait()
+    self.randomLookupLoop = nil
 
-  wk.running = false
+  info "kademlia discovery stopped"
 
-  if not wk.discoveryLoop.isNil():
-    await wk.discoveryLoop.cancelAndWait()
-    wk.discoveryLoop = nil
+proc addServiceToDiscover*(self: WakuKademlia, service: string) =
+  if not self.servicesToDiscover.containsOrIncl(service):
+    discard self.protocol.registerInterest(service)
+    debug "added service to discover", service
 
-  if not wk.protocol.isNil():
-    await wk.protocol.stop()
-  info "Successfully stopped kademlia discovery"
+proc addServiceToAdvertise*(self: WakuKademlia, service: ServiceInfo) =
+  if not self.servicesToAdvertise.containsOrIncl(service):
+    self.protocol.startAdvertising(service)
+    debug "added service to advertise", service = service.id
+
+proc removeServiceToDiscover*(self: WakuKademlia, service: string) =
+  if not self.servicesToDiscover.missingOrExcl(service):
+    self.protocol.unregisterInterest(service)
+    debug "removed service to discover", service
+
+proc removeServiceToAdvertise*(
+    self: WakuKademlia, service: ServiceInfo
+) {.async: (raises: [CancelledError]).} =
+  if not self.servicesToAdvertise.missingOrExcl(service):
+    await self.protocol.stopAdvertising(service.id)
+    debug "removed service to advertise", service = service.id

--- a/logos_delivery/waku/discovery/waku_kademlia.nim
+++ b/logos_delivery/waku/discovery/waku_kademlia.nim
@@ -7,7 +7,7 @@ import
   chronicles,
   results,
   stew/byteutils,
-  libp2p/[peerid, multiaddress, switch],
+  libp2p/[peerid, multiaddress, switch, extended_peer_record],
   libp2p/extended_peer_record,
   libp2p/crypto/crypto,
   libp2p/crypto/rng,
@@ -42,8 +42,8 @@ type WakuKademlia* = ref object
 
 type KademliaDiscoveryConf* = object
   bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
-  servicesToAdvertise*: seq[ServiceInfo]
-  servicesToDiscover*: seq[string]
+  servicesToAdvertise*: HashSet[ServiceInfo]
+  servicesToDiscover*: HashSet[string]
   randomLookupInterval*: Duration
   serviceLookupInterval*: Duration
   kadDhtConfig*: KadDHTConfig
@@ -51,12 +51,12 @@ type KademliaDiscoveryConf* = object
   clientMode*: bool
   xprPublishing*: bool
 
-proc extractMixPubKey(service: ServiceInfo): Option[Curve25519Key] =
+proc extractMixPubKey*(service: ServiceInfo): Option[Curve25519Key] =
   if service.id != MixProtocolID:
     return none(Curve25519Key)
 
   if service.data.len != Curve25519KeySize:
-    error "invalid mix pub key length",
+    trace "invalid mix pub key length",
       expected = Curve25519KeySize,
       actual = service.data.len,
       dataHex = byteutils.toHex(service.data)
@@ -66,15 +66,17 @@ proc extractMixPubKey(service: ServiceInfo): Option[Curve25519Key] =
 
   return some(key)
 
-proc remotePeerInfoFrom(record: ExtendedPeerRecord): Option[RemotePeerInfo] =
+proc remotePeerInfoFrom*(record: ExtendedPeerRecord): Option[RemotePeerInfo] =
   if record.addresses.len == 0:
-    error "missing addresses", peerId = record.peerId
+    trace "missing addresses", peerId = record.peerId
     return none(RemotePeerInfo)
 
   let addrs = record.addresses.mapIt(it.address)
   if addrs.len == 0:
-    error "no dialable addresses", peerId = record.peerId
+    trace "no dialable addresses", peerId = record.peerId
     return none(RemotePeerInfo)
+
+  let protocols = record.services.mapIt(it.id)
 
   var mixPubKey: Option[Curve25519Key] = none(Curve25519Key)
   for service in record.services:
@@ -89,9 +91,33 @@ proc remotePeerInfoFrom(record: ExtendedPeerRecord): Option[RemotePeerInfo] =
 
   return some(
     RemotePeerInfo.init(
-      record.peerId, addrs = addrs, origin = PeerOrigin.Kademlia, mixPubKey = mixPubKey
+      record.peerId,
+      addrs = addrs,
+      protocols = protocols,
+      origin = PeerOrigin.Kademlia,
+      mixPubKey = mixPubKey,
     )
   )
+
+proc processRecords(
+    self: WakuKademlia, records: seq[ExtendedPeerRecord], source: string
+): seq[RemotePeerInfo] =
+  var discovered: seq[RemotePeerInfo]
+  for record in records:
+    let peerInfo = remotePeerInfoFrom(record).valueOr:
+      continue
+
+    self.peerManager.addPeer(peerInfo, PeerOrigin.Kademlia)
+
+    debug "peer added via service discovery",
+      source,
+      peerId = $peerInfo.peerId,
+      addresses = peerInfo.addrs.mapIt($it),
+      protocols = peerInfo.protocols
+
+    discovered.add(peerInfo)
+
+  return discovered
 
 proc lookupServicePeers*(
     self: WakuKademlia, service: string
@@ -110,21 +136,9 @@ proc lookupServicePeers*(
   let advertisements = lookupResult.valueOr:
     return err("service peer lookup failed: " & lookupResult.error)
 
-  var discovered: seq[RemotePeerInfo]
-  for ad in advertisements:
-    let record = ad.data
-    let peerInfo = remotePeerInfoFrom(record).valueOr:
-      continue
+  let records = advertisements.mapIt(it.data)
 
-    self.peerManager.addPeer(peerInfo, PeerOrigin.Kademlia)
-
-    debug "peer added via service discovery",
-      service,
-      peerId = $peerInfo.peerId,
-      addresses = peerInfo.addrs.mapIt($it),
-      protocols = peerInfo.protocols
-
-    discovered.add(peerInfo)
+  let discovered = self.processRecords(records, "service lookup")
 
   debug "service lookup complete", service, found = discovered.len
 
@@ -143,24 +157,12 @@ proc runRandomLookupLoop(self: WakuKademlia) {.async: (raises: [CancelledError])
       error "random lookup failed", error
       continue
 
-    var discoveredPeers: seq[RemotePeerInfo]
-    for record in records:
-      let peerInfo = remotePeerInfoFrom(record).valueOr:
-        continue
+    let discovered = self.processRecords(records, "random walk")
 
-      self.peerManager.addPeer(peerInfo, PeerOrigin.Kademlia)
+    if discovered.len > 0:
+      PeersDiscoveredEvent.emit(peers = discovered)
 
-      debug "peer added via random walk",
-        peerId = $peerInfo.peerId,
-        addresses = peerInfo.addrs.mapIt($it),
-        protocols = peerInfo.protocols
-
-      discoveredPeers.add(peerInfo)
-
-    if discoveredPeers.len > 0:
-      PeersDiscoveredEvent.emit(peers = discoveredPeers)
-
-    debug "random lookup complete", found = discoveredPeers.len
+    debug "random lookup complete", found = discovered.len
 
 proc runServiceLookupLoop(self: WakuKademlia) {.async: (raises: [CancelledError]).} =
   debug "periodic service lookup started",
@@ -169,21 +171,36 @@ proc runServiceLookupLoop(self: WakuKademlia) {.async: (raises: [CancelledError]
   while true:
     await sleepAsync(self.serviceLookupInterval)
 
-    for service in self.servicesToDiscover:
-      let discovered = (await self.lookupServicePeers(service)).valueOr:
-        error "service lookup failed", service, error
+    let futs = self.servicesToDiscover.mapIt(self.lookupServicePeers(it))
+
+    let finishedFuts = await allFinished(futs)
+
+    var discovered: seq[RemotePeerInfo]
+    for fut in finishedFuts:
+      let catchRes = catch:
+        fut.read()
+
+      let res = catchRes.valueOr:
+        error "service lookup failed", error
         continue
 
-      if discovered.len > 0:
-        PeersDiscoveredEvent.emit(peers = discovered)
+      let peerInfos = res.valueOr:
+        error "service lookup failed", error
+        continue
+
+      for peerInfo in peerInfos:
+        discovered.add(peerInfo)
+
+    if discovered.len > 0:
+      PeersDiscoveredEvent.emit(peers = discovered)
 
 proc new*(
     T: type WakuKademlia,
     switch: Switch,
     peerManager: PeerManager,
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])],
-    servicesToAdvertise: seq[ServiceInfo],
-    servicesToDiscover: seq[string],
+    servicesToAdvertise: HashSet[ServiceInfo],
+    servicesToDiscover: HashSet[string],
     randomLookupInterval: Duration = DefaultRandomDiscoveryInterval,
     serviceLookupInterval: Duration = DefaultServiceDiscoveryInterval,
     rng: Rng,
@@ -201,7 +218,7 @@ proc new*(
     config = kadDhtConfig,
     rng = rng,
     client = clientMode,
-    services = servicesToAdvertise,
+    services = servicesToAdvertise.toSeq(),
     discoConfig = discoConfig,
     xprPublishing = xprPublishing,
   )
@@ -211,8 +228,8 @@ proc new*(
     peerManager: peerManager,
     randomLookupInterval: randomLookupInterval,
     serviceLookupInterval: serviceLookupInterval,
-    servicesToDiscover: servicesToDiscover.toHashSet(),
-    servicesToAdvertise: servicesToAdvertise.toHashSet(),
+    servicesToDiscover: servicesToDiscover,
+    servicesToAdvertise: servicesToAdvertise,
   )
 
   return ok(self)

--- a/logos_delivery/waku/events/discovery_events.nim
+++ b/logos_delivery/waku/events/discovery_events.nim
@@ -1,0 +1,15 @@
+import libp2p/peerinfo, brokers/[event_broker, request_broker]
+import logos_delivery/waku/waku_core
+
+EventBroker:
+  # Event emitted when peers are discovered via random or service lookup
+  type PeersDiscoveredEvent* = object
+    peers*: seq[RemotePeerInfo]
+
+RequestBroker:
+  # Request broker for on-demand service peer lookup
+  type ServicePeersRequest* = object
+    serviceId*: string
+    peers*: seq[RemotePeerInfo]
+
+  proc signature*(serviceId: string): Future[Result[ServicePeersRequest, string]]

--- a/logos_delivery/waku/events/events.nim
+++ b/logos_delivery/waku/events/events.nim
@@ -1,3 +1,9 @@
-import ./[message_events, delivery_events, health_events, peer_events, lifecycle_events]
+import
+  ./[
+    message_events, delivery_events, health_events, peer_events, lifecycle_events,
+    discovery_events,
+  ]
 
-export message_events, delivery_events, health_events, peer_events, lifecycle_events
+export
+  message_events, delivery_events, health_events, peer_events, lifecycle_events,
+  discovery_events

--- a/logos_delivery/waku/factory/conf_builder/kademlia_discovery_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/kademlia_discovery_conf_builder.nim
@@ -1,12 +1,10 @@
 import logos_delivery/waku/compat/option_valueor
 import chronicles, std/options, results
-import logos_delivery/waku/factory/waku_conf
+import logos_delivery/waku/discovery/waku_kademlia
 import chronos
-import libp2p/[peerid, multiaddress, peerinfo, extended_peer_record]
+import libp2p/[peerid, multiaddress, peerinfo]
 import libp2p/protocols/kademlia/types
 import libp2p/protocols/service_discovery/types as sd_types
-import logos_delivery/waku/waku_core/peers
-import logos_delivery/waku/discovery/waku_kademlia
 
 logScope:
   topics = "waku conf builder kademlia discovery"
@@ -16,56 +14,11 @@ const
   DefaultRandomLookupInterval* = chronos.seconds(60)
   DefaultServiceLookupInterval* = chronos.seconds(60)
 
-#######################################
-## Kademlia Discovery Config Builder ##
-#######################################
 type KademliaDiscoveryConfBuilder* = object
   enabled*: Option[bool]
   bootstrapNodes*: seq[string]
-  servicesToAdvertise*: seq[(string, seq[byte])]
-  servicesToDiscover*: seq[string]
   randomLookupInterval*: Option[Duration]
   serviceLookupInterval*: Option[Duration]
-
-  # Top-level ServiceDiscovery.new flags
-  clientMode*: Option[bool]
-  xprPublishing*: Option[bool]
-
-  # Full override (power users / code paths)
-  kadDhtConfig*: Option[KadDHTConfig]
-  discoConfig*: Option[sd_types.ServiceDiscoveryConfig]
-
-  # ServiceDiscoveryConfig scalars (discoConfig)
-  kadKRegister*: Option[int]
-  kadKLookup*: Option[int]
-  kadFLookup*: Option[int]
-  kadFReturn*: Option[int]
-  kadAdvertExpiry*: Option[Duration]
-  kadAdvertCacheCap*: Option[uint64]
-  kadOccupancyExp*: Option[float64]
-  kadSafetyParam*: Option[float64]
-  kadIpSimCoefficient*: Option[float64]
-  kadRegistrationWindow*: Option[Duration]
-  kadBucketsCount*: Option[int]
-
-  # KadDHTConfig scalars (config)
-  kadTimeout*: Option[Duration]
-  kadBucketRefreshTime*: Option[Duration]
-  kadRetries*: Option[int]
-  kadReplication*: Option[int]
-  kadAlpha*: Option[int]
-  kadQuorum*: Option[int]
-  kadProviderRecordCapacity*: Option[int]
-  kadProvidedKeyCapacity*: Option[int]
-  kadRepublishProvidedKeysInterval*: Option[Duration]
-  kadCleanupProvidersInterval*: Option[Duration]
-  kadProviderExpirationInterval*: Option[Duration]
-  kadRecordExpirationInterval*: Option[Duration]
-  kadCleanupDataEntriesInterval*: Option[Duration]
-  kadHideConnectionStatus*: Option[bool]
-  kadDisableBootstrapping*: Option[bool]
-  kadProviderRejection*: Option[bool]
-  kadMaxProvidersPerKey*: Option[int] # use some(-1) or none for Opt.none (unlimited)
 
 proc init*(T: type KademliaDiscoveryConfBuilder): KademliaDiscoveryConfBuilder =
   KademliaDiscoveryConfBuilder()
@@ -78,16 +31,6 @@ proc withBootstrapNodes*(
 ) =
   b.bootstrapNodes = bootstrapNodes
 
-proc withServicesToAdvertise*(
-    b: var KademliaDiscoveryConfBuilder, services: seq[(string, seq[byte])]
-) =
-  b.servicesToAdvertise = services
-
-proc withServicesToDiscover*(
-    b: var KademliaDiscoveryConfBuilder, services: seq[string]
-) =
-  b.servicesToDiscover = services
-
 proc withRandomLookupInterval*(
     b: var KademliaDiscoveryConfBuilder, interval: Duration
 ) =
@@ -97,116 +40,6 @@ proc withServiceLookupInterval*(
     b: var KademliaDiscoveryConfBuilder, interval: Duration
 ) =
   b.serviceLookupInterval = some(interval)
-
-proc withClientMode*(b: var KademliaDiscoveryConfBuilder, client: bool) =
-  b.clientMode = some(client)
-
-proc withXprPublishing*(b: var KademliaDiscoveryConfBuilder, publish: bool) =
-  b.xprPublishing = some(publish)
-
-# Disco config with*
-proc withKadKRegister*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadKRegister = some(v)
-
-proc withKadKLookup*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadKLookup = some(v)
-
-proc withKadFLookup*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadFLookup = some(v)
-
-proc withKadFReturn*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadFReturn = some(v)
-
-proc withKadAdvertExpiry*(b: var KademliaDiscoveryConfBuilder, v: Duration) =
-  b.kadAdvertExpiry = some(v)
-
-proc withKadAdvertCacheCap*(b: var KademliaDiscoveryConfBuilder, v: uint64) =
-  b.kadAdvertCacheCap = some(v)
-
-proc withKadOccupancyExp*(b: var KademliaDiscoveryConfBuilder, v: float64) =
-  b.kadOccupancyExp = some(v)
-
-proc withKadSafetyParam*(b: var KademliaDiscoveryConfBuilder, v: float64) =
-  b.kadSafetyParam = some(v)
-
-proc withKadIpSimCoefficient*(b: var KademliaDiscoveryConfBuilder, v: float64) =
-  b.kadIpSimCoefficient = some(v)
-
-proc withKadRegistrationWindow*(b: var KademliaDiscoveryConfBuilder, v: Duration) =
-  b.kadRegistrationWindow = some(v)
-
-proc withKadBucketsCount*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadBucketsCount = some(v)
-
-# KadDHT config with*
-proc withKadTimeout*(b: var KademliaDiscoveryConfBuilder, v: Duration) =
-  b.kadTimeout = some(v)
-
-proc withKadBucketRefreshTime*(b: var KademliaDiscoveryConfBuilder, v: Duration) =
-  b.kadBucketRefreshTime = some(v)
-
-proc withKadRetries*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadRetries = some(v)
-
-proc withKadReplication*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadReplication = some(v)
-
-proc withKadAlpha*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadAlpha = some(v)
-
-proc withKadQuorum*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadQuorum = some(v)
-
-proc withKadProviderRecordCapacity*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadProviderRecordCapacity = some(v)
-
-proc withKadProvidedKeyCapacity*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadProvidedKeyCapacity = some(v)
-
-proc withKadRepublishProvidedKeysInterval*(
-    b: var KademliaDiscoveryConfBuilder, v: Duration
-) =
-  b.kadRepublishProvidedKeysInterval = some(v)
-
-proc withKadCleanupProvidersInterval*(
-    b: var KademliaDiscoveryConfBuilder, v: Duration
-) =
-  b.kadCleanupProvidersInterval = some(v)
-
-proc withKadProviderExpirationInterval*(
-    b: var KademliaDiscoveryConfBuilder, v: Duration
-) =
-  b.kadProviderExpirationInterval = some(v)
-
-proc withKadRecordExpirationInterval*(
-    b: var KademliaDiscoveryConfBuilder, v: Duration
-) =
-  b.kadRecordExpirationInterval = some(v)
-
-proc withKadCleanupDataEntriesInterval*(
-    b: var KademliaDiscoveryConfBuilder, v: Duration
-) =
-  b.kadCleanupDataEntriesInterval = some(v)
-
-proc withKadHideConnectionStatus*(b: var KademliaDiscoveryConfBuilder, v: bool) =
-  b.kadHideConnectionStatus = some(v)
-
-proc withKadDisableBootstrapping*(b: var KademliaDiscoveryConfBuilder, v: bool) =
-  b.kadDisableBootstrapping = some(v)
-
-proc withKadProviderRejection*(b: var KademliaDiscoveryConfBuilder, v: bool) =
-  b.kadProviderRejection = some(v)
-
-proc withKadMaxProvidersPerKey*(b: var KademliaDiscoveryConfBuilder, v: int) =
-  b.kadMaxProvidersPerKey = some(v)
-
-proc withKadDhtConfig*(b: var KademliaDiscoveryConfBuilder, c: KadDHTConfig) =
-  b.kadDhtConfig = some(c)
-
-proc withDiscoConfig*(
-    b: var KademliaDiscoveryConfBuilder, c: sd_types.ServiceDiscoveryConfig
-) =
-  b.discoConfig = some(c)
 
 proc build*(
     b: KademliaDiscoveryConfBuilder
@@ -224,74 +57,16 @@ proc build*(
       return err("Failed to parse kademlia bootstrap node: " & error)
     parsedNodes.add((peerId, @[ma]))
 
-  var servicesToAdvertise: seq[ServiceInfo]
-  for (serviceId, data) in b.servicesToAdvertise:
-    servicesToAdvertise.add(ServiceInfo(id: serviceId, data: data))
-
-  let kadDht =
-    if b.kadDhtConfig.isSome():
-      b.kadDhtConfig.get()
-    else:
-      KadDHTConfig.new(
-        timeout = b.kadTimeout.get(DefaultTimeout),
-        bucketRefreshTime = b.kadBucketRefreshTime.get(DefaultBucketRefreshTime),
-        retries = b.kadRetries.get(DefaultRetries),
-        replication = b.kadReplication.get(DefaultReplication),
-        alpha = b.kadAlpha.get(DefaultAlpha),
-        quorum = b.kadQuorum.get(DefaultQuorum),
-        providerRecordCapacity =
-          b.kadProviderRecordCapacity.get(DefaultProviderRecordCapacity),
-        providedKeyCapacity = b.kadProvidedKeyCapacity.get(DefaultProvidedKeyCapacity),
-        republishProvidedKeysInterval =
-          b.kadRepublishProvidedKeysInterval.get(DefaultRepublishInterval),
-        cleanupProvidersInterval =
-          b.kadCleanupProvidersInterval.get(DefaultCleanupProvidersInterval),
-        providerExpirationInterval =
-          b.kadProviderExpirationInterval.get(DefaultProviderExpirationInterval),
-        recordExpirationInterval =
-          b.kadRecordExpirationInterval.get(DefaultRecordExpirationInterval),
-        cleanupDataEntriesInterval =
-          b.kadCleanupDataEntriesInterval.get(DefaultCleanupDataEntriesInterval),
-        hideConnectionStatus = b.kadHideConnectionStatus.get(true),
-        disableBootstrapping = b.kadDisableBootstrapping.get(false),
-        providerRejection = b.kadProviderRejection.get(false),
-        maxProvidersPerKey =
-          if b.kadMaxProvidersPerKey.isSome() and b.kadMaxProvidersPerKey.get() > 0:
-            Opt.some(b.kadMaxProvidersPerKey.get())
-          else:
-            Opt.none(int),
-      )
-
-  let discoC =
-    if b.discoConfig.isSome():
-      b.discoConfig.get()
-    else:
-      sd_types.ServiceDiscoveryConfig.new(
-        kRegister = b.kadKRegister.get(sd_types.Default_K_register),
-        kLookup = b.kadKLookup.get(sd_types.Default_K_lookup),
-        fLookup = b.kadFLookup.get(sd_types.Default_F_lookup),
-        fReturn = b.kadFReturn.get(sd_types.Default_F_return),
-        advertExpiry = b.kadAdvertExpiry.get(sd_types.Default_E),
-        advertCacheCap = b.kadAdvertCacheCap.get(sd_types.Default_C),
-        occupancyExp = b.kadOccupancyExp.get(sd_types.Default_P_occ),
-        safetyParam = b.kadSafetyParam.get(sd_types.Default_G),
-        ipSimCoefficient = b.kadIpSimCoefficient.get(sd_types.Default_IpSimCoefficient),
-        registrationWindow = b.kadRegistrationWindow.get(sd_types.Default_Delta),
-        bucketsCount = b.kadBucketsCount.get(sd_types.Default_M_buckets),
-      )
-
   return ok(
     some(
       KademliaDiscoveryConf(
         bootstrapNodes: parsedNodes,
-        servicesToAdvertise: servicesToAdvertise,
-        servicesToDiscover: b.servicesToDiscover,
         randomLookupInterval: b.randomLookupInterval.get(DefaultRandomLookupInterval),
         serviceLookupInterval: b.serviceLookupInterval.get(DefaultServiceLookupInterval),
-        kadDhtConfig: kadDht,
-        discoConfig: discoC,
-        clientMode: b.clientMode.get(false),
-        xprPublishing: b.xprPublishing.get(true),
+        kadDhtConfig: KadDHTConfig.new(),
+        discoConfig: sd_types.ServiceDiscoveryConfig.new(),
+        clientMode: false,
+        xprPublishing: true,
       )
     )
   )

--- a/logos_delivery/waku/factory/conf_builder/kademlia_discovery_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/kademlia_discovery_conf_builder.nim
@@ -1,12 +1,30 @@
 import logos_delivery/waku/compat/option_valueor
 import chronicles, std/options, results
-import libp2p/[peerid, multiaddress, peerinfo]
 import logos_delivery/waku/factory/waku_conf
+import chronos
+import libp2p/[peerid, multiaddress, peerinfo, extended_peer_record]
+import libp2p/protocols/kademlia/types
+import libp2p/protocols/service_discovery/types as sd_types
+import logos_delivery/waku/waku_core/peers
 
 logScope:
   topics = "waku conf builder kademlia discovery"
 
-const DefaultKadEnabled*: bool = false
+type KademliaDiscoveryConf* = object
+  bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
+  servicesToAdvertise*: seq[ServiceInfo]
+  servicesToDiscover*: seq[string]
+  randomLookupInterval*: Duration
+  serviceLookupInterval*: Duration
+  kadDhtConfig*: KadDHTConfig
+  discoConfig*: sd_types.ServiceDiscoveryConfig
+  clientMode*: bool
+  xprPublishing*: bool
+
+const
+  DefaultKadEnabled*: bool = false
+  DefaultRandomLookupInterval* = chronos.seconds(60)
+  DefaultServiceLookupInterval* = chronos.seconds(60)
 
 #######################################
 ## Kademlia Discovery Config Builder ##
@@ -14,6 +32,50 @@ const DefaultKadEnabled*: bool = false
 type KademliaDiscoveryConfBuilder* = object
   enabled*: Option[bool]
   bootstrapNodes*: seq[string]
+  servicesToAdvertise*: seq[(string, seq[byte])]
+  servicesToDiscover*: seq[string]
+  randomLookupInterval*: Option[Duration]
+  serviceLookupInterval*: Option[Duration]
+
+  # Top-level ServiceDiscovery.new flags
+  clientMode*: Option[bool]
+  xprPublishing*: Option[bool]
+
+  # Full override (power users / code paths)
+  kadDhtConfig*: Option[KadDHTConfig]
+  discoConfig*: Option[sd_types.ServiceDiscoveryConfig]
+
+  # ServiceDiscoveryConfig scalars (discoConfig)
+  kadKRegister*: Option[int]
+  kadKLookup*: Option[int]
+  kadFLookup*: Option[int]
+  kadFReturn*: Option[int]
+  kadAdvertExpiry*: Option[Duration]
+  kadAdvertCacheCap*: Option[uint64]
+  kadOccupancyExp*: Option[float64]
+  kadSafetyParam*: Option[float64]
+  kadIpSimCoefficient*: Option[float64]
+  kadRegistrationWindow*: Option[Duration]
+  kadBucketsCount*: Option[int]
+
+  # KadDHTConfig scalars (config)
+  kadTimeout*: Option[Duration]
+  kadBucketRefreshTime*: Option[Duration]
+  kadRetries*: Option[int]
+  kadReplication*: Option[int]
+  kadAlpha*: Option[int]
+  kadQuorum*: Option[int]
+  kadProviderRecordCapacity*: Option[int]
+  kadProvidedKeyCapacity*: Option[int]
+  kadRepublishProvidedKeysInterval*: Option[Duration]
+  kadCleanupProvidersInterval*: Option[Duration]
+  kadProviderExpirationInterval*: Option[Duration]
+  kadRecordExpirationInterval*: Option[Duration]
+  kadCleanupDataEntriesInterval*: Option[Duration]
+  kadHideConnectionStatus*: Option[bool]
+  kadDisableBootstrapping*: Option[bool]
+  kadProviderRejection*: Option[bool]
+  kadMaxProvidersPerKey*: Option[int] # use some(-1) or none for Opt.none (unlimited)
 
 proc init*(T: type KademliaDiscoveryConfBuilder): KademliaDiscoveryConfBuilder =
   KademliaDiscoveryConfBuilder()
@@ -26,6 +88,136 @@ proc withBootstrapNodes*(
 ) =
   b.bootstrapNodes = bootstrapNodes
 
+proc withServicesToAdvertise*(
+    b: var KademliaDiscoveryConfBuilder, services: seq[(string, seq[byte])]
+) =
+  b.servicesToAdvertise = services
+
+proc withServicesToDiscover*(
+    b: var KademliaDiscoveryConfBuilder, services: seq[string]
+) =
+  b.servicesToDiscover = services
+
+proc withRandomLookupInterval*(
+    b: var KademliaDiscoveryConfBuilder, interval: Duration
+) =
+  b.randomLookupInterval = some(interval)
+
+proc withServiceLookupInterval*(
+    b: var KademliaDiscoveryConfBuilder, interval: Duration
+) =
+  b.serviceLookupInterval = some(interval)
+
+proc withClientMode*(b: var KademliaDiscoveryConfBuilder, client: bool) =
+  b.clientMode = some(client)
+
+proc withXprPublishing*(b: var KademliaDiscoveryConfBuilder, publish: bool) =
+  b.xprPublishing = some(publish)
+
+# Disco config with*
+proc withKadKRegister*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadKRegister = some(v)
+
+proc withKadKLookup*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadKLookup = some(v)
+
+proc withKadFLookup*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadFLookup = some(v)
+
+proc withKadFReturn*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadFReturn = some(v)
+
+proc withKadAdvertExpiry*(b: var KademliaDiscoveryConfBuilder, v: Duration) =
+  b.kadAdvertExpiry = some(v)
+
+proc withKadAdvertCacheCap*(b: var KademliaDiscoveryConfBuilder, v: uint64) =
+  b.kadAdvertCacheCap = some(v)
+
+proc withKadOccupancyExp*(b: var KademliaDiscoveryConfBuilder, v: float64) =
+  b.kadOccupancyExp = some(v)
+
+proc withKadSafetyParam*(b: var KademliaDiscoveryConfBuilder, v: float64) =
+  b.kadSafetyParam = some(v)
+
+proc withKadIpSimCoefficient*(b: var KademliaDiscoveryConfBuilder, v: float64) =
+  b.kadIpSimCoefficient = some(v)
+
+proc withKadRegistrationWindow*(b: var KademliaDiscoveryConfBuilder, v: Duration) =
+  b.kadRegistrationWindow = some(v)
+
+proc withKadBucketsCount*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadBucketsCount = some(v)
+
+# KadDHT config with*
+proc withKadTimeout*(b: var KademliaDiscoveryConfBuilder, v: Duration) =
+  b.kadTimeout = some(v)
+
+proc withKadBucketRefreshTime*(b: var KademliaDiscoveryConfBuilder, v: Duration) =
+  b.kadBucketRefreshTime = some(v)
+
+proc withKadRetries*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadRetries = some(v)
+
+proc withKadReplication*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadReplication = some(v)
+
+proc withKadAlpha*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadAlpha = some(v)
+
+proc withKadQuorum*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadQuorum = some(v)
+
+proc withKadProviderRecordCapacity*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadProviderRecordCapacity = some(v)
+
+proc withKadProvidedKeyCapacity*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadProvidedKeyCapacity = some(v)
+
+proc withKadRepublishProvidedKeysInterval*(
+    b: var KademliaDiscoveryConfBuilder, v: Duration
+) =
+  b.kadRepublishProvidedKeysInterval = some(v)
+
+proc withKadCleanupProvidersInterval*(
+    b: var KademliaDiscoveryConfBuilder, v: Duration
+) =
+  b.kadCleanupProvidersInterval = some(v)
+
+proc withKadProviderExpirationInterval*(
+    b: var KademliaDiscoveryConfBuilder, v: Duration
+) =
+  b.kadProviderExpirationInterval = some(v)
+
+proc withKadRecordExpirationInterval*(
+    b: var KademliaDiscoveryConfBuilder, v: Duration
+) =
+  b.kadRecordExpirationInterval = some(v)
+
+proc withKadCleanupDataEntriesInterval*(
+    b: var KademliaDiscoveryConfBuilder, v: Duration
+) =
+  b.kadCleanupDataEntriesInterval = some(v)
+
+proc withKadHideConnectionStatus*(b: var KademliaDiscoveryConfBuilder, v: bool) =
+  b.kadHideConnectionStatus = some(v)
+
+proc withKadDisableBootstrapping*(b: var KademliaDiscoveryConfBuilder, v: bool) =
+  b.kadDisableBootstrapping = some(v)
+
+proc withKadProviderRejection*(b: var KademliaDiscoveryConfBuilder, v: bool) =
+  b.kadProviderRejection = some(v)
+
+proc withKadMaxProvidersPerKey*(b: var KademliaDiscoveryConfBuilder, v: int) =
+  b.kadMaxProvidersPerKey = some(v)
+
+proc withKadDhtConfig*(b: var KademliaDiscoveryConfBuilder, c: KadDHTConfig) =
+  b.kadDhtConfig = some(c)
+
+proc withDiscoConfig*(
+    b: var KademliaDiscoveryConfBuilder, c: sd_types.ServiceDiscoveryConfig
+) =
+  b.discoConfig = some(c)
+
 proc build*(
     b: KademliaDiscoveryConfBuilder
 ): Result[Option[KademliaDiscoveryConf], string] =
@@ -35,10 +227,81 @@ proc build*(
   # Otherwise enabled if config-enabled or any bootstrap nodes are provided.
   if not b.enabled.get(DefaultKadEnabled) and b.bootstrapNodes.len == 0:
     return ok(none(KademliaDiscoveryConf))
+
   var parsedNodes: seq[(PeerId, seq[MultiAddress])]
   for nodeStr in b.bootstrapNodes:
     let (peerId, ma) = parseFullAddress(nodeStr).valueOr:
       return err("Failed to parse kademlia bootstrap node: " & error)
     parsedNodes.add((peerId, @[ma]))
 
-  return ok(some(KademliaDiscoveryConf(bootstrapNodes: parsedNodes)))
+  var servicesToAdvertise: seq[ServiceInfo]
+  for (serviceId, data) in b.servicesToAdvertise:
+    servicesToAdvertise.add(ServiceInfo(id: serviceId, data: data))
+
+  let kadDht =
+    if b.kadDhtConfig.isSome():
+      b.kadDhtConfig.get()
+    else:
+      KadDHTConfig.new(
+        timeout = b.kadTimeout.get(DefaultTimeout),
+        bucketRefreshTime = b.kadBucketRefreshTime.get(DefaultBucketRefreshTime),
+        retries = b.kadRetries.get(DefaultRetries),
+        replication = b.kadReplication.get(DefaultReplication),
+        alpha = b.kadAlpha.get(DefaultAlpha),
+        quorum = b.kadQuorum.get(DefaultQuorum),
+        providerRecordCapacity =
+          b.kadProviderRecordCapacity.get(DefaultProviderRecordCapacity),
+        providedKeyCapacity = b.kadProvidedKeyCapacity.get(DefaultProvidedKeyCapacity),
+        republishProvidedKeysInterval =
+          b.kadRepublishProvidedKeysInterval.get(DefaultRepublishInterval),
+        cleanupProvidersInterval =
+          b.kadCleanupProvidersInterval.get(DefaultCleanupProvidersInterval),
+        providerExpirationInterval =
+          b.kadProviderExpirationInterval.get(DefaultProviderExpirationInterval),
+        recordExpirationInterval =
+          b.kadRecordExpirationInterval.get(DefaultRecordExpirationInterval),
+        cleanupDataEntriesInterval =
+          b.kadCleanupDataEntriesInterval.get(DefaultCleanupDataEntriesInterval),
+        hideConnectionStatus = b.kadHideConnectionStatus.get(true),
+        disableBootstrapping = b.kadDisableBootstrapping.get(false),
+        providerRejection = b.kadProviderRejection.get(false),
+        maxProvidersPerKey =
+          if b.kadMaxProvidersPerKey.isSome() and b.kadMaxProvidersPerKey.get() > 0:
+            Opt.some(b.kadMaxProvidersPerKey.get())
+          else:
+            Opt.none(int),
+      )
+
+  let discoC =
+    if b.discoConfig.isSome():
+      b.discoConfig.get()
+    else:
+      sd_types.ServiceDiscoveryConfig.new(
+        kRegister = b.kadKRegister.get(sd_types.Default_K_register),
+        kLookup = b.kadKLookup.get(sd_types.Default_K_lookup),
+        fLookup = b.kadFLookup.get(sd_types.Default_F_lookup),
+        fReturn = b.kadFReturn.get(sd_types.Default_F_return),
+        advertExpiry = b.kadAdvertExpiry.get(sd_types.Default_E),
+        advertCacheCap = b.kadAdvertCacheCap.get(sd_types.Default_C),
+        occupancyExp = b.kadOccupancyExp.get(sd_types.Default_P_occ),
+        safetyParam = b.kadSafetyParam.get(sd_types.Default_G),
+        ipSimCoefficient = b.kadIpSimCoefficient.get(sd_types.Default_IpSimCoefficient),
+        registrationWindow = b.kadRegistrationWindow.get(sd_types.Default_Delta),
+        bucketsCount = b.kadBucketsCount.get(sd_types.Default_M_buckets),
+      )
+
+  return ok(
+    some(
+      KademliaDiscoveryConf(
+        bootstrapNodes: parsedNodes,
+        servicesToAdvertise: servicesToAdvertise,
+        servicesToDiscover: b.servicesToDiscover,
+        randomLookupInterval: b.randomLookupInterval.get(DefaultRandomLookupInterval),
+        serviceLookupInterval: b.serviceLookupInterval.get(DefaultServiceLookupInterval),
+        kadDhtConfig: kadDht,
+        discoConfig: discoC,
+        clientMode: b.clientMode.get(false),
+        xprPublishing: b.xprPublishing.get(true),
+      )
+    )
+  )

--- a/logos_delivery/waku/factory/conf_builder/kademlia_discovery_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/kademlia_discovery_conf_builder.nim
@@ -6,20 +6,10 @@ import libp2p/[peerid, multiaddress, peerinfo, extended_peer_record]
 import libp2p/protocols/kademlia/types
 import libp2p/protocols/service_discovery/types as sd_types
 import logos_delivery/waku/waku_core/peers
+import logos_delivery/waku/discovery/waku_kademlia
 
 logScope:
   topics = "waku conf builder kademlia discovery"
-
-type KademliaDiscoveryConf* = object
-  bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
-  servicesToAdvertise*: seq[ServiceInfo]
-  servicesToDiscover*: seq[string]
-  randomLookupInterval*: Duration
-  serviceLookupInterval*: Duration
-  kadDhtConfig*: KadDHTConfig
-  discoConfig*: sd_types.ServiceDiscoveryConfig
-  clientMode*: bool
-  xprPublishing*: bool
 
 const
   DefaultKadEnabled*: bool = false

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -175,12 +175,10 @@ proc setupProtocols(
     var kadConf = conf.kademliaDiscoveryConf.get()
 
     if conf.mixConf.isSome():
-      kadConf.servicesToAdvertise.add(
+      let mixService =
         ServiceInfo(id: MixProtocolID, data: @(conf.mixConf.get().mixPubKey))
-      )
-
-    if conf.mixConf.isSome() and MixProtocolID notin kadConf.servicesToDiscover:
-      kadConf.servicesToDiscover.add(MixProtocolID)
+      kadConf.servicesToAdvertise.incl(mixService)
+      kadConf.servicesToDiscover.incl(mixService.id)
 
     node.mountKademlia(kadConf).isOkOr:
       return err("failed to setup service discovery: " & error)
@@ -190,10 +188,11 @@ proc setupProtocols(
       node.brokerCtx,
       proc(serviceId: string): Future[Result[ServicePeersRequest, string]] {.async.} =
         let peers = (await node.wakuKademlia.lookupServicePeers(serviceId)).valueOr:
-          return err(error)
+          return err("failed call to lookupServicePeers: " & error)
         return ok(ServicePeersRequest(serviceId: serviceId, peers: peers)),
     ).isOkOr:
       error "Can't set provider for ServicePeersRequest", error = error
+      return err("Can't set provider for ServicePeersRequest: " & error)
 
   if conf.storeServiceConf.isSome():
     let storeServiceConf = conf.storeServiceConf.get()

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -8,7 +8,9 @@ import
   libp2p/protocols/connectivity/relay/relay,
   libp2p/nameresolving/dnsresolver,
   libp2p/crypto/crypto,
-  libp2p/crypto/curve25519
+  libp2p/crypto/curve25519,
+  libp2p/extended_peer_record,
+  libp2p_mix/mix_protocol
 
 import
   ./internal_config,
@@ -36,7 +38,8 @@ import
   ../node/peer_manager/peer_store/waku_peer_storage,
   ../node/peer_manager/peer_store/migrations as peer_store_sqlite_migrations,
   ../waku_lightpush_legacy/common,
-  ../common/rate_limit/setting
+  ../common/rate_limit/setting,
+  ../events/discovery_events
 
 ## Peer persistence
 
@@ -167,31 +170,30 @@ proc setupProtocols(
     (await node.mountMix(conf.clusterId, mixConf.mixKey, mixConf.mixnodes)).isOkOr:
       return err("failed to mount waku mix protocol: " & $error)
 
-  # Setup extended kademlia discovery
+  # Setup service discovery
   if conf.kademliaDiscoveryConf.isSome():
-    let mixPubKey =
-      if conf.mixConf.isSome():
-        some(conf.mixConf.get().mixPubKey)
-      else:
-        none(Curve25519Key)
+    var kadConf = conf.kademliaDiscoveryConf.get()
 
-    node.wakuKademlia = WakuKademlia.new(
-      node.switch,
-      ExtendedKademliaDiscoveryParams(
-        bootstrapNodes: conf.kademliaDiscoveryConf.get().bootstrapNodes,
-        mixPubKey: mixPubKey,
-        advertiseMix: conf.mixConf.isSome(),
-      ),
-      node.peerManager,
-      getMixNodePoolSize = proc(): int {.gcsafe, raises: [].} =
-        if node.wakuMix.isNil():
-          0
-        else:
-          node.getMixNodePoolSize(),
-      isNodeStarted = proc(): bool {.gcsafe, raises: [].} =
-        node.started,
-    ).valueOr:
-      return err("failed to setup kademlia discovery: " & error)
+    if conf.mixConf.isSome():
+      kadConf.servicesToAdvertise.add(
+        ServiceInfo(id: MixProtocolID, data: @(conf.mixConf.get().mixPubKey))
+      )
+
+    if conf.mixConf.isSome() and MixProtocolID notin kadConf.servicesToDiscover:
+      kadConf.servicesToDiscover.add(MixProtocolID)
+
+    node.mountKademlia(kadConf).isOkOr:
+      return err("failed to setup service discovery: " & error)
+
+    # Register ServicePeersRequest provider
+    ServicePeersRequest.setProvider(
+      node.brokerCtx,
+      proc(serviceId: string): Future[Result[ServicePeersRequest, string]] {.async.} =
+        let peers = (await node.wakuKademlia.lookupServicePeers(serviceId)).valueOr:
+          return err(error)
+        return ok(ServicePeersRequest(serviceId: serviceId, peers: peers)),
+    ).isOkOr:
+      error "Can't set provider for ServicePeersRequest", error = error
 
   if conf.storeServiceConf.isSome():
     let storeServiceConf = conf.storeServiceConf.get()
@@ -451,11 +453,6 @@ proc startNode*(
   # Maintain relay connections
   if conf.relay:
     node.peerManager.start()
-
-  if not node.wakuKademlia.isNil():
-    let minMixPeers = if conf.mixConf.isSome(): 4 else: 0
-    (await node.wakuKademlia.start(minMixPeers = minMixPeers)).isOkOr:
-      return err("failed to start kademlia discovery: " & error)
 
   return ok()
 

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -1,10 +1,14 @@
 import
   std/[net, options, strutils],
   chronicles,
+  chronos,
   libp2p/crypto/crypto,
   libp2p/multiaddress,
   libp2p/crypto/curve25519,
   libp2p/peerid,
+  libp2p/extended_peer_record,
+  libp2p/protocols/kademlia/types,
+  libp2p/protocols/service_discovery/types as sd_types,
   secp256k1,
   results
 
@@ -17,7 +21,8 @@ import
   ../common/rate_limit/setting,
   ../waku_enr/capabilities,
   ./networks_config,
-  ../waku_mix
+  ../waku_mix,
+  ./conf_builder/kademlia_discovery_conf_builder
 
 export RlnRelayConf, RlnRelayCreds, RestServerConf, Discv5Conf, MetricsServerConf
 
@@ -54,10 +59,6 @@ type MixConf* = ref object
   mixKey*: Curve25519Key
   mixPubKey*: Curve25519Key
   mixnodes*: seq[MixNodePubInfo]
-
-type KademliaDiscoveryConf* = object
-  bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
-    ## Bootstrap nodes for extended kademlia discovery.
 
 type StoreServiceConf* {.requiresInit.} = object
   dbMigration*: bool

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -16,6 +16,7 @@ import
   ../waku_rln_relay/rln_relay,
   ../rest_api/endpoint/builder,
   ../discovery/waku_discv5,
+  ../discovery/waku_kademlia,
   ../node/waku_metrics,
   ../common/logging,
   ../common/rate_limit/setting,

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -53,6 +53,7 @@ import
     waku_enr,
     waku_peer_exchange,
     waku_rln_relay,
+    factory/conf_builder/kademlia_discovery_conf_builder,
     common/rate_limit/setting,
     common/callbacks,
     common/nimchronos,
@@ -134,7 +135,6 @@ type
       ## Kernel API Relay appHandlers (if any)
     subscriptionManager*: SubscriptionManager
     wakuMix*: WakuMix
-    kademliaDiscoveryLoop*: Future[void]
     wakuKademlia*: WakuKademlia
     ports*: BoundPorts
 
@@ -335,6 +335,29 @@ proc mountMix*(
     node.switch.mount(node.wakuMix)
   catchRes.isOkOr:
     return err(error.msg)
+  return ok()
+
+proc mountKademlia*(
+    node: WakuNode, config: KademliaDiscoveryConf
+): Result[void, string] =
+  if not node.wakuKademlia.isNil():
+    return err("WakuKademlia already mounted, skipping")
+
+  let wk = WakuKademlia.new(
+    node.switch, node.peerManager, config.bootstrapNodes, config.servicesToAdvertise,
+    config.servicesToDiscover, config.randomLookupInterval,
+    config.serviceLookupInterval, node.rng, config.kadDhtConfig, config.discoConfig,
+    config.clientMode, config.xprPublishing,
+  ).valueOr:
+    return err("failed to create service discovery: " & error)
+
+  node.wakuKademlia = wk
+
+  let mountRes = catch:
+    node.switch.mount(wk.protocol)
+  mountRes.isOkOr:
+    return err("failed to mount service discovery: " & error.msg)
+
   return ok()
 
 ## Waku Sync
@@ -603,6 +626,9 @@ proc start*(node: WakuNode) {.async.} =
 
   node.started = true
 
+  if not node.wakuKademlia.isNil():
+    await node.wakuKademlia.start()
+
   if not node.wakuFilterClient.isNil():
     node.wakuFilterClient.registerPushHandler(
       proc(pubsubTopic: PubsubTopic, msg: WakuMessage) {.async, gcsafe.} =
@@ -629,6 +655,9 @@ proc stop*(node: WakuNode) {.async.} =
 
   node.stopProvidersAndListeners()
 
+  if not node.wakuKademlia.isNil():
+    await node.wakuKademlia.stop()
+
   ## NOTE: This will dispatch gossipsub stop to the WakuRelay.stop method override
   await node.switch.stop()
 
@@ -649,9 +678,6 @@ proc stop*(node: WakuNode) {.async.} =
   if not node.wakuPeerExchangeClient.isNil() and
       not node.wakuPeerExchangeClient.pxLoopHandle.isNil():
     await node.wakuPeerExchangeClient.pxLoopHandle.cancelAndWait()
-
-  if not node.wakuKademlia.isNil():
-    await node.wakuKademlia.stop()
 
   if not node.wakuRendezvousClient.isNil():
     await node.wakuRendezvousClient.stopWait()

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -53,7 +53,6 @@ import
     waku_enr,
     waku_peer_exchange,
     waku_rln_relay,
-    factory/conf_builder/kademlia_discovery_conf_builder,
     common/rate_limit/setting,
     common/callbacks,
     common/nimchronos,

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -68,7 +68,8 @@ import
   ./test_waku_switch,
   ./test_waku_rendezvous,
   ./test_waku_metadata,
-  ./waku_discv5/test_waku_discv5
+  ./waku_discv5/test_waku_discv5,
+  ./waku_kademlia/test_waku_kademlia
 
 # Waku Keystore test suite
 import ./test_waku_keystore_keyfile, ./test_waku_keystore

--- a/tests/waku_kademlia/test_waku_kademlia.nim
+++ b/tests/waku_kademlia/test_waku_kademlia.nim
@@ -6,7 +6,7 @@ import
   testutils/unittests,
   libp2p/crypto/crypto as libp2p_keys,
   libp2p/crypto/curve25519,
-  libp2p/[peerid, multiaddress, switch],
+  libp2p/[peerid, multiaddress, switch, extended_peer_record],
   libp2p/extended_peer_record,
   libp2p/protocols/service_discovery/types as sd_types,
   libp2p_mix/mix_protocol
@@ -19,6 +19,23 @@ import ../testlib/[wakucore, testasync, assertions, futures, testutils]
 import ./utils as kad_utils
 
 suite "Waku Kademlia service discovery":
+  asyncTest "seed node starts with no bootstrap nodes":
+    let
+      switch = newTestSwitch()
+      wk = kad_utils.newTestKademlia(
+        switch, servicesToAdvertise = @[ServiceInfo(id: "/seed/svc/1.0.0", data: @[])]
+      )
+    await switch.start()
+    await wk.start()
+
+    await sleepAsync(FUTURE_TIMEOUT)
+
+    check:
+      not wk.protocol.isNil()
+
+    await wk.stop()
+    await switch.stop()
+
   suite "extractMixPubKey":
     proc validKeyBytes(): seq[byte] =
       var b = newSeq[byte](Curve25519KeySize)
@@ -181,112 +198,6 @@ suite "Waku Kademlia service discovery":
       check:
         res.isOk()
         res.value.len == 0
-
-      await wk.stop()
-      await switch.stop()
-
-  suite "service discovery between nodes":
-    proc bootstrapOf(switch: Switch): (PeerId, seq[MultiAddress]) =
-      (switch.peerInfo.peerId, switch.peerInfo.addrs)
-
-    proc startPair(
-        advertiserPort, discovererPort: uint16, service: string
-    ): tuple[
-      advSwitch: Switch, advKad: WakuKademlia, discSwitch: Switch, discKad: WakuKademlia
-    ] =
-      let advSwitch = newTestSwitch(
-        address =
-          some(MultiAddress.init("/ip4/127.0.0.1/tcp/" & $advertiserPort).tryGet())
-      )
-      let advKad = kad_utils.newTestKademlia(
-        advSwitch,
-        servicesToAdvertise = @[ServiceInfo(id: service, data: @[])],
-        randomLookupInterval = chronos.seconds(60),
-        serviceLookupInterval = chronos.seconds(60),
-      )
-      let discSwitch = newTestSwitch(
-        address =
-          some(MultiAddress.init("/ip4/127.0.0.1/tcp/" & $discovererPort).tryGet())
-      )
-      let discKad = kad_utils.newTestKademlia(
-        discSwitch,
-        bootstrapNodes = @[advSwitch.bootstrapOf()],
-        servicesToDiscover = @[service],
-        randomLookupInterval = chronos.seconds(60),
-        serviceLookupInterval = chronos.seconds(60),
-      )
-      (advSwitch, advKad, discSwitch, discKad)
-
-    proc stopAll(
-        advSwitch: Switch,
-        advKad: WakuKademlia,
-        discSwitch: Switch,
-        discKad: WakuKademlia,
-    ) {.async.} =
-      await allFutures(advKad.stop(), discKad.stop())
-      await allFutures(advSwitch.stop(), discSwitch.stop())
-
-    xasyncTest "two-node service advertise/discover":
-      ## Skipped: the underlying ServiceDiscovery DHT lookup does not converge
-      ## reliably with a two-node setup using a bare test switch. Needs
-      ## investigation of routing-table population and advert propagation before
-      ## this can be re-enabled. The unit suites (extractMixPubKey,
-      ## remotePeerInfoFrom, lookupServicePeers) cover the waku_kademlia logic.
-
-      let service = "/test/svc/1.0.0"
-      let (advSwitch, advKad, discSwitch, discKad) = startPair(61600, 61601, service)
-
-      await allFutures(advSwitch.start(), discSwitch.start())
-      await allFutures(advKad.start(), discKad.start())
-
-      await discSwitch.connect(
-        advSwitch.peerInfo.peerId, advSwitch.peerInfo.listenAddrs
-      )
-      await sleepAsync(FUTURE_TIMEOUT_LONG * 3)
-
-      let res = await discKad.lookupServicePeers(service)
-      check:
-        res.isOk()
-        res.value.len >= 1
-        res.value.anyIt(it.peerId == advSwitch.peerInfo.peerId)
-
-      await stopAll(advSwitch, advKad, discSwitch, discKad)
-
-    xasyncTest "service lookup adds peer to PeerManager with Kademlia origin":
-      ## Skipped alongside the two-node test; same DHT convergence blocker.
-
-      let service = "/test/svc/1.0.0"
-      let (advSwitch, advKad, discSwitch, discKad) = startPair(61610, 61611, service)
-
-      await allFutures(advSwitch.start(), discSwitch.start())
-      await allFutures(advKad.start(), discKad.start())
-
-      await discSwitch.connect(
-        advSwitch.peerInfo.peerId, advSwitch.peerInfo.listenAddrs
-      )
-      await sleepAsync(FUTURE_TIMEOUT_LONG * 3)
-
-      discard await discKad.lookupServicePeers(service)
-
-      let storedPeer = discSwitch.peerStore.getPeer(advSwitch.peerInfo.peerId)
-      check:
-        storedPeer.origin == PeerOrigin.Kademlia
-
-      await stopAll(advSwitch, advKad, discSwitch, discKad)
-
-    asyncTest "seed node starts with no bootstrap nodes":
-      let
-        switch = newTestSwitch()
-        wk = kad_utils.newTestKademlia(
-          switch, servicesToAdvertise = @[ServiceInfo(id: "/seed/svc/1.0.0", data: @[])]
-        )
-      await switch.start()
-      await wk.start()
-
-      await sleepAsync(FUTURE_TIMEOUT)
-
-      check:
-        not wk.protocol.isNil()
 
       await wk.stop()
       await switch.stop()

--- a/tests/waku_kademlia/test_waku_kademlia.nim
+++ b/tests/waku_kademlia/test_waku_kademlia.nim
@@ -1,0 +1,292 @@
+import
+  std/[options, sequtils, strutils],
+  results,
+  chronos,
+  chronicles,
+  testutils/unittests,
+  libp2p/crypto/crypto as libp2p_keys,
+  libp2p/crypto/curve25519,
+  libp2p/[peerid, multiaddress, switch],
+  libp2p/extended_peer_record,
+  libp2p/protocols/service_discovery/types as sd_types,
+  libp2p_mix/mix_protocol
+
+import
+  logos_delivery/waku/discovery/waku_kademlia,
+  logos_delivery/waku/waku_core/peers,
+  logos_delivery/waku/node/peer_manager/waku_peer_store
+import ../testlib/[wakucore, testasync, assertions, futures, testutils]
+import ./utils as kad_utils
+
+suite "Waku Kademlia service discovery":
+  suite "extractMixPubKey":
+    proc validKeyBytes(): seq[byte] =
+      var b = newSeq[byte](Curve25519KeySize)
+      for i in 0 ..< Curve25519KeySize:
+        b[i] = byte(i)
+      b
+
+    test "non-mix service returns none":
+      let svc = ServiceInfo(id: "/foo/1.0.0", data: validKeyBytes())
+      check:
+        extractMixPubKey(svc).isNone()
+
+    test "mix service with wrong data length returns none":
+      let svc = ServiceInfo(id: MixProtocolID, data: @[0u8, 1u8, 2u8])
+      check:
+        extractMixPubKey(svc).isNone()
+
+    test "mix service with correct length returns some":
+      let bytes = validKeyBytes()
+      let svc = ServiceInfo(id: MixProtocolID, data: bytes)
+      let res = extractMixPubKey(svc)
+      require:
+        res.isSome()
+      let key = res.get()
+      check:
+        key.getBytes() == bytes
+
+    test "round-trip matches intoCurve25519Key on raw bytes":
+      let bytes = validKeyBytes()
+      let svc = ServiceInfo(id: MixProtocolID, data: bytes)
+      let extracted = extractMixPubKey(svc).get()
+      let direct = intoCurve25519Key(bytes)
+      check:
+        extracted.getBytes() == direct.getBytes()
+
+  suite "remotePeerInfoFrom":
+    proc randomPeerId(): PeerId =
+      PeerId.init(generateSecp256k1Key()).tryGet()
+
+    proc testAddr(port: uint16): MultiAddress =
+      MultiAddress.init("/ip4/127.0.0.1/tcp/" & $port).tryGet()
+
+    proc mixService(data: seq[byte]): ServiceInfo =
+      ServiceInfo(id: MixProtocolID, data: data)
+
+    proc validMixService(): ServiceInfo =
+      var b = newSeq[byte](Curve25519KeySize)
+      for i in 0 ..< Curve25519KeySize:
+        b[i] = byte(i)
+      mixService(b)
+
+    test "empty addresses returns none":
+      let record = buildExtendedPeerRecord(randomPeerId(), @[])
+      check:
+        remotePeerInfoFrom(record).isNone()
+
+    test "origin set to PeerOrigin.Kademlia":
+      let
+        pid = randomPeerId()
+        record = buildExtendedPeerRecord(pid, @[testAddr(61600)])
+        res = remotePeerInfoFrom(record)
+      require:
+        res.isSome()
+      let peerInfo = res.get()
+      check:
+        peerInfo.origin == PeerOrigin.Kademlia
+        peerInfo.peerId == pid
+
+    test "mixPubKey extracted from first mix service":
+      let
+        pid = randomPeerId()
+        svc = validMixService()
+        record = buildExtendedPeerRecord(pid, @[testAddr(61600)], @[svc])
+        res = remotePeerInfoFrom(record)
+      require:
+        res.isSome()
+      let peerInfo = res.get()
+      check:
+        peerInfo.mixPubKey.isSome()
+        peerInfo.mixPubKey.get().getBytes() == svc.data
+
+    test "mixPubKey stays none when no mix service present":
+      let
+        pid = randomPeerId()
+        svc = ServiceInfo(id: "/other/1.0.0", data: @[1u8])
+        record = buildExtendedPeerRecord(pid, @[testAddr(61600)], @[svc])
+        res = remotePeerInfoFrom(record)
+      require:
+        res.isSome()
+      check:
+        res.get().mixPubKey.isNone()
+
+    test "addresses mapped correctly":
+      let
+        pid = randomPeerId()
+        addrs = @[testAddr(61600), testAddr(61601), testAddr(61602)]
+        record = buildExtendedPeerRecord(pid, addrs)
+        res = remotePeerInfoFrom(record)
+      require:
+        res.isSome()
+      let peerInfo = res.get()
+      check:
+        peerInfo.addrs.len == 3
+        peerInfo.addrs == addrs
+
+    test "multiple mix services, first one wins":
+      let
+        pid = randomPeerId()
+        firstBytes = block:
+          var b = newSeq[byte](Curve25519KeySize)
+          for i in 0 ..< Curve25519KeySize:
+            b[i] = byte(i)
+          b
+        secondBytes = block:
+          var b = newSeq[byte](Curve25519KeySize)
+          for i in 0 ..< Curve25519KeySize:
+            b[i] = byte(i + 100)
+          b
+        record = buildExtendedPeerRecord(
+          pid, @[testAddr(61600)], @[mixService(firstBytes), mixService(secondBytes)]
+        )
+        res = remotePeerInfoFrom(record)
+      require:
+        res.isSome()
+      check:
+        res.get().mixPubKey.get().getBytes() == firstBytes
+
+    test "mix service with bad key length is skipped silently":
+      let
+        pid = randomPeerId()
+        badSvc = mixService(@[0u8, 1u8, 2u8])
+        record = buildExtendedPeerRecord(pid, @[testAddr(61600)], @[badSvc])
+        res = remotePeerInfoFrom(record)
+      require:
+        res.isSome()
+      let peerInfo = res.get()
+      check:
+        peerInfo.peerId == pid
+        peerInfo.mixPubKey.isNone()
+
+  suite "lookupServicePeers":
+    asyncTest "returns err when protocol is nil":
+      let
+        switch = newTestSwitch()
+        wk = kad_utils.newTestKademlia(switch)
+      wk.protocol = nil
+      let res = await wk.lookupServicePeers("/some/service/1.0.0")
+      check:
+        res.isErr()
+        res.error.contains("service discovery not mounted")
+
+    asyncTest "returns ok with empty seq when no advertisements":
+      let
+        switch = newTestSwitch()
+        wk = kad_utils.newTestKademlia(switch)
+      await switch.start()
+      await wk.start()
+
+      let res = await wk.lookupServicePeers("/nonexistent/service/1.0.0")
+      check:
+        res.isOk()
+        res.value.len == 0
+
+      await wk.stop()
+      await switch.stop()
+
+  suite "service discovery between nodes":
+    proc bootstrapOf(switch: Switch): (PeerId, seq[MultiAddress]) =
+      (switch.peerInfo.peerId, switch.peerInfo.addrs)
+
+    proc startPair(
+        advertiserPort, discovererPort: uint16, service: string
+    ): tuple[
+      advSwitch: Switch, advKad: WakuKademlia, discSwitch: Switch, discKad: WakuKademlia
+    ] =
+      let advSwitch = newTestSwitch(
+        address =
+          some(MultiAddress.init("/ip4/127.0.0.1/tcp/" & $advertiserPort).tryGet())
+      )
+      let advKad = kad_utils.newTestKademlia(
+        advSwitch,
+        servicesToAdvertise = @[ServiceInfo(id: service, data: @[])],
+        randomLookupInterval = chronos.seconds(60),
+        serviceLookupInterval = chronos.seconds(60),
+      )
+      let discSwitch = newTestSwitch(
+        address =
+          some(MultiAddress.init("/ip4/127.0.0.1/tcp/" & $discovererPort).tryGet())
+      )
+      let discKad = kad_utils.newTestKademlia(
+        discSwitch,
+        bootstrapNodes = @[advSwitch.bootstrapOf()],
+        servicesToDiscover = @[service],
+        randomLookupInterval = chronos.seconds(60),
+        serviceLookupInterval = chronos.seconds(60),
+      )
+      (advSwitch, advKad, discSwitch, discKad)
+
+    proc stopAll(
+        advSwitch: Switch,
+        advKad: WakuKademlia,
+        discSwitch: Switch,
+        discKad: WakuKademlia,
+    ) {.async.} =
+      await allFutures(advKad.stop(), discKad.stop())
+      await allFutures(advSwitch.stop(), discSwitch.stop())
+
+    xasyncTest "two-node service advertise/discover":
+      ## Skipped: the underlying ServiceDiscovery DHT lookup does not converge
+      ## reliably with a two-node setup using a bare test switch. Needs
+      ## investigation of routing-table population and advert propagation before
+      ## this can be re-enabled. The unit suites (extractMixPubKey,
+      ## remotePeerInfoFrom, lookupServicePeers) cover the waku_kademlia logic.
+
+      let service = "/test/svc/1.0.0"
+      let (advSwitch, advKad, discSwitch, discKad) = startPair(61600, 61601, service)
+
+      await allFutures(advSwitch.start(), discSwitch.start())
+      await allFutures(advKad.start(), discKad.start())
+
+      await discSwitch.connect(
+        advSwitch.peerInfo.peerId, advSwitch.peerInfo.listenAddrs
+      )
+      await sleepAsync(FUTURE_TIMEOUT_LONG * 3)
+
+      let res = await discKad.lookupServicePeers(service)
+      check:
+        res.isOk()
+        res.value.len >= 1
+        res.value.anyIt(it.peerId == advSwitch.peerInfo.peerId)
+
+      await stopAll(advSwitch, advKad, discSwitch, discKad)
+
+    xasyncTest "service lookup adds peer to PeerManager with Kademlia origin":
+      ## Skipped alongside the two-node test; same DHT convergence blocker.
+
+      let service = "/test/svc/1.0.0"
+      let (advSwitch, advKad, discSwitch, discKad) = startPair(61610, 61611, service)
+
+      await allFutures(advSwitch.start(), discSwitch.start())
+      await allFutures(advKad.start(), discKad.start())
+
+      await discSwitch.connect(
+        advSwitch.peerInfo.peerId, advSwitch.peerInfo.listenAddrs
+      )
+      await sleepAsync(FUTURE_TIMEOUT_LONG * 3)
+
+      discard await discKad.lookupServicePeers(service)
+
+      let storedPeer = discSwitch.peerStore.getPeer(advSwitch.peerInfo.peerId)
+      check:
+        storedPeer.origin == PeerOrigin.Kademlia
+
+      await stopAll(advSwitch, advKad, discSwitch, discKad)
+
+    asyncTest "seed node starts with no bootstrap nodes":
+      let
+        switch = newTestSwitch()
+        wk = kad_utils.newTestKademlia(
+          switch, servicesToAdvertise = @[ServiceInfo(id: "/seed/svc/1.0.0", data: @[])]
+        )
+      await switch.start()
+      await wk.start()
+
+      await sleepAsync(FUTURE_TIMEOUT)
+
+      check:
+        not wk.protocol.isNil()
+
+      await wk.stop()
+      await switch.stop()

--- a/tests/waku_kademlia/utils.nim
+++ b/tests/waku_kademlia/utils.nim
@@ -1,0 +1,50 @@
+{.used.}
+
+import std/[options, sets]
+import chronos, chronicles, results
+import libp2p/[peerid, multiaddress, switch]
+import libp2p/extended_peer_record
+import libp2p/protocols/service_discovery/types as sd_types
+import libp2p/crypto/crypto as libp2p_keys
+
+import
+  logos_delivery/waku/discovery/waku_kademlia,
+  logos_delivery/waku/node/peer_manager/peer_manager
+import ../testlib/[wakucore, common]
+
+export wakucore, common, peerid, multiaddress, switch, extended_peer_record, sd_types
+
+proc newTestKademlia*(
+    switch: Switch,
+    bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
+    servicesToAdvertise: seq[ServiceInfo] = @[],
+    servicesToDiscover: seq[string] = @[],
+    randomLookupInterval: Duration = 100.milliseconds,
+    serviceLookupInterval: Duration = 100.milliseconds,
+    clientMode: bool = false,
+    xprPublishing: bool = true,
+): WakuKademlia =
+  let peerManager = PeerManager.new(switch)
+
+  let wk = WakuKademlia
+    .new(
+      switch = switch,
+      peerManager = peerManager,
+      bootstrapNodes = bootstrapNodes,
+      servicesToAdvertise = toHashSet(servicesToAdvertise),
+      servicesToDiscover = toHashSet(servicesToDiscover),
+      randomLookupInterval = randomLookupInterval,
+      serviceLookupInterval = serviceLookupInterval,
+      rng = rng(),
+      clientMode = clientMode,
+      xprPublishing = xprPublishing,
+    )
+    .tryGet()
+
+  switch.mount(wk.protocol)
+  wk
+
+proc buildExtendedPeerRecord*(
+    peerId: PeerId, addrs: seq[MultiAddress], services: seq[ServiceInfo] = @[]
+): ExtendedPeerRecord =
+  ExtendedPeerRecord.init(peerId = peerId, addresses = addrs, services = services)

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -685,159 +685,17 @@ hence would have reachability issues.""",
       name: "kad-bootstrap-node"
     .}: seq[string]
 
-    kadDiscoverServices* {.
-      desc:
-        "Service ID to periodically discover via kademlia (e.g. 'mix'). Argument may be repeated.",
-      name: "kad-discover-service"
-    .}: seq[string]
-
-    kadAdvertiseServices* {.
-      desc:
-        "Service to advertise in format 'serviceId:hexEncodedData' (e.g. mix:0123abcd). Argument may be repeated.",
-      name: "kad-advertise-service"
-    .}: seq[string]
-
     kadRandomLookupIntervalSec* {.
-      desc: "Interval seconds between random kademlia lookups (0 uses default).",
-      defaultValue: 0,
+      desc: "Interval seconds between random kademlia lookups.",
+      defaultValue: 60,
       name: "kad-random-lookup-interval"
     .}: uint32
 
     kadServiceLookupIntervalSec* {.
-      desc:
-        "Interval seconds between service-specific kademlia lookups (0 uses default).",
-      defaultValue: 0,
+      desc: "Interval seconds between service-specific kademlia lookups.",
+      defaultValue: 60,
       name: "kad-service-lookup-interval"
     .}: uint32
-
-    # ServiceDiscoveryConfig (disco) tunables
-    kadKRegister* {.
-      desc: "Kademlia kRegister (providers per service registration).",
-      defaultValue: none(int),
-      name: "kad-k-register"
-    .}: Option[int]
-    kadKLookup* {.
-      desc: "Kademlia kLookup.", defaultValue: none(int), name: "kad-k-lookup"
-    .}: Option[int]
-    kadFLookup* {.
-      desc: "Kademlia fLookup.", defaultValue: none(int), name: "kad-f-lookup"
-    .}: Option[int]
-    kadFReturn* {.
-      desc: "Kademlia fReturn.", defaultValue: none(int), name: "kad-f-return"
-    .}: Option[int]
-    kadAdvertExpirySec* {.
-      desc: "Advert expiry seconds.",
-      defaultValue: none(uint32),
-      name: "kad-advert-expiry"
-    .}: Option[uint32]
-    kadAdvertCacheCap* {.
-      desc: "Advert cache capacity.",
-      defaultValue: none(uint64),
-      name: "kad-advert-cache-cap"
-    .}: Option[uint64]
-    kadOccupancyExp* {.
-      desc: "Occupancy exponent (float).",
-      defaultValue: none(float),
-      name: "kad-occupancy-exp"
-    .}: Option[float]
-    kadSafetyParam* {.
-      desc: "Safety param G (float).",
-      defaultValue: none(float),
-      name: "kad-safety-param"
-    .}: Option[float]
-    kadIpSimCoefficient* {.
-      desc: "IP similarity coefficient (float).",
-      defaultValue: none(float),
-      name: "kad-ip-sim-coefficient"
-    .}: Option[float]
-    kadRegistrationWindowSec* {.
-      desc: "Registration window seconds.",
-      defaultValue: none(uint32),
-      name: "kad-registration-window"
-    .}: Option[uint32]
-    kadBucketsCount* {.
-      desc: "Buckets count (M).", defaultValue: none(int), name: "kad-buckets-count"
-    .}: Option[int]
-
-    # KadDHTConfig tunables (core kademlia)
-    kadTimeoutSec* {.
-      desc: "Kademlia RPC timeout seconds.",
-      defaultValue: none(uint32),
-      name: "kad-timeout"
-    .}: Option[uint32]
-    kadBucketRefreshTimeSec* {.
-      desc: "Bucket refresh time seconds.",
-      defaultValue: none(uint32),
-      name: "kad-bucket-refresh-time"
-    .}: Option[uint32]
-    kadRetries* {.
-      desc: "Kademlia retries.", defaultValue: none(int), name: "kad-retries"
-    .}: Option[int]
-    kadReplication* {.
-      desc: "Kademlia replication (k).",
-      defaultValue: none(int),
-      name: "kad-replication"
-    .}: Option[int]
-    kadAlpha* {.
-      desc: "Kademlia alpha (concurrency).", defaultValue: none(int), name: "kad-alpha"
-    .}: Option[int]
-    kadQuorum* {.desc: "Kademlia quorum.", defaultValue: none(int), name: "kad-quorum".}:
-      Option[int]
-    kadProviderRecordCapacity* {.
-      desc: "Provider record capacity.",
-      defaultValue: none(int),
-      name: "kad-provider-record-capacity"
-    .}: Option[int]
-    kadProvidedKeyCapacity* {.
-      desc: "Provided key capacity.",
-      defaultValue: none(int),
-      name: "kad-provided-key-capacity"
-    .}: Option[int]
-    kadRepublishProvidedKeysIntervalSec* {.
-      desc: "Republish provided keys interval seconds.",
-      defaultValue: none(uint32),
-      name: "kad-republish-provided-keys-interval"
-    .}: Option[uint32]
-    kadCleanupProvidersIntervalSec* {.
-      desc: "Cleanup providers interval seconds.",
-      defaultValue: none(uint32),
-      name: "kad-cleanup-providers-interval"
-    .}: Option[uint32]
-    kadProviderExpirationIntervalSec* {.
-      desc: "Provider expiration interval seconds.",
-      defaultValue: none(uint32),
-      name: "kad-provider-expiration-interval"
-    .}: Option[uint32]
-    kadRecordExpirationIntervalSec* {.
-      desc: "Record expiration interval seconds.",
-      defaultValue: none(uint32),
-      name: "kad-record-expiration-interval"
-    .}: Option[uint32]
-    kadCleanupDataEntriesIntervalSec* {.
-      desc: "Cleanup data entries interval seconds.",
-      defaultValue: none(uint32),
-      name: "kad-cleanup-data-entries-interval"
-    .}: Option[uint32]
-    kadHideConnectionStatus* {.
-      desc: "Hide connection status in kademlia.",
-      defaultValue: none(bool),
-      name: "kad-hide-connection-status"
-    .}: Option[bool]
-    kadDisableBootstrapping* {.
-      desc: "Disable kademlia bootstrapping.",
-      defaultValue: none(bool),
-      name: "kad-disable-bootstrapping"
-    .}: Option[bool]
-    kadProviderRejection* {.
-      desc: "Enable provider rejection (with max-providers-per-key).",
-      defaultValue: none(bool),
-      name: "kad-provider-rejection"
-    .}: Option[bool]
-    kadMaxProvidersPerKey* {.
-      desc: "Max providers per key ( >0 to enforce; omit or <=0 for unlimited).",
-      defaultValue: none(int),
-      name: "kad-max-providers-per-key"
-    .}: Option[int]
 
     ## websocket config
     websocketSupport* {.
@@ -1336,17 +1194,6 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   if n.enableKadDiscovery.isSome():
     b.kademliaDiscoveryConf.withEnabled(n.enableKadDiscovery.get())
   b.kademliaDiscoveryConf.withBootstrapNodes(n.kadBootstrapNodes)
-  b.kademliaDiscoveryConf.withServicesToDiscover(n.kadDiscoverServices)
-
-  if n.kadAdvertiseServices.len > 0:
-    var adv: seq[(string, seq[byte])]
-    for s in n.kadAdvertiseServices:
-      let parts = s.split(':', 1)
-      if parts.len == 2:
-        let data = utils.fromHex(parts[1])
-        adv.add((parts[0], data))
-    if adv.len > 0:
-      b.kademliaDiscoveryConf.withServicesToAdvertise(adv)
 
   if n.kadRandomLookupIntervalSec > 0:
     b.kademliaDiscoveryConf.withRandomLookupInterval(
@@ -1356,84 +1203,6 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
     b.kademliaDiscoveryConf.withServiceLookupInterval(
       chronos.seconds(n.kadServiceLookupIntervalSec.int64)
     )
-
-  # Disco tunables
-  if n.kadKRegister.isSome():
-    b.kademliaDiscoveryConf.withKadKRegister(n.kadKRegister.get())
-  if n.kadKLookup.isSome():
-    b.kademliaDiscoveryConf.withKadKLookup(n.kadKLookup.get())
-  if n.kadFLookup.isSome():
-    b.kademliaDiscoveryConf.withKadFLookup(n.kadFLookup.get())
-  if n.kadFReturn.isSome():
-    b.kademliaDiscoveryConf.withKadFReturn(n.kadFReturn.get())
-  if n.kadAdvertExpirySec.isSome():
-    b.kademliaDiscoveryConf.withKadAdvertExpiry(
-      chronos.seconds(n.kadAdvertExpirySec.get().int64)
-    )
-  if n.kadAdvertCacheCap.isSome():
-    b.kademliaDiscoveryConf.withKadAdvertCacheCap(n.kadAdvertCacheCap.get())
-  if n.kadOccupancyExp.isSome():
-    b.kademliaDiscoveryConf.withKadOccupancyExp(n.kadOccupancyExp.get())
-  if n.kadSafetyParam.isSome():
-    b.kademliaDiscoveryConf.withKadSafetyParam(n.kadSafetyParam.get())
-  if n.kadIpSimCoefficient.isSome():
-    b.kademliaDiscoveryConf.withKadIpSimCoefficient(n.kadIpSimCoefficient.get())
-  if n.kadRegistrationWindowSec.isSome():
-    b.kademliaDiscoveryConf.withKadRegistrationWindow(
-      chronos.seconds(n.kadRegistrationWindowSec.get().int64)
-    )
-  if n.kadBucketsCount.isSome():
-    b.kademliaDiscoveryConf.withKadBucketsCount(n.kadBucketsCount.get())
-
-  # KadDHT tunables
-  if n.kadTimeoutSec.isSome():
-    b.kademliaDiscoveryConf.withKadTimeout(chronos.seconds(n.kadTimeoutSec.get().int64))
-  if n.kadBucketRefreshTimeSec.isSome():
-    b.kademliaDiscoveryConf.withKadBucketRefreshTime(
-      chronos.seconds(n.kadBucketRefreshTimeSec.get().int64)
-    )
-  if n.kadRetries.isSome():
-    b.kademliaDiscoveryConf.withKadRetries(n.kadRetries.get())
-  if n.kadReplication.isSome():
-    b.kademliaDiscoveryConf.withKadReplication(n.kadReplication.get())
-  if n.kadAlpha.isSome():
-    b.kademliaDiscoveryConf.withKadAlpha(n.kadAlpha.get())
-  if n.kadQuorum.isSome():
-    b.kademliaDiscoveryConf.withKadQuorum(n.kadQuorum.get())
-  if n.kadProviderRecordCapacity.isSome():
-    b.kademliaDiscoveryConf.withKadProviderRecordCapacity(
-      n.kadProviderRecordCapacity.get()
-    )
-  if n.kadProvidedKeyCapacity.isSome():
-    b.kademliaDiscoveryConf.withKadProvidedKeyCapacity(n.kadProvidedKeyCapacity.get())
-  if n.kadRepublishProvidedKeysIntervalSec.isSome():
-    b.kademliaDiscoveryConf.withKadRepublishProvidedKeysInterval(
-      chronos.seconds(n.kadRepublishProvidedKeysIntervalSec.get().int64)
-    )
-  if n.kadCleanupProvidersIntervalSec.isSome():
-    b.kademliaDiscoveryConf.withKadCleanupProvidersInterval(
-      chronos.seconds(n.kadCleanupProvidersIntervalSec.get().int64)
-    )
-  if n.kadProviderExpirationIntervalSec.isSome():
-    b.kademliaDiscoveryConf.withKadProviderExpirationInterval(
-      chronos.seconds(n.kadProviderExpirationIntervalSec.get().int64)
-    )
-  if n.kadRecordExpirationIntervalSec.isSome():
-    b.kademliaDiscoveryConf.withKadRecordExpirationInterval(
-      chronos.seconds(n.kadRecordExpirationIntervalSec.get().int64)
-    )
-  if n.kadCleanupDataEntriesIntervalSec.isSome():
-    b.kademliaDiscoveryConf.withKadCleanupDataEntriesInterval(
-      chronos.seconds(n.kadCleanupDataEntriesIntervalSec.get().int64)
-    )
-  if n.kadHideConnectionStatus.isSome():
-    b.kademliaDiscoveryConf.withKadHideConnectionStatus(n.kadHideConnectionStatus.get())
-  if n.kadDisableBootstrapping.isSome():
-    b.kademliaDiscoveryConf.withKadDisableBootstrapping(n.kadDisableBootstrapping.get())
-  if n.kadProviderRejection.isSome():
-    b.kademliaDiscoveryConf.withKadProviderRejection(n.kadProviderRejection.get())
-  if n.kadMaxProvidersPerKey.isSome():
-    b.kademliaDiscoveryConf.withKadMaxProvidersPerKey(n.kadMaxProvidersPerKey.get())
 
   # Mode-driven configuration overrides
   case n.mode

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -685,6 +685,160 @@ hence would have reachability issues.""",
       name: "kad-bootstrap-node"
     .}: seq[string]
 
+    kadDiscoverServices* {.
+      desc:
+        "Service ID to periodically discover via kademlia (e.g. 'mix'). Argument may be repeated.",
+      name: "kad-discover-service"
+    .}: seq[string]
+
+    kadAdvertiseServices* {.
+      desc:
+        "Service to advertise in format 'serviceId:hexEncodedData' (e.g. mix:0123abcd). Argument may be repeated.",
+      name: "kad-advertise-service"
+    .}: seq[string]
+
+    kadRandomLookupIntervalSec* {.
+      desc: "Interval seconds between random kademlia lookups (0 uses default).",
+      defaultValue: 0,
+      name: "kad-random-lookup-interval"
+    .}: uint32
+
+    kadServiceLookupIntervalSec* {.
+      desc:
+        "Interval seconds between service-specific kademlia lookups (0 uses default).",
+      defaultValue: 0,
+      name: "kad-service-lookup-interval"
+    .}: uint32
+
+    # ServiceDiscoveryConfig (disco) tunables
+    kadKRegister* {.
+      desc: "Kademlia kRegister (providers per service registration).",
+      defaultValue: none(int),
+      name: "kad-k-register"
+    .}: Option[int]
+    kadKLookup* {.
+      desc: "Kademlia kLookup.", defaultValue: none(int), name: "kad-k-lookup"
+    .}: Option[int]
+    kadFLookup* {.
+      desc: "Kademlia fLookup.", defaultValue: none(int), name: "kad-f-lookup"
+    .}: Option[int]
+    kadFReturn* {.
+      desc: "Kademlia fReturn.", defaultValue: none(int), name: "kad-f-return"
+    .}: Option[int]
+    kadAdvertExpirySec* {.
+      desc: "Advert expiry seconds.",
+      defaultValue: none(uint32),
+      name: "kad-advert-expiry"
+    .}: Option[uint32]
+    kadAdvertCacheCap* {.
+      desc: "Advert cache capacity.",
+      defaultValue: none(uint64),
+      name: "kad-advert-cache-cap"
+    .}: Option[uint64]
+    kadOccupancyExp* {.
+      desc: "Occupancy exponent (float).",
+      defaultValue: none(float),
+      name: "kad-occupancy-exp"
+    .}: Option[float]
+    kadSafetyParam* {.
+      desc: "Safety param G (float).",
+      defaultValue: none(float),
+      name: "kad-safety-param"
+    .}: Option[float]
+    kadIpSimCoefficient* {.
+      desc: "IP similarity coefficient (float).",
+      defaultValue: none(float),
+      name: "kad-ip-sim-coefficient"
+    .}: Option[float]
+    kadRegistrationWindowSec* {.
+      desc: "Registration window seconds.",
+      defaultValue: none(uint32),
+      name: "kad-registration-window"
+    .}: Option[uint32]
+    kadBucketsCount* {.
+      desc: "Buckets count (M).", defaultValue: none(int), name: "kad-buckets-count"
+    .}: Option[int]
+
+    # KadDHTConfig tunables (core kademlia)
+    kadTimeoutSec* {.
+      desc: "Kademlia RPC timeout seconds.",
+      defaultValue: none(uint32),
+      name: "kad-timeout"
+    .}: Option[uint32]
+    kadBucketRefreshTimeSec* {.
+      desc: "Bucket refresh time seconds.",
+      defaultValue: none(uint32),
+      name: "kad-bucket-refresh-time"
+    .}: Option[uint32]
+    kadRetries* {.
+      desc: "Kademlia retries.", defaultValue: none(int), name: "kad-retries"
+    .}: Option[int]
+    kadReplication* {.
+      desc: "Kademlia replication (k).",
+      defaultValue: none(int),
+      name: "kad-replication"
+    .}: Option[int]
+    kadAlpha* {.
+      desc: "Kademlia alpha (concurrency).", defaultValue: none(int), name: "kad-alpha"
+    .}: Option[int]
+    kadQuorum* {.desc: "Kademlia quorum.", defaultValue: none(int), name: "kad-quorum".}:
+      Option[int]
+    kadProviderRecordCapacity* {.
+      desc: "Provider record capacity.",
+      defaultValue: none(int),
+      name: "kad-provider-record-capacity"
+    .}: Option[int]
+    kadProvidedKeyCapacity* {.
+      desc: "Provided key capacity.",
+      defaultValue: none(int),
+      name: "kad-provided-key-capacity"
+    .}: Option[int]
+    kadRepublishProvidedKeysIntervalSec* {.
+      desc: "Republish provided keys interval seconds.",
+      defaultValue: none(uint32),
+      name: "kad-republish-provided-keys-interval"
+    .}: Option[uint32]
+    kadCleanupProvidersIntervalSec* {.
+      desc: "Cleanup providers interval seconds.",
+      defaultValue: none(uint32),
+      name: "kad-cleanup-providers-interval"
+    .}: Option[uint32]
+    kadProviderExpirationIntervalSec* {.
+      desc: "Provider expiration interval seconds.",
+      defaultValue: none(uint32),
+      name: "kad-provider-expiration-interval"
+    .}: Option[uint32]
+    kadRecordExpirationIntervalSec* {.
+      desc: "Record expiration interval seconds.",
+      defaultValue: none(uint32),
+      name: "kad-record-expiration-interval"
+    .}: Option[uint32]
+    kadCleanupDataEntriesIntervalSec* {.
+      desc: "Cleanup data entries interval seconds.",
+      defaultValue: none(uint32),
+      name: "kad-cleanup-data-entries-interval"
+    .}: Option[uint32]
+    kadHideConnectionStatus* {.
+      desc: "Hide connection status in kademlia.",
+      defaultValue: none(bool),
+      name: "kad-hide-connection-status"
+    .}: Option[bool]
+    kadDisableBootstrapping* {.
+      desc: "Disable kademlia bootstrapping.",
+      defaultValue: none(bool),
+      name: "kad-disable-bootstrapping"
+    .}: Option[bool]
+    kadProviderRejection* {.
+      desc: "Enable provider rejection (with max-providers-per-key).",
+      defaultValue: none(bool),
+      name: "kad-provider-rejection"
+    .}: Option[bool]
+    kadMaxProvidersPerKey* {.
+      desc: "Max providers per key ( >0 to enforce; omit or <=0 for unlimited).",
+      defaultValue: none(int),
+      name: "kad-max-providers-per-key"
+    .}: Option[int]
+
     ## websocket config
     websocketSupport* {.
       desc: "Enable websocket:  true|false",
@@ -1182,6 +1336,104 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   if n.enableKadDiscovery.isSome():
     b.kademliaDiscoveryConf.withEnabled(n.enableKadDiscovery.get())
   b.kademliaDiscoveryConf.withBootstrapNodes(n.kadBootstrapNodes)
+  b.kademliaDiscoveryConf.withServicesToDiscover(n.kadDiscoverServices)
+
+  if n.kadAdvertiseServices.len > 0:
+    var adv: seq[(string, seq[byte])]
+    for s in n.kadAdvertiseServices:
+      let parts = s.split(':', 1)
+      if parts.len == 2:
+        let data = utils.fromHex(parts[1])
+        adv.add((parts[0], data))
+    if adv.len > 0:
+      b.kademliaDiscoveryConf.withServicesToAdvertise(adv)
+
+  if n.kadRandomLookupIntervalSec > 0:
+    b.kademliaDiscoveryConf.withRandomLookupInterval(
+      chronos.seconds(n.kadRandomLookupIntervalSec.int64)
+    )
+  if n.kadServiceLookupIntervalSec > 0:
+    b.kademliaDiscoveryConf.withServiceLookupInterval(
+      chronos.seconds(n.kadServiceLookupIntervalSec.int64)
+    )
+
+  # Disco tunables
+  if n.kadKRegister.isSome():
+    b.kademliaDiscoveryConf.withKadKRegister(n.kadKRegister.get())
+  if n.kadKLookup.isSome():
+    b.kademliaDiscoveryConf.withKadKLookup(n.kadKLookup.get())
+  if n.kadFLookup.isSome():
+    b.kademliaDiscoveryConf.withKadFLookup(n.kadFLookup.get())
+  if n.kadFReturn.isSome():
+    b.kademliaDiscoveryConf.withKadFReturn(n.kadFReturn.get())
+  if n.kadAdvertExpirySec.isSome():
+    b.kademliaDiscoveryConf.withKadAdvertExpiry(
+      chronos.seconds(n.kadAdvertExpirySec.get().int64)
+    )
+  if n.kadAdvertCacheCap.isSome():
+    b.kademliaDiscoveryConf.withKadAdvertCacheCap(n.kadAdvertCacheCap.get())
+  if n.kadOccupancyExp.isSome():
+    b.kademliaDiscoveryConf.withKadOccupancyExp(n.kadOccupancyExp.get())
+  if n.kadSafetyParam.isSome():
+    b.kademliaDiscoveryConf.withKadSafetyParam(n.kadSafetyParam.get())
+  if n.kadIpSimCoefficient.isSome():
+    b.kademliaDiscoveryConf.withKadIpSimCoefficient(n.kadIpSimCoefficient.get())
+  if n.kadRegistrationWindowSec.isSome():
+    b.kademliaDiscoveryConf.withKadRegistrationWindow(
+      chronos.seconds(n.kadRegistrationWindowSec.get().int64)
+    )
+  if n.kadBucketsCount.isSome():
+    b.kademliaDiscoveryConf.withKadBucketsCount(n.kadBucketsCount.get())
+
+  # KadDHT tunables
+  if n.kadTimeoutSec.isSome():
+    b.kademliaDiscoveryConf.withKadTimeout(chronos.seconds(n.kadTimeoutSec.get().int64))
+  if n.kadBucketRefreshTimeSec.isSome():
+    b.kademliaDiscoveryConf.withKadBucketRefreshTime(
+      chronos.seconds(n.kadBucketRefreshTimeSec.get().int64)
+    )
+  if n.kadRetries.isSome():
+    b.kademliaDiscoveryConf.withKadRetries(n.kadRetries.get())
+  if n.kadReplication.isSome():
+    b.kademliaDiscoveryConf.withKadReplication(n.kadReplication.get())
+  if n.kadAlpha.isSome():
+    b.kademliaDiscoveryConf.withKadAlpha(n.kadAlpha.get())
+  if n.kadQuorum.isSome():
+    b.kademliaDiscoveryConf.withKadQuorum(n.kadQuorum.get())
+  if n.kadProviderRecordCapacity.isSome():
+    b.kademliaDiscoveryConf.withKadProviderRecordCapacity(
+      n.kadProviderRecordCapacity.get()
+    )
+  if n.kadProvidedKeyCapacity.isSome():
+    b.kademliaDiscoveryConf.withKadProvidedKeyCapacity(n.kadProvidedKeyCapacity.get())
+  if n.kadRepublishProvidedKeysIntervalSec.isSome():
+    b.kademliaDiscoveryConf.withKadRepublishProvidedKeysInterval(
+      chronos.seconds(n.kadRepublishProvidedKeysIntervalSec.get().int64)
+    )
+  if n.kadCleanupProvidersIntervalSec.isSome():
+    b.kademliaDiscoveryConf.withKadCleanupProvidersInterval(
+      chronos.seconds(n.kadCleanupProvidersIntervalSec.get().int64)
+    )
+  if n.kadProviderExpirationIntervalSec.isSome():
+    b.kademliaDiscoveryConf.withKadProviderExpirationInterval(
+      chronos.seconds(n.kadProviderExpirationIntervalSec.get().int64)
+    )
+  if n.kadRecordExpirationIntervalSec.isSome():
+    b.kademliaDiscoveryConf.withKadRecordExpirationInterval(
+      chronos.seconds(n.kadRecordExpirationIntervalSec.get().int64)
+    )
+  if n.kadCleanupDataEntriesIntervalSec.isSome():
+    b.kademliaDiscoveryConf.withKadCleanupDataEntriesInterval(
+      chronos.seconds(n.kadCleanupDataEntriesIntervalSec.get().int64)
+    )
+  if n.kadHideConnectionStatus.isSome():
+    b.kademliaDiscoveryConf.withKadHideConnectionStatus(n.kadHideConnectionStatus.get())
+  if n.kadDisableBootstrapping.isSome():
+    b.kademliaDiscoveryConf.withKadDisableBootstrapping(n.kadDisableBootstrapping.get())
+  if n.kadProviderRejection.isSome():
+    b.kademliaDiscoveryConf.withKadProviderRejection(n.kadProviderRejection.get())
+  if n.kadMaxProvidersPerKey.isSome():
+    b.kademliaDiscoveryConf.withKadMaxProvidersPerKey(n.kadMaxProvidersPerKey.get())
 
   # Mode-driven configuration overrides
   case n.mode


### PR DESCRIPTION
Service discovery integration!

I added all the config options and modified the existing `WakuKademlia` to integrate service discovery.

Brokers are used for communication. Events are emitted when new peers are found. There's also a way to request peers for specific services.

`WakuKademlia` is not a libp2p protocol and must be started and stopped BUT the service discovery protocol inside IS and must be mounted to the switch.