### PR TITLE
feat(channels): add channelExists to reliable channels API

### DIFF
--- a/library/channels_api/channel_api.nim
+++ b/library/channels_api/channel_api.nim
@@ -30,6 +30,21 @@ proc logosdelivery_channel_create(
 
   return ok(string(id))
 
+proc logosdelivery_channel_exists(
+    ctx: ptr FFIContext[LogosDelivery],
+    callback: FFICallBack,
+    userData: pointer,
+    channelIdStr: cstring,
+) {.ffi.} =
+  ## Returns `"true"` or `"false"`; a missing channel is not an error.
+  requireInitializedNode(ctx, "ChannelExists"):
+    return err(errMsg)
+
+  requireChannels(ctx, "ChannelExists"):
+    return err(errMsg)
+
+  return ok($ctx.myLib[].reliableChannelManager.channelExists(ChannelId($channelIdStr)))
+
 proc logosdelivery_channel_send(
     ctx: ptr FFIContext[LogosDelivery],
     callback: FFICallBack,

--- a/library/liblogosdelivery.h
+++ b/library/liblogosdelivery.h
@@ -86,6 +86,13 @@ extern "C"
                            const char *contentTopic,
                            const char *senderId);
 
+  // Check whether a reliable channel is currently open. Returns "true" or
+  // "false"; an unknown channel id is not an error.
+  int logosdelivery_channel_exists(void *ctx,
+                           FFICallBack callback,
+                           void *userData,
+                           const char *channelId);
+
   // Send a message on a reliable channel.
   // messageJson: { "payload": "base64-encoded-payload", "ephemeral": false }
   // Returns a request ID that can be used to track delivery.

--- a/logos_delivery/api/reliable_channel_manager_api.nim
+++ b/logos_delivery/api/reliable_channel_manager_api.nim
@@ -10,6 +10,7 @@ type ReliableChannelApi* = concept c
   createReliableChannel(
     c, channelId = ChannelId, contentTopic = ContentTopic, senderId = SdsParticipantID
   ) is Result[ChannelId, string]
+  channelExists(c, channelId = ChannelId) is bool
   closeChannel(c, channelId = ChannelId) is Future[Result[void, string]]
   send(c, channelId = ChannelId, appPayload = seq[byte]) is
     Future[Result[RequestId, string]]

--- a/logos_delivery/channels/api/channel_lifecycle.nim
+++ b/logos_delivery/channels/api/channel_lifecycle.nim
@@ -74,6 +74,12 @@ proc createReliableChannel*(
   self.channels[channelId] = chn
   return ok(channelId)
 
+proc channelExists*(self: ReliableChannelManager, channelId: ChannelId): bool =
+  ## True while the channel is held by the manager, i.e. between a successful
+  ## `createReliableChannel` and `closeChannel`. Persisted SDS state for a
+  ## closed channel does not count as existing.
+  return self.channels.hasKey(channelId)
+
 proc closeChannel*(
     self: ReliableChannelManager, channelId: ChannelId
 ): Future[Result[void, string]] {.async: (raises: []).} =

--- a/tests/channels/test_all.nim
+++ b/tests/channels/test_all.nim
@@ -1,3 +1,4 @@
 {.used.}
 
+import ./test_channel_lifecycle
 import ./test_reliable_channel_send_receive

--- a/tests/channels/test_channel_lifecycle.nim
+++ b/tests/channels/test_channel_lifecycle.nim
@@ -1,0 +1,39 @@
+{.used.}
+
+import chronos, testutils/unittests
+import brokers/broker_context
+
+import ../testlib/[common, testasync]
+
+import logos_delivery/api/conf/channels_conf
+import logos_delivery/channels/reliable_channel_manager
+import logos_delivery/channels/api/channel_lifecycle
+import logos_delivery/channels/encryption/noop_encryption
+
+suite "Reliable Channel - lifecycle":
+  asyncTest "channelExists tracks create and close":
+    const
+      channelId = ChannelId("lifecycle-channel")
+      contentTopic = ContentTopic("/reliable-channel/test/proto")
+
+    var manager: ReliableChannelManager
+    lockNewGlobalBrokerContext:
+      manager = ReliableChannelManager.new(ReliableChannelManagerConf()).expect(
+          "ReliableChannelManager.new"
+        )
+      setNoopEncryption()
+
+      check not manager.channelExists(channelId)
+
+      discard manager
+        .createReliableChannel(channelId, contentTopic, SdsParticipantID("local"))
+        .expect("createReliableChannel")
+
+      check manager.channelExists(channelId)
+
+      ## An unrelated id must not be reported as existing.
+      check not manager.channelExists(ChannelId("other-channel"))
+
+      (await manager.closeChannel(channelId)).expect("closeChannel")
+
+      check not manager.channelExists(channelId)


### PR DESCRIPTION
Closes #4039.

Exposes `channelExists` on the reliable channels API, plus the FFI sibling.

## Changes

- `logos_delivery/channels/api/channel_lifecycle.nim` — `channelExists(self, channelId): bool`, alongside `createReliableChannel` / `closeChannel`. The manager already holds `channels*: Table[ChannelId, ReliableChannel]`, so it's a `hasKey` lookup.
- `logos_delivery/api/reliable_channel_manager_api.nim` — added to the `ReliableChannelApi` concept, so the structural contract stays complete.
- `library/channels_api/channel_api.nim` — `logosdelivery_channel_exists`, following the `requireInitializedNode` / `requireChannels` pattern of its siblings.
- `library/liblogosdelivery.h` — matching C declaration.
- `tests/channels/test_channel_lifecycle.nim` — new lifecycle suite, wired into `test_all.nim`.

## Semantics

**"Exists" = currently held by the manager**, i.e. between a successful `createReliableChannel` and `closeChannel`.

This is the one judgement call the issue doesn't settle. `closeChannel` documents that persisted SDS state survives a close ("re-creating the channel restores it"), so a closed-but-persisted channel reports `false`. That reads as the right answer for a liveness check — "can I send on this right now?" — but if the intent was "does state exist for this channel id", this needs to look at persistency instead. **Flagging for review.**

Over FFI the result is `"true"` / `"false"` via the usual `ok(string)` path — there's no existing bool convention in the FFI layer, so an unknown channel id is a successful `"false"`, not an error.

## Verification

- `channel_lifecycle.nim` and `liblogosdelivery.nim` (static lib, the FFI surface) both compile clean.
- New test passes: `1 tests run: 1 OK, 0 FAILED`. It covers absent → created → present → unrelated-id-absent → closed → absent.
- Mutation-checked the test: forcing `channelExists` to `return false` makes it fail (`1 FAILED`), so it genuinely exercises the implementation rather than passing vacuously.

Built against `origin/master` (77cb8a6) with freshly installed locked deps (libp2p 2.0.0, librln v2.0.2).

## Not done

No FFI integration test — the existing `library/` surface has no test harness I could extend, so the FFI proc is compile-verified only. Say the word if you want one.
