### PR TITLE
fix(conf): default QUIC off on the messaging path

### DIFF
--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -130,7 +130,7 @@ proc toWakuNodeConf*(
   conf.websocketPort = self.websocketPort.get(Port(0))
   conf.quicPort = self.quicPort.get(Port(0))
   conf.websocketSupport = self.websocketSupport.get(false)
-  conf.quicSupport = self.quicSupport.get(true)
+  conf.quicSupport = self.quicSupport.get(false)
 
   return ok(conf)
 

--- a/tests/api/test_conf.nim
+++ b/tests/api/test_conf.nim
@@ -45,27 +45,27 @@ suite "MessagingClientConf - field mapping + transport policy":
       kc.numShardsInNetwork == 4
       kc.maxMessageSize == "150KiB"
 
-  test "messaging transport defaults: ephemeral ports, websocket off, quic on":
+  test "messaging transport defaults: ephemeral ports, websocket off, quic off":
     let kc = MessagingClientConf().toWakuNodeConf(LogosDeliveryMode.Core).valueOr:
         raiseAssert error
     check:
       kc.tcpPort == Port(0)
       kc.discv5UdpPort == Port(0)
       kc.websocketSupport == false
-      kc.quicSupport == true
+      kc.quicSupport == false
 
   test "explicit transport overrides win":
     let mc = MessagingClientConf(
       p2pTcpPort: Opt.some(Port(1234)),
       websocketSupport: Opt.some(true),
-      quicSupport: Opt.some(false),
+      quicSupport: Opt.some(true),
     )
     let kc = mc.toWakuNodeConf(LogosDeliveryMode.Core).valueOr:
       raiseAssert error
     check:
       kc.tcpPort == Port(1234)
       kc.websocketSupport == true
-      kc.quicSupport == false
+      kc.quicSupport == true
 
 suite "MessagingClientConf - preset resolution":
   test "resolvePreset lifts only messaging-exclusive fields, not kernel-mirrored ones":


### PR DESCRIPTION
The structured (messaging) path was the only place defaulting `quicSupport` to `true` — the kernel CLI default is `false` and no preset sets it. Booting the resulting QUIC listener crashes (#4085), reproduced via logos-delivery-module on the first end-to-end boot of the structured shape (logos-co/logos-delivery-module#79). Keep QUIC opt-in everywhere until the transport is validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)