### PR TITLE
feat(conf): add localStoragePath to MessagingClientConf

### DIFF
--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -45,6 +45,8 @@ type MessagingClientConf* = object
     ## Store retention policy (e.g. "time:3600;size:1GB").
   storeMaxNumDbConnections* {.name: "store-max-num-db-connections".}: Opt[int]
     ## Maximum number of simultaneous store database connections.
+  localStoragePath* {.name: "local-storage-path".}: Opt[string]
+    ## Path to store local data.
   logLevel* {.name: "log-level".}: Opt[logging.LogLevel]
     ## Process log level (TRACE..FATAL); applied by the kernel on node creation.
   logFormat* {.name: "log-format".}: Opt[logging.LogFormat]
@@ -98,6 +100,8 @@ proc toWakuNodeConf*(
     conf.storeMaxNumDbConnections = self.storeMaxNumDbConnections.get()
   if self.storenode.isSome():
     conf.storenode = self.storenode.get()
+  if self.localStoragePath.isSome():
+    conf.localStoragePath = self.localStoragePath.get()
 
   if self.clusterId.isSome():
     conf.clusterId = self.clusterId

--- a/tests/api/test_conf.nim
+++ b/tests/api/test_conf.nim
@@ -154,6 +154,13 @@ suite "parseLogosDeliveryConf - JSON parsing":
       WakuNodeConf(lc.kernelConf).clusterId == Opt.some(7'u16) # kernel field
       lc.messagingConf.get().reliabilityEnabled == Opt.some(true) # messaging-only
 
+  test "localStoragePath override maps to the kernel":
+    let lc = parseLogosDeliveryConf(
+      """{"mode": "Core", "messagingOverrides": {"localStoragePath": "/tmp/inst-1/data"}}"""
+    ).valueOr:
+      raiseAssert error
+    check WakuNodeConf(lc.kernelConf).localStoragePath == "/tmp/inst-1/data"
+
   test "messaging overrides are recorded verbatim, unset fields left none":
     let lc = parseLogosDeliveryConf("""{"messagingOverrides": {"clusterId": 7}}""").valueOr:
       raiseAssert error


### PR DESCRIPTION
Adds `localStoragePath` to `MessagingClientConf`, mapped to the kernel field in `toWakuNodeConf`.

The structured shapes had no way to set the node's storage directory: `localStoragePath` is kernel-only and the structured parser rejects bare kernel fields. logos-delivery-module injects a per-instance storage path into every config and needs a place the structured full-stack shape accepts — see logos-co/logos-delivery-module#79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)