### PR TITLE
chore: bump dependencies for nim-libp2p 2.2.0

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -12,8 +12,12 @@ skipDirs = @["tests", "examples", "tools", "apps", "simulations", "metrics"]
 
 const RequiredNimVersion = "2.2.4"
   ## This is the nim compiler version that we are working on. Other versions may behave differently.
-const RequiredNimbleVersion = "0.22.3"
-  ## Enforced nimble version to ensure a reproducible flow
+const RequiredNimbleVersion = "0.24.1"
+  ## Enforced nimble version to ensure a reproducible flow.
+  ## 0.24.x is required for the libp2p v2.2.0 dependency graph: 0.22.3's
+  ## lock-file solver cannot reconcile the name-based `libp2p == 2.2.0`
+  ## requirement with transitive range constraints (nim-sds, libp2p_mix)
+  ## and fails `nimble lock` / `nimble setup` on this graph.
 
 ### Dependencies
 requires "nim >= 2.2.4",
@@ -28,9 +32,14 @@ requires "nim >= 2.2.4",
   "toml_serialization",
   "faststreams",
   # Networking & P2P
-  "https://github.com/vacp2p/nim-libp2p.git#v2.0.0",
+  # Name-based (registry) requirement: transitive constraints on the name
+  # `libp2p` (nim-sds `>= 1.15.2`, libp2p_mix) do not unify with a special
+  # `url#tag` pin in nimble 0.22's solver, so pin the exact version by name.
+  "libp2p == 2.2.0",
   "eth",
-  "nat_traversal",
+  # nat_traversal is not a direct dependency but stays in the graph
+  # transitively: libp2p's NATService links the miniupnpc/libnatpmp static
+  # libs, so Nat.mk and the iOS vendor-lib build steps below must stay.
   "dnsdisc",
   "dnsclient",
   "httputils >= 0.4.1",
@@ -67,9 +76,12 @@ requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb
 
 requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 
-requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
+# Exact lsquic pin: libp2p only floors it (>= 0.5.4); without this anchor a
+# re-solve (e.g. `nimble setup` after a manifest edit) floats to the newest
+# lsquic release and silently rewrites the lock.
+requires "lsquic == 0.5.6"
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
-requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
+requires "https://github.com/logos-co/nim-libp2p-mix#395b65aadf0a4ad273e544647b7e06f1ca77cf67"
 
 proc getMyCPU(): string =
   ## Need to set cpu more explicit manner to avoid arch issues between dependencies

--- a/nimble.lock
+++ b/nimble.lock
@@ -11,81 +11,28 @@
         "sha1": "68bb85cbfb1832ce4db43943911b046c3af3caab"
       }
     },
-    "unittest2": {
-      "version": "0.2.5",
-      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
-      "url": "https://github.com/status-im/nim-unittest2",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
-      }
-    },
-    "bearssl": {
-      "version": "0.2.8",
-      "vcsRevision": "22c6a76ce015bc07e011562bdcfc51d9446c1e82",
-      "url": "https://github.com/status-im/nim-bearssl",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "da4dd7ae96d536bdaf42dca9c85d7aed024b6a86"
-      }
-    },
-    "bearssl_pkey_decoder": {
-      "version": "#21dd3710df9345ed2ad8bf8f882761e07863b8e0",
-      "vcsRevision": "21dd3710df9345ed2ad8bf8f882761e07863b8e0",
-      "url": "https://github.com/vacp2p/bearssl_pkey_decoder",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "bearssl"
-      ],
-      "checksums": {
-        "sha1": "21b42e2e6ddca6c875d3fc50f36a5115abf51714"
-      }
-    },
-    "jwt": {
-      "version": "#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
-      "vcsRevision": "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
-      "url": "https://github.com/vacp2p/nim-jwt.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "bearssl",
-        "bearssl_pkey_decoder"
-      ],
-      "checksums": {
-        "sha1": "3cd368666fd2bc7f99f253452289e827abcac13c"
-      }
-    },
-    "testutils": {
-      "version": "0.8.1",
-      "vcsRevision": "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d",
-      "url": "https://github.com/status-im/nim-testutils",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "96a11cf8b84fa9bd12d4a553afa1cc4b7f9df4e3"
-      }
-    },
-    "db_connector": {
+    "libbacktrace": {
       "version": "0.1.0",
-      "vcsRevision": "29450a2063970712422e1ab857695c12d80112a6",
-      "url": "https://github.com/nim-lang/db_connector",
+      "vcsRevision": "ebc972d99769633b9ef3ee766778ee5aa1996499",
+      "url": "https://github.com/status-im/nim-libbacktrace",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "4f2e67d0e4b61af9ac5575509305660b473f01a4"
+        "sha1": "8f75f4cc7813c9caf1e565b8a65ee3e9134a2bc7"
+      }
+    },
+    "npeg": {
+      "version": "1.3.0",
+      "vcsRevision": "409f6796d0e880b3f0222c964d1da7de6e450811",
+      "url": "https://github.com/zevv/npeg",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "64f15c85a059c889cb11c5fe72372677c50da621"
       }
     },
     "results": {
@@ -113,6 +60,95 @@
         "sha1": "1a376d3e710590ef2c48748a546369755f0a7c97"
       }
     },
