### PR TITLE
feat(mix): add --mix-disable-cover-traffic CLI knob

### DIFF
--- a/logos_delivery/waku/factory/conf_builder/mix_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/mix_conf_builder.nim
@@ -17,6 +17,7 @@ type MixConfBuilder* = object
   mixNodes: seq[MixNodePubInfo]
   userMessageLimit: Option[int]
   disableSpamProtection: bool
+  disableCoverTraffic: bool
 
 proc init*(T: type MixConfBuilder): MixConfBuilder =
   MixConfBuilder()
@@ -36,6 +37,9 @@ proc withUserMessageLimit*(b: var MixConfBuilder, limit: int) =
 proc withDisableSpamProtection*(b: var MixConfBuilder, disable: bool) =
   b.disableSpamProtection = disable
 
+proc withDisableCoverTraffic*(b: var MixConfBuilder, disable: bool) =
+  b.disableCoverTraffic = disable
+
 proc build*(b: MixConfBuilder): Result[Option[MixConf], string] =
   if not b.enabled.get(DefaultMixEnabled):
     return ok(none[MixConf]())
@@ -51,6 +55,7 @@ proc build*(b: MixConfBuilder): Result[Option[MixConf], string] =
             mixNodes: b.mixNodes,
             userMessageLimit: b.userMessageLimit,
             disableSpamProtection: b.disableSpamProtection,
+            disableCoverTraffic: b.disableCoverTraffic,
           )
         )
       )
@@ -65,6 +70,7 @@ proc build*(b: MixConfBuilder): Result[Option[MixConf], string] =
             mixNodes: b.mixNodes,
             userMessageLimit: b.userMessageLimit,
             disableSpamProtection: b.disableSpamProtection,
+            disableCoverTraffic: b.disableCoverTraffic,
           )
         )
       )

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -170,7 +170,7 @@ proc setupProtocols(
     (
       await node.mountMix(
         conf.clusterId, mixConf.mixKey, mixConf.mixnodes, mixConf.userMessageLimit,
-        mixConf.disableSpamProtection,
+        mixConf.disableSpamProtection, mixConf.disableCoverTraffic,
       )
     ).isOkOr:
       return err("failed to mount waku mix protocol: " & $error)

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -62,6 +62,7 @@ type MixConf* = ref object
   mixnodes*: seq[MixNodePubInfo]
   userMessageLimit*: Option[int]
   disableSpamProtection*: bool
+  disableCoverTraffic*: bool
 
 type StoreServiceConf* {.requiresInit.} = object
   dbMigration*: bool

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -329,6 +329,7 @@ proc mountMix*(
     mixnodes: seq[MixNodePubInfo],
     userMessageLimit: Option[int] = none(int),
     disableSpamProtection: bool = false,
+    disableCoverTraffic: bool = false,
 ): Future[Result[void, string]] {.async.} =
   info "mounting mix protocol", nodeId = node.info #TODO log the config used
 
@@ -361,7 +362,7 @@ proc mountMix*(
 
   node.wakuMix = WakuMix.new(
     localaddrStr, node.peerManager, clusterId, mixPrivKey, mixnodes, publishMessage,
-    userMessageLimit, disableSpamProtection,
+    userMessageLimit, disableSpamProtection, disableCoverTraffic,
   ).valueOr:
     error "Waku Mix protocol initialization failed", err = error
     return

--- a/logos_delivery/waku/waku_mix/protocol.nim
+++ b/logos_delivery/waku/waku_mix/protocol.nim
@@ -111,6 +111,7 @@ proc new*(
     publishMessage: PublishMessage,
     userMessageLimit: Option[int] = none(int),
     disableSpamProtection: bool = false,
+    disableCoverTraffic: bool = false,
 ): WakuMixResult[T] =
   let mixPubKey = public(mixPrivKey)
   trace "mixPubKey", mixPubKey = mixPubKey
@@ -146,11 +147,16 @@ proc new*(
   else:
     info "mix spam protection disabled"
 
-  let ct = ConstantRateCoverTraffic.new(
-    totalSlots = ctTotalSlots,
-    epochDuration = ctEpochDuration,
-    useInternalEpochTimer = disableSpamProtection,
-  )
+  var coverTrafficOpt = default(Opt[CoverTraffic])
+  if not disableCoverTraffic:
+    let ct = ConstantRateCoverTraffic.new(
+      totalSlots = ctTotalSlots,
+      epochDuration = ctEpochDuration,
+      useInternalEpochTimer = disableSpamProtection,
+    )
+    coverTrafficOpt = Opt.some(CoverTraffic(ct))
+  else:
+    info "mix cover traffic disabled"
 
   var mixRlnSpam: MixRlnSpamProtection
   if spamProtectionOpt.isSome():
@@ -172,7 +178,7 @@ proc new*(
         ExponentialDelayStrategy.new(meanDelay = 100, rng = crypto.newRng())
       )
     ),
-    coverTraffic = Opt.some(CoverTraffic(ct)),
+    coverTraffic = coverTrafficOpt,
   )
 
   processBootNodes(bootnodes, peermgr, m)

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -681,6 +681,12 @@ hence would have reachability issues.""",
       name: "mix-disable-spam-protection"
     .}: bool
 
+    mixDisableCoverTraffic* {.
+      desc: "Disable constant-rate cover traffic emission for mix protocol.",
+      defaultValue: false,
+      name: "mix-disable-cover-traffic"
+    .}: bool
+
     # Kademlia Discovery config
     # Option-typed; desc states the default since the CLI can't auto-show it for none().
     enableKadDiscovery* {.
@@ -1152,6 +1158,7 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   if n.mixUserMessageLimit.isSome():
     b.mixConf.withUserMessageLimit(n.mixUserMessageLimit.get())
   b.mixConf.withDisableSpamProtection(n.mixDisableSpamProtection)
+  b.mixConf.withDisableCoverTraffic(n.mixDisableCoverTraffic)
 
   b.filterServiceConf.withEnabled(n.filter)
   b.filterServiceConf.withSubscriptionTimeout(n.filterSubscriptionTimeout)


### PR DESCRIPTION
### Summary
Adds `--mix-disable-cover-traffic` CLI flag (default `false`) to suppress cover-traffic emission while keeping mix routing + DoS protection (RLN) active.

### Motivation
For testnet-0.2 fleet deployment we want to disable cover traffic without killing DoS protection.  
                                                                                                                          
### Changes                                      
Mirrors `--mix-disable-spam-protection`.                                                                                                                 
                                                                                                                        
### Tested                                                                                                               
- `wakunode2` builds clean               
- `--help` shows the new flag                                                                                           
- Default unchanged: cover traffic remains ON