### PR TITLE
chore: remove fleet mode enum

### DIFF
--- a/logos_delivery/api/conf/channels_conf.nim
+++ b/logos_delivery/api/conf/channels_conf.nim
@@ -1,0 +1,15 @@
+import std/options
+
+type ReliableChannelManagerConf* = object
+  ## All-`Option` partial; unset fields fall back to `createReliableChannel` defaults.
+  segmentationEnableReedSolomon*: Option[bool]
+    ## Add Reed-Solomon parity segments for recovery of lost segments.
+  segmentationSegmentSizeBytes*: Option[int] ## Maximum segment size in bytes.
+  sdsAcknowledgementTimeoutMs*: Option[int]
+    ## Time to wait before retransmitting an unacknowledged message.
+  sdsMaxRetransmissions*: Option[int]
+    ## Maximum retransmission attempts before delivery fails.
+  sdsCausalHistorySize*: Option[int] ## Number of message ids kept in causal history.
+  rateLimitEnabled*: Option[bool] ## Enable rate limiting.
+  rateLimitEpochPeriodSec*: Option[int] ## Rate-limit epoch length in seconds.
+  rateLimitMessagesPerEpoch*: Option[int] ## Messages allowed per rate-limit epoch.

--- a/logos_delivery/api/conf/logos_delivery_conf.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf.nim
@@ -4,9 +4,9 @@ import std/options
 import results
 
 import logos_delivery/api/conf/messaging_conf
-import logos_delivery/channels/reliable_channel_manager
+import logos_delivery/api/conf/channels_conf
 
-export options, messaging_conf, reliable_channel_manager
+export options, messaging_conf, channels_conf
 
 type LogosDeliveryConf* = object
   ## Aggregates the per-layer config objects. A layer is mounted iff its config