+    "unicodedb": {
+      "version": "0.13.2",
+      "vcsRevision": "66f2458710dc641dd4640368f9483c8a0ec70561",
+      "url": "https://github.com/nitely/nim-unicodedb",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "739102d885d99bb4571b1955f5f12aee423c935b"
+      }
+    },
+    "regex": {
+      "version": "0.26.3",
+      "vcsRevision": "4593305ed1e49731fc75af1dc572dd2559aad19c",
+      "url": "https://github.com/nitely/nim-regex",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unicodedb"
+      ],
+      "checksums": {
+        "sha1": "4d24e7d7441137cd202e16f2359a5807ddbdc31f"
+      }
+    },
+    "boringssl": {
+      "version": "0.0.8",
+      "vcsRevision": "e77caabae78fbc9aa5b78a0a521181b077c82571",
+      "url": "https://github.com/vacp2p/nim-boringssl",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "2f603bb6d70683393bbb091bf6bd325d9c52be9f"
+      }
+    },
+    "unittest2": {
+      "version": "0.2.5",
+      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
+      "url": "https://github.com/status-im/nim-unittest2.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
+      }
+    },
+    "bearssl": {
+      "version": "0.2.11",
+      "vcsRevision": "7c307026d4d86dc560880c6fa716f5e626ff7fc2",
+      "url": "https://github.com/status-im/nim-bearssl",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "352e6d47bd46300a50b8911d8989b3b429fe3038"
+      }
+    },
+    "bearssl_pkey_decoder": {
+      "version": "#d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368",
+      "vcsRevision": "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368",
+      "url": "https://github.com/vacp2p/bearssl_pkey_decoder",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "bearssl"
+      ],
+      "checksums": {
+        "sha1": "8666edbcb77cb9f97c659114d57c4ba0e7ab74c3"
+      }
+    },
+    "jwt": {
+      "version": "#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
+      "vcsRevision": "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
+      "url": "https://github.com/vacp2p/nim-jwt.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "bearssl",
+        "bearssl_pkey_decoder"
+      ],
+      "checksums": {
+        "sha1": "3cd368666fd2bc7f99f253452289e827abcac13c"
+      }
+    },
     "stew": {
       "version": "0.5.0",
       "vcsRevision": "4382b18f04b3c43c8409bfcd6b62063773b2bbaa",
@@ -127,9 +163,22 @@
         "sha1": "db22942939773ab7d5a0f2b2668c237240c67dd6"
       }
     },
