### PR TITLE
feat: enforce the per-epoch rate limit at the send service (RLN-sourced)

### DIFF
--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -4,9 +4,9 @@ import results, libp2p/crypto/crypto
 import logos_delivery/api/conf/kernel_conf
 import logos_delivery/waku/common/logging
 import logos_delivery/waku/factory/networks_config
-import logos_delivery/messaging/rate_limit_manager/rate_limit_manager
+import logos_delivery/messaging/rate_limit_manager/rate_limit_config
 
-export kernel_conf, rate_limit_manager
+export kernel_conf, rate_limit_config
 
 # `LogosDeliveryMode` and `EntryLayer` are defined at the leaf (`cli_args`) so
 # they can appear on `WakuNodeConf`; re-exported here via `kernel_conf`.

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -55,6 +55,13 @@ type MessagingClientConf* = object
     ## Per-epoch message rate limit enforced by the send service. `Opt` like
     ## every other field so `merge` propagates a caller's override; unset falls
     ## back to `DefaultRateLimitConfig` (rate limiting disabled).
+    ##
+    ## Known limitation — settable only programmatically (build the object, or
+    ## via `merge`), not through the JSON config or a CLI flag. It carries no
+    ## `{.name.}` pragma, and because `RateLimitConfig` is a nested object with
+    ## no `parseCmdArg`, the JSON overrides walker rejects it with "cannot be
+    ## set via JSON" (see `applyJsonFieldsToConf`). Exposing it over JSON/CLI
+    ## needs a `parseCmdArg(RateLimitConfig)` or nested-object support there.
 
 proc applyMode*(conf: var WakuNodeConf, mode: LogosDeliveryMode): ConfResult[void] =
   ## Sets the protocol flags implied by the mode.

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -52,16 +52,12 @@ type MessagingClientConf* = object
   nodeKey* {.name: "nodekey".}: Opt[crypto.PrivateKey]
     ## P2P node private key (64-char hex): stable identity / peerId across restarts.
   rateLimit*: Opt[RateLimitConfig]
-    ## Per-epoch message rate limit enforced by the send service. `Opt` like
-    ## every other field so `merge` propagates a caller's override; unset falls
+    ## Per-epoch message rate limit enforced by the send service; unset falls
     ## back to `DefaultRateLimitConfig` (rate limiting disabled).
     ##
-    ## Known limitation — settable only programmatically (build the object, or
-    ## via `merge`), not through the JSON config or a CLI flag. It carries no
-    ## `{.name.}` pragma, and because `RateLimitConfig` is a nested object with
-    ## no `parseCmdArg`, the JSON overrides walker rejects it with "cannot be
-    ## set via JSON" (see `applyJsonFieldsToConf`). Exposing it over JSON/CLI
-    ## needs a `parseCmdArg(RateLimitConfig)` or nested-object support there.
+    ## Settable only programmatically: as a nested object with no `{.name.}`
+    ## pragma or `parseCmdArg`, it is not reachable from the JSON config or a
+    ## CLI flag.
 
 proc applyMode*(conf: var WakuNodeConf, mode: LogosDeliveryMode): ConfResult[void] =
   ## Sets the protocol flags implied by the mode.

--- a/logos_delivery/messaging/delivery_service/send_service/delivery_task.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/delivery_task.nim
@@ -26,6 +26,14 @@ type DeliveryTask* = ref object
   firstPropagatedTime*: Opt[Moment]
     ## Set once on the first successful propagation; never reset on re-publish.
     ## Anchors the store-validation time cap (see propagationAge).
+  firstAdmittedTime*: Opt[Moment]
+    ## Set when the task first passes rate-limit admission (consumes a budget
+    ## slot / draws an RLN nonce); `none` while still parked waiting for epoch
+    ## budget. Guards re-admission on retry and anchors the delivery-timeout
+    ## reaper from the first real send attempt rather than message creation, so
+    ## a task parked for budget is not aged out before it can be sent. Reset to
+    ## `none` when an RLN rejection clears the proof, since regenerating draws a
+    ## fresh nonce that must be re-admitted.
   propagateEventEmitted*: bool
   errorDesc*: string
 
@@ -83,6 +91,23 @@ proc propagationAge*(self: DeliveryTask): timer.Duration =
     timer.Moment.now() - self.firstPropagatedTime.get()
   else:
     ZeroDuration
+
+proc admissionAge*(self: DeliveryTask): timer.Duration =
+  ## Time elapsed since the task first passed admission; ZeroDuration while it
+  ## has never been admitted (i.e. still parked waiting for epoch budget).
+  if self.firstAdmittedTime.isSome():
+    timer.Moment.now() - self.firstAdmittedTime.get()
+  else:
+    ZeroDuration
+
+proc isDeliveryTimedOut*(self: DeliveryTask, maxTime: timer.Duration): bool =
+  ## True when the task was admitted (drew a slot) and has been trying to
+  ## deliver longer than `maxTime` without ever propagating. A task never
+  ## admitted — still parked waiting for epoch budget — is exempt: it is waiting
+  ## for the epoch to roll, not failing to deliver, and the clock runs from
+  ## admission, not message creation, so budget wait does not count against it.
+  self.firstAdmittedTime.isSome() and self.firstPropagatedTime.isNone() and
+    self.admissionAge() > maxTime
 
 proc isEphemeral*(self: DeliveryTask): bool =
   return self.msg.ephemeral

--- a/logos_delivery/messaging/delivery_service/send_service/delivery_task.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/delivery_task.nim
@@ -27,13 +27,10 @@ type DeliveryTask* = ref object
     ## Set once on the first successful propagation; never reset on re-publish.
     ## Anchors the store-validation time cap (see propagationAge).
   firstAdmittedTime*: Opt[Moment]
-    ## Set when the task first passes rate-limit admission (consumes a budget
-    ## slot / draws an RLN nonce); `none` while still parked waiting for epoch
-    ## budget. Guards re-admission on retry and anchors the delivery-timeout
-    ## reaper from the first real send attempt rather than message creation, so
-    ## a task parked for budget is not aged out before it can be sent. Reset to
-    ## `none` when an RLN rejection clears the proof, since regenerating draws a
-    ## fresh nonce that must be re-admitted.
+    ## Set when the task first passes rate-limit admission; `none` while parked
+    ## waiting for epoch budget. Guards re-admission on retry and anchors the
+    ## delivery-timeout reaper, so a task parked for budget is not aged out
+    ## before it can be sent.
   propagateEventEmitted*: bool
   errorDesc*: string
 
@@ -93,19 +90,18 @@ proc propagationAge*(self: DeliveryTask): timer.Duration =
     return ZeroDuration
 
 proc admissionAge*(self: DeliveryTask): timer.Duration =
-  ## Time elapsed since the task first passed admission; ZeroDuration while it
-  ## has never been admitted (i.e. still parked waiting for epoch budget).
+  ## Time since the task first passed admission; ZeroDuration while never
+  ## admitted (still parked waiting for epoch budget).
   if self.firstAdmittedTime.isSome():
     return timer.Moment.now() - self.firstAdmittedTime.get()
   else:
     return ZeroDuration
 
 proc isDeliveryTimedOut*(self: DeliveryTask, maxTime: timer.Duration): bool =
-  ## True when the task was admitted (drew a slot) and has been trying to
-  ## deliver longer than `maxTime` without ever propagating. A task never
-  ## admitted — still parked waiting for epoch budget — is exempt: it is waiting
-  ## for the epoch to roll, not failing to deliver, and the clock runs from
-  ## admission, not message creation, so budget wait does not count against it.
+  ## True when an admitted task has been trying to deliver longer than `maxTime`
+  ## without ever propagating. A task never admitted (parked for budget) is
+  ## exempt: the clock runs from admission time, so waiting for budget does not count
+  ## against it.
   return
     self.firstAdmittedTime.isSome() and self.firstPropagatedTime.isNone() and
     self.admissionAge() > maxTime

