### PR TITLE
fix(channels): default channels to unencrypted so messages flow

### DIFF
--- a/logos_delivery/channels/reliable_channel_manager.nim
+++ b/logos_delivery/channels/reliable_channel_manager.nim
@@ -18,6 +18,7 @@ import logos_delivery/api/reliable_channel_manager_api
 import logos_delivery/api/conf/channels_conf
 
 import ./reliable_channel
+import ./encryption/noop_encryption
 
 export reliable_channel, channels_conf
 
@@ -40,10 +41,15 @@ proc new*(
   )
 
 proc start*(self: ReliableChannelManager): Result[void, string] =
-  ## Placeholder: per-channel listeners are installed in `ReliableChannel.new`,
-  ## so the manager has nothing to start at this layer. Kept for symmetry
-  ## with the `Waku` mount/start lifecycle and as a hook for future state.
-  discard
+  ## Per-channel listeners are installed in `ReliableChannel.new`, so the only
+  ## thing to wire up here is the encryption brokers. Channels encrypt on egress
+  ## and decrypt on ingress via the `Encrypt`/`Decrypt` request brokers; with no
+  ## provider registered every send and receive would fail, so `channel_send`
+  ## would never reach the wire and `ChannelMessageReceivedEvent` would never
+  ## fire. Install the pass-through noop so channels default to unencrypted
+  ## payloads. `setProvider` refuses to overwrite, so an application that
+  ## installed its own encryption before start keeps it.
+  setNoopEncryption()
   ok()
 
 proc stop*(self: ReliableChannelManager) {.async.} =


### PR DESCRIPTION
This addresses an issue discovered by @AYAHASSAN287 where messages apparently weren't properly delivered when using channels send API.

## Problem

Channels encrypt on egress and decrypt on ingress via the `Encrypt`/`Decrypt` request brokers. Nothing in the production/FFI path registered a provider, so:

- `channel_send` failed at encryption in `onReadyToSend` before `MessagingSend` — nothing reached the wire.
- Any inbound message failed at decryption in `onMessageReceived` before reassembly.

Net effect: `channel_message_received` never fires. `setNoopEncryption()` was only ever called from tests.

## Fix

Install the pass-through noop provider in `ReliableChannelManager.start()` — the symmetric spot to `MessagingClient.start()` wiring `MessagingSend`, on the same FFI worker thread the channel handlers run on (the brokers are thread-local).

`setProvider` refuses to overwrite, so an app that installs its own encryption before `start` keeps it; otherwise channels default to unencrypted payloads.

## Note

This makes channels send **plaintext by default** — matches how `encryption.nim` frames noop as the intended "no encryption wanted" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)