### PR TITLE
refactor: add typed NAT policy boundary

### DIFF
--- a/logos_delivery/waku/common/utils/nat.nim
+++ b/logos_delivery/waku/common/utils/nat.nim
@@ -1,7 +1,8 @@
 {.push raises: [].}
 
-import std/[strutils, net]
-import chronicles, eth/net/nat, results, nativesockets
+import std/net
+import chronicles, eth/net/nat as eth_nat, results, nativesockets
+import ../../net/nat_config
 
 logScope:
   topics = "nat"
@@ -15,19 +16,17 @@ logScope:
 ## Those threads will dead lock each other in tear down.
 var singletonNat: bool = false
 
-# TODO: pass `NatStrategy`, not a string
 proc setupNat*(
-    natConf, clientId: string, tcpPort, udpPort: Port
+    natStrategy: nat_config.NatStrategy, clientId: string, tcpPort, udpPort: Port
 ): Result[tuple[ip: Opt[IpAddress], tcpPort: Opt[Port], udpPort: Opt[Port]], string] {.
     gcsafe
 .} =
   let strategy =
-    case natConf.toLowerAscii()
-    of "any": NatAny
-    of "none": NatNone
-    of "upnp": NatUpnp
-    of "pmp": NatPmp
-    else: NatNone
+    case natStrategy.kind
+    of nat_config.NatAny: eth_nat.NatAny
+    of nat_config.NatUpnp: eth_nat.NatUpnp
+    of nat_config.NatPmp: eth_nat.NatPmp
+    of nat_config.NatNone, nat_config.NatExtIp: eth_nat.NatNone
 
   var endpoint: tuple[ip: Opt[IpAddress], tcpPort: Opt[Port], udpPort: Opt[Port]]
 