--- a/logos_delivery/messaging/delivery_service/send_service/delivery_task.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/delivery_task.nim
@@ -67,38 +67,38 @@ proc new*(
 
 func `==`*(r, l: DeliveryTask): bool =
   if r.isNil() == l.isNil():
-    r.isNil() or r.msgHash == l.msgHash
+    return r.isNil() or r.msgHash == l.msgHash
   else:
-    false
+    return false
 
 proc messageAge*(self: DeliveryTask): timer.Duration =
   let actual = getNanosecondTime(getTime().toUnixFloat())
   if self.msg.timestamp >= 0 and self.msg.timestamp < actual:
-    nanoseconds(actual - self.msg.timestamp)
+    return nanoseconds(actual - self.msg.timestamp)
   else:
-    ZeroDuration
+    return ZeroDuration
 
 proc deliveryAge*(self: DeliveryTask): timer.Duration =
   if self.state == DeliveryState.SuccessfullyPropagated:
-    timer.Moment.now() - self.deliveryTime
+    return timer.Moment.now() - self.deliveryTime
   else:
-    ZeroDuration
+    return ZeroDuration
 
 proc propagationAge*(self: DeliveryTask): timer.Duration =
   ## Time elapsed since the message was first successfully propagated.
   ## Stable across re-publishes; ZeroDuration until first propagation.
   if self.firstPropagatedTime.isSome():
-    timer.Moment.now() - self.firstPropagatedTime.get()
+    return timer.Moment.now() - self.firstPropagatedTime.get()
   else:
-    ZeroDuration
+    return ZeroDuration
 
 proc admissionAge*(self: DeliveryTask): timer.Duration =
   ## Time elapsed since the task first passed admission; ZeroDuration while it
   ## has never been admitted (i.e. still parked waiting for epoch budget).
   if self.firstAdmittedTime.isSome():
-    timer.Moment.now() - self.firstAdmittedTime.get()
+    return timer.Moment.now() - self.firstAdmittedTime.get()
   else:
-    ZeroDuration
+    return ZeroDuration
 
 proc isDeliveryTimedOut*(self: DeliveryTask, maxTime: timer.Duration): bool =
   ## True when the task was admitted (drew a slot) and has been trying to
@@ -106,7 +106,8 @@ proc isDeliveryTimedOut*(self: DeliveryTask, maxTime: timer.Duration): bool =
   ## admitted — still parked waiting for epoch budget — is exempt: it is waiting
   ## for the epoch to roll, not failing to deliver, and the clock runs from
   ## admission, not message creation, so budget wait does not count against it.
-  self.firstAdmittedTime.isSome() and self.firstPropagatedTime.isNone() and
+  return
+    self.firstAdmittedTime.isSome() and self.firstPropagatedTime.isNone() and
     self.admissionAge() > maxTime
 
 proc isEphemeral*(self: DeliveryTask): bool =

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -85,7 +85,11 @@ proc new*(
     preferP2PReliability: bool,
     waku: Waku,
     rateLimitManager: RateLimitManager,
+    sendProcessor: BaseSendProcessor = nil,
 ): Result[T, string] =
+  ## `sendProcessor` overrides the relay/lightpush processor chain that is
+  ## otherwise built from `waku`; passing one lets a caller drive the scheduler
+  ## against a processor whose delivery outcome it controls.
   if not waku.hasRelay() and not waku.hasLightpush():
     return err(
       "Could not create SendService. wakuRelay or wakuLightpushClient should be set"
@@ -93,8 +97,12 @@ proc new*(
 
   let checkStoreForMessages = preferP2PReliability and waku.isStoreMounted()
 
-  let sendProcessorChain = setupSendProcessorChain(waku, waku.brokerCtx).valueOr:
-    return err("failed to setup SendProcessorChain: " & $error)
+  let sendProcessorChain =
+    if sendProcessor.isNil():
+      setupSendProcessorChain(waku, waku.brokerCtx).valueOr:
+        return err("failed to setup SendProcessorChain: " & $error)
+    else:
+      sendProcessor
 
   let sendService = SendService(
     brokerCtx: waku.brokerCtx,
@@ -252,7 +260,7 @@ proc evaluateAndCleanUp(self: SendService) =
     )
   )
 
-proc trySendMessages(self: SendService) {.async.} =
+proc trySendMessages*(self: SendService) {.async.} =
   let tasksToSend = self.taskCache.filterIt(it.state == DeliveryState.NextRoundRetry)
 
   for task in tasksToSend:

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -197,15 +197,19 @@ proc reportTaskResult(self: SendService, task: DeliveryTask) =
     # rest of the states are intermediate and does not translate to event
     discard
 
-  # Only tasks that never propagated are reported as hard send failures here.
+  # Hard-fail a task that was admitted (drew a slot) but has been trying to
+  # deliver longer than MaxTimeInCache without ever propagating. A task still
+  # parked for epoch budget (never admitted) is exempt — it is waiting for the
+  # epoch to roll, not failing to deliver, and the timeout is measured from
+  # admission, not message creation, so budget wait does not count against it.
   # Propagated-but-not-store-validated tasks are handled (warn + drop, no event)
   # in evaluateAndCleanUp.
-  if task.firstPropagatedTime.isNone() and task.messageAge() > MaxTimeInCache:
+  if task.isDeliveryTimedOut(MaxTimeInCache):
     error "Failed to send message",
       requestId = task.requestId,
       msgHash = task.msgHash.to0xHex(),
       error = "Message too old",
-      age = task.messageAge()
+      age = task.admissionAge()
     task.state = DeliveryState.FailedToDeliver
     MessageErrorEvent.emit(
       self.brokerCtx,
@@ -253,12 +257,17 @@ proc trySendMessages(self: SendService) {.async.} =
 
   for task in tasksToSend:
     # Todo, check if it has any perf gain to run them concurrent...
-    if task.firstPropagatedTime.isNone():
-      ## Never propagated: this transmission consumes a fresh epoch slot, so
-      ## it must be admitted. Tasks that stay over budget remain in
-      ## `NextRoundRetry` and are retried as the epoch rolls over.
+    if task.firstAdmittedTime.isNone():
+      ## Not yet admitted: this transmission will consume a fresh epoch slot, so
+      ## it must be admitted (and draw a nonce). Guarding on admission rather
+      ## than propagation means a task that failed to propagate is not
+      ## re-charged every tick — it keeps its slot and its proof. Tasks that
+      ## stay over budget remain in `NextRoundRetry` and are retried as the
+      ## epoch rolls over.
       (await self.rateLimitManager.admit(task.msg.payload)).isOkOr:
         continue
+      task.firstAdmittedTime = Opt.some(Moment.now())
+
     await self.sendProcessor.process(task)
 
 proc serviceLoop(self: SendService) {.async.} =
@@ -294,6 +303,7 @@ proc send*(self: SendService, task: DeliveryTask) {.async.} =
     task.state = DeliveryState.NextRoundRetry
     self.addTask(task)
     return
+  task.firstAdmittedTime = Opt.some(Moment.now())
 
   await self.sendProcessor.process(task)
   reportTaskResult(self, task)

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -260,22 +260,30 @@ proc evaluateAndCleanUp(self: SendService) =
     )
   )
 
+proc admitOnce(self: SendService, task: DeliveryTask): Future[bool] {.async.} =
+  ## Charges the task's first transmission against the epoch budget — at most
+  ## once per task lifetime (`firstAdmittedTime`): a transmission consumes a
+  ## fresh epoch slot only until it is admitted, then the task keeps its slot
+  ## and retries resend the same bytes for free. Returns false when the task
+  ## must stay parked (`NextRoundRetry`) for a later round; it is retried as
+  ## the epoch rolls over.
+  if task.firstAdmittedTime.isSome():
+    return true
+
+  (await self.rateLimitManager.admit(task.msg.payload)).isOkOr:
+    debug "over rate-limit budget, task waits for the epoch to roll",
+      requestId = task.requestId, msgHash = task.msgHash.to0xHex()
+    return false
+  task.firstAdmittedTime = Opt.some(Moment.now())
+  return true
+
 proc trySendMessages*(self: SendService) {.async.} =
   let tasksToSend = self.taskCache.filterIt(it.state == DeliveryState.NextRoundRetry)
 
   for task in tasksToSend:
     # Todo, check if it has any perf gain to run them concurrent...
-    if task.firstAdmittedTime.isNone():
-      ## Not yet admitted: this transmission will consume a fresh epoch slot, so
-      ## it must be admitted (and draw a nonce). Guarding on admission rather
-      ## than propagation means a task that failed to propagate is not
-      ## re-charged every tick — it keeps its slot and its proof. Tasks that
-      ## stay over budget remain in `NextRoundRetry` and are retried as the
-      ## epoch rolls over.
-      (await self.rateLimitManager.admit(task.msg.payload)).isOkOr:
-        continue
-      task.firstAdmittedTime = Opt.some(Moment.now())
-
+    if not (await self.admitOnce(task)):
+      continue
     await self.sendProcessor.process(task)
 
 proc serviceLoop(self: SendService) {.async.} =
@@ -305,13 +313,12 @@ proc send*(self: SendService, task: DeliveryTask) {.async.} =
     error "SendService.send: failed to subscribe to content topic",
       contentTopic = task.msg.contentTopic, error = error
 
-  (await self.rateLimitManager.admit(task.msg.payload)).isOkOr:
-    info "SendService.send: over rate-limit budget, parking task",
+  if not (await self.admitOnce(task)):
+    info "SendService.send: parking task for a later round",
       requestId = task.requestId, msgHash = task.msgHash.to0xHex()
     task.state = DeliveryState.NextRoundRetry
     self.addTask(task)
     return
-  task.firstAdmittedTime = Opt.some(Moment.now())
 
   await self.sendProcessor.process(task)
   reportTaskResult(self, task)

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -48,8 +48,8 @@ type SendService* = ref object of RootObj
   serviceLoopHandle: Future[void] ## handle that allows to stop the async task
   sendProcessor: BaseSendProcessor
   rateLimitManager: RateLimitManager
-    ## Meters first transmissions against the per-epoch budget; re-publishes
-    ## of an already-propagated message resend the same bytes and are free.
+    ## Charges first transmissions against the per-epoch budget; re-publishes
+    ## are free.
 
   waku: Waku
   checkStoreForMessages: bool
@@ -87,9 +87,8 @@ proc new*(
     rateLimitManager: RateLimitManager,
     sendProcessor: BaseSendProcessor = nil,
 ): Result[T, string] =
-  ## `sendProcessor` overrides the relay/lightpush processor chain that is
-  ## otherwise built from `waku`; passing one lets a caller drive the scheduler
-  ## against a processor whose delivery outcome it controls.
+  ## `sendProcessor` overrides the relay/lightpush chain built from `waku`,
+  ## letting a caller drive the scheduler against a scripted delivery outcome.
   if not waku.hasRelay() and not waku.hasLightpush():
     return err(
       "Could not create SendService. wakuRelay or wakuLightpushClient should be set"
@@ -205,13 +204,8 @@ proc reportTaskResult(self: SendService, task: DeliveryTask) =
     # rest of the states are intermediate and does not translate to event
     discard
 
-  # Hard-fail a task that was admitted (drew a slot) but has been trying to
-  # deliver longer than MaxTimeInCache without ever propagating. A task still
-  # parked for epoch budget (never admitted) is exempt — it is waiting for the
-  # epoch to roll, not failing to deliver, and the timeout is measured from
-  # admission, not message creation, so budget wait does not count against it.
-  # Propagated-but-not-store-validated tasks are handled (warn + drop, no event)
-  # in evaluateAndCleanUp.
+  # Hard-fail a task admitted but never propagated within MaxTimeInCache.
+  # Propagated-but-unvalidated tasks are dropped in evaluateAndCleanUp instead.
   if task.isDeliveryTimedOut(MaxTimeInCache):
     error "Failed to send message",
       requestId = task.requestId,
@@ -261,12 +255,9 @@ proc evaluateAndCleanUp(self: SendService) =
   )
 
 proc admitOnce(self: SendService, task: DeliveryTask): Future[bool] {.async.} =
-  ## Charges the task's first transmission against the epoch budget — at most
-  ## once per task lifetime (`firstAdmittedTime`): a transmission consumes a
-  ## fresh epoch slot only until it is admitted, then the task keeps its slot
-  ## and retries resend the same bytes for free. Returns false when the task
-  ## must stay parked (`NextRoundRetry`) for a later round; it is retried as
-  ## the epoch rolls over.
+  ## Charges the task's first transmission against the epoch budget, at most
+  ## once per task (`firstAdmittedTime`); retries then resend for free. Returns
+  ## false when the task must stay parked for a later epoch.
   if task.firstAdmittedTime.isSome():
     return true
 

--- a/logos_delivery/messaging/messaging_client.nim
+++ b/logos_delivery/messaging/messaging_client.nim
@@ -6,6 +6,7 @@ import
   logos_delivery/api/conf/messaging_conf,
   logos_delivery/api/messaging_client_api,
   logos_delivery/waku/waku,
+  logos_delivery/waku/api/publish,
   logos_delivery/waku/factory/conf_builder/waku_conf_builder,
   logos_delivery/messaging/delivery_service/[recv_service, send_service],
   logos_delivery/messaging/rate_limit_manager/rate_limit_manager
@@ -19,6 +20,16 @@ type MessagingClient* = ref object
   recvService*: RecvService
   started*: bool
 
+proc rlnQuotaProvider(waku: Waku): QuotaProvider =
+  ## Sources the rate limit manager's epoch + limit from RLN. Late-binding: the
+  ## closure queries `waku` on each admission, so a node whose RLN mounts after
+  ## this client is constructed upgrades from the wall-clock fallback to RLN's
+  ## epoch and user message limit automatically.
+  return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+    let q = waku.currentRlnEpochQuota().valueOr:
+      return Opt.none(EpochQuota)
+    Opt.some(EpochQuota(epochIndex: q.epochIndex, userMessageLimit: q.messageLimit))
+
 proc new*(
     T: type MessagingClient, conf: MessagingClientConf, waku: Waku
 ): Result[T, string] =
@@ -26,7 +37,11 @@ proc new*(
   ## for transport while exposing its own send/recv API.
   let reliability = conf.reliabilityEnabled.get(DefaultP2pReliability)
   let sendService = ?SendService.new(
-    reliability, waku, RateLimitManager.new(conf.rateLimit.get(DefaultRateLimitConfig))
+    reliability,
+    waku,
+    RateLimitManager.new(
+      conf.rateLimit.get(DefaultRateLimitConfig), rlnQuotaProvider(waku)
+    ),
   )
   let recvService = RecvService.new(waku)
   return ok(

--- a/logos_delivery/messaging/messaging_client.nim
+++ b/logos_delivery/messaging/messaging_client.nim
@@ -21,10 +21,9 @@ type MessagingClient* = ref object
   started*: bool
 
 proc rlnQuotaProvider(waku: Waku): QuotaProvider =
-  ## Sources the rate limit manager's epoch + limit from RLN. Late-binding: the
-  ## closure queries `waku` on each admission, so a node whose RLN mounts after
-  ## this client is constructed upgrades from the wall-clock fallback to RLN's
-  ## epoch and user message limit automatically.
+  ## Sources the rate limit manager's epoch and limit from RLN. The closure
+  ## queries `waku` on each admission, so a node whose RLN mounts after
+  ## construction upgrades from the wall-clock fallback automatically.
   return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
     let q = waku.currentRlnEpochQuota().valueOr:
       return Opt.none(EpochQuota)

--- a/logos_delivery/messaging/messaging_client.nim
+++ b/logos_delivery/messaging/messaging_client.nim
@@ -36,13 +36,10 @@ proc new*(
   ## The messaging layer chains onto Waku: it drives the underlying Waku kernel
   ## for transport while exposing its own send/recv API.
   let reliability = conf.reliabilityEnabled.get(DefaultP2pReliability)
-  let sendService = ?SendService.new(
-    reliability,
-    waku,
-    RateLimitManager.new(
-      conf.rateLimit.get(DefaultRateLimitConfig), rlnQuotaProvider(waku)
-    ),
+  let rateLimitManager = ?RateLimitManager.new(
+    conf.rateLimit.get(DefaultRateLimitConfig), rlnQuotaProvider(waku)
   )
+  let sendService = ?SendService.new(reliability, waku, rateLimitManager)
   let recvService = RecvService.new(waku)
   return ok(
     T(

--- a/logos_delivery/messaging/messaging_client.nim
+++ b/logos_delivery/messaging/messaging_client.nim
@@ -28,7 +28,8 @@ proc rlnQuotaProvider(waku: Waku): QuotaProvider =
   return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
     let q = waku.currentRlnEpochQuota().valueOr:
       return Opt.none(EpochQuota)
-    Opt.some(EpochQuota(epochIndex: q.epochIndex, userMessageLimit: q.messageLimit))
+    return
+      Opt.some(EpochQuota(epochIndex: q.epochIndex, userMessageLimit: q.messageLimit))
 
 proc new*(
     T: type MessagingClient, conf: MessagingClientConf, waku: Waku

--- a/logos_delivery/messaging/rate_limit_manager/quota_source.nim
+++ b/logos_delivery/messaging/rate_limit_manager/quota_source.nim
@@ -1,0 +1,38 @@
+## Epoch + user-message-limit source for the rate limit manager.
+##
+## "Quota" is the tracking issues' word (#3838: "we should know our remaining
+## quota") for what RLN expresses as an epoch's user message limit: each epoch
+## grants `userMessageLimit` message ids (nonces), and the epoch rolling over
+## refills the allowance.
+##
+## The manager rate-limits per epoch, but must not know *where* the epoch and
+## the limit come from. With RLN mounted both are RLN's; without it, a
+## wall-clock window and the configured limit stand in. Epoch and limit are
+## read together, through one provider, so a read cannot straddle an epoch
+## boundary and pair a fresh epoch with a stale limit. The provider is a
+## callback so the manager stays free of any dependency on the `Waku` kernel —
+## the RLN-backed provider is built one layer up, where the kernel handle is in
+## scope. It returns `none` when RLN is not mounted, which is the signal to
+## fall back to the wall clock.
+
+import std/[options, times]
+
+type
+  EpochQuota* = object
+    epochIndex*: uint64
+      ## Current epoch as its numeric value (`timestamp div` the epoch length);
+      ## the kernel's `Epoch` type is the same value serialized to 32 bytes.
+    userMessageLimit*: uint64
+      ## Message ids the epoch grants — the hard ceiling on admissions before
+      ## the epoch rolls over.
+
+  QuotaProvider* = proc(): Option[EpochQuota] {.gcsafe, raises: [].}
+    ## The epoch and its user message limit, or `none` when RLN is not mounted.
+
+proc wallClockEpochIndex*(epochPeriodSec: uint64): uint64 =
+  ## Absolute wall-clock epoch: `unixTime div epochPeriodSec`. Absolute (not a
+  ## sliding window anchored at first use) so it matches RLN's `calcEpoch`, and
+  ## so two managers started at different moments agree on the boundary.
+  ## `epochPeriodSec` is assumed positive; the manager only calls this when
+  ## enforcing.
+  uint64(getTime().toUnix()) div epochPeriodSec

--- a/logos_delivery/messaging/rate_limit_manager/quota_source.nim
+++ b/logos_delivery/messaging/rate_limit_manager/quota_source.nim
@@ -15,7 +15,8 @@
 ## scope. It returns `none` when RLN is not mounted, which is the signal to
 ## fall back to the wall clock.
 
-import std/[options, times]
+import std/times
+import results
 
 type
   EpochQuota* = object
@@ -26,7 +27,7 @@ type
       ## Message ids the epoch grants — the hard ceiling on admissions before
       ## the epoch rolls over.
 
-  QuotaProvider* = proc(): Option[EpochQuota] {.gcsafe, raises: [].}
+  QuotaProvider* = proc(): Opt[EpochQuota] {.gcsafe, raises: [].}
     ## The epoch and its user message limit, or `none` when RLN is not mounted.
 
 proc wallClockEpochIndex*(epochPeriodSec: uint64): uint64 =

--- a/logos_delivery/messaging/rate_limit_manager/quota_source.nim
+++ b/logos_delivery/messaging/rate_limit_manager/quota_source.nim
@@ -1,39 +1,22 @@
 ## Epoch + user-message-limit source for the rate limit manager.
 ##
-## "Quota" is the tracking issues' word (#3838: "we should know our remaining
-## quota") for what RLN expresses as an epoch's user message limit: each epoch
-## grants `userMessageLimit` message ids (nonces), and the epoch rolling over
-## refills the allowance.
-##
-## The manager rate-limits per epoch, but must not know *where* the epoch and
-## the limit come from. With RLN mounted both are RLN's; without it, a
-## wall-clock window and the configured limit stand in. Epoch and limit are
-## read together, through one provider, so a read cannot straddle an epoch
-## boundary and pair a fresh epoch with a stale limit. The provider is a
-## callback so the manager stays free of any dependency on the `Waku` kernel —
-## the RLN-backed provider is built one layer up, where the kernel handle is in
-## scope. It returns `none` when RLN is not mounted, which is the signal to
-## fall back to the wall clock.
+## Both values are read through one provider call, so a read cannot pair a
+## fresh epoch with a stale limit. The provider is a callback, keeping the
+## manager free of any `Waku` dependency.
 
 import std/times
 import results
 
 type
   EpochQuota* = object
-    epochIndex*: uint64
-      ## Current epoch as its numeric value (`timestamp div` the epoch length);
-      ## the kernel's `Epoch` type is the same value serialized to 32 bytes.
-    userMessageLimit*: uint64
-      ## Message ids the epoch grants — the hard ceiling on admissions before
-      ## the epoch rolls over.
+    epochIndex*: uint64 ## Current epoch (`timestamp div` epoch length).
+    userMessageLimit*: uint64 ## Messages the epoch grants.
 
   QuotaProvider* = proc(): Opt[EpochQuota] {.gcsafe, raises: [].}
-    ## The epoch and its user message limit, or `none` when RLN is not mounted.
+    ## `none` when RLN is not mounted — the signal to fall back to the
+    ## wall clock.
 
 proc wallClockEpochIndex*(epochPeriodSec: uint64): uint64 =
-  ## Absolute wall-clock epoch: `unixTime div epochPeriodSec`. Absolute (not a
-  ## sliding window anchored at first use) so it matches RLN's `calcEpoch`, and
-  ## so two managers started at different moments agree on the boundary.
-  ## `epochPeriodSec` is assumed positive; the manager only calls this when
-  ## enforcing.
+  ## Absolute epoch (`unixTime div epochPeriodSec`), the same derivation RLN
+  ## uses, so independent nodes agree on the boundary.
   return uint64(getTime().toUnix()) div epochPeriodSec

--- a/logos_delivery/messaging/rate_limit_manager/quota_source.nim
+++ b/logos_delivery/messaging/rate_limit_manager/quota_source.nim
@@ -36,4 +36,4 @@ proc wallClockEpochIndex*(epochPeriodSec: uint64): uint64 =
   ## so two managers started at different moments agree on the boundary.
   ## `epochPeriodSec` is assumed positive; the manager only calls this when
   ## enforcing.
-  uint64(getTime().toUnix()) div epochPeriodSec
+  return uint64(getTime().toUnix()) div epochPeriodSec

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
@@ -1,0 +1,39 @@
+## Configuration for the messaging rate limit manager.
+##
+## Field names follow the RELIABLE-CHANNEL-API spec's `RateLimitConfig`
+## (`enabled`, `epochPeriodSec`): this is a messaging-API config object, so it
+## uses the API spec's vocabulary rather than RLN's internal `RlnConf` names.
+## `messagesPerEpoch` is the local cap; the spec leaves the actual limit to RLN,
+## which the manager honours by clamping the cap to RLN's user message limit.
+##
+## Kept separate from the enforcement engine so the API config layer can depend
+## on the vocabulary (`RateLimitConfig`) without pulling in the manager and its
+## RLN quota seam.
+
+type
+  RateLimitError* {.pure.} = enum
+    OverBudget
+
+  RateLimitConfig* = object
+    enabled*: bool ## spec: rate limiting opt-in; SHOULD be true when RLN active
+    epochPeriodSec*: uint64
+      ## Epoch length, in seconds (spec: the epoch size used by the RLN relay).
+      ## Only shapes the wall-clock fallback window; when the RLN quota source is
+      ## wired in it is ignored (the period is RLN's).
+    messagesPerEpoch*: uint64
+      ## Local cap on messages admitted per epoch. When RLN is mounted the
+      ## effective limit is clamped to RLN's user message limit; config can only
+      ## tighten it, never widen it.
+
+const
+  DefaultEpochPeriodSec* = 600'u64
+  DefaultMessagesPerEpoch* = 1'u64
+
+  DefaultRateLimitConfig* = RateLimitConfig(
+    epochPeriodSec: DefaultEpochPeriodSec, messagesPerEpoch: DefaultMessagesPerEpoch
+  ) ## Used when no rate-limit config is supplied; `enabled` defaults false.
+
+func isEnforcing*(config: RateLimitConfig): bool =
+  ## Whether the config asks for actual rate limiting. A disabled or zeroed
+  ## configuration admits everything, so the manager can short-circuit.
+  config.enabled and config.epochPeriodSec > 0 and config.messagesPerEpoch > 0

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
@@ -23,8 +23,3 @@ const
   DefaultRateLimitConfig* = RateLimitConfig(
     epochPeriodSec: DefaultEpochPeriodSec, messagesPerEpoch: DefaultMessagesPerEpoch
   ) ## Used when no rate-limit config is supplied; `enabled` defaults false.
-
-func isEnforcing*(config: RateLimitConfig): bool =
-  ## Whether the config asks for actual rate limiting; a disabled or zeroed
-  ## config admits everything.
-  return config.enabled and config.epochPeriodSec > 0 and config.messagesPerEpoch > 0

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
@@ -36,4 +36,4 @@ const
 func isEnforcing*(config: RateLimitConfig): bool =
   ## Whether the config asks for actual rate limiting. A disabled or zeroed
   ## configuration admits everything, so the manager can short-circuit.
-  config.enabled and config.epochPeriodSec > 0 and config.messagesPerEpoch > 0
+  return config.enabled and config.epochPeriodSec > 0 and config.messagesPerEpoch > 0

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_config.nim
@@ -1,29 +1,20 @@
 ## Configuration for the messaging rate limit manager.
 ##
-## Field names follow the RELIABLE-CHANNEL-API spec's `RateLimitConfig`
-## (`enabled`, `epochPeriodSec`): this is a messaging-API config object, so it
-## uses the API spec's vocabulary rather than RLN's internal `RlnConf` names.
-## `messagesPerEpoch` is the local cap; the spec leaves the actual limit to RLN,
-## which the manager honours by clamping the cap to RLN's user message limit.
-##
-## Kept separate from the enforcement engine so the API config layer can depend
-## on the vocabulary (`RateLimitConfig`) without pulling in the manager and its
-## RLN quota seam.
+## Kept separate from `rate_limit_manager` so `messaging_conf` can depend on
+## `RateLimitConfig` without pulling in the manager itself.
 
 type
   RateLimitError* {.pure.} = enum
     OverBudget
 
   RateLimitConfig* = object
-    enabled*: bool ## spec: rate limiting opt-in; SHOULD be true when RLN active
+    enabled*: bool
     epochPeriodSec*: uint64
-      ## Epoch length, in seconds (spec: the epoch size used by the RLN relay).
-      ## Only shapes the wall-clock fallback window; when the RLN quota source is
-      ## wired in it is ignored (the period is RLN's).
+      ## Epoch length in seconds. Shapes only the wall-clock fallback window;
+      ## ignored once the RLN quota source supplies the period.
     messagesPerEpoch*: uint64
-      ## Local cap on messages admitted per epoch. When RLN is mounted the
-      ## effective limit is clamped to RLN's user message limit; config can only
-      ## tighten it, never widen it.
+      ## Local cap on messages admitted per epoch. When RLN is mounted the cap
+      ## is clamped to RLN's limit
 
 const
   DefaultEpochPeriodSec* = 600'u64
@@ -34,6 +25,6 @@ const
   ) ## Used when no rate-limit config is supplied; `enabled` defaults false.
 
 func isEnforcing*(config: RateLimitConfig): bool =
-  ## Whether the config asks for actual rate limiting. A disabled or zeroed
-  ## configuration admits everything, so the manager can short-circuit.
+  ## Whether the config asks for actual rate limiting; a disabled or zeroed
+  ## config admits everything.
   return config.enabled and config.epochPeriodSec > 0 and config.messagesPerEpoch > 0

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
@@ -1,12 +1,13 @@
 ## Rate Limit Manager for the Messaging API.
 ##
 ## Tracks messages sent per RLN epoch and rejects admission when the
-## limit is approached, ensuring RLN compliance on enforcing relays.
+## budget is exhausted, ensuring RLN compliance on enforcing relays.
 ##
-## For the skeleton this is a pass-through: every call is admitted.
-## Real per-epoch budgeting will use `queue`, `currentEpochStart`,
-## `sentInCurrentEpoch`, and `resetEpoch` to park messages and admit
-## them as the epoch rolls over.
+## Budgeting is a lazily rolled fixed window: the first admission after
+## `epochPeriodSec` has elapsed resets the counter. Parking and retrying
+## of over-budget messages is owned by the send service scheduler; this
+## module only answers whether one more transmission fits the current
+## epoch's budget.
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
@@ -24,7 +25,6 @@ type
 
   RateLimitManager* = ref object
     config*: RateLimitConfig
-    queue*: seq[seq[byte]]
     currentEpochStart*: Time
     sentInCurrentEpoch*: int
 
@@ -37,22 +37,28 @@ const
   ) ## Used when no rate-limit config is supplied; `enabled` defaults false.
 
 proc new*(T: type RateLimitManager, config: RateLimitConfig): T =
-  return
-    T(config: config, queue: @[], currentEpochStart: getTime(), sentInCurrentEpoch: 0)
-
-proc admit*(
-    self: RateLimitManager, msg: seq[byte]
-): Future[Result[void, RateLimitError]] {.async: (raises: []).} =
-  ## Skeleton behaviour: admits immediately. Real per-epoch budgeting
-  ## will consult `config`, `sentInCurrentEpoch`, and the elapsed
-  ## `epochPeriodSec` window before admitting or parking `msg`.
-  return ok()
-
-proc dequeueReady*(self: RateLimitManager): seq[seq[byte]] =
-  ## Returns the set of queued messages that may be dispatched now
-  ## without exceeding the configured rate limit.
-  discard
+  return T(config: config, currentEpochStart: getTime(), sentInCurrentEpoch: 0)
 
 proc resetEpoch*(self: RateLimitManager) =
   self.currentEpochStart = getTime()
   self.sentInCurrentEpoch = 0
+
+proc admit*(
+    self: RateLimitManager, msg: seq[byte]
+): Future[Result[void, RateLimitError]] {.async: (raises: []).} =
+  ## Charges one message against the current epoch's budget, rolling the
+  ## window first when `epochPeriodSec` has elapsed. A disabled or
+  ## non-positive configuration admits everything.
+  if not self.config.enabled or self.config.epochPeriodSec <= 0 or
+      self.config.messagesPerEpoch <= 0:
+    return ok()
+
+  if getTime() - self.currentEpochStart >=
+      initDuration(seconds = self.config.epochPeriodSec):
+    self.resetEpoch()
+
+  if self.sentInCurrentEpoch >= self.config.messagesPerEpoch:
+    return err(RateLimitError.OverBudget)
+
+  inc self.sentInCurrentEpoch
+  return ok()

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
@@ -1,63 +1,80 @@
 ## Rate Limit Manager for the Messaging API.
 ##
-## Tracks messages sent per RLN epoch and rejects admission when the
-## budget is exhausted, ensuring RLN compliance on enforcing relays.
+## Rate-limits message transmissions against the per-epoch user message limit
+## and rejects admission once it is spent, keeping the node within the quota
+## that RLN-enforcing relays check. Each admission mirrors one RLN message id
+## (nonce) draw; the epoch rolling over refills the allowance.
 ##
-## Budgeting is a lazily rolled fixed window: the first admission after
-## `epochPeriodSec` has elapsed resets the counter. Parking and retrying
-## of over-budget messages is owned by the send service scheduler; this
-## module only answers whether one more transmission fits the current
-## epoch's budget.
+## The epoch and the limit come from a `QuotaProvider` when RLN is mounted
+## (see `quota_source`); otherwise a wall-clock window and the configured limit
+## stand in. Parking and retrying over-budget messages is the send service
+## scheduler's job — this module only answers whether one more transmission
+## fits the current epoch.
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import std/times
+import std/options
 import results, chronos
 
-type
-  RateLimitError* {.pure.} = enum
-    OverBudget
+import ./rate_limit_config, ./quota_source
 
-  RateLimitConfig* = object
-    enabled*: bool ## spec: rate limiting opt-in; SHOULD be true when RLN active
-    epochPeriodSec*: int
-    messagesPerEpoch*: int
+export rate_limit_config, quota_source
 
-  RateLimitManager* = ref object
-    config*: RateLimitConfig
-    currentEpochStart*: Time
-    sentInCurrentEpoch*: int
+type RateLimitManager* = ref object
+  config*: RateLimitConfig
+  quotaProvider: QuotaProvider
+    ## Supplies the RLN epoch + user message limit. Nil, or a call returning
+    ## `none`, selects the wall-clock fallback. Queried per admission so a node
+    ## whose RLN mounts after construction upgrades automatically.
+  currentEpochIndex*: uint64
+  sentInCurrentEpoch*: uint64
 
-const
-  DefaultEpochPeriodSec* = 600
-  DefaultMessagesPerEpoch* = 1
+proc new*(
+    T: type RateLimitManager,
+    config: RateLimitConfig,
+    quotaProvider: QuotaProvider = nil,
+): T =
+  return T(
+    config: config,
+    quotaProvider: quotaProvider,
+    currentEpochIndex: 0,
+    sentInCurrentEpoch: 0,
+  )
 
-  DefaultRateLimitConfig* = RateLimitConfig(
-    epochPeriodSec: DefaultEpochPeriodSec, messagesPerEpoch: DefaultMessagesPerEpoch
-  ) ## Used when no rate-limit config is supplied; `enabled` defaults false.
-
-proc new*(T: type RateLimitManager, config: RateLimitConfig): T =
-  return T(config: config, currentEpochStart: getTime(), sentInCurrentEpoch: 0)
-
-proc resetEpoch*(self: RateLimitManager) =
-  self.currentEpochStart = getTime()
-  self.sentInCurrentEpoch = 0
+proc currentQuota(self: RateLimitManager): Option[EpochQuota] =
+  if self.quotaProvider.isNil():
+    return none(EpochQuota)
+  return self.quotaProvider()
 
 proc admit*(
     self: RateLimitManager, msg: seq[byte]
 ): Future[Result[void, RateLimitError]] {.async: (raises: []).} =
-  ## Charges one message against the current epoch's budget, rolling the
-  ## window first when `epochPeriodSec` has elapsed. A disabled or
-  ## non-positive configuration admits everything.
-  if not self.config.enabled or self.config.epochPeriodSec <= 0 or
-      self.config.messagesPerEpoch <= 0:
+  ## Charges one message against the current epoch's user message limit,
+  ## rolling the window first when the epoch has advanced. A disabled or zeroed
+  ## configuration admits everything.
+  if not self.config.isEnforcing():
     return ok()
 
-  if getTime() - self.currentEpochStart >=
-      initDuration(seconds = self.config.epochPeriodSec):
-    self.resetEpoch()
+  let quota = self.currentQuota()
 
-  if self.sentInCurrentEpoch >= self.config.messagesPerEpoch:
+  let epochIndex =
+    if quota.isSome():
+      quota.get().epochIndex
+    else:
+      wallClockEpochIndex(self.config.epochPeriodSec)
+
+  # RLN can only tighten the configured cap, never widen it: exceeding RLN's
+  # user message limit would fail later at proof generation, once the epoch's
+  # message ids are exhausted.
+  var limit = self.config.messagesPerEpoch
+  if quota.isSome() and quota.get().userMessageLimit < limit:
+    limit = quota.get().userMessageLimit
+
+  if epochIndex != self.currentEpochIndex:
+    self.currentEpochIndex = epochIndex
+    self.sentInCurrentEpoch = 0
+
+  if self.sentInCurrentEpoch >= limit:
     return err(RateLimitError.OverBudget)
 
   inc self.sentInCurrentEpoch

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
@@ -13,7 +13,6 @@
 ##
 ## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
 
-import std/options
 import results, chronos
 
 import ./rate_limit_config, ./quota_source
@@ -41,9 +40,9 @@ proc new*(
     sentInCurrentEpoch: 0,
   )
 
-proc currentQuota(self: RateLimitManager): Option[EpochQuota] =
+proc currentQuota(self: RateLimitManager): Opt[EpochQuota] =
   if self.quotaProvider.isNil():
-    return none(EpochQuota)
+    return Opt.none(EpochQuota)
   return self.quotaProvider()
 
 proc admit*(

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
@@ -27,12 +27,19 @@ proc new*(
     T: type RateLimitManager,
     config: RateLimitConfig,
     quotaProvider: QuotaProvider = nil,
-): T =
-  return T(
-    config: config,
-    quotaProvider: quotaProvider,
-    currentEpochIndex: 0,
-    sentInCurrentEpoch: 0,
+): Result[T, string] =
+  ## Rejects an enabled config with a zero epoch period: the wall-clock
+  ## fallback derives the epoch as `unixTime div epochPeriodSec`.
+  if config.enabled and config.epochPeriodSec == 0:
+    return err("rate limit config: epochPeriodSec must be positive when enabled")
+
+  return ok(
+    T(
+      config: config,
+      quotaProvider: quotaProvider,
+      currentEpochIndex: 0,
+      sentInCurrentEpoch: 0,
+    )
   )
 
 proc currentQuota(self: RateLimitManager): Opt[EpochQuota] =
@@ -45,7 +52,7 @@ proc admit*(
 ): Future[Result[void, RateLimitError]] {.async: (raises: []).} =
   ## Charges one message against the current epoch's limit, rolling the window
   ## first when the epoch has advanced. A disabled config admits everything.
-  if not self.config.isEnforcing():
+  if not self.config.enabled:
     return ok()
 
   let quota = self.currentQuota()
@@ -69,5 +76,5 @@ proc admit*(
   if self.sentInCurrentEpoch >= limit:
     return err(RateLimitError.OverBudget)
 
-  inc self.sentInCurrentEpoch
+  self.sentInCurrentEpoch.inc()
   return ok()

--- a/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
+++ b/logos_delivery/messaging/rate_limit_manager/rate_limit_manager.nim
@@ -1,17 +1,13 @@
 ## Rate Limit Manager for the Messaging API.
 ##
-## Rate-limits message transmissions against the per-epoch user message limit
-## and rejects admission once it is spent, keeping the node within the quota
-## that RLN-enforcing relays check. Each admission mirrors one RLN message id
-## (nonce) draw; the epoch rolling over refills the allowance.
+## Rate-limits message transmissions against the per-epoch user message limit,
+## rejecting admission once the epoch's budget is spent. The epoch rolling
+## over refills the budget.
 ##
-## The epoch and the limit come from a `QuotaProvider` when RLN is mounted
-## (see `quota_source`); otherwise a wall-clock window and the configured limit
-## stand in. Parking and retrying over-budget messages is the send service
-## scheduler's job — this module only answers whether one more transmission
-## fits the current epoch.
-##
-## See: https://lip.logos.co/messaging/raw/reliable-channel-api.html
+## The epoch and limit come from a `QuotaProvider` when RLN is mounted;
+## otherwise a wall-clock window and the configured limit stand in. Parking and
+## retrying over-budget messages is the send service's job — this module only
+## answers whether one more transmission fits the current epoch.
 
 import results, chronos
 
@@ -22,9 +18,8 @@ export rate_limit_config, quota_source
 type RateLimitManager* = ref object
   config*: RateLimitConfig
   quotaProvider: QuotaProvider
-    ## Supplies the RLN epoch + user message limit. Nil, or a call returning
-    ## `none`, selects the wall-clock fallback. Queried per admission so a node
-    ## whose RLN mounts after construction upgrades automatically.
+    ## Nil or a `none` result selects the wall-clock fallback. Queried per
+    ## admission so a late RLN mount upgrades automatically.
   currentEpochIndex*: uint64
   sentInCurrentEpoch*: uint64
 
@@ -48,9 +43,8 @@ proc currentQuota(self: RateLimitManager): Opt[EpochQuota] =
 proc admit*(
     self: RateLimitManager, msg: seq[byte]
 ): Future[Result[void, RateLimitError]] {.async: (raises: []).} =
-  ## Charges one message against the current epoch's user message limit,
-  ## rolling the window first when the epoch has advanced. A disabled or zeroed
-  ## configuration admits everything.
+  ## Charges one message against the current epoch's limit, rolling the window
+  ## first when the epoch has advanced. A disabled config admits everything.
   if not self.config.isEnforcing():
     return ok()
 
@@ -63,8 +57,7 @@ proc admit*(
       wallClockEpochIndex(self.config.epochPeriodSec)
 
   # RLN can only tighten the configured cap, never widen it: exceeding RLN's
-  # user message limit would fail later at proof generation, once the epoch's
-  # message ids are exhausted.
+  # limit would fail later at proof generation.
   var limit = self.config.messagesPerEpoch
   if quota.isSome() and quota.get().userMessageLimit < limit:
     limit = quota.get().userMessageLimit

--- a/logos_delivery/waku/api/publish.nim
+++ b/logos_delivery/waku/api/publish.nim
@@ -42,6 +42,19 @@ proc relayPushHandler*(self: Waku): PushMessageHandler =
   ## in (legacy)lightpushPublish; this handler only validates and republishes.
   return getRelayPushHandler(self.node.wakuRelay)
 
+proc currentRlnEpochQuota*(self: Waku): Opt[tuple[epochIndex, messageLimit: uint64]] =
+  ## RLN's current epoch index and the epoch's user message limit, read
+  ## together so the pair cannot straddle an epoch boundary. `none` when RLN is
+  ## not mounted (or its limit is unset) — which the rate limit manager reads as
+  ## "fall back to the wall-clock window and the configured limit".
+  if self.node.rln.isNil():
+    return Opt.none(tuple[epochIndex, messageLimit: uint64])
+
+  let limit = self.node.rln.groupManager.userMessageLimit.valueOr:
+    return Opt.none(tuple[epochIndex, messageLimit: uint64])
+
+  return Opt.some((fromEpoch(self.node.rln.getCurrentEpoch()), uint64(limit)))
+
 proc lightpushPeerAvailable*(self: Waku, shard: PubsubTopic): bool =
   ## True if a lightpush service peer is available for `shard`.
   return self.node.peerManager.selectPeer(WakuLightPushCodec, Opt.some(shard)).isSome()

--- a/logos_delivery/waku/api/publish.nim
+++ b/logos_delivery/waku/api/publish.nim
@@ -43,10 +43,8 @@ proc relayPushHandler*(self: Waku): PushMessageHandler =
   return getRelayPushHandler(self.node.wakuRelay)
 
 proc currentRlnEpochQuota*(self: Waku): Opt[tuple[epochIndex, messageLimit: uint64]] =
-  ## RLN's current epoch index and the epoch's user message limit, read
-  ## together so the pair cannot straddle an epoch boundary. `none` when RLN is
-  ## not mounted (or its limit is unset) — which the rate limit manager reads as
-  ## "fall back to the wall-clock window and the configured limit".
+  ## RLN's current epoch index and user message limit, read together so the
+  ## pair cannot straddle an epoch boundary.
   if self.node.rln.isNil():
     return Opt.none(tuple[epochIndex, messageLimit: uint64])
 

--- a/tests/messaging/test_all.nim
+++ b/tests/messaging/test_all.nim
@@ -1,3 +1,4 @@
 {.used.}
 
-import ./test_rate_limit_manager, ./test_delivery_task_reaping
+import
+  ./test_rate_limit_manager, ./test_delivery_task_reaping, ./test_send_service_scheduler

--- a/tests/messaging/test_all.nim
+++ b/tests/messaging/test_all.nim
@@ -1,3 +1,3 @@
 {.used.}
 
-import ./test_rate_limit_manager
+import ./test_rate_limit_manager, ./test_delivery_task_reaping

--- a/tests/messaging/test_delivery_task_reaping.nim
+++ b/tests/messaging/test_delivery_task_reaping.nim
@@ -1,0 +1,39 @@
+{.used.}
+
+import results, chronos, testutils/unittests
+
+import logos_delivery/messaging/delivery_service/send_service/delivery_task
+
+const MaxTime = chronos.minutes(1)
+
+proc taskWith(admitted, propagated: Opt[Moment]): DeliveryTask =
+  ## Builds a DeliveryTask directly (bypassing `new`, which needs a broker) with
+  ## only the fields the reaping predicate reads.
+  DeliveryTask(firstAdmittedTime: admitted, firstPropagatedTime: propagated)
+
+suite "DeliveryTask - delivery-timeout reaping":
+  test "a task parked for budget (never admitted) is exempt, however old":
+    ## The #4049 fix: budget-parked tasks must survive to the epoch roll instead
+    ## of being aged out with a misleading failure.
+    let task = taskWith(Opt.none(Moment), Opt.none(Moment))
+    check not task.isDeliveryTimedOut(MaxTime)
+
+  test "an admitted, never-propagated task past the window times out":
+    let task = taskWith(Opt.some(Moment.now() - chronos.minutes(2)), Opt.none(Moment))
+    check task.isDeliveryTimedOut(MaxTime)
+
+  test "an admitted task still within the window does not time out":
+    let task = taskWith(Opt.some(Moment.now()), Opt.none(Moment))
+    check not task.isDeliveryTimedOut(MaxTime)
+
+  test "a propagated task is never timed out here (store validation owns it)":
+    let task =
+      taskWith(Opt.some(Moment.now() - chronos.minutes(2)), Opt.some(Moment.now()))
+    check not task.isDeliveryTimedOut(MaxTime)
+
+  test "the timeout clock runs from admission, not message creation":
+    ## A task that waited a long time for budget then just got admitted has a
+    ## fresh clock — it is not reaped immediately on admission.
+    let task = taskWith(Opt.some(Moment.now()), Opt.none(Moment))
+    check task.admissionAge() < MaxTime
+    check not task.isDeliveryTimedOut(MaxTime)

--- a/tests/messaging/test_delivery_task_reaping.nim
+++ b/tests/messaging/test_delivery_task_reaping.nim
@@ -7,14 +7,12 @@ import logos_delivery/messaging/delivery_service/send_service/delivery_task
 const MaxTime = chronos.minutes(1)
 
 proc taskWith(admitted, propagated: Opt[Moment]): DeliveryTask =
-  ## Builds a DeliveryTask directly (bypassing `new`, which needs a broker) with
-  ## only the fields the reaping predicate reads.
+  ## Builds a DeliveryTask directly (bypassing `new`, which needs a broker).
   return DeliveryTask(firstAdmittedTime: admitted, firstPropagatedTime: propagated)
 
 suite "DeliveryTask - delivery-timeout reaping":
   test "a task parked for budget (never admitted) is exempt, however old":
-    ## The #4049 fix: budget-parked tasks must survive to the epoch roll instead
-    ## of being aged out with a misleading failure.
+    ## Budget-parked tasks must survive to the epoch roll, not be aged out.
     let task = taskWith(Opt.none(Moment), Opt.none(Moment))
     check not task.isDeliveryTimedOut(MaxTime)
 
@@ -32,8 +30,7 @@ suite "DeliveryTask - delivery-timeout reaping":
     check not task.isDeliveryTimedOut(MaxTime)
 
   test "the timeout clock runs from admission, not message creation":
-    ## A task that waited a long time for budget then just got admitted has a
-    ## fresh clock — it is not reaped immediately on admission.
+    ## A just-admitted task has a fresh clock, even after a long budget wait.
     let task = taskWith(Opt.some(Moment.now()), Opt.none(Moment))
     check task.admissionAge() < MaxTime
     check not task.isDeliveryTimedOut(MaxTime)

--- a/tests/messaging/test_delivery_task_reaping.nim
+++ b/tests/messaging/test_delivery_task_reaping.nim
@@ -9,7 +9,7 @@ const MaxTime = chronos.minutes(1)
 proc taskWith(admitted, propagated: Opt[Moment]): DeliveryTask =
   ## Builds a DeliveryTask directly (bypassing `new`, which needs a broker) with
   ## only the fields the reaping predicate reads.
-  DeliveryTask(firstAdmittedTime: admitted, firstPropagatedTime: propagated)
+  return DeliveryTask(firstAdmittedTime: admitted, firstPropagatedTime: propagated)
 
 suite "DeliveryTask - delivery-timeout reaping":
   test "a task parked for budget (never admitted) is exempt, however old":

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -1,15 +1,14 @@
 {.used.}
 
-import std/options
-import chronos, testutils/unittests, stew/byteutils
+import results, chronos, testutils/unittests, stew/byteutils
 
 import logos_delivery/messaging/rate_limit_manager/rate_limit_manager
 
 proc fixedQuota(epochIndex, userMessageLimit: uint64): QuotaProvider =
   ## A quota source pinned to one epoch — the epoch never rolls on its own, so
   ## limit-boundary tests are deterministic without touching the wall clock.
-  return proc(): Option[EpochQuota] {.gcsafe, raises: [].} =
-    some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
+  return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+    Opt.some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
 
 suite "RateLimitManager - admission":
   asyncTest "admit is a pass-through when disabled":
@@ -49,8 +48,8 @@ suite "RateLimitManager - admission":
     var epoch = 1'u64
     let rl = RateLimitManager.new(
       RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
-      proc(): Option[EpochQuota] {.gcsafe, raises: [].} =
-        some(EpochQuota(epochIndex: epoch, userMessageLimit: 100)),
+      proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+        Opt.some(EpochQuota(epochIndex: epoch, userMessageLimit: 100)),
     )
     check (await rl.admit("first".toBytes())).isOk()
     check (await rl.admit("second".toBytes())).isErr()

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -1,8 +1,15 @@
 {.used.}
 
+import std/options
 import chronos, testutils/unittests, stew/byteutils
 
 import logos_delivery/messaging/rate_limit_manager/rate_limit_manager
+
+proc fixedQuota(epochIndex, userMessageLimit: uint64): QuotaProvider =
+  ## A quota source pinned to one epoch — the epoch never rolls on its own, so
+  ## limit-boundary tests are deterministic without touching the wall clock.
+  return proc(): Option[EpochQuota] {.gcsafe, raises: [].} =
+    some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
 
 suite "RateLimitManager - admission":
   asyncTest "admit is a pass-through when disabled":
@@ -10,12 +17,25 @@ suite "RateLimitManager - admission":
       RateLimitConfig(enabled: false, epochPeriodSec: 600, messagesPerEpoch: 1)
     )
     for _ in 0 ..< 10:
-      let res = await rl.admit("payload".toBytes())
-      check res.isOk()
+      check (await rl.admit("payload".toBytes())).isOk()
 
-  asyncTest "admits up to the budget then rejects with OverBudget":
+  asyncTest "zeroed limit or epoch period is treated as disabled":
+    let zeroLimit = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 0)
+    )
+    check (await zeroLimit.admit("a".toBytes())).isOk()
+
+    let zeroEpoch = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 0, messagesPerEpoch: 1)
+    )
+    check (await zeroEpoch.admit("a".toBytes())).isOk()
+    check (await zeroEpoch.admit("b".toBytes())).isOk()
+
+  asyncTest "admits up to the message limit then rejects with OverBudget":
+    ## Fixed-epoch quota so the window cannot roll mid-test.
     let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3)
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3),
+      fixedQuota(epochIndex = 42, userMessageLimit = 100),
     )
     for i in 0 ..< 3:
       check (await rl.admit(("msg" & $i).toBytes())).isOk()
@@ -24,33 +44,44 @@ suite "RateLimitManager - admission":
       res.isErr()
       res.error == RateLimitError.OverBudget
 
-  asyncTest "budget frees when the epoch rolls over":
+  asyncTest "allowance refills when the epoch rolls over":
+    ## Drive the roll through the provider — no sleeps, no flake.
+    var epoch = 1'u64
     let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 1, messagesPerEpoch: 1)
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+      proc(): Option[EpochQuota] {.gcsafe, raises: [].} =
+        some(EpochQuota(epochIndex: epoch, userMessageLimit: 100)),
     )
     check (await rl.admit("first".toBytes())).isOk()
     check (await rl.admit("second".toBytes())).isErr()