+    "testutils": {
+      "version": "0.8.1",
+      "vcsRevision": "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d",
+      "url": "https://github.com/status-im/nim-testutils",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "96a11cf8b84fa9bd12d4a553afa1cc4b7f9df4e3"
+      }
+    },
     "zlib": {
-      "version": "0.1.0",
-      "vcsRevision": "e680f269fb01af2c34a2ba879ff281795a5258fe",
+      "version": "0.2.0",
+      "vcsRevision": "190246aa0bb6569781370964fa2faa474203d6dd",
       "url": "https://github.com/status-im/nim-zlib",
       "downloadMethod": "git",
       "dependencies": [
@@ -138,12 +187,12 @@
         "results"
       ],
       "checksums": {
-        "sha1": "bbde4f5a97a84b450fef7d107461e5f35cf2b47f"
+        "sha1": "a8c0c569d82315f3ffc1249ab42b0404e84fddc3"
       }
     },
     "httputils": {
-      "version": "0.4.1",
-      "vcsRevision": "f142cb2e8bd812dd002a6493b6082827bb248592",
+      "version": "0.4.3",
+      "vcsRevision": "a9ca86095e262251d8ebafa1c6504fd476c41e43",
       "url": "https://github.com/status-im/nim-http-utils",
       "downloadMethod": "git",
       "dependencies": [
@@ -153,12 +202,12 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "016774ab31c3afff9a423f7d80584905ee59c570"
+        "sha1": "dcdd6633bc35695c2b1ac0f0bd1c5ff4e3623cb5"
       }
     },
     "chronos": {
-      "version": "4.2.2",
-      "vcsRevision": "45f43a9ad8bd8bcf5903b42f365c1c879bd54240",
+      "version": "4.2.3",
+      "vcsRevision": "447b3fd8ae0619e847bff46d823d56779e21851b",
       "url": "https://github.com/status-im/nim-chronos",
       "downloadMethod": "git",
       "dependencies": [
@@ -170,12 +219,12 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "3a4c9477df8cef20a04e4f1b54a2d74fdfc2a3d0"
+        "sha1": "8b2b063ee6243915ddf47e7b36f56ef7d8062c0f"
       }
     },
     "metrics": {
-      "version": "0.2.1",
-      "vcsRevision": "a1296caf3ebb5f30f51a5feae7749a30df2824c2",
+      "version": "0.2.2",
+      "vcsRevision": "9f2e1d4a4164deb37603b16cedd1707408ee5955",
       "url": "https://github.com/status-im/nim-metrics",
       "downloadMethod": "git",
       "dependencies": [
@@ -185,12 +234,12 @@
         "stew"
       ],
       "checksums": {
-        "sha1": "84bb09873d7677c06046f391c7b473cd2fcff8a2"
+        "sha1": "d64e789ba2a3b848eb7c628d728623126182c3f1"
       }
     },
     "faststreams": {
-      "version": "0.5.0",
-      "vcsRevision": "ce27581a3e881f782f482cb66dc5b07a02bd615e",
+      "version": "0.5.1",
+      "vcsRevision": "50889cd16ec8771106cdd0eeea460039e8571e06",
       "url": "https://github.com/status-im/nim-faststreams",
       "downloadMethod": "git",
       "dependencies": [
@@ -199,7 +248,7 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "ee61e507b805ae1df7ec936f03f2d101b0d72383"
+        "sha1": "969ceb3666e807db8fe5c8df63466749822367a9"
       }
     },
     "snappy": {
@@ -219,8 +268,8 @@
       }
     },
     "serialization": {
-      "version": "0.5.2",
-      "vcsRevision": "b0f2fa32960ea532a184394b0f27be37bd80248b",
+      "version": "0.5.3",
+      "vcsRevision": "4092500cea76154576539371709ae801afbd2a9d",
       "url": "https://github.com/status-im/nim-serialization",
       "downloadMethod": "git",
       "dependencies": [
@@ -230,7 +279,24 @@
         "stew"
       ],
       "checksums": {
-        "sha1": "fa35c1bb76a0a02a2379fe86eaae0957c7527cb8"
+        "sha1": "c087d26c50da40436599163888532660d6f9e631"
+      }
+    },
+    "protobuf_serialization": {
+      "version": "0.5.3",
+      "vcsRevision": "8406e7287196661614ce6a8e8be20f755376af7f",
+      "url": "https://github.com/status-im/nim-protobuf-serialization",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "stew",
+        "faststreams",
+        "serialization",
+        "npeg",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "3307412f9755f7ec2079e12cf036fc103aa130b0"
       }
     },
     "toml_serialization": {
@@ -250,7 +316,7 @@
     },
     "confutils": {
       "version": "0.1.0",
-      "vcsRevision": "36f3115ca350f40841ac0eecc7dfa5fe7790c864",
+      "vcsRevision": "7728f6bd81a1eedcfe277d02ea85fdb805bcc05a",
       "url": "https://github.com/status-im/nim-confutils",
       "downloadMethod": "git",
       "dependencies": [
@@ -260,22 +326,24 @@
         "results"
       ],
       "checksums": {
-        "sha1": "2fbe6418ddd9f79fb11a0addd7666a3e787adbe0"
+        "sha1": "8bc8c30b107fdba73b677e5f257c6c42ae1cdc8e"
       }
     },
     "cbor_serialization": {
-      "version": "0.3.0",
-      "vcsRevision": "1664160e04d153573373afddc552b9cbf6fbe4dc",
+      "version": "0.4.1",
+      "vcsRevision": "e32d61c54f69b396f47645f9b7373ea2e149013a",
       "url": "https://github.com/vacp2p/nim-cbor-serialization",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
         "serialization",
         "stew",
-        "results"
+        "npeg",
+        "results",
+        "unittest2"
       ],
       "checksums": {
-        "sha1": "ab126eae09a6e39c72972a6a0b83cb06a2ffe8f0"
+        "sha1": "4782b43d06594ac59730b3939110ba93de7d3156"
       }
     },
     "json_serialization": {
@@ -372,16 +440,28 @@
         "sha1": "0be03a5da29fdd4409ea74a60fd0ccce882601b4"
       }
     },
+    "db_connector": {
+      "version": "0.1.0",
+      "vcsRevision": "29450a2063970712422e1ab857695c12d80112a6",
+      "url": "https://github.com/nim-lang/db_connector",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "4f2e67d0e4b61af9ac5575509305660b473f01a4"
+      }
+    },
     "sqlite3_abi": {
-      "version": "3.53.0.0",
-      "vcsRevision": "8240e8e2819dfce1b67fa2733135d01b5cc80ae0",
+      "version": "3.53.3.0",
+      "vcsRevision": "a4d052efe81472b8d5271ece8e5a3caea90a45eb",
       "url": "https://github.com/arnetheduck/nim-sqlite3-abi",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "fb7a6e6f36fc4eb4dfa6634dbcbf5cd0dfd0ebf0"
+        "sha1": "20571756875f29ef292acf10a71c27139e6bf44e"
       }
     },
     "dnsclient": {
@@ -396,31 +476,6 @@
         "sha1": "65262c7e533ff49d6aca5539da4bc6c6ce132f40"
       }
     },
