### PR TITLE
ci: pull and publish the Logos Attic cache in nix builds

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -30,6 +30,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Self-hosted runners have Nix preinstalled.
+      - uses: logos-co/setup-nix-cache-action@v1
+        with:
+          install-nix: false
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
+
       - name: 'Run Nix build for ${{ matrix.nixpkg }}'
         shell: bash
         run: nix build -L '.#${{ matrix.nixpkg }}'

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
   description = "logos-delivery nim build flake";
 
   nixConfig = {
-    extra-substituters = [ "https://nix-cache.status.im/" ];
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
     extra-trusted-public-keys = [
-      "nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY="
+      "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU="
     ];
   };
 


### PR DESCRIPTION
> [!WARNING]
> Blocked by:
> - https://github.com/status-im/infra-logos/issues/39

Adopts [`setup-nix-cache-action@v1`](https://github.com/logos-co/setup-nix-cache-action) in `ci-nix.yml` (with `install-nix: false` — the self-hosted runners have Nix preinstalled), same as logos-co/logos-delivery-module#69. `flake.nix` moves its substituter from the old status.im nix-cache to `cache.nix.logos.co/public`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)