-    await sleepAsync(1100.milliseconds)
+    epoch = 2
     check (await rl.admit("third".toBytes())).isOk()
     check (await rl.admit("fourth".toBytes())).isErr()
 
-  asyncTest "resetEpoch forces a fresh budget":
+  asyncTest "RLN user message limit clamps a looser configured cap":
+    ## config cap 5, RLN grants 2 — the third admission must reject, since
+    ## exceeding RLN's limit would fail at proof generation anyway.
+    let rl = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 5),
+      fixedQuota(epochIndex = 7, userMessageLimit = 2),
+    )
+    check (await rl.admit("a".toBytes())).isOk()
+    check (await rl.admit("b".toBytes())).isOk()
+    check (await rl.admit("c".toBytes())).isErr()
+
+  asyncTest "config cap can tighten below the RLN limit":
+    ## config cap 1, RLN grants 100 — the config cap wins.
+    let rl = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+      fixedQuota(epochIndex = 7, userMessageLimit = 100),
+    )
+    check (await rl.admit("a".toBytes())).isOk()
+    check (await rl.admit("b".toBytes())).isErr()
+
+  asyncTest "falls back to the wall-clock window when no quota source is set":
+    ## No provider: rate limiting still enforces within a single wall-clock epoch.
     let rl = RateLimitManager.new(
       RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1)
     )
     check (await rl.admit("first".toBytes())).isOk()
     check (await rl.admit("second".toBytes())).isErr()
