### PR TITLE
fix: announce NAT-mapped external addresses

### DIFF
--- a/logos_delivery/waku/factory/internal_config.nim
+++ b/logos_delivery/waku/factory/internal_config.nim
@@ -88,8 +88,8 @@ proc networkConfiguration*(
     wakuFlags: CapabilitiesBitfield,
     dnsAddrsNameServers: seq[IpAddress],
     natExtIp = Opt.none(IpAddress),
-    natExtTcpPort = Opt.none(Port),
-    natExtUdpPort = Opt.none(Port),
+    extTcpPort = Opt.none(Port),
+    extUdpPort = Opt.none(Port),
 ): Future[NetConfigResult] {.async.} =
   let tcpBindPort = conf.p2pTcpPort
 
@@ -103,9 +103,9 @@ proc networkConfiguration*(
   ## External IP/ports as far as they can be known at this point: `extip:` is
   ## static configuration, while UPnP/NAT-PMP mappings are performed by the
   ## switch's NATService at startup; the caller passes their results in
-  ## (`natExtIp`/`natExt*Port`) when recomputing the config on a running node.
+  ## (`natExtIp`/`extTcpPort`/`extUdpPort`) when recomputing the config on a
+  ## running node.
   var extIp = natExtIp
-  let (extTcpPort, extUdpPort) = (natExtTcpPort, natExtUdpPort)
   if extIp.isNone() and conf.natStrategy.kind == NatExtIp:
     extIp = Opt.some(conf.natStrategy.extIp)
 
@@ -116,18 +116,25 @@ proc networkConfiguration*(
       else:
         Opt.none(Port)
 
-    ## TODO: the NAT setup assumes a manual port mapping configuration if extIp
-    ## config is set. This probably implies adding manual config item for
-    ## extPort as well. The following heuristic assumes that, in absence of
-    ## manual config, the external port is the same as the bind port.
+    ## The bind-port fallback below assumes the operator vouches for the
+    ## external endpoint (`extip:` implies a manual port mapping, dns4 a name
+    ## that resolves to this node). For a NAT-discovered external IP the
+    ## mapped ports are authoritative instead: a transport without a mapping
+    ## in place has no external endpoint and must not announce a guessed one.
+    natDiscovered = natExtIp.isSome()
+
     extPort =
-      if (extIp.isSome() or conf.dns4DomainName.isSome()) and extTcpPort.isNone():
+      if natDiscovered:
+        extTcpPort
+      elif (extIp.isSome() or conf.dns4DomainName.isSome()) and extTcpPort.isNone():
         Opt.some(tcpBindPort)
       else:
         extTcpPort
 
     extQuicPort =
-      if (extIp.isSome() or conf.dns4DomainName.isSome()) and extUdpPort.isNone():
+      if natDiscovered:
+        extUdpPort
+      elif (extIp.isSome() or conf.dns4DomainName.isSome()) and extUdpPort.isNone():
         quicBindPort
       else:
         extUdpPort

--- a/logos_delivery/waku/net/net_config.nim
+++ b/logos_delivery/waku/net/net_config.nim
@@ -201,11 +201,11 @@ proc init*(
         except CatchableError:
           return err(getCurrentExceptionMsg())
 
-      if quicHostAddress.isSome():
+      # No bind-port guessing here: when the external quic port is unknown
+      # (e.g. no NAT mapping for it), no external quic address is announced.
+      if quicHostAddress.isSome() and extQuicPort.isSome():
         try:
-          quicExtAddress = Opt.some(
-            ipQuicEndPoint(extIp.get(), extQuicPort.get(quicBindPort.get(bindPort)))
-          )
+          quicExtAddress = Opt.some(ipQuicEndPoint(extIp.get(), extQuicPort.get()))
         except CatchableError:
           return err("failed to set ip quic endpoint: " & getCurrentExceptionMsg())
 

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -124,6 +124,12 @@ type
     wakuRendezvous*: WakuRendezVous
     wakuRendezvousClient*: rendezvous_client.WakuRendezVousClient
     announcedAddresses*: seq[MultiAddress]
+    baseAnnouncedAddresses*: seq[MultiAddress]
+      ## Announced addresses as configuration produced them. The NAT fold
+      ## recomputes from this, so a lapsed mapping stops being announced.
+    natMappedAddresses: seq[MultiAddress]
+      ## Latest address-mapper chain output: the NATService's mapped
+      ## addresses when mappings exist, the listen addresses otherwise.
     extMultiAddrsOnly*: bool # When true, skip automatic IP address replacement
     started*: bool # Indicates that node has started listening
     topicSubscriptionQueue*: AsyncEventQueue[SubscriptionEvent]
@@ -460,12 +466,65 @@ proc mountRendezvous*(
   except LPError:
     error "failed to mount wakuRendezvous", error = getCurrentExceptionMsg()
 
-proc isBindIpWithZeroPort(inputMultiAdd: MultiAddress): bool =
-  let inputStr = $inputMultiAdd
-  if inputStr.contains("0.0.0.0/tcp/0") or inputStr.contains("127.0.0.1/tcp/0"):
-    return true
+proc natExternalIp*(node: WakuNode): Opt[IpAddress] =
+  ## External IP discovered by the switch's NATService, if any.
+  let natSvc = natService(node.switch).valueOr:
+    return Opt.none(IpAddress)
+  return natSvc.externalIp
 
-  return false
+func ipOf(ma: MultiAddress): Opt[IpAddress] =
+  let ta = initTAddress(ma).valueOr:
+    return Opt.none(IpAddress)
+  try:
+    return Opt.some(ta.address())
+  except ValueError:
+    return Opt.none(IpAddress)
+
+proc natMappedExternalAddresses*(node: WakuNode): seq[MultiAddress] =
+  ## Captured chain output carrying the discovered external IP.
+  let externalIp = node.natExternalIp().valueOr:
+    return @[]
+  return node.natMappedAddresses.filterIt(it.ipOf() == Opt.some(externalIp))
+
+proc setBaseAnnouncedAddresses*(node: WakuNode, addresses: seq[MultiAddress]) =
+  ## Set the base the fold re-derives from. NAT-mapped addresses are stripped:
+  ## the fold adds them back from the live mapping every time, so one left in
+  ## the base would outlive the mapping it came from and keep being announced.
+  let externalIp = node.natExternalIp()
+  node.baseAnnouncedAddresses =
+    if externalIp.isNone():
+      addresses
+    else:
+      addresses.filterIt(it.ipOf() != externalIp)
+
+proc foldNatMappedAddresses*(node: WakuNode) =
+  ## Recompute the announced addresses from the base and the NATService's
+  ## current mappings. Recomputed rather than edited, so a mapping that
+  ## lapses stops being announced.
+  if node.extMultiAddrsOnly:
+    return
+
+  ## Without a NATService the announced addresses stay as configured.
+  if natService(node.switch).isNone():
+    return
+
+  let mapped = node.natMappedExternalAddresses()
+  var newAnnounced =
+    if mapped.len == 0:
+      node.baseAnnouncedAddresses
+    else:
+      var addrs = mapped
+      for address in node.baseAnnouncedAddresses:
+        if address.isPublicMA() and address notin addrs:
+          addrs.add(address)
+      addrs
+
+  if newAnnounced == node.announcedAddresses:
+    return
+
+  info "Replacing announced addresses with NAT-mapped external addresses",
+    previous = $node.announcedAddresses, updated = $newAnnounced
+  node.announcedAddresses = newAnnounced
 
 proc updateAnnouncedAddrWithPrimaryIpAddr*(node: WakuNode): Result[void, string] =
   # Skip automatic IP replacement if extMultiAddrsOnly is set
@@ -497,6 +556,18 @@ proc updateAnnouncedAddrWithPrimaryIpAddr*(node: WakuNode): Result[void, string]
     newAnnouncedAddresses.add(newMultiAddr)
 
   node.announcedAddresses = newAnnouncedAddresses
+
+  ## The same substitution has to reach the base, which the NAT fold
+  ## re-derives from. Rewriting only the announced set would let the next
+  ## fold (the NATService refreshes every 30 minutes) recompute from a base
+  ## still holding the bind-IP form and undo this.
+  var newBaseAddresses = newSeq[MultiAddress](0)
+  for address in node.baseAnnouncedAddresses:
+    let rewritten = ($address).replace("0.0.0.0", localIp).replace("127.0.0.1", localIp)
+    let rewrittenMultiAddr = MultiAddress.init(rewritten).valueOr:
+      return err("error rewriting base announced address: " & $error)
+    newBaseAddresses.add(rewrittenMultiAddr)
+  node.baseAnnouncedAddresses = newBaseAddresses
 
   ## Update the Switch addresses
   node.switch.peerInfo.addrs = newAnnouncedAddresses
@@ -620,10 +691,9 @@ proc start*(node: WakuNode) {.async.} =
   logos_delivery_version.set(1, labelValues = [git_version])
   info "Starting Waku node", version = git_version
 
-  var zeroPortPresent = false
-  for address in node.announcedAddresses:
-    if isBindIpWithZeroPort(address):
-      zeroPortPresent = true
+  ## Computed before start: whether the config left any port to the sockets
+  ## (see hasZeroPort); such configs postpone the primary-IP announce rewrite.
+  let zeroPortPresent = node.announcedAddresses.anyIt(it.hasZeroPort())
 
   if not node.wakuStoreResume.isNil():
     await node.wakuStoreResume.start()
@@ -638,12 +708,21 @@ proc start*(node: WakuNode) {.async.} =
   ## in the announced addresses with the resolved ones.
   node.resolveAnnouncedAddresses()
 
-  ## Mapper that answers with the announced addresses. Installed after
-  ## switch.start: the announced addresses are correct by then, and the
-  ## chain is not being walked by the switch's own starting services.
+  ## Everything the NAT fold derives comes from this base. switch.start has
+  ## already run peerInfo.update once, so the resolved addresses can already
+  ## carry the NATService's mapped endpoint; setBaseAnnouncedAddresses keeps
+  ## it out of the base.
+  node.setBaseAnnouncedAddresses(node.announcedAddresses)
+
+  ## Last stage of the address-mapper chain: capture the chain output and
+  ## fold it into the announced addresses, which stay authoritative for
+  ## peerInfo.addrs. Installed after switch.start, so the chain is not being
+  ## walked by the switch's own starting services while we add to it.
   let addressMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.gcsafe, async: (raises: [CancelledError]).} =
+    node.natMappedAddresses = listenAddrs
+    node.foldNatMappedAddresses()
     return node.announcedAddresses
   node.switch.peerInfo.addressMappers.add(addressMapper)
 

--- a/logos_delivery/waku/waku.nim
+++ b/logos_delivery/waku/waku.nim
@@ -273,11 +273,24 @@ proc getRunningNetConfig(waku: Waku): Future[Result[NetConfig, string]] {.async.
   if quicPort.isSome() and conf.quicConf.isSome():
     conf.quicConf.get().port = quicPort.get()
 
+  # NATService results feed the recomputed NetConfig and the ENR. The
+  # external IP is used only when a mapping is actually in place: a
+  # discovered IP without one is not reachable.
+  let natMappedAddresses = waku.node.natMappedExternalAddresses()
+  let natMappedPorts = getPorts(natMappedAddresses).valueOr:
+    return err("Could not retrieve NAT-mapped ports: " & error)
+  let natExtIp =
+    if natMappedAddresses.len > 0:
+      waku.node.natExternalIp()
+    else:
+      Opt.none(IpAddress)
+
   # Rebuild NetConfig from the bound ports already read back into `conf`.
   let netConf = (
     await networkConfiguration(
       conf.clusterId, conf.endpointConf, conf.discv5Conf, conf.webSocketConf,
-      conf.quicConf, conf.wakuFlags, conf.dnsAddrsNameServers,
+      conf.quicConf, conf.wakuFlags, conf.dnsAddrsNameServers, natExtIp,
+      natMappedPorts.tcpPort, natMappedPorts.quicPort,
     )
   ).valueOr:
     return err("Could not update NetConfig: " & error)
@@ -296,8 +309,13 @@ proc updateEnr(waku: Waku): Future[Result[void, string]] {.async.} =
   waku.node.enr = record
 
   # If TCP/WS was configured with port 0, node.announcedAddresses was built
-  # pre-bind with a port value of 0. In any case, the resync is harmless.
+  # pre-bind with a port value of 0, so resync from the recomputed config.
+  # That config is scalar (one external IP, one port per transport, as the
+  # ENR slots hold), while the mapped set can carry one entry per interface,
+  # so the fold re-derives the announced set instead of the base replacing it.
+  waku.node.setBaseAnnouncedAddresses(netConf.announcedAddresses)
   waku.node.announcedAddresses = netConf.announcedAddresses
+  waku.node.foldNatMappedAddresses()
 
   return ok()
 

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -55,6 +55,7 @@ import
 
 import
   # Waku v2 tests
+  ./test_announced_addresses,
   ./test_nat_config,
   ./test_wakunode,
   ./test_peer_store_extended,

--- a/tests/test_announced_addresses.nim
+++ b/tests/test_announced_addresses.nim
@@ -1,0 +1,247 @@
+{.used.}
+
+## Regression tests for the announced-addresses pipeline: how the config's
+## intent, the switch-resolved listen addresses and the NAT-mapped external
+## addresses combine into what the node announces.
+
+import
+  results,
+  std/[sequtils, strutils, net],
+  testutils/unittests,
+  chronos,
+  libp2p/crypto/crypto,
+  libp2p/multiaddress,
+  libp2p/switch,
+  libp2p/services/natservice
+import
+  logos_delivery/waku/[
+    waku_core,
+    waku_node,
+    waku_enr,
+    net/net_config,
+    net/nat_config,
+    factory/internal_config,
+    factory/waku_conf,
+    factory/builder,
+  ],
+  ./testlib/common,
+  ./testlib/wakucore,
+  ./testlib/wakunode
+
+proc buildNode(bindPort: Port, quicBindPort: Port): WakuNode =
+  ## A node built straight from NetConfig, so port combinations that
+  ## newTestWakuNode normalizes away (e.g. quic dynamic while tcp is
+  ## explicit) can be expressed.
+  let nodeKey = generateSecp256k1Key()
+  let netConf = NetConfig.init(
+    clusterId = DefaultClusterId,
+    bindIp = parseIpAddress("127.0.0.1"),
+    bindPort = bindPort,
+    quicBindPort = Opt.some(quicBindPort),
+    quicEnabled = true,
+  ).valueOr:
+    raiseAssert "invalid NetConfig: " & $error
+
+  var enrBuilder = EnrBuilder.init(nodeKey)
+  enrBuilder.withIpAddressAndPorts(
+    ipAddr = netConf.enrIp, tcpPort = netConf.enrPort, udpPort = netConf.discv5UdpPort
+  )
+  let record = enrBuilder.build().valueOr:
+    raiseAssert "invalid ENR: " & $error
+
+  var builder = WakuNodeBuilder.init()
+  builder.withRng(rng())
+  builder.withNodeKey(nodeKey)
+  builder.withRecord(record)
+  builder.withNetworkConfiguration(netConf)
+  builder.withSwitchConfiguration(maxConnections = Opt.some(50))
+  builder.build().get()
+
+suite "Announced addresses":
+  asyncTest "NAT-mapped addresses keep updating announced addresses after start":
+    ## The NATService renews mappings on every peerInfo.update (the refresh
+    ## loop beats every 30 minutes); its output must keep flowing into the
+    ## announced addresses instead of being frozen at start time.
+    let node = buildNode(bindPort = Port(0), quicBindPort = Port(0))
+    await node.start()
+
+    # A NATService that has discovered an external IP.
+    let natSvc = NATService.new(upnpConfig(), rng())
+    natSvc.externalIp = Opt.some(parseIpAddress("203.0.113.9"))
+    node.switch.services.add(Service(natSvc))
+
+    # A mapper standing in for the NATService's own: injects the mapped
+    # external address into the chain, as the real one does after a
+    # successful port mapping.
+    let mapped = MultiAddress.init("/ip4/203.0.113.9/tcp/4444").get()
+    node.switch.peerInfo.addressMappers.insert(
+      proc(
+          addrs: seq[MultiAddress]
+      ): Future[seq[MultiAddress]] {.gcsafe, async: (raises: [CancelledError]).} =
+        return addrs & @[mapped],
+      0,
+    )
+
+    await node.switch.peerInfo.update()
+    check mapped in node.announcedAddresses
+    await node.stop()
+
+  asyncTest "a dynamically allocated quic port postpones the primary-IP rewrite":
+    ## The "is any port dynamically allocated" decision must see every
+    ## transport: a config with an explicit tcp port but a dynamic quic port
+    ## is a dynamic config, and the primary-IP announce rewrite is postponed
+    ## for it, exactly as it is when the tcp port is dynamic.
+    let node = buildNode(bindPort = Port(61893), quicBindPort = Port(0))
+    await node.start()
+    check node.announcedAddresses.allIt("127.0.0.1" in $it)
+    await node.stop()
+
+  asyncTest "a NAT external IP without a quic mapping announces no external quic address":
+    ## When the external IP comes from NAT discovery, each transport's
+    ## external address is only real if that transport's port mapping is in
+    ## place; a guessed port must not be announced.
+    let conf = defaultTestWakuConf()
+    conf.quicConf = Opt.some(QuicConf(port: Port(60820)))
+    conf.endpointConf.natStrategy = NatStrategy(kind: NatUpnp)
+    conf.endpointConf.p2pTcpPort = Port(60821)
+
+    let netConf = (
+      await networkConfiguration(
+        conf.clusterId,
+        conf.endpointConf,
+        conf.discv5Conf,
+        conf.webSocketConf,
+        conf.quicConf,
+        conf.wakuFlags,
+        conf.dnsAddrsNameServers,
+        Opt.some(parseIpAddress("203.0.113.9")),
+        Opt.some(Port(60111)),
+        Opt.none(Port),
+      )
+    ).valueOr:
+      raiseAssert "networkConfiguration failed: " & error
+
+    check:
+      netConf.announcedAddresses.anyIt("203.0.113.9/tcp/60111" in $it)
+      not netConf.announcedAddresses.anyIt("203.0.113.9" in $it and "quic" in $it)
+
+suite "Announced addresses - multi-homed NAT":
+  asyncTest "every mapped endpoint survives a resync from the recomputed config":
+    ## A multi-homed node gets one NAT mapping per listening interface. The
+    ## recomputed NetConfig can only carry one external IP and one port per
+    ## transport, because that is what the ENR's ip/tcp/udp slots hold. The
+    ## resync must therefore keep the mapped set rather than replace it,
+    ## otherwise every endpoint past the first is dropped from what the node
+    ## announces and from the ENR's multiaddrs field.
+    let node = buildNode(bindPort = Port(0), quicBindPort = Port(0))
+    await node.start()
+
+    let natSvc = NATService.new(upnpConfig(), rng())
+    natSvc.externalIp = Opt.some(parseIpAddress("203.0.113.9"))
+    node.switch.services.add(Service(natSvc))
+
+    # Two interfaces mapped to two external tcp ports on the same gateway.
+    let mappedA = MultiAddress.init("/ip4/203.0.113.9/tcp/4444").get()
+    let mappedB = MultiAddress.init("/ip4/203.0.113.9/tcp/5555").get()
+    node.switch.peerInfo.addressMappers.insert(
+      proc(
+          addrs: seq[MultiAddress]
+      ): Future[seq[MultiAddress]] {.gcsafe, async: (raises: [CancelledError]).} =
+        return addrs & @[mappedA, mappedB],
+      0,
+    )
+    await node.switch.peerInfo.update()
+
+    check:
+      mappedA in node.natMappedExternalAddresses()
+      mappedB in node.natMappedExternalAddresses()
+      mappedA in node.announcedAddresses
+      mappedB in node.announcedAddresses
+
+    ## updateEnr resyncs the configured base from a scalar rebuild that can
+    ## only name one port per transport. The fold re-derives from base plus
+    ## mappings, so the second endpoint must survive the resync.
+    node.setBaseAnnouncedAddresses(@[mappedA])
+    node.foldNatMappedAddresses()
+
+    check:
+      mappedA in node.announcedAddresses
+      mappedB in node.announcedAddresses # lost if the base replaced the set
+
+    await node.stop()
+
+  asyncTest "a lapsed NAT mapping stops being announced":
+    ## Gateway reboots, lease expires: the NATService stops mapping and its
+    ## stage passes the listen addresses through. The node must stop
+    ## advertising the external endpoint that no longer forwards, while the
+    ## operator's own public entry survives.
+    let node = buildNode(bindPort = Port(0), quicBindPort = Port(0))
+    await node.start()
+
+    let natSvc = NATService.new(upnpConfig(), rng())
+    natSvc.externalIp = Opt.some(parseIpAddress("203.0.113.9"))
+    node.switch.services.add(Service(natSvc))
+
+    let operatorAddr = MultiAddress.init("/ip4/93.184.216.34/tcp/1234").get()
+    let mapped = MultiAddress.init("/ip4/203.0.113.9/tcp/4444").get()
+
+    ## As the running-node resync hands it back: the recomputed config already
+    ## carries the mapped endpoint. It must not settle into the base, or it
+    ## would outlive the mapping and never be dropped below.
+    node.setBaseAnnouncedAddresses(node.announcedAddresses & @[operatorAddr, mapped])
+    check mapped notin node.baseAnnouncedAddresses
+
+    let mappingAlive = new(bool)
+    mappingAlive[] = true
+    node.switch.peerInfo.addressMappers.insert(
+      proc(
+          addrs: seq[MultiAddress]
+      ): Future[seq[MultiAddress]] {.gcsafe, async: (raises: [CancelledError]).} =
+        if mappingAlive[]:
+          return addrs & @[mapped]
+        return addrs,
+      0,
+    )
+
+    await node.switch.peerInfo.update()
+    check:
+      mapped in node.announcedAddresses
+      operatorAddr in node.announcedAddresses
+
+    mappingAlive[] = false
+    await node.switch.peerInfo.update()
+    check:
+      mapped notin node.announcedAddresses # stale endpoint must be dropped
+      operatorAddr in node.announcedAddresses # operator intent survives
+
+    await node.stop()
+
+  asyncTest "a NAT refresh does not revert the primary-IP announce rewrite":
+    ## Regression: the fold recomputes the announced set from the base on
+    ## every peerInfo.update, and the NATService runs one every 30 minutes.
+    ## When the primary-IP rewrite reached only the announced set, that
+    ## refresh recomputed from a base still holding the bind-IP form and
+    ## reverted the node to it - on the default --nat any with no gateway,
+    ## which is most cloud and container deployments.
+    let node = buildNode(bindPort = Port(0), quicBindPort = Port(0))
+    await node.start()
+
+    ## A NATService whose discovery never found a gateway: attached, but with
+    ## no external IP and no mappings.
+    let natSvc = NATService.new(upnpConfig(), rng())
+    node.switch.services.add(Service(natSvc))
+
+    node.baseAnnouncedAddresses = @[MultiAddress.init("/ip4/127.0.0.1/tcp/1234").get()]
+    node.announcedAddresses = node.baseAnnouncedAddresses
+
+    updateAnnouncedAddrWithPrimaryIpAddr(node).isOkOr:
+      raiseAssert "primary ip rewrite failed: " & $error
+
+    let afterRewrite = node.announcedAddresses
+    check "127.0.0.1" notin $node.baseAnnouncedAddresses
+
+    ## The refresh tick.
+    await node.switch.peerInfo.update()
+    check node.announcedAddresses == afterRewrite
+
+    await node.stop()


### PR DESCRIPTION
## PR Description

Fix NAT announced addresses (stack: PR 6 of 8)

Announced addresses and the ENR now follow the NATService's actual mappings, at start and on every lease renewal, via the address-mapper chain.

With operator `extip:`, missing external ports fall back to bind ports. With a NAT-discovered IP, there is no fallback: without a mapping there is no announced address for that transport.

Announced addresses are recomputed from the configured base plus the current mappings rather than edited in place, so a mapping that lapses stops being announced instead of lingering as a dead endpoint.

The recomputed `NetConfig` can only name one external IP and one port per transport, since that is what the ENR's ip/tcp/udp slots hold. A multi-homed node therefore keeps every mapped endpoint in the announced set and in the ENR's multiaddrs field.

## Changes

* capture NAT-mapped addresses from the address mapper chain
* recompute announced addresses from the configured base and the mappings
* keep every mapped endpoint when resyncing from the recomputed config
* stop announcing external endpoints once their mapping lapses
* feed NAT results into recomputed NetConfig and ENR
* announce no guessed external quic port without a mapping
