### PR TITLE
feat: rate-limit enforcement and RLN proofing at the send service transmission stage

### DIFF
--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -4,9 +4,9 @@ import results, libp2p/crypto/crypto
 import logos_delivery/api/conf/kernel_conf
 import logos_delivery/waku/common/logging
 import logos_delivery/waku/factory/networks_config
-import logos_delivery/messaging/rate_limit_manager/rate_limit_manager
+import logos_delivery/messaging/rate_limit_manager/rate_limit_config
 
-export kernel_conf, rate_limit_manager
+export kernel_conf, rate_limit_config
 
 # `LogosDeliveryMode` and `EntryLayer` are defined at the leaf (`cli_args`) so
 # they can appear on `WakuNodeConf`; re-exported here via `kernel_conf`.

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -55,6 +55,13 @@ type MessagingClientConf* = object
     ## Per-epoch message rate limit enforced by the send service. `Opt` like
     ## every other field so `merge` propagates a caller's override; unset falls
     ## back to `DefaultRateLimitConfig` (rate limiting disabled).
+    ##
+    ## Known limitation — settable only programmatically (build the object, or
+    ## via `merge`), not through the JSON config or a CLI flag. It carries no
+    ## `{.name.}` pragma, and because `RateLimitConfig` is a nested object with
+    ## no `parseCmdArg`, the JSON overrides walker rejects it with "cannot be
+    ## set via JSON" (see `applyJsonFieldsToConf`). Exposing it over JSON/CLI
+    ## needs a `parseCmdArg(RateLimitConfig)` or nested-object support there.
 
 proc applyMode*(conf: var WakuNodeConf, mode: LogosDeliveryMode): ConfResult[void] =
   ## Sets the protocol flags implied by the mode.

--- a/logos_delivery/messaging/delivery_service/send_service/delivery_task.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/delivery_task.nim
@@ -26,6 +26,14 @@ type DeliveryTask* = ref object
   firstPropagatedTime*: Opt[Moment]
     ## Set once on the first successful propagation; never reset on re-publish.
     ## Anchors the store-validation time cap (see propagationAge).
+  firstAdmittedTime*: Opt[Moment]
+    ## Set when the task first passes rate-limit admission (consumes a budget
+    ## slot / draws an RLN nonce); `none` while still parked waiting for epoch
+    ## budget. Guards re-admission on retry and anchors the delivery-timeout
+    ## reaper from the first real send attempt rather than message creation, so
+    ## a task parked for budget is not aged out before it can be sent. Reset to
+    ## `none` when an RLN rejection clears the proof, since regenerating draws a
+    ## fresh nonce that must be re-admitted.
   propagateEventEmitted*: bool
   errorDesc*: string
 
@@ -83,6 +91,23 @@ proc propagationAge*(self: DeliveryTask): timer.Duration =
     timer.Moment.now() - self.firstPropagatedTime.get()
   else:
     ZeroDuration
+
+proc admissionAge*(self: DeliveryTask): timer.Duration =
+  ## Time elapsed since the task first passed admission; ZeroDuration while it
+  ## has never been admitted (i.e. still parked waiting for epoch budget).
+  if self.firstAdmittedTime.isSome():
+    timer.Moment.now() - self.firstAdmittedTime.get()
+  else:
+    ZeroDuration
+
+proc isDeliveryTimedOut*(self: DeliveryTask, maxTime: timer.Duration): bool =
+  ## True when the task was admitted (drew a slot) and has been trying to
+  ## deliver longer than `maxTime` without ever propagating. A task never
+  ## admitted — still parked waiting for epoch budget — is exempt: it is waiting
+  ## for the epoch to roll, not failing to deliver, and the clock runs from
+  ## admission, not message creation, so budget wait does not count against it.
+  self.firstAdmittedTime.isSome() and self.firstPropagatedTime.isNone() and
+    self.admissionAge() > maxTime
 
 proc isEphemeral*(self: DeliveryTask): bool =
   return self.msg.ephemeral

--- a/logos_delivery/messaging/delivery_service/send_service/lightpush_processor.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/lightpush_processor.nim
@@ -33,6 +33,17 @@ method sendImpl*(
     await self.waku.lightpushPublishToAny(task.pubsubTopic, task.msg)
   ).valueOr:
     error "LightpushSendProcessor.sendImpl failed", error = error.desc.get($error.code)
+
+    if error.isRlnRejection():
+      ## The proof was refused, so it must not be sent again: drop it and let
+      ## the refreshed merkle path produce a new one on the next round.
+      ## Re-admission gates the regeneration, so a task cannot spin through the
+      ## epoch budget by retrying.
+      self.waku.onRlnProofRejected()
+      task.msg.proof = @[]
+      task.state = DeliveryState.NextRoundRetry
+      return
+
     case error.code
     of LightPushErrorCode.NO_PEERS_TO_RELAY, LightPushErrorCode.TOO_MANY_REQUESTS,
         LightPushErrorCode.OUT_OF_RLN_PROOF, LightPushErrorCode.SERVICE_NOT_AVAILABLE,

