### PR TITLE
extract generateRlnValidator into temp adapter dir

### DIFF
--- a/logos_delivery/waku/node/waku_node/relay.nim
+++ b/logos_delivery/waku/node/waku_node/relay.nim
@@ -29,6 +29,7 @@ import
     waku_archive,
     waku_store_sync,
     waku_rln_relay,
+    waku_rln_relay/adapters/relay as waku_rln_relay_adapter,
     node/waku_node,
     node/subscription_manager,
     node/peer_manager,

--- a/logos_delivery/waku/waku_rln_relay/adapters/relay.nim
+++ b/logos_delivery/waku/waku_rln_relay/adapters/relay.nim
@@ -8,11 +8,7 @@ import
   stew/byteutils,
   libp2p/protocols/pubsub/pubsub
 
-import
-  ../rln_relay,
-  ../protocol_types,
-  ../protocol_metrics,
-  ../conversion_utils
+import ../rln_relay, ../protocol_types, ../protocol_metrics, ../conversion_utils
 
 import logos_delivery/waku/[waku_relay, waku_core]
 

--- a/logos_delivery/waku/waku_rln_relay/adapters/relay.nim
+++ b/logos_delivery/waku/waku_rln_relay/adapters/relay.nim
@@ -1,0 +1,82 @@
+{.push raises: [].}
+
+import
+  std/options,
+  chronicles,
+  chronos,
+  results,
+  stew/byteutils,
+  libp2p/protocols/pubsub/pubsub
+
+import
+  ../rln_relay,
+  ../protocol_types,
+  ../protocol_metrics,
+  ../conversion_utils
+
+import logos_delivery/waku/[waku_relay, waku_core]
+
+logScope:
+  topics = "waku rln_relay adapter"
+
+proc generateRlnValidator*(
+    wakuRlnRelay: WakuRLNRelay, spamHandler = none(SpamHandler)
+): WakuValidatorHandler =
+  ## Bridges RLN's protocol-agnostic message validation into a relay
+  ## (gossipsub) validator. The core decision is made by
+  ## `validateMessageAndUpdateLog`; this adapter maps the result to
+  ## `pubsub.ValidationResult` so the validator can be installed on
+  ## WakuRelay's validator chain.
+  ## Validation logic follows https://rfc.vac.dev/spec/17/
+  proc validator(
+      topic: string, message: WakuMessage
+  ): Future[pubsub.ValidationResult] {.async.} =
+    trace "rln-relay topic validator is called"
+    wakuRlnRelay.clearNullifierLog()
+
+    let msgProof = RateLimitProof.init(message.proof).valueOr:
+      trace "generateRlnValidator reject", error = error
+      return pubsub.ValidationResult.Reject
+
+    # validate the message and update log
+    let validationRes = await wakuRlnRelay.validateMessageAndUpdateLog(message)
+
+    let
+      proof = byteutils.toHex(msgProof.proof)
+      epoch = fromEpoch(msgProof.epoch)
+      root = inHex(msgProof.merkleRoot)
+      shareX = inHex(msgProof.shareX)
+      shareY = inHex(msgProof.shareY)
+      nullifier = inHex(msgProof.nullifier)
+      payload = string.fromBytes(message.payload)
+    case validationRes
+    of Valid:
+      trace "message validity is verified, relaying",
+        proof = proof,
+        root = root,
+        shareX = shareX,
+        shareY = shareY,
+        nullifier = nullifier
+      waku_rln_valid_messages_total.inc(labelValues = [topic])
+      return pubsub.ValidationResult.Accept
+    of Invalid:
+      trace "message validity could not be verified, discarding",
+        proof = proof,
+        root = root,
+        shareX = shareX,
+        shareY = shareY,
+        nullifier = nullifier
+      return pubsub.ValidationResult.Reject
+    of Spam:
+      trace "A spam message is found! yay! discarding:",
+        proof = proof,
+        root = root,
+        shareX = shareX,
+        shareY = shareY,
+        nullifier = nullifier
+      if spamHandler.isSome():
+        let handler = spamHandler.get()
+        handler(message)
+      return pubsub.ValidationResult.Reject
+
+  return validator

--- a/logos_delivery/waku/waku_rln_relay/rln_relay.nim
+++ b/logos_delivery/waku/waku_rln_relay/rln_relay.nim
@@ -26,12 +26,8 @@ import
   ./nonce_manager
 
 import
