### PR TITLE
chore: adjust artifact builds and uploads to contain logosdeliverynode app

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -69,10 +69,11 @@ jobs:
           make V=1 CI=false POSTGRES=1\
             NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" \
             wakunode2\
+            logosdeliverynode\
             chat2\
             tools
 
-          tar -cvzf ${{steps.vars.outputs.nwaku}} ./build/wakunode2 ./build/chat2
+          tar -cvzf ${{steps.vars.outputs.nwaku}} ./build/wakunode2 ./build/logosdeliverynode ./build/chat2
           tar -cvzf ${{steps.vars.outputs.nwakutools}} ./build/wakucanary ./build/networkmonitor
 
       - name: upload artifacts

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -116,6 +116,7 @@ jobs:
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" V=1 update
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false wakunode2
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" CI=false chat2
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false logosdeliverynode
           tar -cvzf ${{steps.vars.outputs.waku}} ./build/
 
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false libwaku

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Building logosdeliverynode.exe
       run: |
         export PATH="$GITHUB_WORKSPACE/.nim_runtime/bin:$HOME/.nimble/bin:$PATH"
-        make logosdeliverynode V=3 -j${{ env.NPROC }}
+        make logosdeliverynode POSTGRES=1 V=3 -j${{ env.NPROC }}
 
     - name: Building liblogosdelivery.dll
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -120,6 +120,11 @@ jobs:
         export PATH="$GITHUB_WORKSPACE/.nim_runtime/bin:$HOME/.nimble/bin:$PATH"
         make wakunode2 V=3 -j${{ env.NPROC }}
 
+    - name: Building logosdeliverynode.exe
+      run: |
+        export PATH="$GITHUB_WORKSPACE/.nim_runtime/bin:$HOME/.nimble/bin:$PATH"
+        make logosdeliverynode V=3 -j${{ env.NPROC }}
+
     - name: Building liblogosdelivery.dll
       run: |
         export PATH="$GITHUB_WORKSPACE/.nim_runtime/bin:$HOME/.nimble/bin:$PATH"
@@ -131,6 +136,12 @@ jobs:
           echo "wakunode2.exe build successful"
         else
           echo "Build failed: wakunode2.exe not found"
+          exit 1
+        fi
+        if [ -f "./build/logosdeliverynode.exe" ]; then
+          echo "logosdeliverynode.exe build successful"
+        else
+          echo "Build failed: logosdeliverynode.exe not found"
           exit 1
         fi
         if [ -f "./build/liblogosdelivery.dll" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,18 @@ ENTRYPOINT ["/usr/bin/wakunode"]
 CMD ["--help"]
 
 
+# LOGOS DELIVERY NODE IMAGE ----------------------------------------------------
+
+# Reuses the prod image but exposes the binary under its own name so the image
+# identity and entrypoint are logosdeliverynode rather than the generic
+# /usr/bin/wakunode symlink. Build with --build-arg MAKE_TARGET=logosdeliverynode.
+FROM prod AS logosdeliverynode
+
+RUN ln -sv /usr/local/bin/logosdeliverynode /usr/bin/logosdeliverynode
+
+ENTRYPOINT ["/usr/bin/logosdeliverynode"]
+
+
 # DEBUG IMAGE ------------------------------------------------------------------
 
 # Build debug tools: heaptrack

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,9 @@ CMD ["--help"]
 # /usr/bin/wakunode symlink. Build with --build-arg MAKE_TARGET=logosdeliverynode.
 FROM prod AS logosdeliverynode
 
+LABEL source="https://github.com/logos-messaging/logos-delivery"
+LABEL description="Logos Delivery node"
+
 RUN ln -sv /usr/local/bin/logosdeliverynode /usr/bin/logosdeliverynode
 
 ENTRYPOINT ["/usr/bin/logosdeliverynode"]

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -14,7 +14,7 @@ pipeline {
   options {
     timestamps()
     disableRestartFromStage()
-    timeout(time: 20, unit: 'MINUTES')
+    timeout(time: 40, unit: 'MINUTES')
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
@@ -36,6 +36,11 @@ pipeline {
       name: 'IMAGE_NAME',
       description: 'Name of Docker image to push.',
       defaultValue: params.IMAGE_NAME ?: 'harbor.status.im/wakuorg/nwaku',
+    )
+    string(
+      name: 'LOGOSDELIVERY_IMAGE_NAME',
+      description: 'Name of the logosdeliverynode Docker image to push.',
+      defaultValue: params.LOGOSDELIVERY_IMAGE_NAME ?: 'harbor.status.im/wakuorg/logosdelivery',
     )
     string(
       name: 'DOCKER_CRED',
@@ -106,6 +111,23 @@ pipeline {
             "--target='prod' ."
           )
         }
+
+        /* logosdeliverynode image is always built, regardless of the primary
+         * target / heaptrack selection above. It uses the dedicated
+         * 'logosdeliverynode' stage so its entrypoint is /usr/bin/logosdeliverynode. */
+        echo 'Building logosdeliverynode image'
+        logosDeliveryImage = docker.build(
+          "${params.LOGOSDELIVERY_IMAGE_NAME}:${params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)}",
+          "--label=build='${env.BUILD_URL}' " +
+          "--label=commit='${git.commit()}' " +
+          "--label=version='${git.describe('--tags')}' " +
+          "--build-arg=MAKE_TARGET='logosdeliverynode' " +
+          "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
+          "--build-arg=POSTGRES='1' " +
+          "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
+          "--build-arg=DEBUG='${params.DEBUG ? "1" : "0"} ' " +
+          "--target='logosdeliverynode' ."
+        )
       } }
     }
 