--- a/logos_delivery/messaging/delivery_service/send_service/lightpush_processor.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/lightpush_processor.nim
@@ -37,10 +37,11 @@ method sendImpl*(
     if error.isRlnRejection():
       ## The proof was refused, so it must not be sent again: drop it and let
       ## the refreshed merkle path produce a new one on the next round.
-      ## Re-admission gates the regeneration, so a task cannot spin through the
-      ## epoch budget by retrying.
+      ## Resetting admission re-charges the fresh nonce that regeneration draws,
+      ## so a task cannot spin through the epoch budget by retrying.
       self.waku.onRlnProofRejected()
       task.msg.proof = @[]
+      task.firstAdmittedTime = Opt.none(Moment)
       task.state = DeliveryState.NextRoundRetry
       return
 

--- a/logos_delivery/messaging/delivery_service/send_service/relay_processor.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/relay_processor.nim
@@ -69,9 +69,11 @@ method sendImpl*(self: RelaySendProcessor, task: DeliveryTask) {.async.} =
       ## The relay validator refused the proof. Dropping it and retrying is not
       ## the same as failing: the message is valid, its proof went stale against
       ## a moved merkle root. Clearing it makes the next round regenerate one
-      ## against the refreshed path.
+      ## against the refreshed path; resetting admission re-charges the fresh
+      ## nonce that regeneration draws.
       self.waku.onRlnProofRejected()
       task.msg.proof = @[]
+      task.firstAdmittedTime = Opt.none(Moment)
       task.state = DeliveryState.NextRoundRetry
       return
 

--- a/logos_delivery/messaging/delivery_service/send_service/relay_processor.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/relay_processor.nim
@@ -1,6 +1,7 @@
 import results, chronos, chronicles
 import brokers/broker_context
 import logos_delivery/waku/[waku_core], logos_delivery/waku/waku_lightpush/[common, rpc]
+import logos_delivery/waku/waku, logos_delivery/waku/api/publish
 import logos_delivery/waku/requests/health_requests
 import logos_delivery/api/types
 import ./[delivery_task, send_processor]
@@ -9,6 +10,7 @@ logScope:
   topics = "send service relay processor"
 
 type RelaySendProcessor* = ref object of BaseSendProcessor
+  waku: Waku
   publishProc: PushMessageHandler
   fallbackStateToSet: DeliveryState
 
@@ -16,6 +18,7 @@ proc new*(
     T: typedesc[RelaySendProcessor],
     lightpushAvailable: bool,
     publishProc: PushMessageHandler,
+    waku: Waku,
     brokerCtx: BrokerContext,
 ): RelaySendProcessor =
   let fallbackStateToSet =
@@ -25,6 +28,7 @@ proc new*(
       DeliveryState.FailedToDeliver
 
   return RelaySendProcessor(
+    waku: waku,
     publishProc: publishProc,
     fallbackStateToSet: fallbackStateToSet,
     brokerCtx: brokerCtx,
@@ -60,6 +64,17 @@ method sendImpl*(self: RelaySendProcessor, task: DeliveryTask) {.async.} =
     let errorMessage = error.desc.get($error.code)
     error "Failed to publish message with relay",
       request = task.requestId, msgHash = task.msgHash.to0xHex(), error = errorMessage
+
+    if error.isRlnRejection():
+      ## The relay validator refused the proof. Dropping it and retrying is not
+      ## the same as failing: the message is valid, its proof went stale against
+      ## a moved merkle root. Clearing it makes the next round regenerate one
+      ## against the refreshed path.
+      self.waku.onRlnProofRejected()
+      task.msg.proof = @[]
+      task.state = DeliveryState.NextRoundRetry
+      return
+
     if error.code != LightPushErrorCode.NO_PEERS_TO_RELAY:
       task.state = DeliveryState.FailedToDeliver
       task.errorDesc = errorMessage

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -259,6 +259,15 @@ proc trySendMessages(self: SendService) {.async.} =
       ## `NextRoundRetry` and are retried as the epoch rolls over.
       (await self.rateLimitManager.admit(task.msg.payload)).isOkOr:
         continue
+
+      ## Strictly after admission, so a rejected message never draws a nonce.
+      ## A no-op when RLN is not mounted, or when a prior round already
+      ## attached a proof.
+      task.msg = (await self.waku.attachRlnProof(task.msg)).valueOr:
+        error "SendService: failed to attach RLN proof, retrying next round",
+          requestId = task.requestId, error = error
+        continue
+
     await self.sendProcessor.process(task)
 
 proc serviceLoop(self: SendService) {.async.} =
@@ -291,6 +300,15 @@ proc send*(self: SendService, task: DeliveryTask) {.async.} =
   (await self.rateLimitManager.admit(task.msg.payload)).isOkOr:
     info "SendService.send: over rate-limit budget, parking task",
       requestId = task.requestId, msgHash = task.msgHash.to0xHex()
+    task.state = DeliveryState.NextRoundRetry
+    self.addTask(task)
+    return
+
+  ## Strictly after admission, so a rejected message never draws a nonce.
+  ## A no-op when RLN is not mounted.
+  task.msg = (await self.waku.attachRlnProof(task.msg)).valueOr:
+    error "SendService.send: failed to attach RLN proof, parking task",
+      requestId = task.requestId, error = error
     task.state = DeliveryState.NextRoundRetry
     self.addTask(task)
     return

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -199,15 +199,19 @@ proc reportTaskResult(self: SendService, task: DeliveryTask) =
     # rest of the states are intermediate and does not translate to event
     discard
 
-  # Only tasks that never propagated are reported as hard send failures here.
+  # Hard-fail a task that was admitted (drew a slot) but has been trying to
+  # deliver longer than MaxTimeInCache without ever propagating. A task still
+  # parked for epoch budget (never admitted) is exempt — it is waiting for the
+  # epoch to roll, not failing to deliver, and the timeout is measured from
+  # admission, not message creation, so budget wait does not count against it.
   # Propagated-but-not-store-validated tasks are handled (warn + drop, no event)
   # in evaluateAndCleanUp.
-  if task.firstPropagatedTime.isNone() and task.messageAge() > MaxTimeInCache:
+  if task.isDeliveryTimedOut(MaxTimeInCache):
     error "Failed to send message",
       requestId = task.requestId,
       msgHash = task.msgHash.to0xHex(),
       error = "Message too old",
-      age = task.messageAge()
+      age = task.admissionAge()
     task.state = DeliveryState.FailedToDeliver
     MessageErrorEvent.emit(
       self.brokerCtx,
@@ -255,12 +259,16 @@ proc trySendMessages(self: SendService) {.async.} =
 
   for task in tasksToSend:
     # Todo, check if it has any perf gain to run them concurrent...
-    if task.firstPropagatedTime.isNone():
-      ## Never propagated: this transmission consumes a fresh epoch slot, so
-      ## it must be admitted. Tasks that stay over budget remain in
-      ## `NextRoundRetry` and are retried as the epoch rolls over.
+    if task.firstAdmittedTime.isNone():
+      ## Not yet admitted: this transmission will consume a fresh epoch slot, so
+      ## it must be admitted (and draw a nonce). Guarding on admission rather
+      ## than propagation means a task that failed to propagate is not
+      ## re-charged every tick — it keeps its slot and its proof. Tasks that
+      ## stay over budget remain in `NextRoundRetry` and are retried as the
+      ## epoch rolls over.
       (await self.rateLimitManager.admit(task.msg.payload)).isOkOr:
         continue
+      task.firstAdmittedTime = Opt.some(Moment.now())
 
       ## Strictly after admission, so a rejected message never draws a nonce.
       ## A no-op when RLN is not mounted, or when a prior round already
@@ -305,6 +313,7 @@ proc send*(self: SendService, task: DeliveryTask) {.async.} =
     task.state = DeliveryState.NextRoundRetry
     self.addTask(task)
     return
+  task.firstAdmittedTime = Opt.some(Moment.now())
 
   ## Strictly after admission, so a rejected message never draws a nonce.
   ## A no-op when RLN is not mounted.

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -68,7 +68,9 @@ proc setupSendProcessorChain(
 
   if isRelayAvail:
     let publishProc = waku.relayPushHandler()
-    processors.add(RelaySendProcessor.new(isLightPushAvail, publishProc, brokerCtx))
+    processors.add(
+      RelaySendProcessor.new(isLightPushAvail, publishProc, waku, brokerCtx)
+    )
   if isLightPushAvail:
     processors.add(LightpushSendProcessor.new(waku, brokerCtx))
 

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -87,7 +87,11 @@ proc new*(
     preferP2PReliability: bool,
     waku: Waku,
     rateLimitManager: RateLimitManager,
+    sendProcessor: BaseSendProcessor = nil,
 ): Result[T, string] =
+  ## `sendProcessor` overrides the relay/lightpush processor chain that is
+  ## otherwise built from `waku`; passing one lets a caller drive the scheduler
+  ## against a processor whose delivery outcome it controls.
   if not waku.hasRelay() and not waku.hasLightpush():
     return err(
       "Could not create SendService. wakuRelay or wakuLightpushClient should be set"
@@ -95,8 +99,12 @@ proc new*(
 
   let checkStoreForMessages = preferP2PReliability and waku.isStoreMounted()
 
-  let sendProcessorChain = setupSendProcessorChain(waku, waku.brokerCtx).valueOr:
-    return err("failed to setup SendProcessorChain: " & $error)
+  let sendProcessorChain =
+    if sendProcessor.isNil():
+      setupSendProcessorChain(waku, waku.brokerCtx).valueOr:
+        return err("failed to setup SendProcessorChain: " & $error)
+    else:
+      sendProcessor
 
   let sendService = SendService(
     brokerCtx: waku.brokerCtx,
@@ -254,7 +262,7 @@ proc evaluateAndCleanUp(self: SendService) =
     )
   )
 
-proc trySendMessages(self: SendService) {.async.} =
+proc trySendMessages*(self: SendService) {.async.} =
   let tasksToSend = self.taskCache.filterIt(it.state == DeliveryState.NextRoundRetry)
 
   for task in tasksToSend:

--- a/logos_delivery/messaging/messaging_client.nim
+++ b/logos_delivery/messaging/messaging_client.nim
@@ -6,6 +6,7 @@ import
   logos_delivery/api/conf/messaging_conf,
   logos_delivery/api/messaging_client_api,
   logos_delivery/waku/waku,
+  logos_delivery/waku/api/publish,
   logos_delivery/waku/factory/conf_builder/waku_conf_builder,
   logos_delivery/messaging/delivery_service/[recv_service, send_service],
   logos_delivery/messaging/rate_limit_manager/rate_limit_manager
@@ -19,6 +20,16 @@ type MessagingClient* = ref object
   recvService*: RecvService
   started*: bool
 
+proc rlnQuotaProvider(waku: Waku): QuotaProvider =
+  ## Sources the rate limit manager's epoch + limit from RLN. Late-binding: the
+  ## closure queries `waku` on each admission, so a node whose RLN mounts after
+  ## this client is constructed upgrades from the wall-clock fallback to RLN's
+  ## epoch and user message limit automatically.
+  return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+    let q = waku.currentRlnEpochQuota().valueOr:
+      return Opt.none(EpochQuota)
+    Opt.some(EpochQuota(epochIndex: q.epochIndex, userMessageLimit: q.messageLimit))
+
 proc new*(
     T: type MessagingClient, conf: MessagingClientConf, waku: Waku
 ): Result[T, string] =
@@ -26,7 +37,11 @@ proc new*(
   ## for transport while exposing its own send/recv API.
   let reliability = conf.reliabilityEnabled.get(DefaultP2pReliability)
   let sendService = ?SendService.new(
-    reliability, waku, RateLimitManager.new(conf.rateLimit.get(DefaultRateLimitConfig))
+    reliability,
+    waku,
+    RateLimitManager.new(
+      conf.rateLimit.get(DefaultRateLimitConfig), rlnQuotaProvider(waku)
+    ),
   )
   let recvService = RecvService.new(waku)
   return ok(

--- a/logos_delivery/messaging/rate_limit_manager/quota_source.nim
+++ b/logos_delivery/messaging/rate_limit_manager/quota_source.nim
@@ -1,0 +1,38 @@
+## Epoch + user-message-limit source for the rate limit manager.
+##
+## "Quota" is the tracking issues' word (#3838: "we should know our remaining
+## quota") for what RLN expresses as an epoch's user message limit: each epoch
+## grants `userMessageLimit` message ids (nonces), and the epoch rolling over
+## refills the allowance.
+##
+## The manager rate-limits per epoch, but must not know *where* the epoch and
+## the limit come from. With RLN mounted both are RLN's; without it, a
+## wall-clock window and the configured limit stand in. Epoch and limit are
+## read together, through one provider, so a read cannot straddle an epoch
+## boundary and pair a fresh epoch with a stale limit. The provider is a
+## callback so the manager stays free of any dependency on the `Waku` kernel —
+## the RLN-backed provider is built one layer up, where the kernel handle is in
+## scope. It returns `none` when RLN is not mounted, which is the signal to
+## fall back to the wall clock.
+
+import std/[options, times]
+
+type
+  EpochQuota* = object
+    epochIndex*: uint64
+      ## Current epoch as its numeric value (`timestamp div` the epoch length);
+      ## the kernel's `Epoch` type is the same value serialized to 32 bytes.
+    userMessageLimit*: uint64
+      ## Message ids the epoch grants — the hard ceiling on admissions before
+      ## the epoch rolls over.
+
+  QuotaProvider* = proc(): Option[EpochQuota] {.gcsafe, raises: [].}
+    ## The epoch and its user message limit, or `none` when RLN is not mounted.
+
+proc wallClockEpochIndex*(epochPeriodSec: uint64): uint64 =
+  ## Absolute wall-clock epoch: `unixTime div epochPeriodSec`. Absolute (not a
+  ## sliding window anchored at first use) so it matches RLN's `calcEpoch`, and
+  ## so two managers started at different moments agree on the boundary.
+  ## `epochPeriodSec` is assumed positive; the manager only calls this when
+  ## enforcing.
+  uint64(getTime().toUnix()) div epochPeriodSec

--- a/logos_delivery/messaging/rate_limit_manager/quota_source.nim
+++ b/logos_delivery/messaging/rate_limit_manager/quota_source.nim
@@ -15,7 +15,8 @@
 ## scope. It returns `none` when RLN is not mounted, which is the signal to
 ## fall back to the wall clock.
 
-import std/[options, times]
+import std/times
+import results
 
 type
   EpochQuota* = object
@@ -26,7 +27,7 @@ type
       ## Message ids the epoch grants — the hard ceiling on admissions before
       ## the epoch rolls over.
 
-  QuotaProvider* = proc(): Option[EpochQuota] {.gcsafe, raises: [].}
+  QuotaProvider* = proc(): Opt[EpochQuota] {.gcsafe, raises: [].}
     ## The epoch and its user message limit, or `none` when RLN is not mounted.
 
 proc wallClockEpochIndex*(epochPeriodSec: uint64): uint64 =

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
@@ -1,0 +1,39 @@
+## Configuration for the messaging rate limit manager.
+##
+## Field names follow the RELIABLE-CHANNEL-API spec's `RateLimitConfig`
+## (`enabled`, `epochPeriodSec`): this is a messaging-API config object, so it
+## uses the API spec's vocabulary rather than RLN's internal `RlnConf` names.
+## `messagesPerEpoch` is the local cap; the spec leaves the actual limit to RLN,
+## which the manager honours by clamping the cap to RLN's user message limit.
+##
+## Kept separate from the enforcement engine so the API config layer can depend
+## on the vocabulary (`RateLimitConfig`) without pulling in the manager and its
+## RLN quota seam.
+
+type
+  RateLimitError* {.pure.} = enum
+    OverBudget
+
+  RateLimitConfig* = object
+    enabled*: bool ## spec: rate limiting opt-in; SHOULD be true when RLN active
+    epochPeriodSec*: uint64
+      ## Epoch length, in seconds (spec: the epoch size used by the RLN relay).
+      ## Only shapes the wall-clock fallback window; when the RLN quota source is
+      ## wired in it is ignored (the period is RLN's).
+    messagesPerEpoch*: uint64
+      ## Local cap on messages admitted per epoch. When RLN is mounted the
+      ## effective limit is clamped to RLN's user message limit; config can only
+      ## tighten it, never widen it.
+
+const
+  DefaultEpochPeriodSec* = 600'u64
+  DefaultMessagesPerEpoch* = 1'u64
+
+  DefaultRateLimitConfig* = RateLimitConfig(
+    epochPeriodSec: DefaultEpochPeriodSec, messagesPerEpoch: DefaultMessagesPerEpoch
+  ) ## Used when no rate-limit config is supplied; `enabled` defaults false.
+
+func isEnforcing*(config: RateLimitConfig): bool =
+  ## Whether the config asks for actual rate limiting. A disabled or zeroed
+  ## configuration admits everything, so the manager can short-circuit.
+  config.enabled and config.epochPeriodSec > 0 and config.messagesPerEpoch > 0

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
@@ -1,12 +1,13 @@
 ## Rate Limit Manager for the Messaging API.
 ##
 ## Tracks messages sent per RLN epoch and rejects admission when the
-## limit is approached, ensuring RLN compliance on enforcing relays.
+## budget is exhausted, ensuring RLN compliance on enforcing relays.
 ##
-## For the skeleton this is a pass-through: every call is admitted.
-## Real per-epoch budgeting will use `queue`, `currentEpochStart`,
-## `sentInCurrentEpoch`, and `resetEpoch` to park messages and admit
-## them as the epoch rolls over.
+## Budgeting is a lazily rolled fixed window: the first admission after
+## `epochPeriodSec` has elapsed resets the counter. Parking and retrying
+## of over-budget messages is owned by the send service scheduler; this
+## module only answers whether one more transmission fits the current
+## epoch's budget.
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
@@ -24,7 +25,6 @@ type
 
   RateLimitManager* = ref object
     config*: RateLimitConfig
-    queue*: seq[seq[byte]]
     currentEpochStart*: Time
     sentInCurrentEpoch*: int
 
@@ -37,22 +37,28 @@ const
   ) ## Used when no rate-limit config is supplied; `enabled` defaults false.
 
 proc new*(T: type RateLimitManager, config: RateLimitConfig): T =
-  return
-    T(config: config, queue: @[], currentEpochStart: getTime(), sentInCurrentEpoch: 0)
-
-proc admit*(
-    self: RateLimitManager, msg: seq[byte]
-): Future[Result[void, RateLimitError]] {.async: (raises: []).} =
-  ## Skeleton behaviour: admits immediately. Real per-epoch budgeting
-  ## will consult `config`, `sentInCurrentEpoch`, and the elapsed
-  ## `epochPeriodSec` window before admitting or parking `msg`.
-  return ok()
-
-proc dequeueReady*(self: RateLimitManager): seq[seq[byte]] =
-  ## Returns the set of queued messages that may be dispatched now
-  ## without exceeding the configured rate limit.
-  discard
+  return T(config: config, currentEpochStart: getTime(), sentInCurrentEpoch: 0)
 
 proc resetEpoch*(self: RateLimitManager) =
   self.currentEpochStart = getTime()
   self.sentInCurrentEpoch = 0
+
+proc admit*(
+    self: RateLimitManager, msg: seq[byte]
+): Future[Result[void, RateLimitError]] {.async: (raises: []).} =
+  ## Charges one message against the current epoch's budget, rolling the
+  ## window first when `epochPeriodSec` has elapsed. A disabled or
+  ## non-positive configuration admits everything.
+  if not self.config.enabled or self.config.epochPeriodSec <= 0 or
+      self.config.messagesPerEpoch <= 0:
+    return ok()
+
+  if getTime() - self.currentEpochStart >=
+      initDuration(seconds = self.config.epochPeriodSec):
+    self.resetEpoch()
+
+  if self.sentInCurrentEpoch >= self.config.messagesPerEpoch:
+    return err(RateLimitError.OverBudget)
+
+  inc self.sentInCurrentEpoch
+  return ok()

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
@@ -1,63 +1,80 @@
 ## Rate Limit Manager for the Messaging API.
 ##
-## Tracks messages sent per RLN epoch and rejects admission when the
-## budget is exhausted, ensuring RLN compliance on enforcing relays.
+## Rate-limits message transmissions against the per-epoch user message limit
+## and rejects admission once it is spent, keeping the node within the quota
+## that RLN-enforcing relays check. Each admission mirrors one RLN message id
+## (nonce) draw; the epoch rolling over refills the allowance.
 ##
-## Budgeting is a lazily rolled fixed window: the first admission after
-## `epochPeriodSec` has elapsed resets the counter. Parking and retrying
-## of over-budget messages is owned by the send service scheduler; this
-## module only answers whether one more transmission fits the current
-## epoch's budget.
+## The epoch and the limit come from a `QuotaProvider` when RLN is mounted
+## (see `quota_source`); otherwise a wall-clock window and the configured limit
+## stand in. Parking and retrying over-budget messages is the send service
+## scheduler's job — this module only answers whether one more transmission
+## fits the current epoch.
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import std/times
+import std/options
 import results, chronos
 
-type
-  RateLimitError* {.pure.} = enum
-    OverBudget
+import ./rate_limit_config, ./quota_source
 
-  RateLimitConfig* = object
-    enabled*: bool ## spec: rate limiting opt-in; SHOULD be true when RLN active
-    epochPeriodSec*: int
-    messagesPerEpoch*: int
+export rate_limit_config, quota_source
 
-  RateLimitManager* = ref object
-    config*: RateLimitConfig
-    currentEpochStart*: Time
-    sentInCurrentEpoch*: int
+type RateLimitManager* = ref object
+  config*: RateLimitConfig
+  quotaProvider: QuotaProvider
+    ## Supplies the RLN epoch + user message limit. Nil, or a call returning
+    ## `none`, selects the wall-clock fallback. Queried per admission so a node
+    ## whose RLN mounts after construction upgrades automatically.
+  currentEpochIndex*: uint64
+  sentInCurrentEpoch*: uint64
 
-const
-  DefaultEpochPeriodSec* = 600
-  DefaultMessagesPerEpoch* = 1
+proc new*(
+    T: type RateLimitManager,
+    config: RateLimitConfig,
+    quotaProvider: QuotaProvider = nil,
+): T =
+  return T(
+    config: config,
+    quotaProvider: quotaProvider,
+    currentEpochIndex: 0,
+    sentInCurrentEpoch: 0,
+  )
 
-  DefaultRateLimitConfig* = RateLimitConfig(
-    epochPeriodSec: DefaultEpochPeriodSec, messagesPerEpoch: DefaultMessagesPerEpoch
-  ) ## Used when no rate-limit config is supplied; `enabled` defaults false.
-
-proc new*(T: type RateLimitManager, config: RateLimitConfig): T =
-  return T(config: config, currentEpochStart: getTime(), sentInCurrentEpoch: 0)
-
-proc resetEpoch*(self: RateLimitManager) =
-  self.currentEpochStart = getTime()
-  self.sentInCurrentEpoch = 0
+proc currentQuota(self: RateLimitManager): Option[EpochQuota] =
+  if self.quotaProvider.isNil():
+    return none(EpochQuota)
+  return self.quotaProvider()
 
 proc admit*(
     self: RateLimitManager, msg: seq[byte]
 ): Future[Result[void, RateLimitError]] {.async: (raises: []).} =
-  ## Charges one message against the current epoch's budget, rolling the
-  ## window first when `epochPeriodSec` has elapsed. A disabled or
-  ## non-positive configuration admits everything.
-  if not self.config.enabled or self.config.epochPeriodSec <= 0 or
-      self.config.messagesPerEpoch <= 0:
+  ## Charges one message against the current epoch's user message limit,
+  ## rolling the window first when the epoch has advanced. A disabled or zeroed
+  ## configuration admits everything.
+  if not self.config.isEnforcing():
     return ok()
 
-  if getTime() - self.currentEpochStart >=
-      initDuration(seconds = self.config.epochPeriodSec):
-    self.resetEpoch()
+  let quota = self.currentQuota()
 
-  if self.sentInCurrentEpoch >= self.config.messagesPerEpoch:
+  let epochIndex =
+    if quota.isSome():
+      quota.get().epochIndex
+    else:
+      wallClockEpochIndex(self.config.epochPeriodSec)
+
+  # RLN can only tighten the configured cap, never widen it: exceeding RLN's
+  # user message limit would fail later at proof generation, once the epoch's
+  # message ids are exhausted.
+  var limit = self.config.messagesPerEpoch
+  if quota.isSome() and quota.get().userMessageLimit < limit:
+    limit = quota.get().userMessageLimit
+
+  if epochIndex != self.currentEpochIndex:
+    self.currentEpochIndex = epochIndex
+    self.sentInCurrentEpoch = 0
+
+  if self.sentInCurrentEpoch >= limit:
     return err(RateLimitError.OverBudget)
 
   inc self.sentInCurrentEpoch

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
@@ -13,7 +13,6 @@
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import std/options
 import results, chronos
 
 import ./rate_limit_config, ./quota_source
@@ -41,9 +40,9 @@ proc new*(
     sentInCurrentEpoch: 0,
   )
 
-proc currentQuota(self: RateLimitManager): Option[EpochQuota] =
+proc currentQuota(self: RateLimitManager): Opt[EpochQuota] =
   if self.quotaProvider.isNil():
-    return none(EpochQuota)
+    return Opt.none(EpochQuota)
   return self.quotaProvider()
 
 proc admit*(

--- a/logos_delivery/waku/api/publish.nim
+++ b/logos_delivery/waku/api/publish.nim
@@ -7,7 +7,7 @@
 ## so the messaging layer never inspects `waku.node` directly.
 {.push raises: [].}
 
-import std/times
+import std/[times, strutils]
 import results, chronos
 
 import logos_delivery/waku/waku
@@ -66,6 +66,31 @@ proc attachRlnProof*(
     return err("failed to attach RLN proof: " & error)
 
   return ok(msgWithProof)
+
+func isRlnRejection*(error: ErrorStatus): bool =
+  ## True when a publish failure means "the RLN proof was not accepted", so the
+  ## message is worth retrying with a freshly generated proof rather than being
+  ## failed outright.
+  ##
+  ## OUT_OF_RLN_PROOF is always RLN. INVALID_MESSAGE also covers non-RLN
+  ## rejections (an oversized message, say), so it additionally has to carry the
+  ## validator's error marker — this is the same gate the kernel lightpush path
+  ## applies before scheduling a refresh.
+  return
+    error.code == LightPushErrorCode.OUT_OF_RLN_PROOF or (
+      error.code == LightPushErrorCode.INVALID_MESSAGE and
+      error.desc.get("").contains(RlnValidatorErrorMsg)
+    )
+
+proc onRlnProofRejected*(self: Waku) =
+  ## Called when a publish was rejected as RLN-invalid. Starts refetching the
+  ## merkle path in the background, so the next proof generated for the message
+  ## is built against a fresh one. Non-blocking: the send service's own loop is
+  ## what retries, and it must not stall waiting on an RPC round trip.
+  if self.node.rln.isNil():
+    return
+
+  self.node.rln.groupManager.scheduleMerkleProofRefresh()
 
 proc lightpushPeerAvailable*(self: Waku, shard: PubsubTopic): bool =
   ## True if a lightpush service peer is available for `shard`.

--- a/logos_delivery/waku/api/publish.nim
+++ b/logos_delivery/waku/api/publish.nim
@@ -82,6 +82,19 @@ func isRlnRejection*(error: ErrorStatus): bool =
       error.desc.get("").contains(RlnValidatorErrorMsg)
     )
 
+proc currentRlnEpochQuota*(self: Waku): Opt[tuple[epochIndex, messageLimit: uint64]] =
+  ## RLN's current epoch index and the epoch's user message limit, read
+  ## together so the pair cannot straddle an epoch boundary. `none` when RLN is
+  ## not mounted (or its limit is unset) — which the rate limit manager reads as
+  ## "fall back to the wall-clock window and the configured limit".
+  if self.node.rln.isNil():
+    return Opt.none(tuple[epochIndex, messageLimit: uint64])
+
+  let limit = self.node.rln.groupManager.userMessageLimit.valueOr:
+    return Opt.none(tuple[epochIndex, messageLimit: uint64])
+
+  return Opt.some((fromEpoch(self.node.rln.getCurrentEpoch()), uint64(limit)))
+
 proc onRlnProofRejected*(self: Waku) =
   ## Called when a publish was rejected as RLN-invalid. Starts refetching the
   ## merkle path in the background, so the next proof generated for the message

--- a/logos_delivery/waku/api/publish.nim
+++ b/logos_delivery/waku/api/publish.nim
@@ -7,6 +7,7 @@
 ## so the messaging layer never inspects `waku.node` directly.
 {.push raises: [].}
 
+import std/times
 import results, chronos
 
 import logos_delivery/waku/waku
@@ -38,9 +39,33 @@ proc hasLightpush*(self: Waku): bool =
 
 proc relayPushHandler*(self: Waku): PushMessageHandler =
   ## Builds the relay publish handler used by the send pipeline. Caller
-  ## ensures relay is mounted. RLN proof generation is handled client-side
-  ## in (legacy)lightpushPublish; this handler only validates and republishes.
+  ## ensures relay is mounted. The handler validates and republishes; the
+  ## proof is attached by the messaging layer via `attachRlnProof`.
   return getRelayPushHandler(self.node.wakuRelay)
+
+proc attachRlnProof*(
+    self: Waku, message: WakuMessage
+): Future[Result[WakuMessage, string]] {.async.} =
+  ## Returns `message` carrying an RLN proof. A message that already has one is
+  ## returned untouched, so retrying a task neither redraws a nonce nor changes
+  ## the bytes. Without RLN mounted the message passes through unproven.
+  ##
+  ## Uses the root-refreshing generator: a message can wait in the send
+  ## service's task cache while the group root moves on chain, so the proof is
+  ## validated against the acceptable-root window and regenerated once against a
+  ## refetched merkle path if it went stale.
+  if self.node.rln.isNil() or message.proof.len > 0:
+    return ok(message)
+
+  var msgWithProof = message
+  msgWithProof.proof = (
+    await self.node.rln.generateRLNProofWithRootRefresh(
+      message.toRLNSignal(), float64(getTime().toUnix())
+    )
+  ).valueOr:
+    return err("failed to attach RLN proof: " & error)
+
+  return ok(msgWithProof)
 
 proc lightpushPeerAvailable*(self: Waku, shard: PubsubTopic): bool =
   ## True if a lightpush service peer is available for `shard`.

--- a/logos_delivery/waku/node/waku_node/lightpush.nim
+++ b/logos_delivery/waku/node/waku_node/lightpush.nim
@@ -105,30 +105,6 @@ proc resolveLegacyPubsubTopic(
       return err("Autosharding error: " & error)
   return ok($shard)
 
-proc runRlnRefreshRetry(
-    node: WakuNode,
-    rln: Opt[Rln],
-    msgWithProof: WakuMessage,
-    pubsubForPublish: PubsubTopic,
-    peer: RemotePeerInfo,
-    fallback: legacy_lightpush_protocol.WakuLightPushResult[string],
-): Future[legacy_lightpush_protocol.WakuLightPushResult[string]] {.async, gcsafe.} =
-  ## Refreshes the RLN merkle proof path and retries the publish once. Only the
-  ## refresh is bounded by RlnMerkleProofRefreshTimeout (returning `fallback` on
-  ## timeout); the retried publish runs unbounded, matching the first attempt.
-  info "legacy lightpush send rejected as RLN-invalid; " &
-    "refreshing merkle proof and retrying once"
-  rln.get().groupManager.invalidateMerkleProofCache()
-
-  let refreshFut = attachRLNProof(rln.get(), msgWithProof)
-  if not (await refreshFut.withTimeout(RlnMerkleProofRefreshTimeout)):
-    warn "legacy lightpush RLN proof refresh timed out; returning original error"
-    return fallback
-  let retryMsg = refreshFut.read().valueOr:
-    return err("failed call attachRLNProof from lightpush retry: " & error)
-
-  return await internalLegacyLightpushPublish(node, pubsubForPublish, retryMsg, peer)
-
 proc legacyLightpushPublish*(
     node: WakuNode,
     pubsubTopic: Opt[PubsubTopic],
@@ -161,18 +137,20 @@ proc legacyLightpushPublish*(
     ).valueOr:
       return err(error)
 
-    let firstResult =
+    let publishResult =
       await internalLegacyLightpushPublish(node, pubsubForPublish, msgWithProof, peer)
 
     # Legacy has no status codes, so string-match the RLN error to detect a
-    # stale merkle proof path, then refresh and retry once.
-    if firstResult.isOk() or rln.isNone() or
-        not firstResult.error.contains(RlnValidatorErrorMsg):
-      return firstResult
+    # stale merkle proof path. Schedule the refresh and hand the error back:
+    # retrying is the caller's decision, the same way the non-legacy path
+    # behaves. A retry regenerates the proof against the refreshed cache.
+    if publishResult.isOk() or rln.isNone() or
+        not publishResult.error.contains(RlnValidatorErrorMsg):
+      return publishResult
 
-    return await runRlnRefreshRetry(
-      node, rln, msgWithProof, pubsubForPublish, peer, firstResult
-    )
+    info "legacy lightpush send rejected as RLN-invalid; scheduling merkle proof refresh"
+    rln.get().groupManager.scheduleMerkleProofRefresh()
+    return err(RlnProofRefreshScheduledMsg & ": " & publishResult.error)
   except CatchableError:
     return err(getCurrentExceptionMsg())
 

--- a/logos_delivery/waku/rln/constants.nim
+++ b/logos_delivery/waku/rln/constants.nim
@@ -25,11 +25,6 @@ const RlnValidatorErrorMsg* = "RLN validation failed"
 const RlnProofRefreshScheduledMsg* =
   "stale RLN proof suspected; refresh scheduled, retry the publish"
 
-# Bounds the legacy lightpush merkle proof refresh (eth_call refetch + proof
-# regen) so a hanging RPC cannot stall the caller. The retried publish is not
-# bounded.
-const RlnMerkleProofRefreshTimeout* = 5.seconds
-
 # inputs of the membership contract constructor
 # TODO may be able to make these constants private and put them inside the waku_rln_utils
 const

--- a/logos_delivery/waku/rln/proof.nim
+++ b/logos_delivery/waku/rln/proof.nim
@@ -60,12 +60,14 @@ proc toRLNSignal*(wakumessage: WakuMessage): seq[byte] =
     output = concat(wakumessage.payload, contentTopicBytes, @(timestampBytes))
   return output
 
-proc generateRLNProof*(
-    rln: Rln, input: seq[byte], senderEpochTime: float64
+proc generateRLNProofWithNonce(
+    rln: Rln, input: seq[byte], senderEpochTime: float64, nonce: Nonce
 ): Future[Result[seq[byte], string]] {.async: (raises: []).} =
+  ## Generates a proof against an already drawn `nonce`. Regenerating for an
+  ## unchanged (input, epoch, nonce) is safe: the revealed share is a function
+  ## of those three, so a regenerated proof reveals the same share and cannot
+  ## read as double-signalling.
   let epoch = rln.calcEpoch(senderEpochTime)
-  let nonce = rln.nonceManager.getNonce().valueOr:
-    return err("could not get new message id to generate an rln proof: " & $error)
   try:
     let proof = (await rln.groupManager.generateProof(input, epoch, nonce)).valueOr:
       return err("could not generate rln-v2 proof: " & $error)
@@ -73,13 +75,29 @@ proc generateRLNProof*(
   except CatchableError as e:
     return err("exception generating rln proof: " & e.msg)
 
+proc generateRLNProof*(
+    rln: Rln, input: seq[byte], senderEpochTime: float64
+): Future[Result[seq[byte], string]] {.async: (raises: []).} =
+  let nonce = rln.nonceManager.getNonce().valueOr:
+    return err("could not get new message id to generate an rln proof: " & $error)
+  return await rln.generateRLNProofWithNonce(input, senderEpochTime, nonce)
+
 proc generateRLNProofWithRootRefresh*(
     rln: Rln, input: seq[byte], senderEpochTime: float64
 ): Future[Result[seq[byte], string]] {.async.} =
   ## Generates an RLN proof and checks its merkle root against the
   ## acceptable-root window. If the root is stale, invalidates the cache and
   ## regenerates once against a refetched path. Returns the proof bytes.
-  let proofBytes = (await rln.generateRLNProof(input, senderEpochTime)).valueOr:
+  ##
+  ## The regeneration reuses the nonce drawn for the first attempt: only the
+  ## merkle path differs between the two, so drawing again would spend two
+  ## message ids from the epoch budget on a message that is sent once. That
+  ## would drift the budget the rate limit manager accounts for away from the
+  ## one the nonce manager enforces.
+  let nonce = rln.nonceManager.getNonce().valueOr:
+    return err("could not get new message id to generate an rln proof: " & $error)
+
+  let proofBytes = (await rln.generateRLNProofWithNonce(input, senderEpochTime, nonce)).valueOr:
     return err("failed to generate RLN proof: " & $error)
 
   let rlnProof = RateLimitProof.init(proofBytes).valueOr:
@@ -90,7 +108,7 @@ proc generateRLNProofWithRootRefresh*(
 
   info "RLN: stale merkle root detected; refreshing merkle path and regenerating proof"
   rln.groupManager.invalidateMerkleProofCache()
-  return await rln.generateRLNProof(input, senderEpochTime)
+  return await rln.generateRLNProofWithNonce(input, senderEpochTime, nonce)
 
 proc attachRLNProof*(
     r: Rln, message: WakuMessage

--- a/tests/messaging/test_all.nim
+++ b/tests/messaging/test_all.nim
@@ -1,3 +1,3 @@
 {.used.}
 
-import ./test_rate_limit_manager
+import ./test_rate_limit_manager, ./test_rln_proof_attach

--- a/tests/messaging/test_all.nim
+++ b/tests/messaging/test_all.nim
@@ -1,3 +1,7 @@
 {.used.}
 
-import ./test_rate_limit_manager, ./test_rln_proof_attach, ./test_delivery_task_reaping
+import
+  ./test_rate_limit_manager,
+  ./test_rln_proof_attach,
+  ./test_delivery_task_reaping,
+  ./test_send_service_scheduler

--- a/tests/messaging/test_all.nim
+++ b/tests/messaging/test_all.nim
@@ -1,3 +1,3 @@
 {.used.}
 
-import ./test_rate_limit_manager, ./test_rln_proof_attach
+import ./test_rate_limit_manager, ./test_rln_proof_attach, ./test_delivery_task_reaping

--- a/tests/messaging/test_delivery_task_reaping.nim
+++ b/tests/messaging/test_delivery_task_reaping.nim
@@ -1,0 +1,39 @@
+{.used.}
+
+import results, chronos, testutils/unittests
+
+import logos_delivery/messaging/delivery_service/send_service/delivery_task
+
+const MaxTime = chronos.minutes(1)
+
+proc taskWith(admitted, propagated: Opt[Moment]): DeliveryTask =
+  ## Builds a DeliveryTask directly (bypassing `new`, which needs a broker) with
+  ## only the fields the reaping predicate reads.
+  DeliveryTask(firstAdmittedTime: admitted, firstPropagatedTime: propagated)
+
+suite "DeliveryTask - delivery-timeout reaping":
+  test "a task parked for budget (never admitted) is exempt, however old":
+    ## The #4049 fix: budget-parked tasks must survive to the epoch roll instead
+    ## of being aged out with a misleading failure.
+    let task = taskWith(Opt.none(Moment), Opt.none(Moment))
+    check not task.isDeliveryTimedOut(MaxTime)
+
+  test "an admitted, never-propagated task past the window times out":
+    let task = taskWith(Opt.some(Moment.now() - chronos.minutes(2)), Opt.none(Moment))
+    check task.isDeliveryTimedOut(MaxTime)
+
+  test "an admitted task still within the window does not time out":
+    let task = taskWith(Opt.some(Moment.now()), Opt.none(Moment))
+    check not task.isDeliveryTimedOut(MaxTime)
+
+  test "a propagated task is never timed out here (store validation owns it)":
+    let task =
+      taskWith(Opt.some(Moment.now() - chronos.minutes(2)), Opt.some(Moment.now()))
+    check not task.isDeliveryTimedOut(MaxTime)
+
+  test "the timeout clock runs from admission, not message creation":
+    ## A task that waited a long time for budget then just got admitted has a
+    ## fresh clock — it is not reaped immediately on admission.
+    let task = taskWith(Opt.some(Moment.now()), Opt.none(Moment))
+    check task.admissionAge() < MaxTime
+    check not task.isDeliveryTimedOut(MaxTime)

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -1,15 +1,14 @@
 {.used.}
 
-import std/options
-import chronos, testutils/unittests, stew/byteutils
+import results, chronos, testutils/unittests, stew/byteutils
 
 import logos_delivery/messaging/rate_limit_manager/rate_limit_manager
 
 proc fixedQuota(epochIndex, userMessageLimit: uint64): QuotaProvider =
   ## A quota source pinned to one epoch — the epoch never rolls on its own, so
   ## limit-boundary tests are deterministic without touching the wall clock.
-  return proc(): Option[EpochQuota] {.gcsafe, raises: [].} =
-    some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
+  return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+    Opt.some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
 
 suite "RateLimitManager - admission":
   asyncTest "admit is a pass-through when disabled":
@@ -49,8 +48,8 @@ suite "RateLimitManager - admission":
     var epoch = 1'u64
     let rl = RateLimitManager.new(
       RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
-      proc(): Option[EpochQuota] {.gcsafe, raises: [].} =
-        some(EpochQuota(epochIndex: epoch, userMessageLimit: 100)),
+      proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+        Opt.some(EpochQuota(epochIndex: epoch, userMessageLimit: 100)),
     )
     check (await rl.admit("first".toBytes())).isOk()
     check (await rl.admit("second".toBytes())).isErr()

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -1,8 +1,15 @@
 {.used.}
 
+import std/options
 import chronos, testutils/unittests, stew/byteutils
 
 import logos_delivery/messaging/rate_limit_manager/rate_limit_manager
+
+proc fixedQuota(epochIndex, userMessageLimit: uint64): QuotaProvider =
+  ## A quota source pinned to one epoch — the epoch never rolls on its own, so
+  ## limit-boundary tests are deterministic without touching the wall clock.
+  return proc(): Option[EpochQuota] {.gcsafe, raises: [].} =
+    some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
 
 suite "RateLimitManager - admission":
   asyncTest "admit is a pass-through when disabled":
@@ -10,12 +17,25 @@ suite "RateLimitManager - admission":
       RateLimitConfig(enabled: false, epochPeriodSec: 600, messagesPerEpoch: 1)
     )
     for _ in 0 ..< 10:
-      let res = await rl.admit("payload".toBytes())
-      check res.isOk()
+      check (await rl.admit("payload".toBytes())).isOk()
 
-  asyncTest "admits up to the budget then rejects with OverBudget":
+  asyncTest "zeroed limit or epoch period is treated as disabled":
+    let zeroLimit = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 0)
+    )
+    check (await zeroLimit.admit("a".toBytes())).isOk()
+
+    let zeroEpoch = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 0, messagesPerEpoch: 1)
+    )
+    check (await zeroEpoch.admit("a".toBytes())).isOk()
+    check (await zeroEpoch.admit("b".toBytes())).isOk()
+
+  asyncTest "admits up to the message limit then rejects with OverBudget":
+    ## Fixed-epoch quota so the window cannot roll mid-test.
     let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3)
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3),
+      fixedQuota(epochIndex = 42, userMessageLimit = 100),
     )
     for i in 0 ..< 3:
       check (await rl.admit(("msg" & $i).toBytes())).isOk()
@@ -24,33 +44,44 @@ suite "RateLimitManager - admission":
       res.isErr()
       res.error == RateLimitError.OverBudget
 
-  asyncTest "budget frees when the epoch rolls over":
+  asyncTest "allowance refills when the epoch rolls over":
+    ## Drive the roll through the provider — no sleeps, no flake.
+    var epoch = 1'u64
     let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 1, messagesPerEpoch: 1)
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+      proc(): Option[EpochQuota] {.gcsafe, raises: [].} =
+        some(EpochQuota(epochIndex: epoch, userMessageLimit: 100)),
     )
     check (await rl.admit("first".toBytes())).isOk()
     check (await rl.admit("second".toBytes())).isErr()
-    await sleepAsync(1100.milliseconds)
+    epoch = 2
     check (await rl.admit("third".toBytes())).isOk()
     check (await rl.admit("fourth".toBytes())).isErr()
 
-  asyncTest "resetEpoch forces a fresh budget":
+  asyncTest "RLN user message limit clamps a looser configured cap":
+    ## config cap 5, RLN grants 2 — the third admission must reject, since
+    ## exceeding RLN's limit would fail at proof generation anyway.
+    let rl = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 5),
+      fixedQuota(epochIndex = 7, userMessageLimit = 2),
+    )
+    check (await rl.admit("a".toBytes())).isOk()
+    check (await rl.admit("b".toBytes())).isOk()
+    check (await rl.admit("c".toBytes())).isErr()
+
+  asyncTest "config cap can tighten below the RLN limit":
+    ## config cap 1, RLN grants 100 — the config cap wins.
+    let rl = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+      fixedQuota(epochIndex = 7, userMessageLimit = 100),
+    )
+    check (await rl.admit("a".toBytes())).isOk()
+    check (await rl.admit("b".toBytes())).isErr()
+
+  asyncTest "falls back to the wall-clock window when no quota source is set":
+    ## No provider: rate limiting still enforces within a single wall-clock epoch.
     let rl = RateLimitManager.new(
       RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1)
     )
     check (await rl.admit("first".toBytes())).isOk()
     check (await rl.admit("second".toBytes())).isErr()
