### PR TITLE
fix: retry send tasks stuck in Entry state (#3847)

### DIFF
--- a/logos_delivery/messaging/delivery_service/send_service/send_processor.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_processor.nim
@@ -32,5 +32,10 @@ method process*(
     currentProcessor = currentProcessor.fallbackProcessor
     keepTrying = task.state == DeliveryState.FallbackRetry
 
-  if task.state == DeliveryState.FallbackRetry:
+  # A task still in `FallbackRetry` exhausted the chain without delivering, and
+  # one still in `Entry` was never attempted because no processor had a usable
+  # peer yet (e.g. a lightpush peer that finishes registering right after the
+  # first send). Both must be queued for the next round so the service loop
+  # retries them; otherwise the task would sit untouched until it ages out.
+  if task.state == DeliveryState.FallbackRetry or task.state == DeliveryState.Entry:
     task.state = DeliveryState.NextRoundRetry

--- a/tests/api/test_api_send.nim
+++ b/tests/api/test_api_send.nim
@@ -360,6 +360,43 @@ suite "Waku API - Send":
     (await node.stop()).isOkOr:
       raiseAssert "Failed to stop node: " & error
 
+  asyncTest "Edge sender delivers via lightpush (no relay)":
+    ## Reproduces issue #3847: an Edge node (no relay mounted) that is only
+    ## connected to a lightpush-capable peer must deliver through lightpush.
+    var node: Waku
+    lockNewGlobalBrokerContext:
+      node = (await createNode(createApiNodeConf(cli_args.WakuMode.Edge))).valueOr:
+        raiseAssert error
+      node.mountMessagingClient().isOkOr:
+        raiseAssert "Failed to mount messaging: " & error
+      (await node.start()).isOkOr:
+        raiseAssert "Failed to start Waku node: " & error
+
+      # Edge node has no relay; its only path to the network is the
+      # lightpush peer it is connected to.
+      await node.node.connectToNodes(@[lightpushNodePeerInfo])
+
+    check node.node.wakuRelay.isNil()
+
+    let eventManager = newSendEventListenerManager(node.brokerCtx)
+    defer:
+      await eventManager.teardown()
+
+    let envelope = MessageEnvelope.init(
+      ContentTopic("/waku/2/default-content/proto"), "test payload"
+    )
+
+    let requestId = (await node.send(envelope)).valueOr:
+      raiseAssert error
+
+    const eventTimeout = 10.seconds
+    discard await eventManager.waitForEvents(eventTimeout)
+
+    eventManager.validate({SendEventOutcome.Propagated}, requestId)
+
+    (await node.stop()).isOkOr:
+      raiseAssert "Failed to stop node: " & error
+
   asyncTest "Send fully validates fallback to lightpush":
     var node: Waku
     lockNewGlobalBrokerContext:


### PR DESCRIPTION
## Problem

Fixes #3847 reported by @AYAHASSAN287 .

When a sender is **not** explicitly configured with `lightpushnode`, message delivery could fail even though a lightpush-capable peer was connected — no `message_propagated` event was ever emitted (affecting interop scenarios S08/S10/S15).

## Root cause

The failure is a delivery-state retry bug, not a peer-discovery bug:

- A `DeliveryTask` starts in `DeliveryState.Entry` (`delivery_task.nim`).
- The send loop (`SendService.serviceLoop → trySendMessages`) only retries tasks in `NextRoundRetry`.
- `send_processor.process` only promoted `FallbackRetry → NextRoundRetry`.

For an **Edge sender** (no relay mounted), the processor chain is lightpush-only. If the lightpush peer is not yet registered in the peer store at the exact moment of the first send — identify/metadata complete ~100 ms *after* the connection is established — `isValidProcessor` is `false`, `sendImpl` is never called, and the task stays in `Entry` forever. It is never retried, so the message is only ever surfaced as an error once it ages out (`MaxTimeInCache`, 1 min). That is the `lightpushCount=0` / no-`message_propagated` symptom.

The Core relay path was unaffected because relay's `isValidProcessor` is always `true`, so those tasks always reached `FallbackRetry → NextRoundRetry`.

## Fix

Promote a task left in `Entry` after the chain (nothing attempted, no processor had a usable peer yet) to `NextRoundRetry` as well, so it is re-attempted once the lightpush peer finishes registering. Retries stay bounded by `MaxTimeInCache`.

## Testing

Added an Edge-sender regression test in `tests/api/test_api_send.nim` (Edge node, no relay, connected only to a lightpush peer):

- **Before:** FAILED — `sent=0, propagated=0, error=0`; `sendImpl` never invoked.
- **After:** PASSES — `Trying message delivery via Lightpush (tryCount=1)` → `Message propagated via Lightpush` → `PROPAGATED` event on the first retry.

Full suite: `7 tests run, 7 OK, 0 FAILED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)