-    rl.resetEpoch()
-    check (await rl.admit("third".toBytes())).isOk()
-
-  asyncTest "non-positive budget or period is treated as disabled":
-    let zeroBudget = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 0)
-    )
-    check (await zeroBudget.admit("a".toBytes())).isOk()
-
-    let zeroPeriod = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 0, messagesPerEpoch: 1)
-    )
-    check (await zeroPeriod.admit("a".toBytes())).isOk()
-    check (await zeroPeriod.admit("b".toBytes())).isOk()

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -13,14 +13,44 @@ suite "RateLimitManager - admission":
       let res = await rl.admit("payload".toBytes())
       check res.isOk()
 
-  asyncTest "admit is a pass-through in the skeleton even when enabled":
-    ## Documents the current skeleton behaviour: per-epoch enforcement is
-    ## not wired yet, so every call is admitted regardless of the
-    ## configured budget. This test flips to red as soon as real
-    ## enforcement lands, at which point it should be replaced with
-    ## budget-boundary assertions.
+  asyncTest "admits up to the budget then rejects with OverBudget":
+    let rl = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3)
+    )
+    for i in 0 ..< 3:
+      check (await rl.admit(("msg" & $i).toBytes())).isOk()
+    let res = await rl.admit("over".toBytes())
+    check:
+      res.isErr()
+      res.error == RateLimitError.OverBudget
+
+  asyncTest "budget frees when the epoch rolls over":
+    let rl = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 1, messagesPerEpoch: 1)
+    )
+    check (await rl.admit("first".toBytes())).isOk()
+    check (await rl.admit("second".toBytes())).isErr()
+    await sleepAsync(1100.milliseconds)
+    check (await rl.admit("third".toBytes())).isOk()
+    check (await rl.admit("fourth".toBytes())).isErr()
+
+  asyncTest "resetEpoch forces a fresh budget":
     let rl = RateLimitManager.new(
       RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1)
     )
     check (await rl.admit("first".toBytes())).isOk()