-    rl.resetEpoch()
-    check (await rl.admit("third".toBytes())).isOk()
-
-  asyncTest "non-positive budget or period is treated as disabled":
-    let zeroBudget = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 0)
-    )
-    check (await zeroBudget.admit("a".toBytes())).isOk()
-
-    let zeroPeriod = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 0, messagesPerEpoch: 1)
-    )
-    check (await zeroPeriod.admit("a".toBytes())).isOk()
-    check (await zeroPeriod.admit("b".toBytes())).isOk()

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -13,14 +13,44 @@ suite "RateLimitManager - admission":
       let res = await rl.admit("payload".toBytes())
       check res.isOk()
 
-  asyncTest "admit is a pass-through in the skeleton even when enabled":
-    ## Documents the current skeleton behaviour: per-epoch enforcement is
-    ## not wired yet, so every call is admitted regardless of the
-    ## configured budget. This test flips to red as soon as real
-    ## enforcement lands, at which point it should be replaced with
-    ## budget-boundary assertions.
+  asyncTest "admits up to the budget then rejects with OverBudget":
+    let rl = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3)
+    )
+    for i in 0 ..< 3:
+      check (await rl.admit(("msg" & $i).toBytes())).isOk()
+    let res = await rl.admit("over".toBytes())
+    check:
+      res.isErr()
+      res.error == RateLimitError.OverBudget
+
+  asyncTest "budget frees when the epoch rolls over":
+    let rl = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 1, messagesPerEpoch: 1)
+    )
+    check (await rl.admit("first".toBytes())).isOk()
+    check (await rl.admit("second".toBytes())).isErr()
+    await sleepAsync(1100.milliseconds)
+    check (await rl.admit("third".toBytes())).isOk()
+    check (await rl.admit("fourth".toBytes())).isErr()
+
+  asyncTest "resetEpoch forces a fresh budget":
     let rl = RateLimitManager.new(
       RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1)
     )
     check (await rl.admit("first".toBytes())).isOk()