-    "unicodedb": {
-      "version": "0.13.2",
-      "vcsRevision": "66f2458710dc641dd4640368f9483c8a0ec70561",
-      "url": "https://github.com/nitely/nim-unicodedb",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "739102d885d99bb4571b1955f5f12aee423c935b"
-      }
-    },
-    "regex": {
-      "version": "0.26.3",
-      "vcsRevision": "4593305ed1e49731fc75af1dc572dd2559aad19c",
-      "url": "https://github.com/nitely/nim-regex",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unicodedb"
-      ],
-      "checksums": {
-        "sha1": "4d24e7d7441137cd202e16f2359a5807ddbdc31f"
-      }
-    },
     "nimcrypto": {
       "version": "0.6.4",
       "vcsRevision": "721fb99ee099b632eb86dfad1f0d96ee87583774",
@@ -431,6 +486,25 @@
       ],
       "checksums": {
         "sha1": "f9ab24fa940ed03d0fb09729a7303feb50b7eaec"
+      }
+    },
+    "lsquic": {
+      "version": "0.5.6",
+      "vcsRevision": "b778d16d6f00b47249e2674c23f21aa26b711eb7",
+      "url": "https://github.com/vacp2p/nim-lsquic",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "zlib",
+        "stew",
+        "chronos",
+        "nimcrypto",
+        "unittest2",
+        "chronicles",
+        "boringssl"
+      ],
+      "checksums": {
+        "sha1": "2676f1facb400ad3cfa1b338149d9c20fc5967c4"
       }
     },
     "websock": {
@@ -454,7 +528,7 @@
       }
     },
     "json_rpc": {
-      "version": "0.6.1",
+      "version": "#v0.6.1",
       "vcsRevision": "6f1fff8ba685c9192fab153a9d66484ad9066e78",
       "url": "https://github.com/status-im/nim-json-rpc.git",
       "downloadMethod": "git",
@@ -475,25 +549,6 @@
         "sha1": "596db0aafcb3c83f5dba6d42993f2276e0d00eb5"
       }
     },