-    check (await rl.admit("second".toBytes())).isOk()
+    check (await rl.admit("second".toBytes())).isErr()
+    rl.resetEpoch()
+    check (await rl.admit("third".toBytes())).isOk()
+
+  asyncTest "non-positive budget or period is treated as disabled":
+    let zeroBudget = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 0)
+    )
+    check (await zeroBudget.admit("a".toBytes())).isOk()
+
+    let zeroPeriod = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 0, messagesPerEpoch: 1)
+    )
+    check (await zeroPeriod.admit("a".toBytes())).isOk()
+    check (await zeroPeriod.admit("b".toBytes())).isOk()

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -8,7 +8,8 @@ proc fixedQuota(epochIndex, userMessageLimit: uint64): QuotaProvider =
   ## A quota source pinned to one epoch — the epoch never rolls on its own, so
   ## limit-boundary tests are deterministic without touching the wall clock.
   return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
-    Opt.some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
+    return
+      Opt.some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
 
 suite "RateLimitManager - admission":
   asyncTest "admit is a pass-through when disabled":

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -5,8 +5,8 @@ import results, chronos, testutils/unittests, stew/byteutils
 import logos_delivery/messaging/rate_limit_manager/rate_limit_manager
 
 proc fixedQuota(epochIndex, userMessageLimit: uint64): QuotaProvider =