-    check (await rl.admit("second".toBytes())).isOk()
+    check (await rl.admit("second".toBytes())).isErr()
+    rl.resetEpoch()
+    check (await rl.admit("third".toBytes())).isOk()
+
+  asyncTest "non-positive budget or period is treated as disabled":
+    let zeroBudget = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 0)
+    )
+    check (await zeroBudget.admit("a".toBytes())).isOk()
+
+    let zeroPeriod = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 0, messagesPerEpoch: 1)
+    )
+    check (await zeroPeriod.admit("a".toBytes())).isOk()
+    check (await zeroPeriod.admit("b".toBytes())).isOk()

--- a/tests/messaging/test_rln_proof_attach.nim
+++ b/tests/messaging/test_rln_proof_attach.nim
@@ -48,6 +48,11 @@ suite "SendService RLN proof attach":
       attached.payload == msg.payload
       attached.contentTopic == msg.contentTopic
 
+  asyncTest "currentRlnEpochQuota is none when RLN is not mounted":
+    ## The rate limit manager reads `none` as "use the wall-clock fallback".
+    let waku = (await Waku.new(testConf())).expect("Waku.new")
+    check waku.currentRlnEpochQuota().isNone()
+
 suite "SendService RLN proof attach - RLN mounted":
   var
     waku {.threadvar.}: Waku
