### PR TITLE
fix compilation problem in new discovery branch

### DIFF
--- a/logos_delivery/waku/discovery/waku_kademlia.nim
+++ b/logos_delivery/waku/discovery/waku_kademlia.nim
@@ -1,7 +1,7 @@
 import logos_delivery/waku/compat/option_valueor
 {.push raises: [].}
 
-import std/[sequtils, sets]
+import std/[options, sequtils, sets]
 import
   chronos,
   chronicles,
@@ -39,6 +39,17 @@ type WakuKademlia* = ref object
   serviceLookupInterval: Duration
   servicesToDiscover: HashSet[string]
   servicesToAdvertise: HashSet[ServiceInfo]
+
+type KademliaDiscoveryConf* = object
+  bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
+  servicesToAdvertise*: seq[ServiceInfo]
+  servicesToDiscover*: seq[string]
+  randomLookupInterval*: Duration
+  serviceLookupInterval*: Duration
+  kadDhtConfig*: KadDHTConfig
+  discoConfig*: ServiceDiscoveryConfig
+  clientMode*: bool
+  xprPublishing*: bool
 
 proc extractMixPubKey(service: ServiceInfo): Option[Curve25519Key] =
   if service.id != MixProtocolID:

--- a/logos_delivery/waku/factory/conf_builder/kademlia_discovery_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/kademlia_discovery_conf_builder.nim
@@ -6,20 +6,10 @@ import libp2p/[peerid, multiaddress, peerinfo, extended_peer_record]
 import libp2p/protocols/kademlia/types
 import libp2p/protocols/service_discovery/types as sd_types
 import logos_delivery/waku/waku_core/peers
+import logos_delivery/waku/discovery/waku_kademlia
 
 logScope:
   topics = "waku conf builder kademlia discovery"
-
-type KademliaDiscoveryConf* = object
-  bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
-  servicesToAdvertise*: seq[ServiceInfo]
-  servicesToDiscover*: seq[string]
-  randomLookupInterval*: Duration
-  serviceLookupInterval*: Duration
-  kadDhtConfig*: KadDHTConfig
-  discoConfig*: sd_types.ServiceDiscoveryConfig
-  clientMode*: bool
-  xprPublishing*: bool
 
 const
   DefaultKadEnabled*: bool = false

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -16,6 +16,7 @@ import
   ../waku_rln_relay/rln_relay,
   ../rest_api/endpoint/builder,
   ../discovery/waku_discv5,
+  ../discovery/waku_kademlia,
   ../node/waku_metrics,
   ../common/logging,
   ../common/rate_limit/setting,

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -53,7 +53,6 @@ import
     waku_enr,
     waku_peer_exchange,
     waku_rln_relay,
-    factory/conf_builder/kademlia_discovery_conf_builder,
     common/rate_limit/setting,
     common/callbacks,
     common/nimchronos,


### PR DESCRIPTION
## Description

A possible/suggested compilation fix for the compilation errors in the `feat--new-service-disco` branch (PR #3947).

## Changes

* relocate KademliaDiscoveryConf to the discovery layer to break a node -> factory import cycle