-  ## A quota source pinned to one epoch — the epoch never rolls on its own, so
-  ## limit-boundary tests are deterministic without touching the wall clock.
+  ## A quota source pinned to one epoch, so limit-boundary tests don't touch
+  ## the wall clock.
   return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
     return
       Opt.some(EpochQuota(epochIndex: epochIndex, userMessageLimit: userMessageLimit))
@@ -44,7 +44,7 @@ suite "RateLimitManager - admission":
       res.isErr()
       res.error == RateLimitError.OverBudget
 
-  asyncTest "allowance refills when the epoch rolls over":
+  asyncTest "budget refills when the epoch rolls over":
     ## Drive the roll through the provider — no sleeps, no flake.
     var epoch = 1'u64
     let rl = RateLimitManager.new(
@@ -59,8 +59,7 @@ suite "RateLimitManager - admission":
     check (await rl.admit("fourth".toBytes())).isErr()
 
   asyncTest "RLN user message limit clamps a looser configured cap":
-    ## config cap 5, RLN grants 2 — the third admission must reject, since
-    ## exceeding RLN's limit would fail at proof generation anyway.
+    ## config cap 5, RLN grants 2 — the lower RLN limit wins.
     let rl = RateLimitManager.new(
       RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 5),
       fixedQuota(epochIndex = 7, userMessageLimit = 2),

--- a/tests/messaging/test_rate_limit_manager.nim
+++ b/tests/messaging/test_rate_limit_manager.nim
@@ -13,30 +13,36 @@ proc fixedQuota(epochIndex, userMessageLimit: uint64): QuotaProvider =
 
 suite "RateLimitManager - admission":
   asyncTest "admit is a pass-through when disabled":
-    let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: false, epochPeriodSec: 600, messagesPerEpoch: 1)
-    )
+    let rl = RateLimitManager
+      .new(RateLimitConfig(enabled: false, epochPeriodSec: 600, messagesPerEpoch: 1))
+      .expect("RateLimitManager.new")
     for _ in 0 ..< 10:
       check (await rl.admit("payload".toBytes())).isOk()
 
