### PR TITLE
fix(library): honor the log level a node is configured with

### DIFF
--- a/library/nim.cfg
+++ b/library/nim.cfg
@@ -23,5 +23,12 @@
   lib
 --noMain
 
+# Logging
+# Filter statements against the level set at runtime, which is what
+# logging.setupLog applies from a node's `logLevel`. Without this chronicles
+# resolves each statement's level at compile time and that configuration is
+# accepted and ignored.
+--define:chronicles_runtime_filtering=on
+
 # Enable FFI macro features when needed for debugging
 # --define:ffiDumpMacros


### PR DESCRIPTION
## Description

A node's `logLevel` reaches chronicles: `Waku.new` passes it to `logging.setupLog`, which calls `topics_registry.setLogLevel`. Nothing reads it back. chronicles consults the runtime level only when compiled with `chronicles_runtime_filtering`, which defaults to off, so each statement's level is resolved at compile time and the configured value is accepted and ignored.

liblogosdelivery therefore logs everything from the compile-time level up and an application embedding it cannot quiet it. With `"logLevel": "ERROR"` in the node configuration you still get a steady stream of DBG/INF lines: kademlia record walks every few seconds, filter subscription maintenance, autonat probes, mesh peer checks and heartbeats.

## Changes

[library: enable chronicles runtime filtering](https://github.com/logos-messaging/logos-delivery/pull/4056/commits)

One define in `library/nim.cfg`. It goes there rather than in `nix/default.nix` so that every path that builds the library picks it up: the nix package flake consumers link, and the `make liblogosdelivery` targets behind the release assets and the Windows DLL. It also matches how `apps/*/nim.cfg` already configure chronicles, `apps/wakucanary/nim.cfg` with this same define and nothing else.

Behaviour does not change until an application sets a level. The runtime level is an `Atomic[LogLevel]` that zero-initializes to `NONE` and the gate is `logStmtLevel >= activeLogLevel`, so with nothing configured every statement passes exactly as it does today. Topic-annotated statements take the same path, with `TopicState` defaulting to `Normal`. The compile-time level remains the ceiling, so `chroniclesLogLevel` still decides what is available to select at runtime and existing overrides of it are unaffected.

Not included, deliberately: `chronicles_sinks` and `chronicles_default_output_device`, the pair `logging.setupLogFormat` needs before `logFormat` TEXT/JSON does anything. That is a separate defect, and enabling the dynamic device here would route every record logged before `setupLogFormat` runs through `defaultDynamicWriter`, which reports them on stderr as "log message not delivered" rather than printing them.

## Issue

No issue in this repo. Reported downstream as logos-co/logos-chat-ui#37, where an embedding application's console is dominated by this output.