@@ -89,6 +94,15 @@ suite "SendService RLN proof attach - RLN mounted":
     let attached = (await waku.attachRlnProof(testMessage())).expect("attachRlnProof")
 
     check attached.proof.len > 0
+
+  asyncTest "currentRlnEpochQuota reports RLN's epoch and user message limit":
+    ## Wires the rate limit manager to RLN: the manager clamps its configured
+    ## cap to `messageLimit` and rolls on `epochIndex`.
+    let quota = waku.currentRlnEpochQuota()
+    check:
+      quota.isSome()
+      quota.get().messageLimit == 20'u64 # the mounted userMessageLimit
+      quota.get().epochIndex > 0'u64 # unixTime div epochSize, far from zero
 
   asyncTest "is idempotent: a message that already carries a proof is untouched":
     ## Pins the retry contract: the send service re-attaches on every round, so

--- a/tests/messaging/test_rln_proof_attach.nim
+++ b/tests/messaging/test_rln_proof_attach.nim
@@ -1,0 +1,102 @@
+{.used.}
+
+import std/[options, net, osproc]
+import chronos, testutils/unittests, results, stew/byteutils
+import
+  logos_delivery/waku/[waku, waku_core, rln],
+  logos_delivery/waku/node/waku_node,
+  logos_delivery/waku/node/waku_node/relay,
+  logos_delivery/waku/api/publish,
+  logos_delivery/api/conf/messaging_conf,
+  logos_delivery/waku/factory/waku_conf
+import
+  ../testlib/testasync,
+  ../waku_rln_relay/utils_onchain,
+  ../waku_rln_relay/rln/waku_rln_relay_utils
+
+proc testConf(): WakuConf =
+  var conf = MessagingClientConf()
+    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
+      raiseAssert error
+  conf.listenAddress = parseIpAddress("0.0.0.0")
+  conf.tcpPort = Port(0)
+  conf.discv5UdpPort = Port(0)
+  conf.clusterId = Opt.some(3'u16)
+  conf.numShardsInNetwork = 1
+  conf.rest = false
+  return conf.toWakuConf().valueOr:
+    raiseAssert error
+
+proc testMessage(): WakuMessage =
+  WakuMessage(
+    payload: "hello".toBytes(),
+    contentTopic: "/test/1/attach/proto",
+    timestamp: 1_700_000_000_000_000_000,
+  )
+
+suite "SendService RLN proof attach":
+  asyncTest "passes the message through unproven when RLN is not mounted":
+    ## The default (no-RLN) configuration must be unaffected: no proof is
+    ## attached and the message reaches the send processors unchanged.
+    let waku = (await Waku.new(testConf())).expect("Waku.new")
+    let msg = testMessage()
+
+    let attached = (await waku.attachRlnProof(msg)).expect("attachRlnProof")
+
+    check:
+      attached.proof.len == 0
+      attached.payload == msg.payload
+      attached.contentTopic == msg.contentTopic
+
+suite "SendService RLN proof attach - RLN mounted":
+  var
+    waku {.threadvar.}: Waku
+    anvilProc {.threadvar.}: Process
+    manager {.threadvar.}: OnchainGroupManager
+
+  asyncSetup:
+    anvilProc = runAnvil(stateFile = Opt.some(DEFAULT_ANVIL_STATE_PATH))
+    manager = waitFor setupOnchainGroupManager(deployContracts = false)
+
+    waku = (await Waku.new(testConf())).expect("Waku.new")
+    await waku.node.setRlnValidator(
+      getWakuRlnConfig(
+        manager = manager,
+        userMessageLimit = 20,
+        index = MembershipIndex(1),
+        epochSizeSec = 600,
+      )
+    )
+
+    let credentials = generateCredentials()
+    (
+      waitFor cast[OnchainGroupManager](waku.node.rln.groupManager).register(
+        credentials, UserMessageLimit(20)
+      )
+    ).isOkOr:
+      assert false, "failed to register RLN credentials: " & error
+
+  asyncTeardown:
+    ## The RLN proof-generator provider is registered on the global broker
+    ## context; without stopping RLN it leaks into the next test's setup.
+    try:
+      await waku.node.rln.stop()
+    except Exception:
+      assert false, "failed to stop RLN: " & getCurrentExceptionMsg()
+    stopAnvil(anvilProc)
+
+  asyncTest "attaches a proof":
+    let attached = (await waku.attachRlnProof(testMessage())).expect("attachRlnProof")
+
+    check attached.proof.len > 0
+
+  asyncTest "is idempotent: a message that already carries a proof is untouched":
+    ## Pins the retry contract: the send service re-attaches on every round, so
+    ## re-attaching must neither draw a fresh nonce nor change the bytes —
+    ## otherwise a retried task would resend under a new nullifier.
+    let first = (await waku.attachRlnProof(testMessage())).expect("first attach")
+    let second = (await waku.attachRlnProof(first)).expect("second attach")
+
+    check:
+      first.proof.len > 0
+      second.proof == first.proof

--- a/tests/messaging/test_send_service_scheduler.nim
+++ b/tests/messaging/test_send_service_scheduler.nim
@@ -1,0 +1,151 @@
+{.used.}
+
+import std/net
+import chronos, chronicles, testutils/unittests, results, stew/byteutils
+
+import
+  logos_delivery/waku/waku,
+  logos_delivery/waku/waku_core,
+  logos_delivery/api/types,
+  logos_delivery/api/conf/messaging_conf,
+  logos_delivery/waku/factory/waku_conf,
+  logos_delivery/messaging/rate_limit_manager/rate_limit_manager,
+  logos_delivery/messaging/delivery_service/send_service/
+    [send_service, send_processor, delivery_task]
+import ../testlib/testasync
+
+## Scheduler-level coverage for the rate-limit seam in the send service: that a
+## task is charged against the budget exactly once no matter how many rounds it
+## takes to deliver, and that an over-budget task is parked and then released
+## when the epoch rolls. A fake processor stands in for relay/lightpush so the
+## delivery outcome is scripted and the loop is driven a tick at a time — no
+## network, no wall-clock sleeps.
+
+type FakeSendProcessor = ref object of BaseSendProcessor
+  calls: int
+  script: seq[DeliveryState]
+    ## State to stamp on the task per invocation; the last entry repeats.
+
+method process(self: FakeSendProcessor, task: DeliveryTask): Future[void] {.async.} =
+  let outcome = self.script[min(self.calls, self.script.high)]
+  inc self.calls
+  task.state = outcome
+  if outcome == DeliveryState.SuccessfullyPropagated and
+      task.firstPropagatedTime.isNone():
+    task.firstPropagatedTime = Opt.some(Moment.now())
+
+proc testConf(): WakuConf =
+  var conf = MessagingClientConf()
+    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
+      raiseAssert error
+  conf.listenAddress = parseIpAddress("0.0.0.0")
+  conf.tcpPort = Port(0)
+  conf.discv5UdpPort = Port(0)
+  conf.clusterId = Opt.some(3'u16)
+  conf.numShardsInNetwork = 1
+  conf.rest = false
+  return conf.toWakuConf().valueOr:
+    raiseAssert error
+
+proc fixedEpochQuota(epoch: ptr uint64, userMessageLimit: uint64): QuotaProvider =
+  ## Quota pinned to whatever `epoch` currently holds, so a test rolls the epoch
+  ## by writing through the pointer instead of waiting on the wall clock.
+  return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+    Opt.some(EpochQuota(epochIndex: epoch[], userMessageLimit: userMessageLimit))
+
+suite "SendService - rate-limit scheduling":
+  var waku {.threadvar.}: Waku
+
+  asyncSetup:
+    waku = (await Waku.new(testConf())).expect("Waku.new")
+
+  asyncTeardown:
+    ## The node is constructed but never started (the scheduler is driven by
+    ## hand), so stop is best-effort cleanup, not an assertion.
+    discard await waku.stop()
+
+  proc buildTask(id, payload: string): DeliveryTask =
+    ## Built directly rather than through `DeliveryTask.new`, which resolves the
+    ## pubsub shard via a broker provider only registered once the node starts.
+    ## The scheduler path under test reads `msg`, `pubsubTopic` and `msgHash`.
+    let msg = WakuMessage(
+      contentTopic: "/test/1/scheduler/proto",
+      payload: payload.toBytes(),
+      timestamp: 1_700_000_000_000_000_000,
+    )
+    let pubsubTopic = PubsubTopic("/waku/2/rs/3/0")
+    DeliveryTask(
+      requestId: RequestId(id),
+      pubsubTopic: pubsubTopic,
+      msg: msg,
+      msgHash: computeMessageHash(pubsubTopic, msg),
+      state: DeliveryState.Entry,
+    )
+
+  asyncTest "a task is charged once even when delivery takes several rounds":
+    ## First round fails to propagate, second succeeds. The retry must not draw a
+    ## second slot: `firstAdmittedTime` guards re-admission.
+    var epoch = 5'u64
+    let manager = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3),
+      fixedEpochQuota(addr epoch, userMessageLimit = 100),
+    )
+    let processor = FakeSendProcessor(
+      script: @[DeliveryState.NextRoundRetry, DeliveryState.SuccessfullyPropagated]
+    )
+    let service =
+      SendService.new(false, waku, manager, processor).expect("SendService.new")
+
+    let task = buildTask("charge-once", "hi")
+    await service.send(task)
+    check:
+      manager.sentInCurrentEpoch == 1'u64
+      task.firstAdmittedTime.isSome()
+      task.state == DeliveryState.NextRoundRetry
+
+    await service.trySendMessages()
+    check:
+      manager.sentInCurrentEpoch == 1'u64 # not re-charged on retry
+      processor.calls == 2
+      task.state == DeliveryState.SuccessfullyPropagated
+
+  asyncTest "an over-budget task is parked, then released when the epoch rolls":
+    ## Budget of one per epoch. The second send is parked (never admitted); it
+    ## stays parked while the epoch holds, and is admitted and delivered on the
+    ## first tick after the epoch rolls.
+    var epoch = 1'u64
+    let manager = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+      fixedEpochQuota(addr epoch, userMessageLimit = 100),
+    )
+    let processor = FakeSendProcessor(script: @[DeliveryState.SuccessfullyPropagated])
+    let service =
+      SendService.new(false, waku, manager, processor).expect("SendService.new")
+
+    let first = buildTask("in-budget", "one")
+    await service.send(first)
+    check:
+      first.state == DeliveryState.SuccessfullyPropagated
+      manager.sentInCurrentEpoch == 1'u64
+
+    let second = buildTask("over-budget", "two")
+    await service.send(second)
+    check:
+      second.state == DeliveryState.NextRoundRetry # parked
+      second.firstAdmittedTime.isNone() # never admitted
+    let callsWhenParked = processor.calls
+
+    # Same epoch: still over budget, so the parked task is not even handed to the
+    # processor.
+    await service.trySendMessages()
+    check:
+      second.state == DeliveryState.NextRoundRetry
+      second.firstAdmittedTime.isNone()
+      processor.calls == callsWhenParked
+
+    # Epoch rolls: budget refills, the parked task is admitted and delivered.
+    epoch = 2'u64
+    await service.trySendMessages()
+    check:
+      second.firstAdmittedTime.isSome()
+      second.state == DeliveryState.SuccessfullyPropagated