-  asyncTest "zeroed limit or epoch period is treated as disabled":
-    let zeroLimit = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 0)
-    )
-    check (await zeroLimit.admit("a".toBytes())).isOk()
+  asyncTest "a zero cap admits nothing":
+    let rl = RateLimitManager
+      .new(RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 0))
+      .expect("RateLimitManager.new")
+    let res = await rl.admit("a".toBytes())
+    check:
+      res.isErr()
+      res.error == RateLimitError.OverBudget
 
-    let zeroEpoch = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 0, messagesPerEpoch: 1)
-    )
-    check (await zeroEpoch.admit("a".toBytes())).isOk()
-    check (await zeroEpoch.admit("b".toBytes())).isOk()
+  test "construction validates the epoch period only when enabled":
+    check:
+      RateLimitManager
+        .new(RateLimitConfig(enabled: true, epochPeriodSec: 0, messagesPerEpoch: 1))
+        .isErr()
+      RateLimitManager.new(RateLimitConfig()).isOk()
 
   asyncTest "admits up to the message limit then rejects with OverBudget":
     ## Fixed-epoch quota so the window cannot roll mid-test.
-    let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3),
-      fixedQuota(epochIndex = 42, userMessageLimit = 100),
-    )
+    let rl = RateLimitManager
+      .new(
+        RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3),
+        fixedQuota(epochIndex = 42, userMessageLimit = 100),
+      )
+      .expect("RateLimitManager.new")
     for i in 0 ..< 3:
       check (await rl.admit(("msg" & $i).toBytes())).isOk()
     let res = await rl.admit("over".toBytes())
@@ -47,11 +53,13 @@ suite "RateLimitManager - admission":
   asyncTest "budget refills when the epoch rolls over":
     ## Drive the roll through the provider — no sleeps, no flake.
     var epoch = 1'u64
-    let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
-      proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
-        Opt.some(EpochQuota(epochIndex: epoch, userMessageLimit: 100)),
-    )
+    let rl = RateLimitManager
+      .new(
+        RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+        proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+          Opt.some(EpochQuota(epochIndex: epoch, userMessageLimit: 100)),
+      )
+      .expect("RateLimitManager.new")
     check (await rl.admit("first".toBytes())).isOk()
     check (await rl.admit("second".toBytes())).isErr()
     epoch = 2
@@ -60,27 +68,31 @@ suite "RateLimitManager - admission":
 
   asyncTest "RLN user message limit clamps a looser configured cap":
     ## config cap 5, RLN grants 2 — the lower RLN limit wins.
-    let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 5),
-      fixedQuota(epochIndex = 7, userMessageLimit = 2),
-    )
+    let rl = RateLimitManager
+      .new(
+        RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 5),
+        fixedQuota(epochIndex = 7, userMessageLimit = 2),
+      )
+      .expect("RateLimitManager.new")
     check (await rl.admit("a".toBytes())).isOk()
     check (await rl.admit("b".toBytes())).isOk()
     check (await rl.admit("c".toBytes())).isErr()
 
   asyncTest "config cap can tighten below the RLN limit":
     ## config cap 1, RLN grants 100 — the config cap wins.
-    let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
-      fixedQuota(epochIndex = 7, userMessageLimit = 100),
-    )
+    let rl = RateLimitManager
+      .new(
+        RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+        fixedQuota(epochIndex = 7, userMessageLimit = 100),
+      )
+      .expect("RateLimitManager.new")
     check (await rl.admit("a".toBytes())).isOk()
     check (await rl.admit("b".toBytes())).isErr()
 
   asyncTest "falls back to the wall-clock window when no quota source is set":
     ## No provider: rate limiting still enforces within a single wall-clock epoch.
-    let rl = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1)
-    )
+    let rl = RateLimitManager
+      .new(RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1))
+      .expect("RateLimitManager.new")
     check (await rl.admit("first".toBytes())).isOk()
     check (await rl.admit("second".toBytes())).isErr()

--- a/tests/messaging/test_send_service_scheduler.nim
+++ b/tests/messaging/test_send_service_scheduler.nim
@@ -1,0 +1,151 @@
+{.used.}
+
+import std/net
+import chronos, chronicles, testutils/unittests, results, stew/byteutils
+
+import
+  logos_delivery/waku/waku,
+  logos_delivery/waku/waku_core,
+  logos_delivery/api/types,
+  logos_delivery/api/conf/messaging_conf,
+  logos_delivery/waku/factory/waku_conf,
+  logos_delivery/messaging/rate_limit_manager/rate_limit_manager,
+  logos_delivery/messaging/delivery_service/send_service/
+    [send_service, send_processor, delivery_task]
+import ../testlib/testasync
+
+## Scheduler-level coverage for the rate-limit seam in the send service: that a
+## task is charged against the budget exactly once no matter how many rounds it
+## takes to deliver, and that an over-budget task is parked and then released
+## when the epoch rolls. A fake processor stands in for relay/lightpush so the
+## delivery outcome is scripted and the loop is driven a tick at a time — no
+## network, no wall-clock sleeps.
+
+type FakeSendProcessor = ref object of BaseSendProcessor
+  calls: int
+  script: seq[DeliveryState]
+    ## State to stamp on the task per invocation; the last entry repeats.
+
+method process(self: FakeSendProcessor, task: DeliveryTask): Future[void] {.async.} =
+  let outcome = self.script[min(self.calls, self.script.high)]
+  inc self.calls
+  task.state = outcome
+  if outcome == DeliveryState.SuccessfullyPropagated and
+      task.firstPropagatedTime.isNone():
+    task.firstPropagatedTime = Opt.some(Moment.now())
+
+proc testConf(): WakuConf =
+  var conf = MessagingClientConf()
+    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
+      raiseAssert error
+  conf.listenAddress = parseIpAddress("0.0.0.0")
+  conf.tcpPort = Port(0)
+  conf.discv5UdpPort = Port(0)
+  conf.clusterId = Opt.some(3'u16)
+  conf.numShardsInNetwork = 1
+  conf.rest = false
+  return conf.toWakuConf().valueOr:
+    raiseAssert error
+
+proc fixedEpochQuota(epoch: ptr uint64, userMessageLimit: uint64): QuotaProvider =
+  ## Quota pinned to whatever `epoch` currently holds, so a test rolls the epoch
+  ## by writing through the pointer instead of waiting on the wall clock.
+  return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
+    Opt.some(EpochQuota(epochIndex: epoch[], userMessageLimit: userMessageLimit))
+
+suite "SendService - rate-limit scheduling":
+  var waku {.threadvar.}: Waku
+
+  asyncSetup:
+    waku = (await Waku.new(testConf())).expect("Waku.new")
+
+  asyncTeardown:
+    ## The node is constructed but never started (the scheduler is driven by
+    ## hand), so stop is best-effort cleanup, not an assertion.
+    discard await waku.stop()
+
+  proc buildTask(id, payload: string): DeliveryTask =
+    ## Built directly rather than through `DeliveryTask.new`, which resolves the
+    ## pubsub shard via a broker provider only registered once the node starts.
+    ## The scheduler path under test reads `msg`, `pubsubTopic` and `msgHash`.
+    let msg = WakuMessage(
+      contentTopic: "/test/1/scheduler/proto",
+      payload: payload.toBytes(),
+      timestamp: 1_700_000_000_000_000_000,
+    )
+    let pubsubTopic = PubsubTopic("/waku/2/rs/3/0")
+    DeliveryTask(
+      requestId: RequestId(id),
+      pubsubTopic: pubsubTopic,
+      msg: msg,
+      msgHash: computeMessageHash(pubsubTopic, msg),
+      state: DeliveryState.Entry,
+    )
+
+  asyncTest "a task is charged once even when delivery takes several rounds":
+    ## First round fails to propagate, second succeeds. The retry must not draw a
+    ## second slot: `firstAdmittedTime` guards re-admission.
+    var epoch = 5'u64
+    let manager = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3),
+      fixedEpochQuota(addr epoch, userMessageLimit = 100),
+    )
+    let processor = FakeSendProcessor(
+      script: @[DeliveryState.NextRoundRetry, DeliveryState.SuccessfullyPropagated]
+    )
+    let service =
+      SendService.new(false, waku, manager, processor).expect("SendService.new")
+
+    let task = buildTask("charge-once", "hi")
+    await service.send(task)
+    check:
+      manager.sentInCurrentEpoch == 1'u64
+      task.firstAdmittedTime.isSome()
+      task.state == DeliveryState.NextRoundRetry
+
+    await service.trySendMessages()
+    check:
+      manager.sentInCurrentEpoch == 1'u64 # not re-charged on retry
+      processor.calls == 2
+      task.state == DeliveryState.SuccessfullyPropagated
+
+  asyncTest "an over-budget task is parked, then released when the epoch rolls":
+    ## Budget of one per epoch. The second send is parked (never admitted); it
+    ## stays parked while the epoch holds, and is admitted and delivered on the
+    ## first tick after the epoch rolls.
+    var epoch = 1'u64
+    let manager = RateLimitManager.new(
+      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+      fixedEpochQuota(addr epoch, userMessageLimit = 100),
+    )
+    let processor = FakeSendProcessor(script: @[DeliveryState.SuccessfullyPropagated])
+    let service =
+      SendService.new(false, waku, manager, processor).expect("SendService.new")
+
+    let first = buildTask("in-budget", "one")
+    await service.send(first)
+    check:
+      first.state == DeliveryState.SuccessfullyPropagated
+      manager.sentInCurrentEpoch == 1'u64
+
+    let second = buildTask("over-budget", "two")
+    await service.send(second)
+    check:
+      second.state == DeliveryState.NextRoundRetry # parked
+      second.firstAdmittedTime.isNone() # never admitted
+    let callsWhenParked = processor.calls
+
+    # Same epoch: still over budget, so the parked task is not even handed to the
+    # processor.
+    await service.trySendMessages()
+    check:
+      second.state == DeliveryState.NextRoundRetry
+      second.firstAdmittedTime.isNone()
+      processor.calls == callsWhenParked
+
+    # Epoch rolls: budget refills, the parked task is admitted and delivered.
+    epoch = 2'u64
+    await service.trySendMessages()
+    check:
+      second.firstAdmittedTime.isSome()
+      second.state == DeliveryState.SuccessfullyPropagated

--- a/tests/messaging/test_send_service_scheduler.nim
+++ b/tests/messaging/test_send_service_scheduler.nim
@@ -14,12 +14,10 @@ import
     [send_service, send_processor, delivery_task]
 import ../testlib/testasync
 