-    "lsquic": {
-      "version": "0.5.1",
-      "vcsRevision": "2f01046bf1d513de8b5f8296c3d8bec819ab0cb9",
-      "url": "https://github.com/vacp2p/nim-lsquic",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "zlib",
-        "stew",
-        "chronos",
-        "nimcrypto",
-        "unittest2",
-        "chronicles",
-        "boringssl"
-      ],
-      "checksums": {
-        "sha1": "959df1a9ac2a574d6fe30a4faf37c37b443e1cfb"
-      }
-    },
     "secp256k1": {
       "version": "0.6.0.3.2",
       "vcsRevision": "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15",
@@ -507,6 +562,54 @@
       ],
       "checksums": {
         "sha1": "6618ef9de17121846a8c1d0317026b0ce8584e10"
+      }
+    },
+    "libp2p": {
+      "version": "2.2.0",
+      "vcsRevision": "0e763288c10b6488e5971608f12aa49ab129720e",
+      "url": "https://github.com/vacp2p/nim-libp2p",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "libbacktrace",
+        "nimcrypto",
+        "bearssl",
+        "boringssl",
+        "chronicles",
+        "chronos",
+        "metrics",
+        "secp256k1",
+        "stew",
+        "unittest2",
+        "results",
+        "serialization",
+        "lsquic",
+        "protobuf_serialization",
+        "websock",
+        "nat_traversal"
+      ],
+      "checksums": {
+        "sha1": "48155b6ee4101ff058f93985a09d9480b2073aca"
+      }
+    },
+    "libp2p_mix": {
+      "version": "#395b65aadf0a4ad273e544647b7e06f1ca77cf67",
+      "vcsRevision": "395b65aadf0a4ad273e544647b7e06f1ca77cf67",
+      "url": "https://github.com/logos-co/nim-libp2p-mix",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "libp2p",
+        "chronicles",
+        "chronos",
+        "metrics",
+        "nimcrypto",
+        "stew",
+        "results",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "1c9d5c568a94f58be2c958210e61b770344eafc2"
       }
     },
     "eth": {
@@ -561,8 +664,8 @@
       }
     },
     "dnsdisc": {
-      "version": "0.1.0",
-      "vcsRevision": "38f2e0f52c0a8f032ef4530835e519d550706d9e",
+      "version": "0.1.1",
+      "vcsRevision": "6cb1b7e3922645275043c68e476cac1501a45e55",
       "url": "https://github.com/status-im/nim-dnsdisc",
       "downloadMethod": "git",
       "dependencies": [
@@ -579,35 +682,7 @@
         "results"
       ],
       "checksums": {
-        "sha1": "055b882a0f6b1d1e57a25a7af99d2e5ac6268154"
-      }
-    },
-    "libp2p": {
-      "version": "2.0.0",
-      "vcsRevision": "c43199378f46d0aaf61be1cad1ee1d63e8f665d6",
-      "url": "https://github.com/vacp2p/nim-libp2p.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "nimcrypto",
-        "dnsclient",
-        "bearssl",
-        "boringssl",
-        "chronicles",
-        "chronos",
-        "metrics",
-        "secp256k1",
-        "stew",
-        "unittest2",
-        "results",
-        "serialization",
-        "lsquic",
-        "protobuf_serialization",
-        "websock",
-        "jwt"
-      ],
-      "checksums": {
-        "sha1": "327dc7a0cb7e9d0be3d6083841bd496c4cbc48dc"
+        "sha1": "6451cab35990f334a46927f49f9176579460934d"
       }
     },
     "taskpools": {
@@ -620,6 +695,22 @@
       ],
       "checksums": {
         "sha1": "09e1b2fdad55b973724d61227971afc0df0b7a81"
+      }
+    },
+    "ffi": {
+      "version": "0.3.0",
+      "vcsRevision": "aad9374354a5e3d98964a9adf80766a12f8f200d",
+      "url": "https://github.com/logos-messaging/nim-ffi",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "chronos",
+        "chronicles",
+        "taskpools",
+        "cbor_serialization"
+      ],
+      "checksums": {
+        "sha1": "db5fc50aa4717418e481cb0b1f7ca36f2d76586c"
       }
     },
     "sds": {
@@ -640,83 +731,6 @@
       ],
       "checksums": {
         "sha1": "175f65038b9877cdf974b07c5f83081f810d5fbe"
-      }
-    },
-    "ffi": {
-      "version": "0.3.0",
-      "vcsRevision": "aad9374354a5e3d98964a9adf80766a12f8f200d",
-      "url": "https://github.com/logos-messaging/nim-ffi",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "chronos",
-        "chronicles",
-        "taskpools",
-        "cbor_serialization"
-      ],
-      "checksums": {
-        "sha1": "db5fc50aa4717418e481cb0b1f7ca36f2d76586c"
-      }
-    },
-    "boringssl": {
-      "version": "0.0.8",
-      "vcsRevision": "e77caabae78fbc9aa5b78a0a521181b077c82571",
-      "url": "https://github.com/vacp2p/nim-boringssl",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "2f603bb6d70683393bbb091bf6bd325d9c52be9f"
-      }
-    },
-    "protobuf_serialization": {
-      "version": "0.4.0",
-      "vcsRevision": "38d24eb3bd93e605fb88199da71d36b1ec0ad60d",
-      "url": "https://github.com/status-im/nim-protobuf-serialization",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "stew",
-        "faststreams",
-        "serialization",
-        "npeg",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "5a7a80fb8cca29e41899ce9540b74e49c874f8fd"
-      }
-    },
-    "npeg": {
-      "version": "1.3.0",
-      "vcsRevision": "409f6796d0e880b3f0222c964d1da7de6e450811",
-      "url": "https://github.com/zevv/npeg",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "64f15c85a059c889cb11c5fe72372677c50da621"
-      }
-    },
-    "libp2p_mix": {
-      "version": "0.1.0",
-      "vcsRevision": "380513117d556bf8f70066f5e72a7fd74fe36ba6",
-      "url": "https://github.com/logos-co/nim-libp2p-mix",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "libp2p",
-        "chronicles",
-        "chronos",
-        "metrics",
-        "nimcrypto",
-        "stew",
-        "results",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "ccfb0f0160ac15ac970471964c730d57edacad91"
       }
     }
   },

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -3,45 +3,17 @@
 { pkgs }:
 
 {
-  unittest2 = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-unittest2";
-    rev = "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189";
-    sha256 = "1n8n36kad50m97b64y7bzzknz9n7szffxhp0bqpk3g2v7zpda8sw";
+  libbacktrace = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-libbacktrace";
+    rev = "ebc972d99769633b9ef3ee766778ee5aa1996499";
+    sha256 = "192wwixwp36r6wiq495d7yr3nbskay75447p99snqq359bqv9snb";
     fetchSubmodules = true;
   };
 
-  bearssl = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-bearssl";
-    rev = "22c6a76ce015bc07e011562bdcfc51d9446c1e82";
-    sha256 = "1cvdd7lfrpa6asmc39al3g4py5nqhpqmvypc36r5qyv7p5arc8a3";
-    fetchSubmodules = true;
-  };
-
-  bearssl_pkey_decoder = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/bearssl_pkey_decoder";
-    rev = "21dd3710df9345ed2ad8bf8f882761e07863b8e0";
-    sha256 = "0bl3f147zmkazbhdkr4cj1nipf9rqiw3g4hh1j424k9hpl55zdpg";
-    fetchSubmodules = true;
-  };
-
-  jwt = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-jwt.git";
-    rev = "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2";
-    sha256 = "1hnxsl5762fdn80hl4xxfdqrcgmxrrfck66js1iqaqfxc4m0fv63";
-    fetchSubmodules = true;
-  };
-
-  testutils = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-testutils";
-    rev = "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d";
-    sha256 = "1vbkr6i5yxhc2ai3b7rbglhmyc98f99x874fqdp6a152a6kqgwxy";
-    fetchSubmodules = true;
-  };
-
-  db_connector = pkgs.fetchgit {
-    url = "https://github.com/nim-lang/db_connector";
-    rev = "29450a2063970712422e1ab857695c12d80112a6";
-    sha256 = "11dna09ccdhj3pzpqa04j7a95ibx907z6n1ff33yf0n92qa4x59z";
+  npeg = pkgs.fetchgit {
+    url = "https://github.com/zevv/npeg";
+    rev = "409f6796d0e880b3f0222c964d1da7de6e450811";
+    sha256 = "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm";
     fetchSubmodules = true;
   };
 
@@ -59,6 +31,55 @@
     fetchSubmodules = true;
   };
 