--- a/tests/node/test_wakunode_legacy_lightpush.nim
+++ b/tests/node/test_wakunode_legacy_lightpush.nim
@@ -187,21 +187,24 @@ suite "RLN Proofs as a Lightpush Service":
 
     # The tests below drive `server.legacyLightpushPublish(...)` against the
     # server node. Because `server.wakuLegacyLightPush` is mounted (and no
-    # legacy client is), the call takes the self-request path — it still runs
-    # the full client-side flow (proof gen, retry on RlnValidatorErrorMsg
-    # substring, one-retry cap), but the request lands in the local
+    # legacy client is), the call takes the self-request path — it runs the
+    # full client-side flow (proof gen, RLN-rejection detection via the
+    # RlnValidatorErrorMsg substring), but the request lands in the local
     # pushHandler. Swapping in a stub pushHandler lets each test control what
-    # attempt N sees.
+    # the publish attempt sees.
+    #
+    # On an RLN rejection the publish schedules a background merkle-proof
+    # refresh and returns the error tagged with RlnProofRefreshScheduledMsg;
+    # the caller (the send service loop) regenerates the proof and republishes
+    # on its next round.
 
-    asyncTest "retry fires on RlnValidatorErrorMsg substring and second attempt succeeds":
+    asyncTest "RLN rejection schedules a refresh and surfaces the tagged error":
       var callCount = 0
       let stub: PushMessageHandler = proc(
           pubsubTopic: PubsubTopic, message: WakuMessage
       ): Future[WakuLightPushResult[void]] {.async.} =
         inc callCount
