### PR TITLE
chore(metrics): sync fleet dashboards from Grafana

### DIFF
--- a/metrics/waku-fleet-dashboard.json
+++ b/metrics/waku-fleet-dashboard.json
@@ -55,8 +55,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -140,8 +139,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue",
-                    "value": null
+                    "color": "blue"
                   }
                 ]
               },
@@ -211,8 +209,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -295,8 +292,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -434,8 +430,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -450,7 +445,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 197
+            "y": 290
           },
           "id": 81,
           "options": {
@@ -531,8 +526,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -547,7 +541,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 197
+            "y": 290
           },
           "id": 82,
           "options": {
@@ -630,8 +624,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -647,7 +640,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 206
+            "y": 299
           },
           "id": 78,
           "interval": "15s",
@@ -734,8 +727,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -751,7 +743,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 206
+            "y": 299
           },
           "id": 79,
           "options": {
@@ -851,7 +843,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 215
+            "y": 308
           },
           "id": 124,
           "options": {
@@ -955,7 +947,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 215
+            "y": 308
           },
           "id": 126,
           "options": {
@@ -1051,7 +1043,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 225
+            "y": 318
           },
           "id": 169,
           "options": {
@@ -1149,7 +1141,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 225
+            "y": 318
           },
           "id": 170,
           "options": {
@@ -1252,7 +1244,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 235
+            "y": 328
           },
           "id": 11,
           "options": {
@@ -1350,7 +1342,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 235
+            "y": 328
           },
           "id": 54,
           "options": {
@@ -1448,7 +1440,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 244
+            "y": 337
           },
           "id": 66,
           "options": {
@@ -1544,7 +1536,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 244
+            "y": 337
           },
           "id": 122,
           "options": {
@@ -1673,7 +1665,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 253
+            "y": 346
           },
           "id": 68,
           "options": {
@@ -1786,7 +1778,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1559
+            "y": 1652
           },
           "id": 48,
           "options": {
@@ -1882,7 +1874,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1559
+            "y": 1652
           },
           "id": 50,
           "options": {
@@ -1978,7 +1970,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2461
+            "y": 2554
           },
           "id": 60,
           "options": {
@@ -2099,7 +2091,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2461
+            "y": 2554
           },
           "id": 8,
           "options": {
@@ -2198,7 +2190,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2467
+            "y": 2560
           },
           "id": 2,
           "options": {
@@ -2301,7 +2293,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2467
+            "y": 2560
           },
           "id": 83,
           "options": {
@@ -2399,7 +2391,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2473
+            "y": 2566
           },
           "id": 3,
           "options": {
@@ -2498,7 +2490,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2473
+            "y": 2566
           },
           "id": 9,
           "options": {
@@ -2623,7 +2615,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2479
+            "y": 2572
           },
           "id": 6,
           "options": {
@@ -2720,7 +2712,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2479
+            "y": 2572
           },
           "id": 7,
           "options": {
@@ -2845,7 +2837,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2485
+            "y": 2578
           },
           "id": 44,
           "options": {
@@ -2967,7 +2959,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2485
+            "y": 2578
           },
           "id": 10,
           "options": {
@@ -3066,7 +3058,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2491
+            "y": 2584
           },
           "id": 64,
           "options": {
@@ -3168,7 +3160,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2493
+            "y": 2586
           },
           "id": 4,
           "options": {
@@ -3265,7 +3257,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2499
+            "y": 2592
           },
           "id": 5,
           "options": {
@@ -3376,7 +3368,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 1560
+            "y": 1653
           },
           "id": 159,
           "options": {
@@ -3472,7 +3464,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 1560
+            "y": 1653
           },
           "id": 117,
           "options": {
@@ -3569,7 +3561,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 1560
+            "y": 1653
           },
           "id": 160,
           "options": {
@@ -3666,7 +3658,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1818
+            "y": 1911
           },
           "id": 119,
           "options": {
@@ -3762,7 +3754,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1818
+            "y": 1911
           },
           "id": 121,
           "options": {
@@ -3858,7 +3850,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 1826
+            "y": 1919
           },
           "id": 113,
           "options": {
@@ -3955,7 +3947,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 1826
+            "y": 1919
           },
           "id": 115,
           "options": {
@@ -4063,7 +4055,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4094,7 +4086,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4162,7 +4154,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4193,7 +4185,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4274,7 +4266,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4305,7 +4297,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4373,7 +4365,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -4404,7 +4396,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4490,7 +4482,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   }
                 ]
               },