--- a/logos_delivery/api/conf/logos_delivery_conf.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf.nim
@@ -20,7 +20,7 @@ proc init*(T: type LogosDeliveryConf, kernelConf: KernelConf): LogosDeliveryConf
 
 proc init*(
     T: type LogosDeliveryConf,
-    mode: LogosDeliveryMode,
+    mode: MessagingMode,
     preset: string,
     messagingOverrides: MessagingClientConf,
     channelsOverrides: ReliableChannelManagerConf,

--- a/logos_delivery/api/conf/logos_delivery_conf_json.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf_json.nim
@@ -13,21 +13,13 @@ const
   KeyKernelConf = "kernelconf"
   KeyMessagingOverrides = "messagingoverrides"
   KeyChannelsOverrides = "channelsoverrides"
+  ModeCore = "core"
+  ModeEdge = "edge"
+  ModeFleet = "fleet"
   # [Legacy flat JSON config] Keys that left the kernel and so must be lifted out of
   # a flat blob before the WakuNodeConf walker sees them (it would reject them).
   KeyReliabilityEnabled = "reliabilityenabled"
   KeyReliability = "reliability"
-
-proc parseMode(s: string): Result[LogosDeliveryMode, string] =
-  case s.strip().toLowerAscii()
-  of "core":
-    return ok(LogosDeliveryMode.Core)
-  of "edge":
-    return ok(LogosDeliveryMode.Edge)
-  of "fleet":
-    return ok(LogosDeliveryMode.Fleet)
-  else:
-    return err("invalid mode: '" & s & "' (expected 'Core', 'Edge' or 'Fleet')")
 
 proc parseOverrides[T](defaults: T, node: JsonNode, label: string): Result[T, string] =
   ## Parse the JSON object `node` as overrides on top of `defaults`.
@@ -43,8 +35,23 @@ proc parseOverrides[T](defaults: T, node: JsonNode, label: string): Result[T, st
   )
   return ok(conf)
 
+proc parseFleetConf(
+    topJsonNode: var Table[string, (string, JsonNode)]
+): ConfResult[LogosDeliveryConf] =
+  ## Kernel-only: a raw kernelConf and no upper layers.
+  if not topJsonNode.hasKey(KeyKernelConf):
+    return err("fleet mode requires a 'kernelConf' object")
+  let (_, v) = topJsonNode.getOrDefault(KeyKernelConf)
+  let kernel = ?parseOverrides(?defaultWakuNodeConf(), v, "kernelConf")
+  topJsonNode.del(KeyKernelConf)
+  if topJsonNode.len > 0:
+    return err(
+      unknownKeysError(topJsonNode, "fleet mode takes only 'kernelConf'; unexpected")
+    )
+  return ok(LogosDeliveryConf.init(KernelConf(kernel)))
+
 proc parseFlatConf(
-    mode: LogosDeliveryMode, topJsonNode: var Table[string, (string, JsonNode)]
+    mode: MessagingMode, topJsonNode: var Table[string, (string, JsonNode)]
 ): ConfResult[LogosDeliveryConf] =
   ## [Legacy flat JSON config] Flat shape: a blob of `WakuNodeConf` fields. `mode`
   ## expands to protocol flags over raw kernel defaults, `reliabilityEnabled` routes
@@ -67,7 +74,7 @@ proc parseFlatConf(
   # the mode's protocol flags (the kernel no longer owns `mode`, so we expand it here,
   # like the old kernel builder did), then let explicit fields override.
   var kernel = ?defaultWakuNodeConf()
-  ?applyMode(kernel, mode)
+  applyMode(kernel, mode)
   ?applyJsonFieldsToConf(
     kernel, topJsonNode, "Failed to parse config field",
     "Unrecognized configuration option(s) found",
@@ -98,25 +105,22 @@ proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
 
   var top = ?collectJsonFields(node)
 
-  var mode = LogosDeliveryMode.Core
+  var mode = MessagingMode.Core
   if top.hasKey(KeyMode):
     let (_, v) = top.getOrDefault(KeyMode)
     if v.kind != JString:
       return err("mode must be a string")
-    mode = ?parseMode(v.getStr())
     top.del(KeyMode)
-
-  if mode == LogosDeliveryMode.Fleet:
-    # Kernel-only: a raw kernelConf and no upper layers.
-    if not top.hasKey(KeyKernelConf):
-      return err("fleet mode requires a 'kernelConf' object")
-    let (_, v) = top.getOrDefault(KeyKernelConf)
-    let kernel = ?parseOverrides(?defaultWakuNodeConf(), v, "kernelConf")
-    top.del(KeyKernelConf)
-    if top.len > 0:
+    case v.getStr().strip().toLowerAscii()
+    of ModeFleet:
+      return parseFleetConf(top)
+    of ModeCore:
+      mode = MessagingMode.Core
+    of ModeEdge:
+      mode = MessagingMode.Edge
+    else:
       return
-        err(unknownKeysError(top, "fleet mode takes only 'kernelConf'; unexpected"))
-    return ok(LogosDeliveryConf.init(KernelConf(kernel)))
+        err("invalid mode: '" & v.getStr() & "' (expected 'Core', 'Edge' or 'Fleet')")
 
   # [Legacy flat JSON config] A wrapper key marks our structured shape. Otherwise any
   # leftover top-level key besides `preset` (mode is already consumed) is a bare

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -1,17 +1,59 @@
 import std/options
 import std/net
 import results
+import libp2p/crypto/crypto
 
 import logos_delivery/api/conf/kernel_conf
-import logos_delivery/messaging/messaging_client
+import logos_delivery/waku/common/logging
 import logos_delivery/waku/factory/networks_config
 
-export kernel_conf, messaging_client
+export kernel_conf
 
 type LogosDeliveryMode* {.pure.} = enum
   Edge # client-only node
   Core # full service node
   Fleet # kernel-only node from a raw kernel config
+
+type MessagingClientConf* = object
+  clusterId* {.name: "cluster-id".}: Option[uint16] ## Network cluster id.
+  numShardsInCluster* {.name: "num-shards-in-network".}: Option[uint16]
+    ## Number of shards in the cluster.
+  p2pTcpPort* {.name: "tcp-port".}: Option[Port] ## TCP listening port.
+  discv5UdpPort* {.name: "discv5-udp-port".}: Option[Port] ## discv5 UDP port.
+  websocketSupport* {.name: "websocket-support".}: Option[bool]
+    ## Enable the websocket transport.
+  websocketPort* {.name: "websocket-port".}: Option[Port] ## Websocket listening port.
+  quicSupport* {.name: "quic-support".}: Option[bool] ## Enable the QUIC transport.
+  quicPort* {.name: "quic-port".}: Option[Port] ## QUIC (UDP) listening port.
+  listenIpv4* {.name: "listen-address".}: Option[IpAddress] ## Inbound bind address.
+  maxMessageSize* {.name: "max-msg-size".}: Option[string]
+    ## Maximum accepted message size (e.g. "150 KiB").
+  entryNodes* {.name: "entry-node".}: Option[seq[string]]
+    ## Bootstrap / connectivity nodes (enrtree or multiaddr).
+  ethRpcEndpoints* {.name: "rln-relay-eth-client-address".}: Option[seq[EthRpcUrl]]
+    ## Ethereum RPC endpoints (required for RLN validation); multiple for fail-over.
+  rlnContractAddress* {.name: "rln-relay-eth-contract-address".}: Option[string]
+    ## RLN contract address; when set, RLN validation is enabled.
+  rlnChainId* {.name: "rln-relay-chain-id".}: Option[uint]
+    ## Chain id the RLN contract is deployed on.
+  rlnEpochSizeSec* {.name: "rln-relay-epoch-sec".}: Option[uint]
+    ## RLN epoch size, in seconds.
+  reliabilityEnabled* {.name: "reliability".}: Option[bool]
+    ## Enable store-based send reliability.
+  store*: Option[bool] ## Enable the store protocol.
+  storenode* {.name: "storenode".}: Option[string]
+  storeMessageDbUrl* {.name: "store-message-db-url".}: Option[string]
+    ## Database connection URL for the store service's persistent storage.
+  storeMessageRetentionPolicy* {.name: "store-message-retention-policy".}:
+    Option[string] ## Store retention policy (e.g. "time:3600;size:1GB").
+  storeMaxNumDbConnections* {.name: "store-max-num-db-connections".}: Option[int]
+    ## Maximum number of simultaneous store database connections.
+  logLevel* {.name: "log-level".}: Option[logging.LogLevel]
+    ## Process log level (TRACE..FATAL); applied by the kernel on node creation.
+  logFormat* {.name: "log-format".}: Option[logging.LogFormat]
+    ## Process log format (TEXT or JSON); applied by the kernel on node creation.
+  nodeKey* {.name: "nodekey".}: Option[crypto.PrivateKey]
+    ## P2P node private key (64-char hex): stable identity / peerId across restarts.
 
 proc applyMode*(conf: var WakuNodeConf, mode: LogosDeliveryMode): ConfResult[void] =
   ## Sets the protocol flags implied by the mode.

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -9,10 +9,9 @@ import logos_delivery/waku/factory/networks_config
 
 export kernel_conf
 
-type LogosDeliveryMode* {.pure.} = enum
+type MessagingMode* {.pure.} = enum
   Edge # client-only node
   Core # full service node
-  Fleet # kernel-only node from a raw kernel config
 
 type MessagingClientConf* = object
   clusterId* {.name: "cluster-id".}: Option[uint16] ## Network cluster id.
@@ -55,33 +54,29 @@ type MessagingClientConf* = object
   nodeKey* {.name: "nodekey".}: Option[crypto.PrivateKey]
     ## P2P node private key (64-char hex): stable identity / peerId across restarts.
 
-proc applyMode*(conf: var WakuNodeConf, mode: LogosDeliveryMode): ConfResult[void] =
+proc applyMode*(conf: var WakuNodeConf, mode: MessagingMode) =
   ## Sets the protocol flags implied by the mode.
   case mode
-  of LogosDeliveryMode.Core:
+  of MessagingMode.Core:
     conf.relay = true
     conf.filter = true
     conf.lightpush = true
     conf.discv5Discovery = some(true)
     conf.peerExchange = true
     conf.rendezvous = true
-  of LogosDeliveryMode.Edge:
+  of MessagingMode.Edge:
     conf.peerExchange = true
     conf.relay = false
     conf.filter = false
     conf.lightpush = false
     conf.store = false
-  of LogosDeliveryMode.Fleet:
-    return
-      err("fleet mode takes a raw kernel config; use LogosDelivery.new(kernelConf)")
-  return ok()
 
 proc toWakuNodeConf*(
-    self: MessagingClientConf, mode: LogosDeliveryMode
+    self: MessagingClientConf, mode: MessagingMode
 ): ConfResult[WakuNodeConf] =
   ## Mode sets the protocol flags; set fields map to their kernel counterpart.
   var conf = ?defaultWakuNodeConf()
-  ?applyMode(conf, mode)
+  applyMode(conf, mode)
 
   if self.store.isSome():
     conf.store = self.store.get()

--- a/logos_delivery/channels/reliable_channel_manager.nim
+++ b/logos_delivery/channels/reliable_channel_manager.nim
@@ -5,7 +5,7 @@
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import std/[options, tables]
+import std/tables
 import results
 import chronos
 import chronicles
@@ -15,30 +15,16 @@ import brokers/broker_context
 
 import logos_delivery/api/types
 import logos_delivery/api/reliable_channel_manager_api
+import logos_delivery/api/conf/channels_conf
 
 import ./reliable_channel
 
-export reliable_channel
+export reliable_channel, channels_conf
 
-type
-  ReliableChannelManagerConf* = object
-    ## All-`Option` partial; unset fields fall back to `createReliableChannel` defaults.
-    segmentationEnableReedSolomon*: Option[bool]
-      ## Add Reed-Solomon parity segments for recovery of lost segments.
-    segmentationSegmentSizeBytes*: Option[int] ## Maximum segment size in bytes.
-    sdsAcknowledgementTimeoutMs*: Option[int]
-      ## Time to wait before retransmitting an unacknowledged message.
-    sdsMaxRetransmissions*: Option[int]
-      ## Maximum retransmission attempts before delivery fails.
-    sdsCausalHistorySize*: Option[int] ## Number of message ids kept in causal history.
-    rateLimitEnabled*: Option[bool] ## Enable rate limiting.
-    rateLimitEpochPeriodSec*: Option[int] ## Rate-limit epoch length in seconds.
-    rateLimitMessagesPerEpoch*: Option[int] ## Messages allowed per rate-limit epoch.
-
-  ReliableChannelManager* = ref object ## Implements `ReliableChannelApi`.
-    channels*: Table[ChannelId, ReliableChannel] ## read by `channels/api.nim`
-    conf*: ReliableChannelManagerConf
-    brokerCtx*: BrokerContext
+type ReliableChannelManager* = ref object ## Implements `ReliableChannelApi`.
+  channels*: Table[ChannelId, ReliableChannel] ## read by `channels/api.nim`
+  conf*: ReliableChannelManagerConf
+  brokerCtx*: BrokerContext
 
 proc new*(
     T: type ReliableChannelManager,

--- a/logos_delivery/logos_delivery.nim
+++ b/logos_delivery/logos_delivery.nim
@@ -144,7 +144,7 @@ proc new*(
 
 proc new*(
     T: type LogosDelivery,
-    mode: LogosDeliveryMode = LogosDeliveryMode.Core,
+    mode: MessagingMode = MessagingMode.Core,
     preset: string = "",
     messagingOverrides: MessagingClientConf = MessagingClientConf(),
     channelsOverrides: ReliableChannelManagerConf = ReliableChannelManagerConf(),

--- a/logos_delivery/messaging/messaging_client.nim
+++ b/logos_delivery/messaging/messaging_client.nim
@@ -1,70 +1,23 @@
 ## Messaging layer core: the `MessagingClient` type plus its construction and
 ## lifecycle. The public operations (subscribe / unsubscribe / send) live in
 ## `messaging/api.nim`.
-import std/[options, net]
-import results, chronos
-import confutils/defs
-import libp2p/crypto/crypto
-import logos_delivery/waku/common/logging
-import logos_delivery/api/conf/kernel_conf
-import chronicles
+import std/options
+import results, chronos, chronicles
 import
+  logos_delivery/api/conf/messaging_conf,
   logos_delivery/api/messaging_client_api,
   logos_delivery/waku/waku,
   logos_delivery/waku/factory/conf_builder/waku_conf_builder,
   logos_delivery/messaging/delivery_service/[recv_service, send_service]
 
-# Surfaces the messaging API interface (and its Message* events) to consumers.
-export messaging_client_api
+export messaging_client_api, messaging_conf
 
-type
-  MessagingClientConf* = object
-    clusterId* {.name: "cluster-id".}: Option[uint16] ## Network cluster id.
-    numShardsInCluster* {.name: "num-shards-in-network".}: Option[uint16]
-      ## Number of shards in the cluster.
-    p2pTcpPort* {.name: "tcp-port".}: Option[Port] ## TCP listening port.
-    discv5UdpPort* {.name: "discv5-udp-port".}: Option[Port] ## discv5 UDP port.
-    websocketSupport* {.name: "websocket-support".}: Option[bool]
-      ## Enable the websocket transport.
-    websocketPort* {.name: "websocket-port".}: Option[Port] ## Websocket listening port.
-    quicSupport* {.name: "quic-support".}: Option[bool] ## Enable the QUIC transport.
-    quicPort* {.name: "quic-port".}: Option[Port] ## QUIC (UDP) listening port.
-    listenIpv4* {.name: "listen-address".}: Option[IpAddress] ## Inbound bind address.
-    maxMessageSize* {.name: "max-msg-size".}: Option[string]
-      ## Maximum accepted message size (e.g. "150 KiB").
-    entryNodes* {.name: "entry-node".}: Option[seq[string]]
-      ## Bootstrap / connectivity nodes (enrtree or multiaddr).
-    ethRpcEndpoints* {.name: "rln-relay-eth-client-address".}: Option[seq[EthRpcUrl]]
-      ## Ethereum RPC endpoints (required for RLN validation); multiple for fail-over.
-    rlnContractAddress* {.name: "rln-relay-eth-contract-address".}: Option[string]
-      ## RLN contract address; when set, RLN validation is enabled.
-    rlnChainId* {.name: "rln-relay-chain-id".}: Option[uint]
-      ## Chain id the RLN contract is deployed on.
-    rlnEpochSizeSec* {.name: "rln-relay-epoch-sec".}: Option[uint]
-      ## RLN epoch size, in seconds.
-    reliabilityEnabled* {.name: "reliability".}: Option[bool]
-      ## Enable store-based send reliability.
-    store*: Option[bool] ## Enable the store protocol.
-    storenode* {.name: "storenode".}: Option[string]
-    storeMessageDbUrl* {.name: "store-message-db-url".}: Option[string]
-      ## Database connection URL for the store service's persistent storage.
-    storeMessageRetentionPolicy* {.name: "store-message-retention-policy".}:
-      Option[string] ## Store retention policy (e.g. "time:3600;size:1GB").
-    storeMaxNumDbConnections* {.name: "store-max-num-db-connections".}: Option[int]
-      ## Maximum number of simultaneous store database connections.
-    logLevel* {.name: "log-level".}: Option[logging.LogLevel]
-      ## Process log level (TRACE..FATAL); applied by the kernel on node creation.
-    logFormat* {.name: "log-format".}: Option[logging.LogFormat]
-      ## Process log format (TEXT or JSON); applied by the kernel on node creation.
-    nodeKey* {.name: "nodekey".}: Option[crypto.PrivateKey]
-      ## P2P node private key (64-char hex): stable identity / peerId across restarts.
-
-  MessagingClient* = ref object
-    brokerCtx*: BrokerContext
-    waku*: Waku ## The Waku kernel this layer drives; read by `messaging/api/*`.
-    sendService*: SendService
-    recvService*: RecvService
-    started*: bool
+type MessagingClient* = ref object
+  brokerCtx*: BrokerContext
+  waku*: Waku ## The Waku kernel this layer drives; read by `messaging/api/*`.
+  sendService*: SendService
+  recvService*: RecvService
+  started*: bool
 
 proc new*(
     T: type MessagingClient, conf: MessagingClientConf, waku: Waku

--- a/tests/api/test_api_receive.nim
+++ b/tests/api/test_api_receive.nim
@@ -83,8 +83,7 @@ proc waitForConnectionStatus(
     await EventConnectionStatusChange.dropListener(brokerCtx, handle)
 
 proc createApiNodeConf(numShards: uint16 = 1): WakuNodeConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
+  var conf = MessagingClientConf().toWakuNodeConf(MessagingMode.Core).valueOr:
       raiseAssert error
   conf.listenAddress = parseIpAddress("0.0.0.0")
   conf.tcpPort = Port(0)

--- a/tests/api/test_api_send.nim
+++ b/tests/api/test_api_send.nim
@@ -120,9 +120,7 @@ proc validate(
   for requestId in manager.errorRequestIds:
     check requestId == expectedRequestId
 
-proc createApiNodeConf(
-    mode: messaging_conf.LogosDeliveryMode = messaging_conf.LogosDeliveryMode.Core
-): WakuNodeConf =
+proc createApiNodeConf(mode: MessagingMode = MessagingMode.Core): WakuNodeConf =
   var conf = MessagingClientConf().toWakuNodeConf(mode).valueOr:
       raiseAssert error
   conf.listenAddress = parseIpAddress("0.0.0.0")
@@ -354,11 +352,7 @@ suite "Waku API - Send":
     ## connected to a lightpush-capable peer must deliver through lightpush.
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (
-        await LogosDelivery.new(
-          createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge)
-        )
-      ).valueOr:
+      node = (await LogosDelivery.new(createApiNodeConf(MessagingMode.Edge))).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error
@@ -393,11 +387,7 @@ suite "Waku API - Send":
     ## later retry must deliver the queued message.
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (
-        await LogosDelivery.new(
-          createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge)
-        )
-      ).valueOr:
+      node = (await LogosDelivery.new(createApiNodeConf(MessagingMode.Edge))).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error
@@ -488,11 +478,7 @@ suite "Waku API - Send":
 
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (
-        await LogosDelivery.new(
-          createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge)
-        )
-      ).valueOr:
+      node = (await LogosDelivery.new(createApiNodeConf(MessagingMode.Edge))).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error

--- a/tests/api/test_api_subscription.nim
+++ b/tests/api/test_api_subscription.nim
@@ -69,8 +69,7 @@ type TestNetwork = ref object
   publisherPeerInfo: RemotePeerInfo
 
 proc createApiNodeConf(
-    mode: messaging_conf.LogosDeliveryMode = messaging_conf.LogosDeliveryMode.Core,
-    numShards: uint16 = 1,
+    mode: MessagingMode = MessagingMode.Core, numShards: uint16 = 1
 ): WakuNodeConf =
   var conf = MessagingClientConf().toWakuNodeConf(mode).valueOr:
       raiseAssert error
@@ -90,8 +89,7 @@ proc setupSubscriberNode(conf: WakuNodeConf): Future[LogosDelivery] {.async.} =
   return node
 
 proc setupNetwork(
-    numShards: uint16 = 1,
-    mode: messaging_conf.LogosDeliveryMode = messaging_conf.LogosDeliveryMode.Core,
+    numShards: uint16 = 1, mode: MessagingMode = MessagingMode.Core
 ): Future[TestNetwork] {.async.} =
   var net = TestNetwork()
 
@@ -101,7 +99,7 @@ proc setupNetwork(
       "Failed to mount metadata"
     )
     (await net.publisher.mountRelay()).expect("Failed to mount relay")
-    if mode == messaging_conf.LogosDeliveryMode.Edge:
+    if mode == MessagingMode.Edge:
       await net.publisher.mountFilter()
     await net.publisher.mountLibp2pPing()
     await net.publisher.start()
@@ -120,7 +118,7 @@ proc setupNetwork(
       "Failed to sub publisher"
     )
 
-  if mode == messaging_conf.LogosDeliveryMode.Edge:
+  if mode == MessagingMode.Edge:
     lockNewGlobalBrokerContext:
       net.meshBuddy = newTestWakuNode(generateSecp256k1Key())
       net.meshBuddy.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
@@ -475,7 +473,7 @@ suite "Messaging API, SubscriptionManager":
     await verifyNetworkState(activeSubs)
 
   asyncTest "Subscription API, edge node subscribe and receive message":
-    let net = await setupNetwork(1, messaging_conf.LogosDeliveryMode.Edge)
+    let net = await setupNetwork(1, MessagingMode.Edge)
     defer:
       await net.teardown()
 
@@ -497,7 +495,7 @@ suite "Messaging API, SubscriptionManager":
     check eventManager.receivedMessages[0].contentTopic == testTopic
 
   asyncTest "Subscription API, edge node ignores unsubscribed content topics":
-    let net = await setupNetwork(1, messaging_conf.LogosDeliveryMode.Edge)
+    let net = await setupNetwork(1, MessagingMode.Edge)
     defer:
       await net.teardown()
 
@@ -519,7 +517,7 @@ suite "Messaging API, SubscriptionManager":
     check eventManager.receivedMessages.len == 0
 
   asyncTest "Subscription API, edge node unsubscribe stops message receipt":
-    let net = await setupNetwork(1, messaging_conf.LogosDeliveryMode.Edge)
+    let net = await setupNetwork(1, MessagingMode.Edge)
     defer:
       await net.teardown()
 
@@ -544,7 +542,7 @@ suite "Messaging API, SubscriptionManager":
     check eventManager.receivedMessages.len == 0
 
   asyncTest "Subscription API, edge node overlapping topics isolation":
-    let net = await setupNetwork(1, messaging_conf.LogosDeliveryMode.Edge)
+    let net = await setupNetwork(1, MessagingMode.Edge)
     defer:
       await net.teardown()
 
@@ -573,7 +571,7 @@ suite "Messaging API, SubscriptionManager":
     check eventManager.receivedMessages[0].contentTopic == topicB
 
   asyncTest "Subscription API, edge node resubscribe after unsubscribe":
-    let net = await setupNetwork(1, messaging_conf.LogosDeliveryMode.Edge)
+    let net = await setupNetwork(1, MessagingMode.Edge)
     defer:
       await net.teardown()
 
@@ -658,7 +656,7 @@ suite "Messaging API, SubscriptionManager":
 
     await meshBuddy.connectToNodes(@[publisherPeerInfo])
 
-    let conf = createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge, numShards)
+    let conf = createApiNodeConf(MessagingMode.Edge, numShards)
     var subscriber: LogosDelivery
     lockNewGlobalBrokerContext:
       subscriber =
@@ -786,7 +784,7 @@ suite "Messaging API, SubscriptionManager":
     await meshBuddy.connectToNodes(@[publisherPeerInfo])
     await sparePeer.connectToNodes(@[publisherPeerInfo])
 
-    let conf = createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge, numShards)
+    let conf = createApiNodeConf(MessagingMode.Edge, numShards)
     var subscriber: LogosDelivery
     lockNewGlobalBrokerContext:
       subscriber =

--- a/tests/api/test_conf.nim
+++ b/tests/api/test_conf.nim
@@ -9,7 +9,7 @@ import logos_delivery/waku/common/logging
 
 suite "MessagingClientConf - mode expansion (toWakuNodeConf)":
   test "Core mode enables relay + service protocols":
-    let kc = MessagingClientConf().toWakuNodeConf(LogosDeliveryMode.Core).valueOr:
+    let kc = MessagingClientConf().toWakuNodeConf(MessagingMode.Core).valueOr:
         raiseAssert error
     check:
       kc.relay == true
@@ -20,7 +20,7 @@ suite "MessagingClientConf - mode expansion (toWakuNodeConf)":
       kc.rendezvous == true
 
   test "Edge mode is client-only (no relay/filter/lightpush/store)":
-    let kc = MessagingClientConf().toWakuNodeConf(LogosDeliveryMode.Edge).valueOr:
+    let kc = MessagingClientConf().toWakuNodeConf(MessagingMode.Edge).valueOr:
         raiseAssert error
     check:
       kc.relay == false
@@ -37,7 +37,7 @@ suite "MessagingClientConf - field mapping + transport policy":
       numShardsInCluster: some(4'u16),
       maxMessageSize: some("150KiB"),
     )
-    let kc = mc.toWakuNodeConf(LogosDeliveryMode.Core).valueOr:
+    let kc = mc.toWakuNodeConf(MessagingMode.Core).valueOr:
       raiseAssert error
     check:
       kc.clusterId == some(3'u16)
@@ -45,7 +45,7 @@ suite "MessagingClientConf - field mapping + transport policy":
       kc.maxMessageSize == "150KiB"
 
   test "messaging transport defaults: ephemeral ports, websocket off, quic on":
-    let kc = MessagingClientConf().toWakuNodeConf(LogosDeliveryMode.Core).valueOr:
+    let kc = MessagingClientConf().toWakuNodeConf(MessagingMode.Core).valueOr:
         raiseAssert error
     check:
       kc.tcpPort == Port(0)
@@ -59,7 +59,7 @@ suite "MessagingClientConf - field mapping + transport policy":
       websocketSupport: some(true),
       quicSupport: some(false),
     )
-    let kc = mc.toWakuNodeConf(LogosDeliveryMode.Core).valueOr:
+    let kc = mc.toWakuNodeConf(MessagingMode.Core).valueOr:
       raiseAssert error
     check:
       kc.tcpPort == Port(1234)
@@ -91,7 +91,7 @@ suite "MessagingClientConf - preset resolution":
     let presetConf = resolvePreset("logos.dev").valueOr:
       raiseAssert error
     let merged = merge(presetConf, MessagingClientConf(numShardsInCluster: some(1'u16)))
-    var kernelConf = toWakuNodeConf(merged, LogosDeliveryMode.Core).valueOr:
+    var kernelConf = toWakuNodeConf(merged, MessagingMode.Core).valueOr:
       raiseAssert error
     kernelConf.preset = "logos.dev"
     let wakuConf = kernelConf.toWakuConf().valueOr:
@@ -282,7 +282,7 @@ suite "LogosDelivery.new - construction (the app-dev entry)":
     lockNewGlobalBrokerContext:
       node = (
         await LogosDelivery.new(
-          LogosDeliveryMode.Core,
+          MessagingMode.Core,
           "",
           MessagingClientConf(
             clusterId: some(3'u16),
@@ -304,7 +304,7 @@ suite "LogosDelivery.new - construction (the app-dev entry)":
     lockNewGlobalBrokerContext:
       node = (
         await LogosDelivery.new(
-          LogosDeliveryMode.Core,
+          MessagingMode.Core,
           "logostest",
           MessagingClientConf(listenIpv4: some(parseIpAddress("0.0.0.0"))),
         )
@@ -315,9 +315,7 @@ suite "LogosDelivery.new - construction (the app-dev entry)":
 
 suite "MessagingClientConf - store override":
   test "store opt-in overrides the mode default; protocol flags follow the mode":
-    let kc = MessagingClientConf(store: some(true)).toWakuNodeConf(
-      LogosDeliveryMode.Edge
-    ).valueOr:
+    let kc = MessagingClientConf(store: some(true)).toWakuNodeConf(MessagingMode.Edge).valueOr:
       raiseAssert error
     check:
       kc.store == true # Edge defaults store off; the explicit opt-in wins
@@ -326,7 +324,7 @@ suite "MessagingClientConf - store override":
 suite "LogosDelivery.new - raw kernel construction":
   asyncTest "a fleet node mounts the kernel only; start/stop tolerate the nil layers":
     let kernel = MessagingClientConf(listenIpv4: some(parseIpAddress("0.0.0.0"))).toWakuNodeConf(
-      LogosDeliveryMode.Core
+      MessagingMode.Core
     ).valueOr:
       raiseAssert error
     var node: LogosDelivery

--- a/tests/channels/test_reliable_channel_send_receive.nim
+++ b/tests/channels/test_reliable_channel_send_receive.nim
@@ -28,8 +28,7 @@ import snapshot_codec
 const TestTimeout = chronos.seconds(15)
 
 proc createApiNodeConf(): WakuNodeConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
+  var conf = MessagingClientConf().toWakuNodeConf(MessagingMode.Core).valueOr:
       raiseAssert error
   conf.listenAddress = parseIpAddress("0.0.0.0")
   conf.tcpPort = Port(0)


### PR DESCRIPTION
## Description

Alternative PR to #4025, per Zoltan's [review: no duplicate enums](https://github.com/logos-messaging/logos-delivery/pull/4025#pullrequestreview-4667296865). "fleet" is consumed in the JSON parser and routes straight to the kernel-only constructor, so it never becomes an enum value and "LogosDeliveryMode" stops existing.

## Changes

* MessagingMode (Edge, Core) replaces LogosDeliveryMode
* "fleet" is a JSON string; it routes to the kernel-only constructor
* applyMode can no longer fail; drop its Result
* parseMode is gone; one case owns the three mode strings
* LogosDelivery.new and LogosDeliveryConf.init take MessagingMode

## Superseded PRs

closes #4025