+  unicodedb = pkgs.fetchgit {
+    url = "https://github.com/nitely/nim-unicodedb";
+    rev = "66f2458710dc641dd4640368f9483c8a0ec70561";
+    sha256 = "092z3glgdb7rmwajm7dmqzvralkm7ixighixk8ycf8sf17zm72ck";
+    fetchSubmodules = true;
+  };
+
+  regex = pkgs.fetchgit {
+    url = "https://github.com/nitely/nim-regex";
+    rev = "4593305ed1e49731fc75af1dc572dd2559aad19c";
+    sha256 = "1b666qws5sva3n5allin0ycvnqlzdjd7xzprpdvv632ccqddzcl9";
+    fetchSubmodules = true;
+  };
+
+  boringssl = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-boringssl";
+    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
+    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
+    fetchSubmodules = true;
+  };
+
+  unittest2 = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-unittest2.git";
+    rev = "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189";
+    sha256 = "1n8n36kad50m97b64y7bzzknz9n7szffxhp0bqpk3g2v7zpda8sw";
+    fetchSubmodules = true;
+  };
+
+  bearssl = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-bearssl";
+    rev = "7c307026d4d86dc560880c6fa716f5e626ff7fc2";
+    sha256 = "0ifi3vy48j0vfwqjhm4xsik5i8k7xi33cmhvzx2aklj8a2a83avn";
+    fetchSubmodules = true;
+  };
+
+  bearssl_pkey_decoder = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/bearssl_pkey_decoder";
+    rev = "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368";
+    sha256 = "0200f7lf3x2hypwr2v9gms6qv7wj8m1phwd25025bfa1w9f2nkbg";
+    fetchSubmodules = true;
+  };
+
+  jwt = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-jwt.git";
+    rev = "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2";
+    sha256 = "1hnxsl5762fdn80hl4xxfdqrcgmxrrfck66js1iqaqfxc4m0fv63";
+    fetchSubmodules = true;
+  };
+
   stew = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-stew";
     rev = "4382b18f04b3c43c8409bfcd6b62063773b2bbaa";
@@ -66,38 +87,45 @@
     fetchSubmodules = true;
   };
 
+  testutils = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-testutils";
+    rev = "74588b8b55d116ca057431ae3a0ca359e0825fcd";
+    sha256 = "1bn4v2f8ppknslihdnvlzr0fkm6nlkdim66m8frw4nfyd8jnw7sn";
+    fetchSubmodules = true;
+  };
+
   zlib = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-zlib";
-    rev = "e680f269fb01af2c34a2ba879ff281795a5258fe";
-    sha256 = "1xw9f1gjsgqihdg7kdkbaq1wankgnx2vn9l3ihc6nqk2jzv5bvk5";
+    rev = "190246aa0bb6569781370964fa2faa474203d6dd";
+    sha256 = "0x5l55gwzb1ay3k9inmi1g25jiv7flry247fcwd8rw3zw9pgchfv";
     fetchSubmodules = true;
   };
 
   httputils = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-http-utils";
-    rev = "f142cb2e8bd812dd002a6493b6082827bb248592";
-    sha256 = "03msj4zdxraz4qx9cidb17g7v0asazxv91nng6xxbzjxz0qaqxw6";
+    rev = "a9ca86095e262251d8ebafa1c6504fd476c41e43";
+    sha256 = "06qiw3zn9gzskp83mn225bvnd2ajc4n0m30x9msljy5p2nn4zjw1";
     fetchSubmodules = true;
   };
 
   chronos = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-chronos";
-    rev = "45f43a9ad8bd8bcf5903b42f365c1c879bd54240";
-    sha256 = "1v1n59zfzznp97pvwgs9kf136bqmv4x2s2y9f24msspa7qv27w39";
+    rev = "447b3fd8ae0619e847bff46d823d56779e21851b";
+    sha256 = "1labwbmdmpf49v10k6rjgkgicxdx0zjf5zk3sdzj1mc0wavgz16r";
     fetchSubmodules = true;
   };
 
   metrics = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-metrics";
-    rev = "a1296caf3ebb5f30f51a5feae7749a30df2824c2";
-    sha256 = "02vxqy20g8012ks939ac25ksc25k727q84si0p2cmihy5bw1a3qm";
+    rev = "9f2e1d4a4164deb37603b16cedd1707408ee5955";
+    sha256 = "05fwkysgj1q3p9ya15pl48nkvl5jv43bmrrkg70z7b6may6fgvqj";
     fetchSubmodules = true;
   };
 
   faststreams = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-faststreams";