@@ -66,14 +65,19 @@ proc setupNat*(
           let (extTcpPort, extUdpPort) = extPorts.get()
           endpoint.tcpPort = Opt.some(extTcpPort)
           endpoint.udpPort = Opt.some(extUdpPort)
-  else: # NatNone
-    if not natConf.startsWith("extip:"):
-      return err("not a valid NAT mechanism: " & $natConf)
-
-    try:
-      # any required port redirection is assumed to be done by hand
-      endpoint.ip = Opt.some(parseIpAddress(natConf[6 ..^ 1]))
-    except ValueError:
-      return err("not a valid IP address: " & $natConf[6 ..^ 1])
+  elif natStrategy.kind == nat_config.NatExtIp:
+    # Any required port redirection is assumed to be configured manually.
+    endpoint.ip = Opt.some(natStrategy.extIp)
 
   return ok(endpoint)
+
+proc setupNat*(
+    natConf, clientId: string, tcpPort, udpPort: Port
+): Result[tuple[ip: Opt[IpAddress], tcpPort: Opt[Port], udpPort: Opt[Port]], string] {.
+    gcsafe
+.} =
+  ## Compatibility overload for applications that have not moved their
+  ## configuration boundary to `NatStrategy` yet.
+  let strategy = parseNatStrategy(natConf).valueOr:
+    return err(error)
+  setupNat(strategy, clientId, tcpPort, udpPort)

--- a/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
@@ -674,12 +674,15 @@ proc build*(
       warn "Log Format not specified, defaulting to TEXT"
       DefaultLogFormat
 
-  let natStrategy =
+  let natStrategyString =
     if builder.natStrategy.isSome():
       builder.natStrategy.get()
     else:
       warn "Nat Strategy is not specified, defaulting to none"
       DefaultNatStrategy
+
+  let natStrategy = parseNatStrategy(natStrategyString).valueOr:
+    return err("Invalid NAT strategy: " & error)
 
   var p2pTcpPort = builder.p2pTcpPort.get(DefaultP2pTcpPort)
 

--- a/logos_delivery/waku/factory/internal_config.nim
+++ b/logos_delivery/waku/factory/internal_config.nim
@@ -102,7 +102,7 @@ proc networkConfiguration*(
 
   # NAT-map the QUIC UDP port (placeholder when QUIC off)
   var (extIp, extTcpPort, extUdpPort) = setupNat(
-    conf.natStrategy.string, clientId, tcpBindPort, quicBindPort.get(tcpBindPort)
+    conf.natStrategy, clientId, tcpBindPort, quicBindPort.get(tcpBindPort)
   ).valueOr:
     return err("failed to setup NAT: " & $error)
 

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -13,6 +13,7 @@ import
   results
 
 import
+  ../net/nat_config,
   ../rln/rln,
   ../rest_api/endpoint/builder,
   ../discovery/waku_discv5,
@@ -26,6 +27,7 @@ import
   ./conf_builder/kademlia_discovery_conf_builder
 
 export RlnConf, RlnCreds, RestServerConf, Discv5Conf, MetricsServerConf
+export nat_config
 
 logScope:
   topics = "waku conf"
@@ -75,8 +77,8 @@ type FilterServiceConf* {.requiresInit.} = object
   subscriptionTimeout*: uint16
   maxCriteria*: uint32
 
-type EndpointConf* = object # TODO: make enum
-  natStrategy*: string
+type EndpointConf* = object
+  natStrategy*: NatStrategy
   p2pTcpPort*: Port
   dns4DomainName*: Opt[string]
   p2pListenAddress*: IpAddress

--- a/logos_delivery/waku/net/nat_config.nim
+++ b/logos_delivery/waku/net/nat_config.nim
@@ -1,0 +1,63 @@
+{.push raises: [].}
+
+## Logos Delivery's public NAT strategy.
+##
+## This type deliberately describes user intent, not a particular NAT backend.
+## The existing nim-eth implementation and libp2p's NATService can therefore be
+## selected independently while preserving the `--nat` CLI contract.
+
+import std/[net, strutils]
+import results
+
+type
+  NatStrategyKind* = enum
+    NatNone
+    NatAny
+    NatUpnp
+    NatPmp
+    NatExtIp
+
+  NatStrategy* = object
+    case kind*: NatStrategyKind
+    of NatExtIp:
+      extIp*: IpAddress
+    else:
+      discard
+
+func `$`*(strategy: NatStrategy): string =
+  case strategy.kind
+  of NatNone:
+    "none"
+  of NatAny:
+    "any"
+  of NatUpnp:
+    "upnp"
+  of NatPmp:
+    "pmp"
+  of NatExtIp:
+    "extip:" & $strategy.extIp
+
+func parseNatStrategy*(value: string): Result[NatStrategy, string] =
+  let normalized = value.toLowerAscii()
+  case normalized
+  of "any":
+    ok(NatStrategy(kind: NatAny))
+  of "none":
+    ok(NatStrategy(kind: NatNone))
+  of "upnp":
+    ok(NatStrategy(kind: NatUpnp))
+  of "pmp":
+    ok(NatStrategy(kind: NatPmp))
+  else:
+    const ExtIpPrefix = "extip:"
+    if not normalized.startsWith(ExtIpPrefix):
+      return err("not a valid NAT mechanism: " & value)
+
+    let ipString = normalized[ExtIpPrefix.len ..^ 1]
+    let ip =
+      try:
+        parseIpAddress(ipString)
+      except ValueError:
+        return err("not a valid IP address: " & ipString)
+
+    ok(NatStrategy(kind: NatExtIp, extIp: ip))

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -55,6 +55,7 @@ import
 
 import
   # Waku v2 tests
+  ./test_nat_config,
   ./test_wakunode,
   ./test_peer_store_extended,
   ./test_message_cache,

--- a/tests/test_nat_config.nim
+++ b/tests/test_nat_config.nim
@@ -1,0 +1,26 @@
+import std/net
+import results, testutils/unittests
+
+import ../logos_delivery/waku/net/nat_config
+
+suite "NAT strategy configuration":
+  test "parse named strategies":
+    check:
+      parseNatStrategy("none").get().kind == NatNone
+      parseNatStrategy("any").get().kind == NatAny
+      parseNatStrategy("UPNP").get().kind == NatUpnp
+      parseNatStrategy("pMp").get().kind == NatPmp
+
+  test "parse static external IP":
+    let strategy = parseNatStrategy("extip:203.0.113.4").get()
+
+    check:
+      strategy.kind == NatExtIp
+      strategy.extIp == parseIpAddress("203.0.113.4")
+      $strategy == "extip:203.0.113.4"
+
+  test "reject invalid strategies":
+    check:
+      parseNatStrategy("").isErr()
+      parseNatStrategy("automatic").isErr()
+      parseNatStrategy("extip:not-an-ip").isErr()

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -1053,7 +1053,8 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   b.withP2pListenAddress(n.listenAddress)
   b.withP2pTcpPort(n.tcpPort)
   b.withPortsShift(n.portsShift)
-  b.withNatStrategy(n.nat)
+  if n.nat != "":
+    b.withNatStrategy(n.nat)
   b.withExtMultiAddrs(n.extMultiAddrs)
   b.withExtMultiAddrsOnly(n.extMultiAddrsOnly)
   b.withMaxConnections(n.maxConnections)


### PR DESCRIPTION
## PR Description

Typed NAT strategy PR (stack: PR 4 of 8)

The `--nat` string becomes a typed `NatStrategy` (`waku/net/nat_config.nim`), parsed once at the CLI edge (no change to the NAT implementation yet).

An empty `nat` field (zero-initialized partial `WakuNodeConf`) means "not specified" and resolves to the default instead of erroring.

## Changes

* model NAT user intent
* parse existing CLI values
* thread strategy through config
* treat an empty nat value as not specified
* add NAT strategy tests
