### PR TITLE
channels_api + messaging_api FFI restructure

### DIFF
--- a/library/channels_api/channel_lifecycle_api.nim
+++ b/library/channels_api/channel_lifecycle_api.nim
@@ -1,0 +1,24 @@
+## Opaque handle to a live reliable channel. Holds the owning manager + the
+## channel id so the channel ops (send / close) need no other context. Only its
+## uint64 id crosses the FFI boundary; the object stays in the ctx registry.
+type ReliableChannelHandle {.ffiHandle.} = ref object
+  manager: ReliableChannelManager
+  channelId: ChannelId
+
+proc channel_create*(
+    self: LogosDelivery, channelId: string, contentTopic: string, senderId: string
+): Future[Result[ReliableChannelHandle, string]] {.ffi.} =
+  ## Creates a reliable channel and returns a handle to it. The send handler and
+  ## rng come from the manager; encryption providers are installed separately.
+  let id = self.reliableChannelManager.createReliableChannel(
+    ChannelId(channelId), ContentTopic(contentTopic), SdsParticipantID(senderId)
+  ).valueOr:
+    return err(error)
+  return ok(ReliableChannelHandle(manager: self.reliableChannelManager, channelId: id))
+
+proc channel_close*(ch: ReliableChannelHandle): Future[Result[string, string]] {.ffi.} =
+  ## Stops the channel's SDS loops and deregisters it from the manager.
+  ## Persisted SDS state survives, so re-creating the channel restores it.
+  (await ch.manager.closeChannel(ch.channelId)).isOkOr:
+    return err(error)
+  return ok("")

--- a/library/channels_api/events.nim
+++ b/library/channels_api/events.nim
@@ -1,0 +1,33 @@
+## Reliable-channel events: per-channel message received / sent / errored,
+## fed by the channel-layer broker events.
+
+proc onChannelMessageReceived*(
+  channelId: string, senderId: string, payload: seq[byte]
+) {.ffiEvent: "on_channel_message_received".}
+
+proc onChannelMessageSent*(
+  channelId: string, requestId: string
+) {.ffiEvent: "on_channel_message_sent".}
+
+proc onChannelMessageError*(
+  channelId: string, requestId: string, error: string
+) {.ffiEvent: "on_channel_message_error".}
+
+proc listenChannelEvents(self: LogosDelivery) =
+  let brokerCtx = self.waku.brokerCtx
+
+  discard ChannelMessageReceivedEvent.listen(
+    brokerCtx,
+    proc(e: ChannelMessageReceivedEvent) {.async: (raises: []).} =
+      onChannelMessageReceived(string(e.channelId), $e.senderId, e.payload),
+  )
+  discard ChannelMessageSentEvent.listen(
+    brokerCtx,
+    proc(e: ChannelMessageSentEvent) {.async: (raises: []).} =
+      onChannelMessageSent(string(e.channelId), $e.requestId),
+  )
+  discard ChannelMessageErrorEvent.listen(
+    brokerCtx,
+    proc(e: ChannelMessageErrorEvent) {.async: (raises: []).} =
+      onChannelMessageError(string(e.channelId), $e.requestId, e.error),
+  )

--- a/library/channels_api/send_api.nim
+++ b/library/channels_api/send_api.nim
@@ -1,0 +1,9 @@
+proc channel_send*(
+    ch: ReliableChannelHandle, payload: seq[byte], ephemeral: bool
+): Future[Result[string, string]] {.ffi.} =
+  ## Sends `payload` on the reliable channel. Routes through the messaging
+  ## layer (ReliableChannelManager.send -> MessagingClient.send); returns the
+  ## channel-layer request id.
+  let requestId = (await ch.manager.send(ch.channelId, payload, ephemeral)).valueOr:
+    return err(error)
+  return ok($requestId)

--- a/library/liblogosdelivery.nim
+++ b/library/liblogosdelivery.nim
@@ -28,7 +28,8 @@ include
   ./events/message_events,
   ./events/connection_status_events,
   ./events/topic_health_events,
-  ./events/connection_change_events
+  ./events/connection_change_events,
+  ./channels_api/events
 
 proc listenInternalEvents(self: LogosDelivery) =
   ## Feed every FFI event from an internal nim-broker event.
@@ -37,6 +38,7 @@ proc listenInternalEvents(self: LogosDelivery) =
   self.listenConnectionStatusEvents()
   self.listenTopicHealthEvents()
   self.listenConnectionChangeEvents()
+  self.listenChannelEvents()
 
 # --- constructor / destructor ----------------------------------------------
 proc logosdelivery_create*(
@@ -68,10 +70,12 @@ proc stop*(self: LogosDelivery): Future[Result[string, string]] {.ffi.} =
     return err(error)
   return ok("")
 
-# --- operations (typed {.ffi.} procs, grouped per protocol) ----------------
+# --- operations (typed {.ffi.} procs, grouped per layer/protocol) ----------
 include
   ./messaging_api/subscriptions_api,
   ./messaging_api/send_api,
+  ./channels_api/channel_lifecycle_api,
+  ./channels_api/send_api,
   ./kernel_api/node_info_api,
   ./kernel_api/debug_node_api,
   ./kernel_api/ping_api,


### PR DESCRIPTION
**Stacked PR 3/3** — base: PR 2 (`…-02`, #3990).

Splits the FFI library into `library/messaging_api/` (send / subscriptions) and `library/channels_api/` (reliable-channel handle: create/send/close + channel events), and relocates node-info. Thin layer on top of the v0.2 migration.

**Builds green.** Review/merge after #3990.