@@ -113,6 +135,9 @@ pipeline {
       steps { script {
         image.inside('--entrypoint=""') { c ->
           sh '/usr/bin/wakunode --version'
+        }
+        logosDeliveryImage.inside('--entrypoint=""') { c ->
+          sh '/usr/bin/logosdeliverynode --version'
         }
       } }
     }
@@ -124,10 +149,13 @@ pipeline {
           credentialsId: params.DOCKER_CRED, url: params.DOCKER_REGISTRY_URL
         ]) {
           image.push()
+          logosDeliveryImage.push()
           /* If Git ref is a tag push it as Docker tag too. */
           if (params.GIT_REF ==~ /v\d+\.\d+\.\d+.*/) {
             image.push(params.GIT_REF)
             image.push('latest-release')
+            logosDeliveryImage.push(params.GIT_REF)
+            logosDeliveryImage.push('latest-release')
           }
         }
       } }

--- a/flake.nix
+++ b/flake.nix
@@ -86,8 +86,16 @@
             targets = ["wakucanary"];
             inherit zerokitRln;
           };
+
+          logosdeliverynode = pkgs.callPackage ./nix/default.nix {
+            inherit pkgs;
+            src = ./.;
+            targets = ["logosdeliverynode"];
+            inherit zerokitRln;
+            gitVersion = "v${nimbleVersion}-g${builtins.substring 0 6 shortRev}";
+          };
         in {
-          inherit liblogosdelivery wakucanary;
+          inherit liblogosdelivery wakucanary logosdeliverynode;
           # Expose librln so downstream consumers link the exact same build.
           rln = zerokitRln;
           default = liblogosdelivery;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,7 +11,15 @@
 let
   deps      = import ./deps.nix    { inherit pkgs; };
 
-  buildWakucanary = builtins.elem "wakucanary" targets;
+  # Binary app targets built as executables; anything else builds the FFI library.
+  appSources = {
+    wakucanary        = "apps/wakucanary/wakucanary.nim";
+    logosdeliverynode = "apps/logos_delivery_node/logosdeliverynode.nim";
+  };
+  appTarget =
+    let requested = builtins.filter (t: builtins.hasAttr t appSources) targets;
+    in if requested == [] then null else builtins.head requested;
+  buildApp = appTarget != null;
 
   nimDefineArgs = pkgs.lib.concatStringsSep " \\\n      " (
        [ "--define:disable_libbacktrace"
@@ -59,7 +67,7 @@ let
   '';
 in
 pkgs.stdenv.mkDerivation {
-  pname = if buildWakucanary then "wakucanary" else "liblogosdelivery";
+  pname = if buildApp then appTarget else "liblogosdelivery";
   version = "dev";
 
   inherit src;
@@ -94,11 +102,11 @@ pkgs.stdenv.mkDerivation {
     make -C $NAT_TRAV/vendor/libnatpmp-upstream \
       CFLAGS="-Wall -Os -fPIC -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4" libnatpmp.a
 
-    ${if buildWakucanary then ''
-    echo "== Building wakucanary =="
+    ${if buildApp then ''
+    echo "== Building ${appTarget} =="
     ${nimCompile {
-      outFile = "build/wakucanary";
-      sourceFile = "apps/wakucanary/wakucanary.nim";
+      outFile = "build/${appTarget}";
+      sourceFile = appSources.${appTarget};
       extraArgs = [ "--path:." ];
     }}
     '' else ''
@@ -129,10 +137,10 @@ pkgs.stdenv.mkDerivation {
     ''}
   '';
 
-  installPhase = if buildWakucanary then ''
+  installPhase = if buildApp then ''
     runHook preInstall
     mkdir -p $out/bin $out/lib
-    cp build/wakucanary $out/bin/
+    cp build/${appTarget} $out/bin/
     runHook postInstall
   '' else ''
     runHook preInstall
@@ -148,20 +156,20 @@ pkgs.stdenv.mkDerivation {
   # Use --add-rpath (not --set-rpath) so fixupPhase's stdenv RUNPATH injection
   # for libstdc++ is preserved.
   postInstall =
-    if buildWakucanary then
+    if buildApp then
       pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
         cp ${zerokitRln}/lib/librln.dylib $out/lib/
-        chmod +w $out/lib/librln.dylib $out/bin/wakucanary
+        chmod +w $out/lib/librln.dylib $out/bin/${appTarget}
         install_name_tool -id @rpath/librln.dylib $out/lib/librln.dylib
-        old=$(otool -L $out/bin/wakucanary | awk 'NR>1{print $1}' | grep librln || true)
+        old=$(otool -L $out/bin/${appTarget} | awk 'NR>1{print $1}' | grep librln || true)
         if [ -n "$old" ]; then
-          install_name_tool -change "$old" @rpath/librln.dylib $out/bin/wakucanary
+          install_name_tool -change "$old" @rpath/librln.dylib $out/bin/${appTarget}
         fi
-        install_name_tool -add_rpath @loader_path/../lib $out/bin/wakucanary
+        install_name_tool -add_rpath @loader_path/../lib $out/bin/${appTarget}
       ''
       + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
         cp ${zerokitRln}/lib/librln.so $out/lib/
-        patchelf --add-rpath '$ORIGIN/../lib' $out/bin/wakucanary
+        patchelf --add-rpath '$ORIGIN/../lib' $out/bin/${appTarget}
       ''
     else
       pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
@@ -180,8 +188,8 @@ pkgs.stdenv.mkDerivation {
 
   meta = with pkgs.lib; {
     description =
-      if buildWakucanary
-      then "Waku network canary tool"
+      if buildApp
+      then "logos-delivery ${appTarget} binary"
       else "logos-delivery shared/static library";
     homepage = "https://github.com/logos-messaging/logos-delivery";
     license  = licenses.mit;


### PR DESCRIPTION
## Summary

Extends the build/packaging pipelines so the `logosdeliverynode` app is built and published everywhere the node artifacts are produced.

### Nix
- Add a `logosdeliverynode` flake package. Generalized the `wakucanary`-only binary path in `nix/default.nix` into an app-target map so any app binary shares one build/install/rln-bundle path; the node build passes `gitVersion` for `--version` reporting.

### GitHub Actions
- **release-assets.yml**: build `logosdeliverynode` (POSTGRES=1) so it ships inside the `waku-<arch>-<os>.tar.gz` release asset.
- **pre-release.yml**: add `logosdeliverynode` to the make targets and to the `nwaku` nightly/RC tarball.
- **windows-build.yml**: build `logosdeliverynode.exe` and assert it exists (compile smoke-test, matching `wakunode2.exe`).

### Jenkins + Docker
- **Jenkinsfile.release**: build a second image for `logosdeliverynode` and push it to `harbor.status.im/wakuorg/logosdelivery:<IMAGE_TAG>` alongside the primary image; pipeline timeout bumped to 40m for the extra compile.
- **Dockerfile**: add a dedicated `logosdeliverynode` stage (`FROM prod`) so the image entrypoint is `/usr/bin/logosdeliverynode` instead of the generic `/usr/bin/wakunode` symlink. The `prod`/wakunode2 image is unchanged.

## Notes
- Windows compilation of the node is exercised for the first time by this change; if it has Windows-specific issues, that job will surface them.
- `Jenkinsfile.prs` (S3/DigitalOcean Spaces `wakunode2` upload) is intentionally left unchanged.
- GitHub Actions `container-image.yml` already builds/pushes a `logosdeliverynode` image to quay.io; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)