-    rev = "ce27581a3e881f782f482cb66dc5b07a02bd615e";
-    sha256 = "0y6bw2scnmr8cxj4fg18w7f34l2bh9qwg5nhlgd84m9fpr5bqarn";
+    rev = "50889cd16ec8771106cdd0eeea460039e8571e06";
+    sha256 = "1hd4bhvw5lzwg924i8dif5mi61h0ayiplq38djvrdbfsjdhw2zvw";
     fetchSubmodules = true;
   };
 
@@ -110,8 +138,15 @@
 
   serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-serialization";
-    rev = "b0f2fa32960ea532a184394b0f27be37bd80248b";
-    sha256 = "0wip1fjx7ka39ck1g1xvmyarzq1p5dlngpqil6zff8k8z5skiz27";
+    rev = "4092500cea76154576539371709ae801afbd2a9d";
+    sha256 = "04pz6d6p3nd1y2khbb667fcd6p2jk4bxv65iaffzq06bqqhalcwc";
+    fetchSubmodules = true;
+  };
+
+  protobuf_serialization = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-protobuf-serialization";
+    rev = "8406e7287196661614ce6a8e8be20f755376af7f";
+    sha256 = "0lb4756a77vr1x1khy3dxl97kyxy7w09ap92ylkkgjp093dic59k";
     fetchSubmodules = true;
   };
 
@@ -124,15 +159,15 @@
 
   confutils = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-confutils";
-    rev = "36f3115ca350f40841ac0eecc7dfa5fe7790c864";
-    sha256 = "1vppqplwlpl7a61r8iki5hlzvhd8lnq41ixpqslv35dnm482c55j";
+    rev = "7728f6bd81a1eedcfe277d02ea85fdb805bcc05a";
+    sha256 = "18bj1ilx10jm2vmqx2wy2xl9rzy7alymi2m4n9jgpa4sbxnfh0x3";
     fetchSubmodules = true;
   };
 
   cbor_serialization = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-cbor-serialization";
-    rev = "1664160e04d153573373afddc552b9cbf6fbe4dc";
-    sha256 = "0c1rj4fk0fcqvsf0yqhxvm8h10aww75gi4yfsjhlczh88ypywii2";
+    rev = "e32d61c54f69b396f47645f9b7373ea2e149013a";
+    sha256 = "0vdmvzfrw4p14ybm5ryci69nldk44r0ghfq99bdh1jdrjjki1yrl";
     fetchSubmodules = true;
   };
 
@@ -178,10 +213,17 @@
     fetchSubmodules = true;
   };
 
+  db_connector = pkgs.fetchgit {
+    url = "https://github.com/nim-lang/db_connector";
+    rev = "29450a2063970712422e1ab857695c12d80112a6";
+    sha256 = "11dna09ccdhj3pzpqa04j7a95ibx907z6n1ff33yf0n92qa4x59z";
+    fetchSubmodules = true;
+  };
+
   sqlite3_abi = pkgs.fetchgit {
     url = "https://github.com/arnetheduck/nim-sqlite3-abi";
-    rev = "8240e8e2819dfce1b67fa2733135d01b5cc80ae0";
-    sha256 = "0g8bc0kiwxxh3h5w06ksa23cw81hnx87rdn93v64m2f053nb6bcm";
+    rev = "a4d052efe81472b8d5271ece8e5a3caea90a45eb";
+    sha256 = "0bndp3dq41m9m63kgspqjkwq9z2pjcgcm93zkhnyrv66dnp2g40b";
     fetchSubmodules = true;
   };
 
@@ -192,24 +234,17 @@
     fetchSubmodules = true;
   };
 
-  unicodedb = pkgs.fetchgit {
-    url = "https://github.com/nitely/nim-unicodedb";
-    rev = "66f2458710dc641dd4640368f9483c8a0ec70561";
-    sha256 = "092z3glgdb7rmwajm7dmqzvralkm7ixighixk8ycf8sf17zm72ck";
-    fetchSubmodules = true;
-  };
-
-  regex = pkgs.fetchgit {
-    url = "https://github.com/nitely/nim-regex";
-    rev = "4593305ed1e49731fc75af1dc572dd2559aad19c";
-    sha256 = "1b666qws5sva3n5allin0ycvnqlzdjd7xzprpdvv632ccqddzcl9";
-    fetchSubmodules = true;
-  };
-
   nimcrypto = pkgs.fetchgit {
     url = "https://github.com/cheatfate/nimcrypto";
     rev = "721fb99ee099b632eb86dfad1f0d96ee87583774";
     sha256 = "178vzb3q8wzjq295ik2pd25rrqf32w381ck76hm5x2d8qnzfmkkc";
+    fetchSubmodules = true;
+  };
+
+  lsquic = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-lsquic";
+    rev = "b778d16d6f00b47249e2674c23f21aa26b711eb7";
+    sha256 = "1wn2bcxn4w916kj7lk0hzf7nxi64x75ksfgx77cr0pcnncygbxvk";
     fetchSubmodules = true;
   };
 
