### PR TITLE
fix: handle on-chain RPC errors gracefully during RLN setup

### DIFF
--- a/logos_delivery/waku/rln/group_manager/on_chain/rpc_wrapper.nim
+++ b/logos_delivery/waku/rln/group_manager/on_chain/rpc_wrapper.nim
@@ -68,9 +68,22 @@ proc sendEthCallWithoutParams*(
   tx.data = Opt.some(byteutils.hexToSeqByte(dataSignature))
   tx.chainId = Opt.some(chainId)
 
-  let resultBytes = await ethRpc.provider.eth_call(tx, "latest")
+  # A revert / rate-limit / dropped connection raises here; return err so RLN
+  # setup fails gracefully instead of crashing the node.
+  let resultBytes =
+    try:
+      await ethRpc.provider.eth_call(tx, "latest")
+    except CatchableError as e:
+      return err("eth_call failed for " & functionSignature & ": " & e.msg)
+
   if resultBytes.len == 0:
     return err("No result returned for function call: " & functionSignature)
+  # UInt256.fromBytesBE panics (Defect) on < 32 bytes; reject short responses.
+  if resultBytes.len != 32:
+    return err(
+      "Unexpected result length (" & $resultBytes.len & " bytes) for function call: " &
+        functionSignature
+    )
   return ok(UInt256.fromBytesBE(resultBytes))
 
 proc sendEthCallWithParams*(
@@ -94,5 +107,10 @@ proc sendEthCallWithParams*(
   tx.data = Opt.some(callData)
   tx.chainId = Opt.some(chainId)
 
-  let resultBytes = await ethRpc.provider.eth_call(tx, "latest")
+  let resultBytes =
+    try:
+      await ethRpc.provider.eth_call(tx, "latest")
+    except CatchableError as e:
+      return err("eth_call failed for " & functionSignature & ": " & e.msg)
+
   return ok(resultBytes)


### PR DESCRIPTION
## Description
RLN on-chain calls (eth_call) didn't catch failures, so a contract revert, Infura rate-limit, or dropped connection crashed the node while mounting RLN on TWN; a short response also panicked UInt256.fromBytesBE with an uncatchable defect. Now these return a Result err so the node fails gracefully instead of crashing. Adds a network-free regression test (mock JSON-RPC server).

close #3376
