### PR TITLE
chore: phase 4 — remove RLN proof generation from lightpush server to client

### DIFF
--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -65,7 +65,6 @@ proc setupSendProcessorChain(
     peerManager: PeerManager,
     lightpushClient: WakuLightPushClient,
     relay: WakuRelay,
-    rlnRelay: Rln,
     brokerCtx: BrokerContext,
 ): Result[BaseSendProcessor, string] =
   let isRelayAvail = not relay.isNil()
@@ -77,12 +76,7 @@ proc setupSendProcessorChain(
   var processors = newSeq[BaseSendProcessor]()
 
   if isRelayAvail:
-    let rln: Option[Rln] =
-      if rlnRelay.isNil():
-        none[Rln]()
-      else:
-        some(rlnRelay)
-    let publishProc = getRelayPushHandler(relay, rln)
+    let publishProc = getRelayPushHandler(relay)
 
     processors.add(RelaySendProcessor.new(isLightPushAvail, publishProc, brokerCtx))
   if isLightPushAvail:
@@ -107,7 +101,7 @@ proc new*(
   let checkStoreForMessages = preferP2PReliability and not w.wakuStoreClient.isNil()
 
   let sendProcessorChain = setupSendProcessorChain(
-    w.peerManager, w.wakuLightPushClient, w.wakuRelay, w.rln, w.brokerCtx
+    w.peerManager, w.wakuLightPushClient, w.wakuRelay, w.brokerCtx
   ).valueOr:
     return err("failed to setup SendProcessorChain: " & $error)
 

--- a/logos_delivery/waku/node/waku_node/lightpush.nim
+++ b/logos_delivery/waku/node/waku_node/lightpush.nim
@@ -47,15 +47,7 @@ proc mountLegacyLightPush*(
     return err(MountWithoutRelayError)
 
   info "mounting legacy lightpush with relay"
-  let rlnPeer =
-    if node.rln.isNil():
-      info "mounting legacy lightpush without rln-relay"
-      none(Rln)
-    else:
-      info "mounting legacy lightpush with rln-relay"
-      some(node.rln)
-  let pushHandler =
-    legacy_lightpush_protocol.getRelayPushHandler(node.wakuRelay, rlnPeer)
+  let pushHandler = legacy_lightpush_protocol.getRelayPushHandler(node.wakuRelay)
 
   node.wakuLegacyLightPush =
     WakuLegacyLightPush.new(node.peerManager, node.rng, pushHandler, some(rateLimit))
@@ -90,6 +82,14 @@ proc legacyLightpushPublish*(
     error "failed to publish message as legacy lightpush not available"
     return err("Waku lightpush not available")
 
+  let rlnPeer =
+    if node.rln.isNil():
+      none(Rln)
+    else:
+      some(node.rln)
+  let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, message)).valueOr:
+    return err(error)
+
   let internalPublish = proc(
       node: WakuNode,
       pubsubTopic: PubsubTopic,
@@ -115,7 +115,7 @@ proc legacyLightpushPublish*(
         await node.wakuLegacyLightPush.handleSelfLightPushRequest(pubsubTopic, message)
   try:
     if pubsubTopic.isSome():
-      return await internalPublish(node, pubsubTopic.get(), message, peer)
+      return await internalPublish(node, pubsubTopic.get(), msgWithProof, peer)
 
     if node.wakuAutoSharding.isNone():
       return err("Pubsub topic must be specified when static sharding is enabled")
@@ -123,7 +123,7 @@ proc legacyLightpushPublish*(
       ?node.wakuAutoSharding.get().getShardsFromContentTopics(message.contentTopic)
 
     for pubsub, _ in topicMap.pairs: # There's only one pair anyway
-      return await internalPublish(node, $pubsub, message, peer)
+      return await internalPublish(node, $pubsub, msgWithProof, peer)
   except CatchableError:
     return err(getCurrentExceptionMsg())
 
@@ -158,14 +158,7 @@ proc mountLightPush*(
     return err(MountWithoutRelayError)
 
   info "mounting lightpush with relay"
-  let rlnPeer =
-    if node.rln.isNil():
-      info "mounting lightpush without rln-relay"
-      none(Rln)
-    else:
-      info "mounting lightpush with rln-relay"
-      some(node.rln)
-  let pushHandler = lightpush_protocol.getRelayPushHandler(node.wakuRelay, rlnPeer)
+  let pushHandler = lightpush_protocol.getRelayPushHandler(node.wakuRelay)
 
   node.wakuLightPush = WakuLightPush.new(
     node.peerManager, node.rng, pushHandler, node.wakuAutoSharding, some(rateLimit)
@@ -282,4 +275,13 @@ proc lightpushPublish*(
       error "lightpush publish error", error = msg
       return lighpushErrorResult(LightPushErrorCode.INTERNAL_SERVER_ERROR, msg)
 
-  return await lightpushPublishHandler(node, pubsubForPublish, message, toPeer, mixify)
+  let rlnPeer =
+    if node.rln.isNil():
+      none(Rln)
+    else:
+      some(node.rln)
+  let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, message)).valueOr:
+    return lighpushErrorResult(LightPushErrorCode.OUT_OF_RLN_PROOF, error)
+
+  return
+    await lightpushPublishHandler(node, pubsubForPublish, msgWithProof, toPeer, mixify)

--- a/logos_delivery/waku/node/waku_node/lightpush.nim
+++ b/logos_delivery/waku/node/waku_node/lightpush.nim
@@ -82,20 +82,18 @@ proc legacyLightpushPublish*(
     error "failed to publish message as legacy lightpush not available"
     return err("Waku lightpush not available")
 
-  # RLN proof is computed over payload || contentTopic || timestamp, so the
-  # timestamp must be set before proof generation — otherwise the downstream
-  # ensureTimestampSet in the client publish would mutate it and invalidate
-  # the proof.
-  var msgWithTimestamp = message
-  ensureTimestampSet(msgWithTimestamp)
+  # toRLNSignal includes the timestamp in the proof input, so the timestamp
+  # must be fixed before proof generation. The downstream ensureTimestampSet
+  # in the client publish becomes an idempotent no-op safety net.
+  let message = ensureTimestampSet(message)
 
-  let rlnPeer =
+  let rln =
     if node.rln.isNil():
       none(Rln)
     else:
       some(node.rln)
-  let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, msgWithTimestamp)).valueOr:
-    return err(error)
+  let msgWithProof = (await checkAndGenerateRLNProof(rln, message)).valueOr:
+    return err("failed call checkAndGenerateRLNProof from lightpush: " & error)
 
   let internalPublish = proc(
       node: WakuNode,
@@ -282,19 +280,17 @@ proc lightpushPublish*(
       error "lightpush publish error", error = msg
       return lighpushErrorResult(LightPushErrorCode.INTERNAL_SERVER_ERROR, msg)
 
-  # RLN proof is computed over payload || contentTopic || timestamp, so the
-  # timestamp must be set before proof generation — otherwise the downstream
-  # ensureTimestampSet in the client publish would mutate it and invalidate
-  # the proof.
-  var msgWithTimestamp = message
-  ensureTimestampSet(msgWithTimestamp)
+  # toRLNSignal includes the timestamp in the proof input, so the timestamp
+  # must be fixed before proof generation. The downstream ensureTimestampSet
+  # in the client publish becomes an idempotent no-op safety net.
+  let message = ensureTimestampSet(message)
 
-  let rlnPeer =
+  let rln =
     if node.rln.isNil():
       none(Rln)
     else:
       some(node.rln)
-  let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, msgWithTimestamp)).valueOr:
+  let msgWithProof = (await checkAndGenerateRLNProof(rln, message)).valueOr:
     return lighpushErrorResult(LightPushErrorCode.OUT_OF_RLN_PROOF, error)
 
   return

--- a/logos_delivery/waku/node/waku_node/lightpush.nim
+++ b/logos_delivery/waku/node/waku_node/lightpush.nim
@@ -82,12 +82,19 @@ proc legacyLightpushPublish*(
     error "failed to publish message as legacy lightpush not available"
     return err("Waku lightpush not available")
 
+  # RLN proof is computed over payload || contentTopic || timestamp, so the
+  # timestamp must be set before proof generation — otherwise the downstream
+  # ensureTimestampSet in the client publish would mutate it and invalidate
+  # the proof.
+  var msgWithTimestamp = message
+  ensureTimestampSet(msgWithTimestamp)
+
   let rlnPeer =
     if node.rln.isNil():
       none(Rln)
     else:
       some(node.rln)
-  let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, message)).valueOr:
+  let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, msgWithTimestamp)).valueOr:
     return err(error)
 
   let internalPublish = proc(
@@ -275,12 +282,19 @@ proc lightpushPublish*(
       error "lightpush publish error", error = msg
       return lighpushErrorResult(LightPushErrorCode.INTERNAL_SERVER_ERROR, msg)
 
+  # RLN proof is computed over payload || contentTopic || timestamp, so the
+  # timestamp must be set before proof generation — otherwise the downstream
+  # ensureTimestampSet in the client publish would mutate it and invalidate
+  # the proof.
+  var msgWithTimestamp = message
+  ensureTimestampSet(msgWithTimestamp)
+
   let rlnPeer =
     if node.rln.isNil():
       none(Rln)
     else:
       some(node.rln)
-  let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, message)).valueOr:
+  let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, msgWithTimestamp)).valueOr:
     return lighpushErrorResult(LightPushErrorCode.OUT_OF_RLN_PROOF, error)
 
   return