-        if callCount == 1:
-          return err(RlnValidatorErrorMsg & ": simulated stale merkle path")
-        return ok()
+        return err(RlnValidatorErrorMsg & ": simulated stale merkle path")
       server.wakuLegacyLightPush.pushHandler = stub
 
       let response = await server.legacyLightpushPublish(
@@ -209,8 +212,10 @@ suite "RLN Proofs as a Lightpush Service":
       )
 
       check:
-        callCount == 2
-        response.isOk()
+        callCount == 1
+        response.isErr()
+        response.error.contains(RlnProofRefreshScheduledMsg)
+        response.error.contains(RlnValidatorErrorMsg)
 
     asyncTest "no retry when error does not contain RlnValidatorErrorMsg":
       var callCount = 0
@@ -230,27 +235,9 @@ suite "RLN Proofs as a Lightpush Service":
         response.isErr()
         response.error == "unrelated failure"
 
-    asyncTest "retry cap: two consecutive RLN errors surface the second":
-      var callCount = 0
-      let stub: PushMessageHandler = proc(
-          pubsubTopic: PubsubTopic, message: WakuMessage
-      ): Future[WakuLightPushResult[void]] {.async.} =
-        inc callCount
-        return err(RlnValidatorErrorMsg & ": still stale")
-      server.wakuLegacyLightPush.pushHandler = stub
-
-      let response = await server.legacyLightpushPublish(
-        Opt.some(pubsubTopic), message, server.peerInfo.toRemotePeerInfo()
-      )
-
-      check:
-        callCount == 2
-        response.isErr()
-        response.error.contains(RlnValidatorErrorMsg)
-
-    asyncTest "no retry when node.rln is nil":
-      # Detach RLN so the retry branch short-circuits on rln.isNone() even
-      # when the error string carries RlnValidatorErrorMsg. Restore before
+    asyncTest "no refresh scheduled when node.rln is nil":
+      # Detach RLN so the RLN-rejection branch short-circuits on rln.isNone()
+      # even when the error string carries RlnValidatorErrorMsg. Restore before
       # teardown so server.stop() sees the same object graph it was
       # constructed with.
       let savedRln = server.rln