-## Scheduler-level coverage for the rate-limit seam in the send service: that a
-## task is charged against the budget exactly once no matter how many rounds it
-## takes to deliver, and that an over-budget task is parked and then released
-## when the epoch rolls. A fake processor stands in for relay/lightpush so the
-## delivery outcome is scripted and the loop is driven a tick at a time — no
-## network, no wall-clock sleeps.
+## Scheduler-level coverage for the send service's rate-limit seam: a task is
+## charged exactly once however many rounds it takes, and an over-budget task
+## is parked then released when the epoch rolls. A fake processor scripts the
+## delivery outcome so the loop runs without network or sleeps.
 
 type FakeSendProcessor = ref object of BaseSendProcessor
   calls: int
@@ -48,8 +46,8 @@ proc testConf(): WakuConf =
     raiseAssert error
 
 proc fixedEpochQuota(epoch: ptr uint64, userMessageLimit: uint64): QuotaProvider =
-  ## Quota pinned to whatever `epoch` currently holds, so a test rolls the epoch
-  ## by writing through the pointer instead of waiting on the wall clock.
+  ## Quota pinned to whatever `epoch` holds, so a test rolls the epoch by
+  ## writing through the pointer.
   return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
     return Opt.some(EpochQuota(epochIndex: epoch[], userMessageLimit: userMessageLimit))
 
@@ -60,14 +58,12 @@ suite "SendService - rate-limit scheduling":
     waku = (await Waku.new(testConf())).expect("Waku.new")
 
   asyncTeardown:
-    ## The node is constructed but never started (the scheduler is driven by
-    ## hand), so stop is best-effort cleanup, not an assertion.
+    ## The node is never started, so stop is best-effort cleanup.
     discard await waku.stop()
 
   proc buildTask(id, payload: string): DeliveryTask =
-    ## Built directly rather than through `DeliveryTask.new`, which resolves the
-    ## pubsub shard via a broker provider only registered once the node starts.
-    ## The scheduler path under test reads `msg`, `pubsubTopic` and `msgHash`.
+    ## Built directly rather than via `DeliveryTask.new`, which needs a broker
+    ## provider only registered once the node starts.
     let msg = WakuMessage(
       contentTopic: "/test/1/scheduler/proto",
       payload: payload.toBytes(),
@@ -110,9 +106,8 @@ suite "SendService - rate-limit scheduling":
       task.state == DeliveryState.SuccessfullyPropagated
 
   asyncTest "an over-budget task is parked, then released when the epoch rolls":
-    ## Budget of one per epoch. The second send is parked (never admitted); it
-    ## stays parked while the epoch holds, and is admitted and delivered on the
-    ## first tick after the epoch rolls.
+    ## Budget of one per epoch. The second send is parked until the epoch rolls,
+    ## then admitted and delivered.
     var epoch = 1'u64
     let manager = RateLimitManager.new(
       RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
@@ -135,7 +130,7 @@ suite "SendService - rate-limit scheduling":
       second.firstAdmittedTime.isNone() # never admitted
     let callsWhenParked = processor.calls
 
-    # Same epoch: still over budget, so the parked task is not even handed to the
+    # Same epoch: still over budget, so the parked task is not handed to the
     # processor.
     await service.trySendMessages()
     check:

--- a/tests/messaging/test_send_service_scheduler.nim
+++ b/tests/messaging/test_send_service_scheduler.nim
@@ -51,7 +51,7 @@ proc fixedEpochQuota(epoch: ptr uint64, userMessageLimit: uint64): QuotaProvider
   ## Quota pinned to whatever `epoch` currently holds, so a test rolls the epoch
   ## by writing through the pointer instead of waiting on the wall clock.
   return proc(): Opt[EpochQuota] {.gcsafe, raises: [].} =
-    Opt.some(EpochQuota(epochIndex: epoch[], userMessageLimit: userMessageLimit))
+    return Opt.some(EpochQuota(epochIndex: epoch[], userMessageLimit: userMessageLimit))
 
 suite "SendService - rate-limit scheduling":
   var waku {.threadvar.}: Waku
@@ -74,7 +74,7 @@ suite "SendService - rate-limit scheduling":
       timestamp: 1_700_000_000_000_000_000,
     )
     let pubsubTopic = PubsubTopic("/waku/2/rs/3/0")
-    DeliveryTask(
+    return DeliveryTask(
       requestId: RequestId(id),
       pubsubTopic: pubsubTopic,
       msg: msg,

--- a/tests/messaging/test_send_service_scheduler.nim
+++ b/tests/messaging/test_send_service_scheduler.nim
@@ -82,10 +82,12 @@ suite "SendService - rate-limit scheduling":
     ## First round fails to propagate, second succeeds. The retry must not draw a
     ## second slot: `firstAdmittedTime` guards re-admission.
     var epoch = 5'u64
-    let manager = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3),
-      fixedEpochQuota(addr epoch, userMessageLimit = 100),
-    )
+    let manager = RateLimitManager
+      .new(
+        RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 3),
+        fixedEpochQuota(addr epoch, userMessageLimit = 100),
+      )
+      .expect("RateLimitManager.new")
     let processor = FakeSendProcessor(
       script: @[DeliveryState.NextRoundRetry, DeliveryState.SuccessfullyPropagated]
     )
@@ -109,10 +111,12 @@ suite "SendService - rate-limit scheduling":
     ## Budget of one per epoch. The second send is parked until the epoch rolls,
     ## then admitted and delivered.
     var epoch = 1'u64
-    let manager = RateLimitManager.new(
-      RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
-      fixedEpochQuota(addr epoch, userMessageLimit = 100),
-    )
+    let manager = RateLimitManager
+      .new(
+        RateLimitConfig(enabled: true, epochPeriodSec: 600, messagesPerEpoch: 1),
+        fixedEpochQuota(addr epoch, userMessageLimit = 100),
+      )
+      .expect("RateLimitManager.new")
     let processor = FakeSendProcessor(script: @[DeliveryState.SuccessfullyPropagated])
     let service =
       SendService.new(false, waku, manager, processor).expect("SendService.new")


### PR DESCRIPTION
Builds on #4021 (rate limit manager moved to the messaging client layer),
now merged to master. This PR turns that skeleton into real per-epoch
enforcement, sourced from RLN when it is mounted.

This is the **enforcement half** of the original #4042. The RLN-proofing
half — attaching proofs at the transmission stage and recovering from
RLN-invalid rejections — is split out to a follow-up PR stacked on this one,
so the kernel-facing changes (lightpush retry contract, nonce reuse) get
their own focused review. This PR stands alone: without the follow-up,
messages still transmit exactly as they do on master today (unproven), and
the limiter simply meters admissions.

Six commits, each reviewable on its own.

---

## 1. Enforce the per-epoch budget in `admit()` (`39bc19a1`)

Replaces the pass-through skeleton with a lazily rolled fixed window: `admit()`
charges one message per call, rolls the window when the epoch advances, and
rejects with `OverBudget` once `messagesPerEpoch` is exhausted. A disabled or
non-positive config admits everything, and the `MessagingClientConf` default
leaves `enabled: false` — metering stays opt-in, nothing changes for existing
nodes.

The `queue`/`dequeueReady` stubs are removed: parking over-budget messages is
the send service scheduler's job (`NextRoundRetry` + the 1s loop); the manager
only answers whether one more transmission fits.

## 2. Split the manager into config / quota source / enforcement (`3701d5d6`)

`rate_limit_manager/` is decomposed into three files: `rate_limit_config.nim`
(config type, defaults, `isEnforcing`), `quota_source.nim` (the `EpochQuota` +
`QuotaProvider` seam and the wall-clock fallback), and `rate_limit_manager.nim`
(the `admit` enforcement). This isolates the RLN seam from the enforcement
logic ahead of wiring it in (commit 4).

## 3. Charge admission once per task; exempt budget-parked tasks from the reaper (`83b3e2e3`, closes #4049)

Two defects the seam had once admission actually enforces, both fixed by a
single `DeliveryTask.firstAdmittedTime` field:

- The retry loop gated admission on `firstPropagatedTime.isNone()`, so a task
  that failed to propagate (e.g. no peers) was **re-admitted every 1s tick**,
  re-charging the epoch budget — with the default of one message per epoch,
  starving all other traffic. Admission is now gated on
  `firstAdmittedTime.isNone()`: a task charges one slot for its lifetime, and
  retries reuse it.
- `reportTaskResult` reaped any never-propagated task older than
  `MaxTimeInCache` (60s) measured **from message creation**, so an over-budget
  task parked for a 600s epoch was hard-failed with a misleading "Unable to
  send within retry time window" long before the epoch could roll (#4049). The
  reaper now runs only for admitted tasks and measures from admission, so a
  task waiting for epoch budget is exempt and gets a full delivery window once
  admitted.

## 4. Source the epoch and budget from RLN (`cffbaf75`)

When RLN is mounted the limiter stops guessing: `admit()` derives the epoch
index and the effective budget from RLN instead of the wall clock.

`Waku.currentRlnEpochQuota` (new, `waku/api/publish.nim`) returns RLN's current
epoch index and `userMessageLimit` **together**, so the pair cannot straddle an
epoch boundary. A late-bound `QuotaProvider` closure in `MessagingClient.new`
queries it per admission — a node whose RLN mounts *after* the client is built
upgrades from the wall-clock fallback automatically.

`admit()` then rolls on RLN's epoch and clamps the configured cap to RLN's
limit (`min(config.messagesPerEpoch, userMessageLimit)` — config can only
tighten, never widen). Without RLN, the wall-clock window and configured budget
stand in exactly as before.

## 5. Cover admit-once and park/release at the send service scheduler (`c88ae054`)

Scheduler-level integration test: charge-once-across-retries and
park→release on an epoch roll, driven a tick at a time against a scripted
fake processor and a fixed-epoch quota provider (no network, no sleeps).

## 6. Consolidate the admission gate into `admitOnce` (`f93fd141`)

`send()` and the retry loop duplicated the admit-then-stamp sequence; both now
call `SendService.admitOnce`, keeping the charge-once invariant in one place.
No behavior change.

---

## Behaviour

- Default config (rate limit disabled, no RLN): unchanged.
- Over-budget is no longer a synchronous error from `send`; it is a delayed
  outcome — the task parks and dispatches when the epoch frees a slot, or ages
  out via the reaper. That is the truthful contract under RLN.

## Not touched

- Proof attach and RLN-rejection recovery (the stacked follow-up PR).
- `dispatchRepair` and the channels layer; the `MessagingSend` broker surface.
- The `rateLimit` config field is settable only programmatically (documented in
  `messaging_conf.nim`); exposing it over JSON/CLI is a separate change.

## Tests

- `tests/messaging/test_rate_limit_manager.nim`: budget boundary (`OverBudget`
  on exhaustion), epoch rollover, RLN-limit clamp (both directions), disabled
  pass-through, wall-clock fallback.
- `tests/messaging/test_delivery_task_reaping.nim`: the reaper predicate —
  budget-parked tasks exempt, admitted-and-old times out, clock runs from
  admission.
- `tests/messaging/test_send_service_scheduler.nim`: scheduler-level
  integration — charge-once-across-retries and park→release on epoch roll.

Messaging suite: 14/14. `wakunode2` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

closes #3855
closes #4049
