### PR TITLE
Temporarily extend ci test job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     name: test-${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Description
The the ci test run on ubuntu is timing out. The RLN tests take a long time to run and can do with improvement. There is a ticket for it [here](https://github.com/logos-messaging/logos-delivery/issues/3968), but until then we are extending the timeout so that we can verify that all tests pass.


## Changes
ci.yml: `timeout-minutes:` 45->60