@@ -4525,7 +4517,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4595,7 +4587,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   }
                 ]
               },
@@ -4630,7 +4622,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4648,111 +4640,6 @@
             }
           ],
           "title": "Wait Queries To Finish (sec)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P6693426190CB2316"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "points",
-                "fillOpacity": 3,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 10,
-                "scaleDistribution": {
-                  "log": 10,
-                  "type": "log"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 27
-          },
-          "id": 146,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max",
-                "min",
-                "stdDev"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Mean",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.5.2",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "P6693426190CB2316"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "waku_legacy_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"} and deriv(waku_legacy_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[45s]) != 0",
-              "interval": "",
-              "legendFormat": "{{phase}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Store V2 Times (sec)",
           "type": "timeseries"
         },
         {
@@ -4806,7 +4693,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   }
                 ]
               },
@@ -4817,7 +4704,7 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
+            "x": 0,
             "y": 27
           },
           "id": 148,
@@ -4841,7 +4728,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -4858,110 +4745,6 @@
             }
           ],
           "title": "Store V3 Times details",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P6693426190CB2316"
-          },
-          "description": "Total time from moment query hits nwaku node to response sent over wire. This represents an aggregation and helps to get an idea of current node's response time.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "points",
-                "fillOpacity": 3,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 2,
-                "pointSize": 10,
-                "scaleDistribution": {
-                  "log": 10,
-                  "type": "log"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 35
-          },
-          "id": 158,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "max",
-                "min",
-                "stdDev"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Mean",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.5.2",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "P6693426190CB2316"
-              },
-              "editorMode": "code",
-              "expr": "sum by(instance) (waku_legacy_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"} unless deriv(waku_legacy_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[45s]) == 0)\n",
-              "hide": false,
-              "legendFormat": "{{instance}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Store V2 Times wire-to-wire",
           "type": "timeseries"
         },
         {
@@ -5015,7 +4798,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   }
                 ]
               },
@@ -5027,7 +4810,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 27
           },
           "id": 157,
           "options": {
@@ -5036,7 +4819,9 @@
                 "mean",
                 "max",
                 "min",
-                "stdDev"
+                "stdDev",
+                "p95",
+                "p90"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -5050,15 +4835,15 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "P6693426190CB2316"
               },
-              "editorMode": "builder",
-              "expr": "sum by(instance) ((waku_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"} or logos_delivery_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}) unless (deriv(waku_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[45s]) or deriv(logos_delivery_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[45s])) == 0)\n",
+              "editorMode": "code",
+              "expr": "sum without (phase) ((waku_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"} or logos_delivery_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"})\n  unless (changes(waku_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[45s]) or changes(logos_delivery_store_time_seconds{instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[45s])) == 0)",
               "hide": false,
               "legendFormat": "{{instance}}",
               "range": true,
@@ -5118,7 +4903,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   }
                 ]
               },
@@ -5130,7 +4915,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 35
           },
           "id": 149,
           "options": {
@@ -5148,7 +4933,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5217,7 +5002,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   }
                 ]
               },
@@ -5254,7 +5039,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 35
           },
           "id": 147,
           "options": {
@@ -5272,7 +5057,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5316,7 +5101,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 43
           },
           "id": 77,
           "maxDataPoints": 60,
@@ -5338,7 +5123,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": false
@@ -5359,7 +5144,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5415,7 +5200,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 43
           },
           "id": 75,
           "maxDataPoints": 60,