-  logos_delivery/waku/[
-    common/error_handling,
-    waku_core,
-    requests/rln_requests,
-    waku_keystore,
-  ]
+  logos_delivery/waku/
+    [common/error_handling, waku_core, requests/rln_requests, waku_keystore]
 
 logScope:
   topics = "waku rln_relay"

--- a/logos_delivery/waku/waku_rln_relay/rln_relay.nim
+++ b/logos_delivery/waku/waku_rln_relay/rln_relay.nim
@@ -12,7 +12,6 @@ import
   web3/eth_api_types,
   eth/keys,
   libp2p/protocols/pubsub/rpc/messages,
-  libp2p/protocols/pubsub/pubsub,
   results,
   stew/[byteutils, arrayops],
   brokers/broker_context
@@ -29,7 +28,6 @@ import
 import
   logos_delivery/waku/[
     common/error_handling,
-    waku_relay, # for WakuRelayHandler
     waku_core,
     requests/rln_requests,
     waku_keystore,
@@ -320,65 +318,6 @@ proc clearNullifierLog*(rlnPeer: WakuRlnRelay) =
     trace "clearing epochs from the nullifier log",
       currentEpoch = currentEpoch, cleanedEpoch = fromEpoch(epochRemove)
     rlnPeer.nullifierLog.del(epochRemove)
-
-proc generateRlnValidator*(
-    wakuRlnRelay: WakuRLNRelay, spamHandler = none(SpamHandler)
-): WakuValidatorHandler =
-  ## this procedure is a thin wrapper for the pubsub addValidator method
-  ## it sets a validator for waku messages, acting in the registered pubsub topic
-  ## the message validation logic is according to https://rfc.vac.dev/spec/17/
-  proc validator(
-      topic: string, message: WakuMessage
-  ): Future[pubsub.ValidationResult] {.async.} =
-    trace "rln-relay topic validator is called"
-    wakuRlnRelay.clearNullifierLog()
-
-    let msgProof = RateLimitProof.init(message.proof).valueOr:
-      trace "generateRlnValidator reject", error = error
-      return pubsub.ValidationResult.Reject
-
-    # validate the message and update log
-    let validationRes = await wakuRlnRelay.validateMessageAndUpdateLog(message)
-
-    let
-      proof = byteutils.toHex(msgProof.proof)
-      epoch = fromEpoch(msgProof.epoch)
-      root = inHex(msgProof.merkleRoot)
-      shareX = inHex(msgProof.shareX)
-      shareY = inHex(msgProof.shareY)
-      nullifier = inHex(msgProof.nullifier)
-      payload = string.fromBytes(message.payload)
-    case validationRes
-    of Valid:
-      trace "message validity is verified, relaying",
-        proof = proof,
-        root = root,
-        shareX = shareX,
-        shareY = shareY,
-        nullifier = nullifier
-      waku_rln_valid_messages_total.inc(labelValues = [topic])
-      return pubsub.ValidationResult.Accept
-    of Invalid:
-      trace "message validity could not be verified, discarding",
-        proof = proof,
-        root = root,
-        shareX = shareX,
-        shareY = shareY,
-        nullifier = nullifier
-      return pubsub.ValidationResult.Reject
-    of Spam:
-      trace "A spam message is found! yay! discarding:",
-        proof = proof,
-        root = root,
-        shareX = shareX,
-        shareY = shareY,
-        nullifier = nullifier
-      if spamHandler.isSome():
-        let handler = spamHandler.get()
-        handler(message)
-      return pubsub.ValidationResult.Reject
-
-  return validator
 
 proc monitorEpochs(wakuRlnRelay: WakuRLNRelay) {.async.} =
   while true:


### PR DESCRIPTION
## Description
Phase 1 of decoupling RLN from relay, see details [here](https://github.com/logos-messaging/logos-delivery/issues/3954#issuecomment-4766298073)
Extract `generateRlnValidator` from `waku_rln_relay/rln_relay.nim` into temp path `waku_rln-relay/adapters/relay.nim` to remove the dependency of rln_relay.nim on waku_relay and libp2p pubsub modules

## Changes
**temporary change:** move `generateRlnValidator` to temp dir `adapters`
No behaviour changes