### PR DESCRIPTION
Builds on #4021 (rate limit manager moved to the messaging client layer), now
merged to master. This PR turns that skeleton into real enforcement: per-epoch
budgeting sourced from RLN, RLN proof attach at the transmission stage, and
RLN-rejection recovery through the send service's existing retry loop —
removing the kernel's inline publish retry along the way.

Seven commits, each reviewable on its own.

---

## Rate-limit enforcement

### 1. Enforce the per-epoch budget in `admit()` (`ea33f2b0`)

Replaces the pass-through skeleton with a lazily rolled fixed window: `admit()`
charges one message per call, rolls the window when the epoch advances, and
rejects with `OverBudget` once `messagesPerEpoch` is exhausted. A disabled or
non-positive config admits everything, and the `MessagingClientConf` default
leaves `enabled: false` — metering stays opt-in, nothing changes for existing
nodes.

The `queue`/`dequeueReady` stubs are removed: parking over-budget messages is
the send service scheduler's job (`NextRoundRetry` + the 1s loop); the manager
only answers whether one more transmission fits.

### 2. Split the manager into config / quota source / enforcement (`2be5449c`)

`rate_limit_manager/` is decomposed into three files: `rate_limit_config.nim`
(config type, defaults, `isEnforcing`), `quota_source.nim` (the `EpochQuota` +
`QuotaProvider` seam and the wall-clock fallback), and `rate_limit_manager.nim`
(the `admit` enforcement). This isolates the RLN seam from the enforcement
logic ahead of wiring it in (commit 6).

### 3. Charge admission once per task; exempt budget-parked tasks from the reaper (`b5bdae16`, closes #4049)

Two defects the seam had once admission actually enforces, both fixed by a
single `DeliveryTask.firstAdmittedTime` field:

- The retry loop gated admission on `firstPropagatedTime.isNone()`, so a task
  that failed to propagate (e.g. no peers) was **re-admitted every 1s tick**,
  re-charging the epoch budget — with the default of one message per epoch,
  starving all other traffic. Admission is now gated on
  `firstAdmittedTime.isNone()`: a task charges one slot / draws one nonce for
  its lifetime, and retries reuse it.
- `reportTaskResult` reaped any never-propagated task older than
  `MaxTimeInCache` (60s) measured **from message creation**, so an over-budget
  task parked for a 600s epoch was hard-failed with a misleading "Unable to
  send within retry time window" long before the epoch could roll (#4049). The
  reaper now runs only for admitted tasks and measures from admission, so a
  task waiting for epoch budget is exempt and gets a full delivery window once
  admitted.

The RLN-rejection branch resets `firstAdmittedTime` along with clearing the
proof, so the regenerated proof's fresh nonce is re-admitted rather than sent
uncharged.

### 4. Source the epoch and budget from RLN (`e18e9441`)

When RLN is mounted the limiter stops guessing: `admit()` derives the epoch
index and the effective budget from RLN instead of the wall clock.

`Waku.currentRlnEpochQuota` (new, `waku/api/publish.nim`) returns RLN's current
epoch index and `userMessageLimit` **together**, so the pair cannot straddle an
epoch boundary. A late-bound `QuotaProvider` closure in `MessagingClient.new`
queries it per admission — a node whose RLN mounts *after* the client is built
upgrades from the wall-clock fallback automatically.

`admit()` then rolls on RLN's epoch and clamps the configured cap to RLN's
limit (`min(config.messagesPerEpoch, userMessageLimit)` — config can only
tighten, never widen). Without RLN, the wall-clock window and configured budget
stand in exactly as before.

---

## RLN proofing at the transmission stage

### 5. Attach RLN proofs (`55b47821`)

Closes a real gap: the relay send path published **without an RLN proof**
(`relayPushHandler` only validates and republishes; proof generation lived
client-side in the lightpush paths), so messages sent through
`SendService → RelaySendProcessor` would be rejected by an RLN-enforcing
network.

`Waku.attachRlnProof` (new, `waku/api/publish.nim`) is called in `SendService`
immediately after `admit()` succeeds, in both `send()` and the retry loop:

- **No RLN mounted → pass-through unproven**, exactly as today.
- **Proof already present → untouched**, so a retried task resends identical
  bytes and never draws a second nonce.
- Otherwise generates via `generateRLNProofWithRootRefresh`: a task can wait in
  the cache while the membership root moves on chain, so the proof is checked
  against the acceptable-root window and regenerated once against a refetched
  merkle path if stale.

Ordering is the invariant: admission strictly precedes proof generation, so a
rate-limited message never consumes a nonce. Generation failure parks the task
(`NextRoundRetry`) rather than failing it — the dominant failure is
`NonceLimitReached`, RLN's own per-epoch budget, which the loop resolves as the
epoch rolls.

### 6. Recover from RLN-invalid rejections through the retry loop (`e9035c70`)

Previously the relay processor **failed such tasks outright** (stale proof =
dead message), while the kernel's legacy lightpush path ran its own inline
retry (`runRlnRefreshRetry`) — a second retry mechanism nested inside the send
service's loop, in the wrong layer.

Now both processors do the same thing on an RLN rejection
(`Waku.isRlnRejection`): clear the stale proof, schedule a **background**
merkle-proof refresh (`Waku.onRlnProofRejected`), park as `NextRoundRetry`. The
next round re-admits and regenerates against the refreshed path. Clearing the
proof is load-bearing — `attachRlnProof` short-circuits on an existing proof,
so without it the task would resend the rejected proof until age-out.

Kernel changes supporting this:

- `runRlnRefreshRetry` removed; the legacy lightpush path now schedules the
  refresh and returns the error tagged `RlnProofRefreshScheduledMsg`, matching
  the non-legacy path. The now-unused `RlnMerkleProofRefreshTimeout` is
  dropped. One retry engine remains: the send service loop.
- `generateRLNProofWithRootRefresh` reuses the nonce drawn for the first
  attempt when regenerating after a stale root. Only the merkle path differs
  between attempts, so a redraw would spend two message ids from the epoch
  budget on one message — and drift the rate limit manager's accounting (one
  `admit()` charge) away from the nonce manager's. Safe: identical
  (input, epoch, nonce) reveals the identical share, so a regenerated proof
  cannot read as double-signalling.

---

## Behaviour

- Default config (rate limit disabled, no RLN): unchanged.
- **Legacy lightpush contract change**: on an RLN-invalid rejection the kernel
  no longer retries inline; callers get the error with the refresh-scheduled
  marker and decide whether to retry (the REST legacy endpoint now surfaces
  this to its clients). The legacy lightpush tests are updated to this
  contract.
- Over-budget is no longer a synchronous error from `send`; it is a delayed
  outcome — the task parks and dispatches when the epoch frees a slot, or ages
  out via the reaper. That is the truthful contract under RLN.

## Not touched

- `dispatchRepair` and the channels layer; the `MessagingSend` broker surface.
- The REST relay handler's `attachRlnProofAndValidate` — edge policy for a
  synchronous HTTP contract, consistent with this design.
- `checkAndGenerateRLNProof` stays in the kernel lightpush paths as an
  attach-if-missing safety net (the REST lightpush edge depends on it;
  pre-proofed messages from `SendService` short-circuit it).

## Tests

- `tests/messaging/test_rate_limit_manager.nim`: budget boundary (`OverBudget`
  on exhaustion), epoch rollover, RLN-limit clamp (both directions), disabled
  pass-through, wall-clock fallback (7 tests).
- `tests/messaging/test_rln_proof_attach.nim` (anvil-backed on-chain group
  manager — the off-chain fixture no longer exists): unmounted pass-through,
  attach when mounted, the idempotency contract the retry loop depends on, and
  `currentRlnEpochQuota` reporting RLN's epoch + user message limit.
- `tests/messaging/test_delivery_task_reaping.nim`: the reaper predicate —
  budget-parked tasks exempt, admitted-and-old times out, clock runs from
  admission (5 tests).
- `tests/messaging/test_send_service_scheduler.nim` (new): scheduler-level
  integration — charge-once-across-retries and park→release on epoch roll,
  driven a tick at a time against a scripted fake processor and a fixed-epoch
  quota provider (no network, no sleeps).
- `tests/node/test_wakunode_legacy_lightpush.nim` updated to the
  schedule-refresh contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Issue

closes #[3855](https://github.com/logos-messaging/logos-delivery/issues/3855)