--- a/logos_delivery/waku/rln/proof.nim
+++ b/logos_delivery/waku/rln/proof.nim
@@ -1,7 +1,7 @@
 {.push raises: [].}
 
-import std/[times, sequtils]
-import chronos, results, stew/byteutils
+import std/[options, times, sequtils]
+import chronos, chronicles, results, stew/byteutils
 
 import ./types, ./protocol_types, ./conversion_utils, ./group_manager, ./nonce_manager
 
@@ -63,3 +63,23 @@ proc generateRLNProof*(
   let proof = (await rlnPeer.groupManager.generateProof(input, epoch, nonce)).valueOr:
     return err("could not generate rln-v2 proof: " & $error)
   return ok(proof.encode().buffer)
+
+proc checkAndGenerateRLNProof*(
+    rlnPeer: Option[Rln], message: WakuMessage
+): Future[Result[WakuMessage, string]] {.async.} =
+  if message.proof.len > 0:
+    return ok(message)
+
+  if rlnPeer.isNone():
+    notice "Publishing message without RLN proof"
+    return ok(message)
+
+  let
+    time = getTime().toUnix()
+    senderEpochTime = float64(time)
+  var msgWithProof = message
+  msgWithProof.proof = (
+    await rlnPeer.get().generateRLNProof(msgWithProof.toRLNSignal(), senderEpochTime)
+  ).valueOr:
+    return err($error)
+  return ok(msgWithProof)

--- a/logos_delivery/waku/rln/proof.nim
+++ b/logos_delivery/waku/rln/proof.nim
@@ -7,17 +7,17 @@ import ./types, ./protocol_types, ./conversion_utils, ./group_manager, ./nonce_m
 
 import logos_delivery/waku/waku_core
 
-proc calcEpoch*(rlnPeer: Rln, t: float64): Epoch =
+proc calcEpoch*(rln: Rln, t: float64): Epoch =
   ## gets time `t` as `flaot64` with subseconds resolution in the fractional part
   ## and returns its corresponding rln `Epoch` value
 
-  let e = uint64(t / rlnPeer.rlnEpochSizeSec.float64)
+  let e = uint64(t / rln.rlnEpochSizeSec.float64)
   return toEpoch(e)
 
-proc nextEpoch*(rlnPeer: Rln, time: float64): float64 =
+proc nextEpoch*(rln: Rln, time: float64): float64 =
   let
-    currentEpoch = uint64(time / rlnPeer.rlnEpochSizeSec.float64)
-    nextEpochTime = float64(currentEpoch + 1) * rlnPeer.rlnEpochSizeSec.float64
+    currentEpoch = uint64(time / rln.rlnEpochSizeSec.float64)
+    nextEpochTime = float64(currentEpoch + 1) * rln.rlnEpochSizeSec.float64
     currentTime = epochTime()
 
   # Ensure we always return a future time
@@ -26,8 +26,8 @@ proc nextEpoch*(rlnPeer: Rln, time: float64): float64 =
   else:
     return epochTime()
 
-proc getCurrentEpoch*(rlnPeer: Rln): Epoch =
-  return rlnPeer.calcEpoch(epochTime())
+proc getCurrentEpoch*(rln: Rln): Epoch =
+  return rln.calcEpoch(epochTime())
 
 proc absDiff*(e1, e2: Epoch): uint64 =
   ## returns the absolute difference between the two rln `Epoch`s `e1` and `e2`
@@ -55,22 +55,22 @@ proc toRLNSignal*(wakumessage: WakuMessage): seq[byte] =
   return output
 
 proc generateRLNProof*(
-    rlnPeer: Rln, input: seq[byte], senderEpochTime: float64
+    rln: Rln, input: seq[byte], senderEpochTime: float64
 ): Future[RlnResult[seq[byte]]] {.async.} =
-  let epoch = rlnPeer.calcEpoch(senderEpochTime)
-  let nonce = rlnPeer.nonceManager.getNonce().valueOr:
+  let epoch = rln.calcEpoch(senderEpochTime)
+  let nonce = rln.nonceManager.getNonce().valueOr:
     return err("could not get new message id to generate an rln proof: " & $error)
-  let proof = (await rlnPeer.groupManager.generateProof(input, epoch, nonce)).valueOr:
+  let proof = (await rln.groupManager.generateProof(input, epoch, nonce)).valueOr:
     return err("could not generate rln-v2 proof: " & $error)
   return ok(proof.encode().buffer)
 
 proc checkAndGenerateRLNProof*(
-    rlnPeer: Option[Rln], message: WakuMessage
+    rln: Option[Rln], message: WakuMessage
 ): Future[Result[WakuMessage, string]] {.async.} =
   if message.proof.len > 0:
     return ok(message)
 
-  if rlnPeer.isNone():
+  if rln.isNone():
     notice "Publishing message without RLN proof"
     return ok(message)
 
@@ -79,7 +79,7 @@ proc checkAndGenerateRLNProof*(
     senderEpochTime = float64(time)
   var msgWithProof = message
   msgWithProof.proof = (
-    await rlnPeer.get().generateRLNProof(msgWithProof.toRLNSignal(), senderEpochTime)
+    await rln.get().generateRLNProof(msgWithProof.toRLNSignal(), senderEpochTime)
   ).valueOr:
-    return err($error)
+    return err("error in checkAndGenerateRLNProof: " & $error)
   return ok(msgWithProof)

--- a/logos_delivery/waku/waku_core/message/message.nim
+++ b/logos_delivery/waku/waku_core/message/message.nim
@@ -27,3 +27,7 @@ type WakuMessage* = object # Data payload transmitted.
   # The proof attribute indicates that the message is not spam. This
   # attribute will be used in the rln-relay protocol.
   proof*: seq[byte]
+
+proc ensureTimestampSet*(message: var WakuMessage) =
+  if message.timestamp == 0:
+    message.timestamp = getNowInNanosecondTime()

--- a/logos_delivery/waku/waku_core/message/message.nim
+++ b/logos_delivery/waku/waku_core/message/message.nim
@@ -28,7 +28,7 @@ type WakuMessage* = object # Data payload transmitted.
   # attribute will be used in the rln-relay protocol.
   proof*: seq[byte]
 
-func ensureTimestampSet*(message: WakuMessage): WakuMessage =
+proc ensureTimestampSet*(message: WakuMessage): WakuMessage =
   result = message
   if result.timestamp == 0:
     result.timestamp = getNowInNanosecondTime()

--- a/logos_delivery/waku/waku_core/message/message.nim
+++ b/logos_delivery/waku/waku_core/message/message.nim
@@ -28,6 +28,7 @@ type WakuMessage* = object # Data payload transmitted.
   # attribute will be used in the rln-relay protocol.
   proof*: seq[byte]
 
-proc ensureTimestampSet*(message: var WakuMessage) =
-  if message.timestamp == 0:
-    message.timestamp = getNowInNanosecondTime()
+func ensureTimestampSet*(message: WakuMessage): WakuMessage =
+  result = message
+  if result.timestamp == 0:
+    result.timestamp = getNowInNanosecondTime()

--- a/logos_delivery/waku/waku_lightpush/callbacks.nim
+++ b/logos_delivery/waku/waku_lightpush/callbacks.nim
@@ -7,47 +7,20 @@ import ../waku_core, ../waku_relay, ./common, ../rln, ../rln/protocol_types
 
 import std/times, libp2p/peerid, stew/byteutils
 
-proc checkAndGenerateRLNProof*(
-    rlnPeer: Option[Rln], message: WakuMessage
-): Future[Result[WakuMessage, string]] {.async.} =
-  # check if the message already has RLN proof
-  if message.proof.len > 0:
-    return ok(message)
-
-  if rlnPeer.isNone():
-    notice "Publishing message without RLN proof"
-    return ok(message)
-  # generate and append RLN proof
-  let
-    time = getTime().toUnix()
-    senderEpochTime = float64(time)
-  var msgWithProof = message
-  msgWithProof.proof = (
-    await rlnPeer.get().generateRLNProof(msgWithProof.toRLNSignal, senderEpochTime)
-  ).valueOr:
-    return err($error)
-  return ok(msgWithProof)
-
 proc getNilPushHandler*(): PushMessageHandler =
   return proc(
       pubsubTopic: string, message: WakuMessage
   ): Future[WakuLightPushResult] {.async.} =
     return lightpushResultInternalError("no waku relay found")
 
-proc getRelayPushHandler*(
-    wakuRelay: WakuRelay, rlnPeer: Option[Rln] = none[Rln]()
-): PushMessageHandler =
+proc getRelayPushHandler*(wakuRelay: WakuRelay): PushMessageHandler =
   return proc(
       pubsubTopic: string, message: WakuMessage
   ): Future[WakuLightPushResult] {.async.} =
-    # append RLN proof
-    let msgWithProof = (await checkAndGenerateRLNProof(rlnPeer, message)).valueOr:
-      return lighpushErrorResult(LightPushErrorCode.OUT_OF_RLN_PROOF, error)
-
-    (await wakuRelay.validateMessage(pubSubTopic, msgWithProof)).isOkOr:
+    (await wakuRelay.validateMessage(pubSubTopic, message)).isOkOr:
       return lighpushErrorResult(LightPushErrorCode.INVALID_MESSAGE, $error)
 
-    let publishedResult = (await wakuRelay.publish(pubsubTopic, msgWithProof)).valueOr:
+    let publishedResult = (await wakuRelay.publish(pubsubTopic, message)).valueOr:
       let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
       notice "Lightpush request has not been published to any peers",
         msg_hash = msgHash, reason = $error

--- a/logos_delivery/waku/waku_lightpush/client.nim
+++ b/logos_delivery/waku/waku_lightpush/client.nim
@@ -24,10 +24,6 @@ type WakuLightPushClient* = ref object
 proc new*(T: type WakuLightPushClient, peerManager: PeerManager, rng: crypto.Rng): T =
   WakuLightPushClient(peerManager: peerManager, rng: rng)
 
-proc ensureTimestampSet(message: var WakuMessage) =
-  if message.timestamp == 0:
-    message.timestamp = getNowInNanosecondTime()
-
 ## Short log string for peer identifiers (overloads for convenience)
 func shortPeerId(peer: PeerId): string =
   shortLog(peer)

--- a/logos_delivery/waku/waku_lightpush/client.nim
+++ b/logos_delivery/waku/waku_lightpush/client.nim
@@ -78,8 +78,7 @@ proc publish*(
     wakuMessage: WakuMessage,
     dest: Connection | PeerId | RemotePeerInfo,
 ): Future[WakuLightPushResult] {.async, gcsafe.} =
-  var message = wakuMessage
-  ensureTimestampSet(message)
+  let message = ensureTimestampSet(wakuMessage)
 
   let msgHash = computeMessageHash(pubSubTopic.get(""), message).to0xHex()
 

--- a/logos_delivery/waku/waku_lightpush_legacy/callbacks.nim
+++ b/logos_delivery/waku/waku_lightpush_legacy/callbacks.nim
@@ -10,45 +10,19 @@ import
 
 import std/times, libp2p/peerid, stew/byteutils
 
-proc checkAndGenerateRLNProof*(
-    rlnPeer: Option[Rln], message: WakuMessage
-): Future[Result[WakuMessage, string]] {.async.} =
-  # check if the message already has RLN proof
-  if message.proof.len > 0:
-    return ok(message)
-
-  if rlnPeer.isNone():
-    notice "Publishing message without RLN proof"
-    return ok(message)
-  # generate and append RLN proof
-  let
-    time = getTime().toUnix()
-    senderEpochTime = float64(time)
-  var msgWithProof = message
-  msgWithProof.proof = (
-    await rlnPeer.get().generateRLNProof(msgWithProof.toRLNSignal(), senderEpochTime)
-  ).valueOr:
-    return err($error)
-  return ok(msgWithProof)
-
 proc getNilPushHandler*(): PushMessageHandler =
   return proc(
       pubsubTopic: string, message: WakuMessage
   ): Future[WakuLightPushResult[void]] {.async.} =
     return err("no waku relay found")
 
-proc getRelayPushHandler*(
-    wakuRelay: WakuRelay, rlnPeer: Option[Rln] = none[Rln]()
-): PushMessageHandler =
+proc getRelayPushHandler*(wakuRelay: WakuRelay): PushMessageHandler =
   return proc(
       pubsubTopic: string, message: WakuMessage
   ): Future[WakuLightPushResult[void]] {.async.} =
-    # append RLN proof
-    let msgWithProof = ?(await checkAndGenerateRLNProof(rlnPeer, message))
+    ?(await wakuRelay.validateMessage(pubSubTopic, message))
 
-    ?(await wakuRelay.validateMessage(pubSubTopic, msgWithProof))
-
-    (await wakuRelay.publish(pubsubTopic, msgWithProof)).isOkOr:
+    (await wakuRelay.publish(pubsubTopic, message)).isOkOr:
       ## Agreed change expected to the lightpush protocol to better handle such case. https://github.com/waku-org/pm/issues/93
       let msgHash = computeMessageHash(pubsubTopic, message).to0xHex()
       notice "Lightpush request has not been published to any peers",

--- a/logos_delivery/waku/waku_lightpush_legacy/client.nim
+++ b/logos_delivery/waku/waku_lightpush_legacy/client.nim
@@ -74,8 +74,7 @@ proc publish*(
   ## On success, returns the msg_hash of the published message
 
   var message = wakuMessage
-  if message.timestamp == 0:
-    message.timestamp = getNowInNanosecondTime()
+  ensureTimestampSet(message)
 
   let msg_hash_hex_str = computeMessageHash(pubsubTopic, message).to0xHex()
   let pushRequest = PushRequest(pubSubTopic: pubSubTopic, message: message)

--- a/logos_delivery/waku/waku_lightpush_legacy/client.nim
+++ b/logos_delivery/waku/waku_lightpush_legacy/client.nim
@@ -73,8 +73,7 @@ proc publish*(
 ): Future[WakuLightPushResult[string]] {.async, gcsafe.} =
   ## On success, returns the msg_hash of the published message
 
-  var message = wakuMessage
-  ensureTimestampSet(message)
+  let message = ensureTimestampSet(wakuMessage)
 
   let msg_hash_hex_str = computeMessageHash(pubsubTopic, message).to0xHex()
   let pushRequest = PushRequest(pubSubTopic: pubSubTopic, message: message)

--- a/tests/node/test_wakunode_legacy_lightpush.nim
+++ b/tests/node/test_wakunode_legacy_lightpush.nim
@@ -100,6 +100,7 @@ suite "RLN Proofs as a Lightpush Service":
     client {.threadvar.}: WakuNode
     anvilProc {.threadvar.}: Process
     manager {.threadvar.}: OnchainGroupManager
+    wakuRlnConfig {.threadvar.}: WakuRlnConfig
 
     serverRemotePeerInfo {.threadvar.}: RemotePeerInfo
     pubsubTopic {.threadvar.}: PubsubTopic
@@ -119,7 +120,7 @@ suite "RLN Proofs as a Lightpush Service":
 
     # mount rln-relay
     # match prod epoch window to reduce test flake
-    let wakuRlnConfig = getWakuRlnConfig(
+    wakuRlnConfig = getWakuRlnConfig(
       manager = manager, index = MembershipIndex(1), epochSizeSec = 600
     )
 
@@ -163,9 +164,15 @@ suite "RLN Proofs as a Lightpush Service":
         newTestWakuNode(generateSecp256k1Key(), parseIpAddress("0.0.0.0"), Port(0))
       lightpushClient.mountLegacyLightPushClient()
 
+      # Attach the RLN proof. In production the client mounts RLN and generates the
+      # proof in legacyLightpushPublish; here we generate it using the server's RLN
+      # instance since both ends share group state via the in-memory manager.
+      let msgWithProof =
+        (await checkAndGenerateRLNProof(some(server.rln), message)).get()
+
       # When the client publishes a message
       let publishResponse = await lightpushClient.legacyLightpushPublish(
-        some(pubsubTopic), message, serverRemotePeerInfo
+        some(pubsubTopic), msgWithProof, serverRemotePeerInfo
       )
 
       if not publishResponse.isOk():

--- a/tests/node/test_wakunode_lightpush.nim
+++ b/tests/node/test_wakunode_lightpush.nim
@@ -97,6 +97,7 @@ suite "RLN Proofs as a Lightpush Service":
     client {.threadvar.}: WakuNode
     anvilProc {.threadvar.}: Process
     manager {.threadvar.}: OnchainGroupManager
+    wakuRlnConfig {.threadvar.}: WakuRlnConfig
 
     serverRemotePeerInfo {.threadvar.}: RemotePeerInfo
     pubsubTopic {.threadvar.}: PubsubTopic
@@ -116,7 +117,7 @@ suite "RLN Proofs as a Lightpush Service":
 
     # mount rln-relay
     # match prod epoch window to reduce test flake
-    let wakuRlnConfig = getWakuRlnConfig(
+    wakuRlnConfig = getWakuRlnConfig(
       manager = manager, index = MembershipIndex(1), epochSizeSec = 600
     )
 
@@ -160,9 +161,15 @@ suite "RLN Proofs as a Lightpush Service":
         newTestWakuNode(generateSecp256k1Key(), parseIpAddress("0.0.0.0"), Port(0))
       lightpushClient.mountLightPushClient()
 
+      # Attach the RLN proof. In production the client mounts RLN and generates the
+      # proof in lightpushPublish; here we generate it using the server's RLN instance
+      # since both ends share group state via the in-memory manager.
+      let msgWithProof =
+        (await checkAndGenerateRLNProof(some(server.rln), message)).get()
+
       # When the client publishes a message
       let publishResponse = await lightpushClient.lightpushPublish(
-        some(pubsubTopic), message, some(serverRemotePeerInfo)
+        some(pubsubTopic), msgWithProof, some(serverRemotePeerInfo)
       )
 
       if not publishResponse.isOk():


### PR DESCRIPTION
## Description
Now that phases 1 to 3 have been merged, the previous implementation of RLN-as-a-service for lightpush clients can be removed and the proof generated by the client itself. 

## Changes
- checkAndGenerateRLNProof moved from waku_lightpush(_legacy)/callbacks.nim
  to rln/proof.nim, alongside generateRLNProof and toRLNSignal.
- (legacy)lightpushPublish now calls checkAndGenerateRLNProof once per
  publish, before mixify, so the proof travels through mix encapsulation.
- Server-side proof generation removed from both getRelayPushHandler
  bodies; the now-dead rlnPeer parameter dropped from both signatures
  and from mount{LightPush,LegacyLightPush} and setupSendProcessorChain.

Test updates: the two "Message is published when RLN enabled" tests
(modern + legacy) now attach the RLN proof in the test body, since the
ephemeral lightpush client does not mount RLN.

## Issue closes #
https://github.com/logos-messaging/logos-delivery/issues/3954