@@ -5437,7 +5222,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": false
@@ -5458,7 +5243,7 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5562,7 +5347,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5578,109 +5363,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 58
-          },
-          "id": 142,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.5.2",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "expr": "(rate(waku_service_network_bytes_total{service=~\"/vac/waku/store/2.*\", direction=\"in\", instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[$__rate_interval]) or rate(logos_delivery_service_network_bytes_total{service=~\"/vac/waku/store/2.*\", direction=\"in\", instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[$__rate_interval]))",
-              "legendFormat": "{{instance}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Store v2 protocol traffic (in)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P6693426190CB2316"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 13,
-            "w": 12,
-            "x": 12,
-            "y": 58
+            "y": 50
           },
           "id": 130,
           "options": {
@@ -5699,7 +5382,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5766,111 +5449,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 13,
-            "w": 12,
-            "x": 0,
-            "y": 71
-          },
-          "id": 132,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Max",
-              "sortDesc": false
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.5.2",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "expr": "(rate(waku_service_network_bytes_total{service=~\"/vac/waku/store/2.*\", direction=\"out\", instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[$__rate_interval]) or rate(logos_delivery_service_network_bytes_total{service=~\"/vac/waku/store/2.*\", direction=\"out\", instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[$__rate_interval]))",
-              "legendFormat": "{{instance}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Store v2 protocol traffic (out)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P6693426190CB2316"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5886,7 +5465,7 @@
             "h": 13,
             "w": 12,
             "x": 12,
-            "y": 71
+            "y": 50
           },
           "id": 143,
           "options": {
@@ -5907,7 +5486,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -5974,7 +5553,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -5990,111 +5569,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 84
-          },
-          "id": 128,
-          "options": {
-            "legend": {
-              "calcs": [
-                "max",
-                "mean"
-              ],
-              "displayMode": "table",
-              "placement": "bottom",
-              "showLegend": true,
-              "sortBy": "Max",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.5.2",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "expr": "(rate(waku_service_requests_total{service =~\"/vac/waku/store/2.*\", instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[$__rate_interval]) or rate(logos_delivery_service_requests_total{service =~\"/vac/waku/store/2.*\", instance=~\"[[host]].([[dc:pipe]]).([[fleet:pipe]])\"}[$__rate_interval]))",
-              "legendFormat": "{{instance}} - {{state}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Store v2 query request rates",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P6693426190CB2316"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "reqps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 13,
-            "w": 12,
-            "x": 12,
-            "y": 84
+            "y": 63
           },
           "id": 141,
           "options": {
@@ -6115,7 +5590,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "11.5.2",
+          "pluginVersion": "12.1.0",
           "targets": [
             {
               "datasource": {
@@ -6142,7 +5617,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 76
       },
       "id": 162,
       "panels": [],
@@ -6199,7 +5674,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
@@ -6211,7 +5686,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 5
+        "y": 77
       },
       "id": 166,
       "options": {
@@ -6227,7 +5702,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -6298,7 +5773,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -6309,7 +5784,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 5
+        "y": 77
       },
       "id": 168,
       "options": {
@@ -6325,7 +5800,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -6363,7 +5838,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -6374,7 +5849,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 13
+        "y": 85
       },
       "id": 164,
       "options": {
@@ -6401,7 +5876,7 @@
         "sizing": "auto",
         "valueMode": "hidden"
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -6442,7 +5917,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -6453,7 +5928,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 13
+        "y": 85
       },
       "id": 171,
       "options": {
@@ -6480,7 +5955,7 @@
         "sizing": "auto",
         "valueMode": "hidden"
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "disableTextWrap": false,
@@ -6548,7 +6023,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           }
@@ -6559,7 +6034,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 93
       },
       "id": 172,
       "options": {
@@ -6575,7 +6050,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "disableTextWrap": false,
@@ -6601,7 +6076,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 101
       },
       "id": 87,
       "panels": [
@@ -6668,7 +6143,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 4386
+            "y": 4479
           },
           "id": 93,
           "options": {
@@ -6767,7 +6242,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 4386
+            "y": 4479
           },
           "id": 89,
           "options": {
@@ -6863,7 +6338,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 4386
+            "y": 4479
           },
           "id": 91,
           "options": {
@@ -6920,7 +6395,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4394
+            "y": 4487
           },
           "id": 95,
           "options": {
@@ -6939,7 +6414,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": false
@@ -7002,7 +6477,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4394
+            "y": 4487
           },
           "id": 97,
           "options": {
@@ -7021,7 +6496,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": false
@@ -7124,7 +6599,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 4402
+            "y": 4495
           },
           "id": 134,
           "options": {
@@ -7227,7 +6702,7 @@
             "h": 13,
             "w": 12,
             "x": 12,
-            "y": 4402
+            "y": 4495
           },
           "id": 136,
           "options": {
@@ -7273,7 +6748,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 102
       },
       "id": 28,
       "panels": [
@@ -7340,7 +6815,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4461
+            "y": 4554
           },
           "id": 30,
           "options": {
@@ -7436,7 +6911,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4461
+            "y": 4554
           },
           "id": 32,
           "options": {
@@ -7534,7 +7009,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 4469
+            "y": 4562
           },
           "id": 138,
           "options": {
@@ -7637,7 +7112,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 4469
+            "y": 4562
           },
           "id": 140,
           "options": {
@@ -7684,7 +7159,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 103
       },
       "id": 151,
       "panels": [
@@ -7753,7 +7228,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 4482
+            "y": 4575
           },
           "id": 153,
           "options": {
@@ -7856,7 +7331,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 4482
+            "y": 4575
           },
           "id": 154,
           "options": {
@@ -7926,7 +7401,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 4494
+            "y": 4587
           },
           "id": 156,
           "options": {
@@ -8035,7 +7510,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 4494
+            "y": 4587
           },
           "id": 155,
           "options": {
@@ -8083,7 +7558,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 104
       },
       "id": 15,
       "panels": [
@@ -8151,7 +7626,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 4507
+            "y": 4600
           },
           "id": 13,
           "options": {
@@ -8249,7 +7724,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 4507
+            "y": 4600
           },
           "id": 18,
           "options": {
@@ -8425,7 +7900,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 4507
+            "y": 4600
           },
           "id": 42,
           "options": {
@@ -8518,7 +7993,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4514
+            "y": 4607
           },
           "id": 103,
           "options": {
@@ -8614,7 +8089,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4514
+            "y": 4607
           },
           "id": 102,
           "options": {
@@ -8677,7 +8152,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4522
+            "y": 4615
           },
           "id": 101,
           "options": {
@@ -8751,7 +8226,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4530
+            "y": 4623
           },
           "id": 105,
           "options": {
@@ -8822,7 +8297,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4530
+            "y": 4623
           },
           "id": 104,
           "options": {
@@ -8876,7 +8351,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 105
       },
       "id": 107,
       "panels": [
@@ -8944,7 +8419,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4539
+            "y": 4632
           },
           "id": 109,
           "options": {
@@ -8984,7 +8459,7 @@
   ],
   "preload": false,
   "refresh": "30s",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
@@ -9051,21 +8526,24 @@
       {
         "current": {
           "text": "All",
-          "value": "$__all"
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "type": "prometheus",
           "uid": "P6693426190CB2316"
         },
-        "definition": "label_values(libp2p_peers, datacenter)",
+        "definition": "label_values(libp2p_peers, dc)",
         "includeAll": true,
         "label": "Data Center",
         "multi": true,
         "name": "dc",
         "options": [],
         "query": {
-          "query": "label_values(libp2p_peers, datacenter)",
-          "refId": "StandardVariableQuery"
+          "qryType": 1,
+          "query": "label_values(libp2p_peers, dc)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
@@ -9094,6 +8572,5 @@
   "timezone": "browser",
   "title": "Nim-Waku V2",
   "uid": "qrp_ZCTGz",
-  "version": 181,
-  "weekStart": ""
+  "version": 191
 }

--- a/metrics/waku-single-node-dashboard.json
+++ b/metrics/waku-single-node-dashboard.json
@@ -58,7 +58,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -107,7 +107,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -142,7 +142,7 @@
             "steps": [
               {
                 "color": "blue",
-                "value": null
+                "value": 0
               }
             ]
           },
@@ -178,7 +178,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -213,7 +213,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -257,7 +257,7 @@
         "text": {},
         "valueMode": "color"
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -297,7 +297,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -353,7 +353,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -436,7 +436,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -467,7 +467,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -533,7 +533,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -564,7 +564,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -632,7 +632,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -666,7 +666,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -736,7 +736,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -768,7 +768,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -838,7 +838,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -870,7 +870,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -938,7 +938,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -969,7 +969,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -1065,7 +1065,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1096,7 +1096,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -1165,7 +1165,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1196,7 +1196,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.1.0",
       "targets": [
         {
           "datasource": {
@@ -1277,8 +1277,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1374,8 +1373,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1471,8 +1469,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1593,8 +1590,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1694,8 +1690,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1798,8 +1793,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1898,8 +1892,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1999,8 +1992,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2126,8 +2118,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2227,8 +2218,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2355,8 +2345,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2478,8 +2467,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2580,8 +2568,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2679,8 +2666,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2780,8 +2766,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5214,8 +5199,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5311,8 +5295,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5408,8 +5391,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5505,8 +5487,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5602,8 +5583,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -5654,7 +5634,7 @@
   ],
   "preload": false,
   "refresh": "30s",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
@@ -5749,6 +5729,5 @@
   "timezone": "browser",
   "title": "Nim-Waku Single Node",
   "uid": "TgQ8wf8Vz",
-  "version": 7,
-  "weekStart": ""
+  "version": 9
 }


### PR DESCRIPTION
Refreshes the two dashboards that live in the shared Grafana, keeping the old-or-new metric name union from #4074.

| dashboard | repo | grafana | change |
|---|---|---|---|
| `metrics/waku-fleet-dashboard.json` | v181 | v191 | drops 5 deprecated Store v2 panels; `Store V3 Times wire-to-wire` moves to `sum without (phase)` and `changes()` |
| `metrics/waku-single-node-dashboard.json` | v7 | v9 | no functional change, Grafana 12 re-save |

Matched by dashboard UID, not filename.

## Changed since the first review

**The two `apps/` dashboards are no longer synced.** They are provisioned into the docker-compose stacks that ship beside them (`docker-compose.yml` mounts `monitoring/configuration/dashboards` into `/var/lib/grafana/dashboards`), so they have to match the local `datasources.yaml` and `prometheus-config.yml`. The Grafana copies fail there twice over: they reference datasource uid `P6693426190CB2316`, while the provisioned datasource has no explicit uid and so gets `P`+sha256("Prometheus")[:16] = `PBFA97CFB590B2093`; and they select on `job=~".*publisher.*"`, while the shipped scrape config puts all 26 publisher and receiver targets in one job named `liteprotocoltester`. Both files are reverted to master.

That also resolves the legend and attribution regressions from the review, which were all in those two files.

**`$dc` is populated from `libp2p_peers`, not `waku_version`.** The export had `label_values(waku_version,dc)`, and `waku_version` became `logos_delivery_version` in #4074, so the DC dropdown would have quietly emptied. `libp2p_*` comes from a dependency and is immune to our renames. Grafana stores variable queries outside `expr`, which is why the #4074 union pass never saw this one — a real gap in that pass, and this was its only instance across all 9 dashboards.

**`Store/Archive` is collapsed again** (the export had it open), and `Store v3 query request rates` moves to x=0 to fill the space its deleted v2 sibling left.

## Checks

- `promtool check rules` passes on all 400 expressions across the 9 dashboards.
- Every renamed metric is paired with its `logos_delivery_` name — now checked in `templating[].query` and `definition` as well as `expr`.
- Both `apps/` dashboards are byte-identical to master.