@@ -227,17 +262,24 @@
     fetchSubmodules = true;
   };
 
-  lsquic = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-lsquic";
-    rev = "2f01046bf1d513de8b5f8296c3d8bec819ab0cb9";
-    sha256 = "16xj0hx13nc95x7scck8lyir0kzx4wqnd6d4h79aai8j9hlcmbsl";
-    fetchSubmodules = true;
-  };
-
   secp256k1 = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-secp256k1";
     rev = "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15";
     sha256 = "1qjrmwbngb73f6r1fznvig53nyal7wj41d1cmqfksrmivk2sgrn2";
+    fetchSubmodules = true;
+  };
+
+  libp2p = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-libp2p";
+    rev = "0e763288c10b6488e5971608f12aa49ab129720e";
+    sha256 = "1wqy7zcpjrbf2585jw6rmzd7f9yq0kv9jvhkrg5nq8xaikf6hhb4";
+    fetchSubmodules = true;
+  };
+
+  libp2p_mix = pkgs.fetchgit {
+    url = "https://github.com/logos-co/nim-libp2p-mix";
+    rev = "395b65aadf0a4ad273e544647b7e06f1ca77cf67";
+    sha256 = "1x8aqm4g42qg9153v4g80msqc95lmginhs2fr1xin9mlfgqza855";
     fetchSubmodules = true;
   };
 
@@ -257,15 +299,8 @@
 
   dnsdisc = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-dnsdisc";
-    rev = "38f2e0f52c0a8f032ef4530835e519d550706d9e";
-    sha256 = "0dk787ny49n41bmzhlrvm87giwajr01gwdw9nlmphch89rdqpxxn";
-    fetchSubmodules = true;
-  };
-
-  libp2p = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-libp2p.git";
-    rev = "c43199378f46d0aaf61be1cad1ee1d63e8f665d6";
-    sha256 = "0q1hkwwz08zfdwwz7cfql1hqil0iyv3dn8jypdwqmg7497l1bmxk";
+    rev = "6cb1b7e3922645275043c68e476cac1501a45e55";
+    sha256 = "02vxprjw4ixicdfczznns62izys9jgmsvy28rzlfd0wqg79gn9mc";
     fetchSubmodules = true;
   };
 
@@ -276,13 +311,6 @@
     fetchSubmodules = true;
   };
 
-  sds = pkgs.fetchgit {
-    url = "https://github.com/logos-messaging/nim-sds.git";
-    rev = "b12f5ee07c5b764303b51fb948b32a4ade1de3b5";
-    sha256 = "1z8f0v1ww7y6zssdacjxfs6s4862dwckw25df3yn1v0qnz40rpc8";
-    fetchSubmodules = true;
-  };
-
   ffi = pkgs.fetchgit {
     url = "https://github.com/logos-messaging/nim-ffi";
     rev = "aad9374354a5e3d98964a9adf80766a12f8f200d";
@@ -290,31 +318,10 @@
     fetchSubmodules = true;
   };
 
-  boringssl = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
-    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
-    fetchSubmodules = true;
-  };
-
-  protobuf_serialization = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-protobuf-serialization";
-    rev = "38d24eb3bd93e605fb88199da71d36b1ec0ad60d";
-    sha256 = "0jr0a41b4r444si6xfa7bclw8mjsk6id10lrdvbxzp99750zspb9";
-    fetchSubmodules = true;
-  };
-
-  npeg = pkgs.fetchgit {
-    url = "https://github.com/zevv/npeg";
-    rev = "409f6796d0e880b3f0222c964d1da7de6e450811";
-    sha256 = "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm";
-    fetchSubmodules = true;
-  };
-
-  libp2p_mix = pkgs.fetchgit {
-    url = "https://github.com/logos-co/nim-libp2p-mix";
-    rev = "380513117d556bf8f70066f5e72a7fd74fe36ba6";
-    sha256 = "05zjf98nl2hxx62m9blk4yip2f31y44r5x4n98lmm5hghb7wbcpk";
+  sds = pkgs.fetchgit {
+    url = "https://github.com/logos-messaging/nim-sds.git";
+    rev = "b12f5ee07c5b764303b51fb948b32a4ade1de3b5";
+    sha256 = "1z8f0v1ww7y6zssdacjxfs6s4862dwckw25df3yn1v0qnz40rpc8";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## PR Description

libp2p v2.2.0 bump PR (stack: PR 1 of 8)

Upgrades the dependencies to nim-libp2p 2.2.0.

This does not compile on its own; the next PR in the stack adapts the source.

## Changes

* bump nim-libp2p
* require nimble 0.24.1 for the 2.2.0 dependency graph
* drop the direct nat_traversal requirement
* update mix revision
* pin lsquic
* refresh dependency locks
