### PR TITLE
feat: harden NAT mapping and discv5 projection

### DIFF
--- a/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
@@ -148,6 +148,7 @@ type WakuConfBuilder* = object
   logFormat: Opt[logging.LogFormat]
 
   natStrategy: Opt[string]
+  natDiscoveryTimeoutMs: Opt[uint32]
 
   p2pTcpPort: Opt[Port]
   p2pListenAddress: Opt[IpAddress]
@@ -290,6 +291,9 @@ proc withDns4DomainName*(b: var WakuConfBuilder, dns4DomainName: string) =
 
 proc withNatStrategy*(b: var WakuConfBuilder, natStrategy: string) =
   b.natStrategy = Opt.some(natStrategy)
+
+proc withNatDiscoveryTimeoutMs*(b: var WakuConfBuilder, timeoutMs: uint32) =
+  b.natDiscoveryTimeoutMs = Opt.some(timeoutMs)
 
 proc withAgentString*(b: var WakuConfBuilder, agentString: string) =
   b.agentString = Opt.some(agentString)
@@ -684,6 +688,13 @@ proc build*(
   let natStrategy = parseNatStrategy(natStrategyString).valueOr:
     return err("Invalid NAT strategy: " & error)
 
+  ## Zero would make the NATService reject its own config at switch build,
+  ## surfacing as an opaque ServiceSetupError instead of a config error.
+  let natDiscoveryTimeoutMs =
+    builder.natDiscoveryTimeoutMs.get(DefaultNatDiscoveryTimeoutMs)
+  if natDiscoveryTimeoutMs == 0:
+    return err("natDiscoveryTimeoutMs must be greater than 0")
+
   var p2pTcpPort = builder.p2pTcpPort.get(DefaultP2pTcpPort)
 
   let p2pListenAddress =
@@ -815,6 +826,7 @@ proc build*(
     # TODO: Separate builders
     endpointConf: EndpointConf(
       natStrategy: natStrategy,
+      natDiscoveryTimeoutMs: natDiscoveryTimeoutMs,
       p2pTcpPort: p2pTcpPort,
       dns4DomainName: dns4DomainName,
       p2pListenAddress: p2pListenAddress,

--- a/logos_delivery/waku/factory/internal_config.nim
+++ b/logos_delivery/waku/factory/internal_config.nim
@@ -90,6 +90,7 @@ proc networkConfiguration*(
     natExtIp = Opt.none(IpAddress),
     extTcpPort = Opt.none(Port),
     extUdpPort = Opt.none(Port),
+    extWsPort = Opt.none(Port),
 ): Future[NetConfigResult] {.async.} =
   let tcpBindPort = conf.p2pTcpPort
 
@@ -139,6 +140,15 @@ proc networkConfiguration*(
       else:
         extUdpPort
 
+    wsExtPort =
+      if natDiscovered:
+        extWsPort
+      elif (extIp.isSome() or conf.dns4DomainName.isSome()) and extWsPort.isNone() and
+        webSocketConf.isSome():
+        Opt.some(webSocketConf.get().port)
+      else:
+        extWsPort
+
   # Resolve and use DNS domain IP
   if conf.dns4DomainName.isSome() and extIp.isNone():
     try:
@@ -174,6 +184,8 @@ proc networkConfiguration*(
     quicBindPort = quicBindPort,
     quicEnabled = quicEnabled,
     extQuicPort = extQuicPort,
+    extWsPort = wsExtPort,
+    natDiscovered = natDiscovered,
     dns4DomainName = conf.dns4DomainName,
     discv5UdpPort = discv5UdpPort,
     wakuFlags = Opt.some(wakuFlags),

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -103,7 +103,10 @@ proc initNode(
   )
   builder.withColocationLimit(conf.colocationLimit)
   builder.withNatConfig(
-    toNatConfig(conf.endpointConf.natStrategy),
+    toNatConfig(
+      conf.endpointConf.natStrategy,
+      conf.endpointConf.natDiscoveryTimeoutMs.int64.milliseconds,
+    ),
     natPortMapperFactory(conf.endpointConf.natStrategy),
   )
 

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -79,6 +79,7 @@ type FilterServiceConf* {.requiresInit.} = object
 
 type EndpointConf* = object
   natStrategy*: NatStrategy
+  natDiscoveryTimeoutMs*: uint32
   p2pTcpPort*: Port
   dns4DomainName*: Opt[string]
   p2pListenAddress*: IpAddress

--- a/logos_delivery/waku/net/nat_config.nim
+++ b/logos_delivery/waku/net/nat_config.nim
@@ -75,8 +75,9 @@ func parseNatStrategy*(value: string): Result[NatStrategy, string] =
 type FallbackPortMapper* = ref object of PortMapper
   ## `--nat any`: try UPnP first, then NAT-PMP. Candidates are probed in
   ## order at discovery time and the first one that finds an external IP
-  ## becomes the active mapper; the losers are closed. Once a mapper is
-  ## active it is never re-elected.
+  ## becomes the active mapper. All candidates are kept: when the active
+  ## mapper later stops finding the gateway (reboot, mechanism change), the
+  ## next discovery re-elects among them.
   candidates: seq[PortMapper]
   active: PortMapper
 
@@ -87,17 +88,17 @@ method discover*(
     self: FallbackPortMapper, timeout: Duration
 ): Future[Result[IpAddress, string]] {.async: (raises: [CancelledError]), gcsafe.} =
   if not self.active.isNil():
-    return await self.active.discover(timeout)
+    let res = await self.active.discover(timeout)
+    if res.isOk():
+      return res
+    debug "active NAT port mapper lost the gateway; re-electing", err = res.error
+    self.active = nil
 
   var errors: seq[string]
   for candidate in self.candidates:
     let res = await candidate.discover(timeout)
     if res.isOk():
       self.active = candidate
-      for other in self.candidates:
-        if other != candidate:
-          await other.close()
-      self.candidates = @[]
       return res
     errors.add(res.error)
   err("all NAT port mappers failed discovery: " & errors.join("; "))
@@ -121,34 +122,160 @@ method unmap*(
   await self.active.unmap(externalPort, proto)
 
 method close*(self: FallbackPortMapper) {.async: (raises: []), gcsafe.} =
-  if not self.active.isNil():
-    await self.active.close()
-    self.active = nil
+  self.active = nil
   for candidate in self.candidates:
     await candidate.close()
   self.candidates = @[]
 
-proc toNatConfig*(strategy: NatStrategy): Opt[NATConfig] =
+type RetryingPortMapper* = ref object of PortMapper
+  ## Wraps a port mapper with a delete-then-re-add fallback: when the gateway
+  ## rejects a mapping request - typically because a stale entry for the same
+  ## external port is holding the slot (left over by a previous run, or by
+  ## firmware that refuses to refresh an existing entry in place) - the stale
+  ## mapping is removed and the request retried once. This also keeps lease
+  ## renewal working on gateways that reject in-place refreshes.
+  inner: PortMapper
+
+proc new*(T: typedesc[RetryingPortMapper], inner: PortMapper): T =
+  T(inner: inner)
+
+method discover*(
+    self: RetryingPortMapper, timeout: Duration
+): Future[Result[IpAddress, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  await self.inner.discover(timeout)
+
+method map*(
+    self: RetryingPortMapper,
+    internalPort: Port,
+    externalPort: Port,
+    proto: MapProto,
+    lease: uint32,
+): Future[Result[Port, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  let first = await self.inner.map(internalPort, externalPort, proto, lease)
+  if first.isOk():
+    return first
+  debug "NAT mapping rejected; removing stale entry and retrying",
+    externalPort, proto, err = first.error
+  discard await self.inner.unmap(externalPort, proto)
+  let retried = await self.inner.map(internalPort, externalPort, proto, lease)
+  if retried.isOk():
+    return retried
+  ## The slot cannot be reclaimed (e.g. the entry belongs to another host):
+  ## fall back to an alternate external port. The gateway reports the port
+  ## actually granted and announced addresses follow it.
+  let alternate = Port(49152'u16 + uint16(externalPort) mod 16000'u16)
+  debug "NAT mapping still rejected; requesting an alternate external port",
+    requested = externalPort, alternate, proto
+  await self.inner.map(internalPort, alternate, proto, lease)
+
+method unmap*(
+    self: RetryingPortMapper, externalPort: Port, proto: MapProto
+): Future[Result[void, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  await self.inner.unmap(externalPort, proto)
+
+method close*(self: RetryingPortMapper) {.async: (raises: []), gcsafe.} =
+  await self.inner.close()
+
+const DefaultNatDiscoveryTimeoutMs* = 1000'u32
+  ## Default bound for the gateway discovery the NATService performs during
+  ## switch start (configurable via the endpoint config). Node start awaits
+  ## discovery, and miniupnpc repeats its SSDP probe rounds each waiting the
+  ## full timeout, so on networks without a gateway the start stall is
+  ## several times this value per mechanism (observed: 44s at libp2p's
+  ## 10-second default, 20s at 3 seconds). One second keeps the worst-case
+  ## stall in single digits while still giving gateways five times the 200ms
+  ## window nim-eth's setupNat allowed them before the libp2p NATService
+  ## migration.
+
+const NatDiscoveryTimeout = DefaultNatDiscoveryTimeoutMs.int64.milliseconds
+
+const NatUdpLeaseSeconds* = uint32(DefaultLeaseDuration.seconds)
+  ## Lease requested for udp mappings made outside the switch's NATService
+  ## (discv5). A permanent (0) lease is deliberately not requested: NAT-PMP
+  ## has no permanent lease at all — RFC 6886 uses a zero lifetime to
+  ## *delete* a mapping, and libp2p's NAT-PMP mapper rejects lease 0 for
+  ## that reason — and UPnP firmware caps long leases anyway (24h observed).
+  ## The caller owns keeping the mapping alive by renewing it well inside
+  ## this lease.
+
+proc toNatConfig*(
+    strategy: NatStrategy, discoveryTimeout = NatDiscoveryTimeout
+): Opt[NATConfig] =
   ## The libp2p `NATConfig` for a strategy, or none when no NATService is
   ## wanted. `NatExtIp` is deliberately not mapped: the static external IP is
   ## folded into `NetConfig`/the ENR before the switch exists, and libp2p's
   ## explicit-ip address mapper would drop dns4 announced addresses.
   case strategy.kind
   of NatUpnp, NatAny:
-    Opt.some(upnpConfig())
+    Opt.some(upnpConfig(discoveryTimeout = discoveryTimeout))
   of NatPmp:
-    Opt.some(natPmpConfig())
+    Opt.some(natPmpConfig(discoveryTimeout = discoveryTimeout))
   of NatNone, NatExtIp:
     Opt.none(NATConfig)
 
 proc natPortMapperFactory*(strategy: NatStrategy): PortMapperFactory =
-  ## For `NatAny`, overrides libp2p's default port mapper with the UPnP-then-
-  ## NAT-PMP fallback; every other strategy uses the library default (nil).
-  if strategy.kind != NatAny:
+  ## The port mapper for a strategy: UPnP-then-NAT-PMP fallback for `NatAny`,
+  ## the matching single mapper for `NatUpnp`/`NatPmp`, nil (no NATService)
+  ## otherwise. Every mapper is wrapped in the delete-then-re-add retrier so
+  ## stale gateway entries cannot wedge mapping or lease renewal.
+  if strategy.kind notin {NatAny, NatUpnp, NatPmp}:
     return nil
+  let kind = strategy.kind
   return proc(mode: PortMappingMode): Opt[PortMapper] {.gcsafe, raises: [].} =
     try:
-      Opt.some(PortMapper(FallbackPortMapper.new(UpnpMapper.new(), NatPmpMapper.new())))
+      let inner =
+        case kind
+        of NatAny:
+          PortMapper(FallbackPortMapper.new(UpnpMapper.new(), NatPmpMapper.new()))
+        of NatUpnp:
+          PortMapper(UpnpMapper.new())
+        of NatPmp:
+          PortMapper(NatPmpMapper.new())
+        else:
+          return Opt.none(PortMapper)
+      Opt.some(PortMapper(RetryingPortMapper.new(inner)))
     except ResourceExhaustedError as e:
-      error "Failed to construct fallback NAT port mapper", err = e.msg
+      error "Failed to construct NAT port mapper", err = e.msg
       Opt.none(PortMapper)
+
+proc mapUdpPort*(
+    mapper: PortMapper,
+    internalPort: Port,
+    externalPort: Port,
+    discoveryTimeout = NatDiscoveryTimeout,
+): Future[Result[tuple[externalIp: IpAddress, externalPort: Port], string]] {.
+    async: (raises: [CancelledError])
+.} =
+  ## Discover the gateway through `mapper` and map a single udp port with a
+  ## `NatUdpLeaseSeconds` lease, for sockets that live outside the switch and
+  ## its NATService (discv5). The caller owns renewal: the lease is finite
+  ## (see `NatUdpLeaseSeconds`), so it must be re-requested before it
+  ## expires. A leftover entry from a crashed run is reclaimed by the
+  ## retrier's delete-and-re-add.
+  let externalIp = (await mapper.discover(discoveryTimeout)).valueOr:
+    return err("NAT discovery failed: " & error)
+  let granted = (
+    await mapper.map(internalPort, externalPort, mpUdp, NatUdpLeaseSeconds)
+  ).valueOr:
+    return err("NAT port mapping failed: " & error)
+  return ok((externalIp: externalIp, externalPort: granted))
+
+proc mapUdpPort*(
+    strategy: NatStrategy,
+    internalPort: Port,
+    externalPort: Port,
+    discoveryTimeout = NatDiscoveryTimeout,
+): Future[Result[tuple[externalIp: IpAddress, externalPort: Port], string]] {.
+    async: (raises: [CancelledError])
+.} =
+  ## As above, constructing (and closing when done) the strategy's mapper.
+  let factory = natPortMapperFactory(strategy)
+  if factory.isNil():
+    return err("NAT strategy has no port mapper: " & $strategy)
+  # The factory captures the strategy; its mode argument is not consulted.
+  let mapper = factory(PortMappingMode.Upnp).valueOr:
+    return err("could not construct NAT port mapper")
+  try:
+    return await mapUdpPort(mapper, internalPort, externalPort, discoveryTimeout)
+  finally:
+    await mapper.close()

--- a/logos_delivery/waku/net/net_config.nim
+++ b/logos_delivery/waku/net/net_config.nim
@@ -121,6 +121,8 @@ proc init*(
     quicBindPort = Opt.none(Port),
     quicEnabled: bool = false,
     extQuicPort = Opt.none(Port),
+    extWsPort = Opt.none(Port),
+    natDiscovered: bool = false,
     dns4DomainName = Opt.none(string),
     discv5UdpPort = Opt.none(Port),
     clusterId: uint16 = 0,
@@ -192,22 +194,34 @@ proc init*(
     if extIp.isSome() and extPort.isSome():
       hostExtAddress = Opt.some(ip4TcpEndPoint(extIp.get(), extPort.get()))
 
+      # With an operator-provided external IP the configured ports are used
+      # as-is (the operator vouches for the endpoint). With a NAT-discovered
+      # one (`natDiscovered`), each transport's external address is only
+      # built from an actually mapped port — no guessing.
       if wsHostAddress.isSome():
-        try:
-          wsExtAddress = Opt.some(
-            ip4TcpEndPoint(extIp.get(), wsBindPort.get(DefaultWsBindPort)) &
-              wsFlag(wssEnabled)
-          )
-        except CatchableError:
-          return err(getCurrentExceptionMsg())
+        let wsPort =
+          if natDiscovered:
+            extWsPort
+          else:
+            Opt.some(extWsPort.get(wsBindPort.get(DefaultWsBindPort)))
+        if wsPort.isSome():
+          try:
+            wsExtAddress =
+              Opt.some(ip4TcpEndPoint(extIp.get(), wsPort.get()) & wsFlag(wssEnabled))
+          except CatchableError:
+            return err(getCurrentExceptionMsg())
 
-      # No bind-port guessing here: when the external quic port is unknown
-      # (e.g. no NAT mapping for it), no external quic address is announced.
-      if quicHostAddress.isSome() and extQuicPort.isSome():
-        try:
-          quicExtAddress = Opt.some(ipQuicEndPoint(extIp.get(), extQuicPort.get()))
-        except CatchableError:
-          return err("failed to set ip quic endpoint: " & getCurrentExceptionMsg())
+      if quicHostAddress.isSome():
+        let quicPort =
+          if natDiscovered:
+            extQuicPort
+          else:
+            Opt.some(extQuicPort.get(quicBindPort.get(bindPort)))
+        if quicPort.isSome():
+          try:
+            quicExtAddress = Opt.some(ipQuicEndPoint(extIp.get(), quicPort.get()))
+          except CatchableError:
+            return err("failed to set ip quic endpoint: " & getCurrentExceptionMsg())
 
   var announcedAddresses = newSeq[MultiAddress]()
 

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -130,6 +130,9 @@ type
     natMappedAddresses: seq[MultiAddress]
       ## Latest address-mapper chain output: the NATService's mapped
       ## addresses when mappings exist, the listen addresses otherwise.
+    onAnnouncedAddressesChange*: proc() {.gcsafe, raises: [].}
+      ## Called when a peerInfo update changes the announced addresses, so
+      ## the owning layer can refresh the ENR.
     extMultiAddrsOnly*: bool # When true, skip automatic IP address replacement
     started*: bool # Indicates that node has started listening
     topicSubscriptionQueue*: AsyncEventQueue[SubscriptionEvent]
@@ -497,7 +500,7 @@ proc setBaseAnnouncedAddresses*(node: WakuNode, addresses: seq[MultiAddress]) =
     else:
       addresses.filterIt(it.ipOf() != externalIp)
 
-proc foldNatMappedAddresses*(node: WakuNode) =
+proc foldNatMappedAddresses*(node: WakuNode, notify = true) =
   ## Recompute the announced addresses from the base and the NATService's
   ## current mappings. Recomputed rather than edited, so a mapping that
   ## lapses stops being announced.
@@ -525,6 +528,10 @@ proc foldNatMappedAddresses*(node: WakuNode) =
   info "Replacing announced addresses with NAT-mapped external addresses",
     previous = $node.announcedAddresses, updated = $newAnnounced
   node.announcedAddresses = newAnnounced
+
+  ## `notify = false` when the caller refreshes the ENR itself right after.
+  if notify and not node.onAnnouncedAddressesChange.isNil():
+    node.onAnnouncedAddressesChange()
 
 proc updateAnnouncedAddrWithPrimaryIpAddr*(node: WakuNode): Result[void, string] =
   # Skip automatic IP replacement if extMultiAddrsOnly is set

--- a/logos_delivery/waku/waku.nim
+++ b/logos_delivery/waku/waku.nim
@@ -35,6 +35,7 @@ import
     node/peer_manager,
     node/health_monitor,
     net/net_config,
+    net/nat_config,
     node/waku_metrics,
     node/subscription_manager,
     rest_api/message_cache,
@@ -76,6 +77,8 @@ type Waku* = ref object ## Implements `KernelApi` (ops in `waku/api/*`).
   wakuDiscv5*: WakuDiscoveryV5
   dynamicBootstrapNodes*: seq[RemotePeerInfo]
   dnsRetryLoopHandle: Future[void]
+
+  discv5NatRenewLoopHandle: Future[void]
   networkConnLoopHandle: Future[void]
 
   node*: WakuNode
@@ -290,7 +293,7 @@ proc getRunningNetConfig(waku: Waku): Future[Result[NetConfig, string]] {.async.
     await networkConfiguration(
       conf.clusterId, conf.endpointConf, conf.discv5Conf, conf.webSocketConf,
       conf.quicConf, conf.wakuFlags, conf.dnsAddrsNameServers, natExtIp,
-      natMappedPorts.tcpPort, natMappedPorts.quicPort,
+      natMappedPorts.tcpPort, natMappedPorts.quicPort, natMappedPorts.websocketPort,
     )
   ).valueOr:
     return err("Could not update NetConfig: " & error)
@@ -315,7 +318,7 @@ proc updateEnr(waku: Waku): Future[Result[void, string]] {.async.} =
   # so the fold re-derives the announced set instead of the base replacing it.
   waku.node.setBaseAnnouncedAddresses(netConf.announcedAddresses)
   waku.node.announcedAddresses = netConf.announcedAddresses
-  waku.node.foldNatMappedAddresses()
+  waku.node.foldNatMappedAddresses(notify = false)
 
   return ok()
 
@@ -356,6 +359,48 @@ proc updateWaku(waku: Waku): Future[Result[void, string]] {.async.} =
   ?updateAddressInENR(waku)
 
   return ok()
+
+proc mapDiscv5Port(
+    waku: Waku, externalPort: Port
+): Future[Result[tuple[externalIp: IpAddress, externalPort: Port], string]] {.
+    async: (raises: [CancelledError])
+.} =
+  await mapUdpPort(
+    waku.conf.endpointConf.natStrategy, waku.wakuDiscV5.udpPort, externalPort,
+    waku.conf.endpointConf.natDiscoveryTimeoutMs.int64.milliseconds,
+  )
+
+const Discv5NatRenewInterval = chronos.seconds(int64(NatUdpLeaseSeconds div 2))
+  ## Half the lease, so a missed renewal still leaves a full cycle of slack.
+  ## Derived rather than fixed: the lease is libp2p's default and may change.
+
+proc discv5NatRenewLoop(
+    waku: Waku, grantedPort: Port
+): Future[void] {.async: (raises: []).} =
+  ## Re-request the discv5 mapping before its lease expires, asking for the
+  ## port the gateway granted. If the gateway hands back a different port the
+  ## ENR is rebuilt, since the advertised one no longer forwards.
+  var granted = grantedPort
+  try:
+    while true:
+      await sleepAsync(Discv5NatRenewInterval)
+      let mapped = await waku.mapDiscv5Port(granted)
+      if mapped.isErr():
+        debug "discv5 NAT mapping renewal failed", err = mapped.error
+      elif mapped.get().externalPort != granted:
+        warn "discv5 NAT mapping renewed on a different external port; " &
+          "refreshing the ENR",
+          previous = granted, newGranted = mapped.get().externalPort
+        granted = mapped.get().externalPort
+        if waku.conf.discv5Conf.isSome():
+          waku.conf.discv5Conf.get().udpPort = granted
+        try:
+          (await updateWaku(waku)).isOkOr:
+            error "failed to refresh ENR after discv5 NAT port change", error = error
+        except CatchableError as e:
+          error "failed to refresh ENR after discv5 NAT port change", error = e.msg
+  except CancelledError:
+    discard
 
 proc startDnsDiscoveryRetryLoop(waku: Waku): Future[void] {.async.} =
   while true:
@@ -451,12 +496,42 @@ proc start*(waku: Waku): Future[Result[void, string]] {.async: (raises: []).} =
     waku.node.ports.discv5Udp = waku.wakuDiscV5.udpPort.uint16
     waku.conf.discv5Conf.get().udpPort = waku.wakuDiscV5.udpPort
 
+    ## The discv5 socket is outside the switch, so the NATService does not
+    ## map it. Map it here and renew it, so the ENR carries the granted
+    ## external port.
+    if conf.endpointConf.natStrategy.kind in {NatAny, NatUpnp, NatPmp}:
+      try:
+        let mapped = await waku.mapDiscv5Port(waku.wakuDiscV5.udpPort)
+        if mapped.isOk():
+          ## From here this conf field holds the external port, which is
+          ## what the ENR rebuild below needs. The bind port stays in
+          ## waku.node.ports.discv5Udp and waku.wakuDiscV5.udpPort.
+          ## Only projected when the switch also has an external address:
+          ## otherwise the ENR would pair a mapped udp port with a local ip,
+          ## advertising an endpoint that does not exist.
+          if waku.node.natExternalIp().isSome():
+            waku.conf.discv5Conf.get().udpPort = mapped.get().externalPort
+          else:
+            debug "discv5 mapped but the switch has no external address; " &
+              "keeping the bind port in the ENR"
+          waku.discv5NatRenewLoopHandle =
+            waku.discv5NatRenewLoop(mapped.get().externalPort)
+        else:
+          debug "discv5 NAT port mapping not available", err = mapped.error
+      except CancelledError:
+        debug "discv5 NAT port mapping cancelled"
+
   ## Update waku data that is set dynamically on node start
   try:
     (await updateWaku(waku)).isOkOr:
       return err("Error in start: " & $error)
   except CatchableError:
     return err("Caught exception in start: " & getCurrentExceptionMsg())
+
+  ## Keep the ENR matching the announced addresses as mappings change.
+  waku.node.onAnnouncedAddressesChange = proc() {.gcsafe, raises: [].} =
+    updateAddressInENR(waku).isOkOr:
+      error "failed to refresh ENR after announced address change", error = error
 
   waku.node.subscriptionManager.subscribeAllAutoshards().isOkOr:
     return err("failed to auto-subscribe autosharding shards: " & $error)
@@ -560,6 +635,9 @@ proc stop*(waku: Waku): Future[Result[void, string]] {.async: (raises: []).} =
 
     if not waku.dnsRetryLoopHandle.isNil():
       await waku.dnsRetryLoopHandle.cancelAndWait()
+
+    if not waku.discv5NatRenewLoopHandle.isNil():
+      await waku.discv5NatRenewLoopHandle.cancelAndWait()
 
     if not waku.healthMonitor.isNil():
       await waku.healthMonitor.stopHealthMonitor()

--- a/tests/test_announced_addresses.nim
+++ b/tests/test_announced_addresses.nim
@@ -82,8 +82,16 @@ suite "Announced addresses":
       0,
     )
 
+    ## The hook the factory uses to refresh the ENR must fire when the
+    ## announced addresses change.
+    var changeSignalled = false
+    node.onAnnouncedAddressesChange = proc() {.gcsafe, raises: [].} =
+      changeSignalled = true
+
     await node.switch.peerInfo.update()
-    check mapped in node.announcedAddresses
+    check:
+      mapped in node.announcedAddresses
+      changeSignalled
     await node.stop()
 
   asyncTest "a dynamically allocated quic port postpones the primary-IP rewrite":
@@ -124,6 +132,37 @@ suite "Announced addresses":
     check:
       netConf.announcedAddresses.anyIt("203.0.113.9/tcp/60111" in $it)
       not netConf.announcedAddresses.anyIt("203.0.113.9" in $it and "quic" in $it)
+
+  asyncTest "a NAT external IP without a ws mapping announces no external ws address":
+    ## Same provenance rule as quic: with a NAT-discovered external IP, the
+    ## websocket external address is only real if the ws port mapping is in
+    ## place; the configured ws port must not be guessed into it.
+    let conf = defaultTestWakuConf()
+    conf.webSocketConf = Opt.some(
+      WebSocketConf(port: Port(60822), secureConf: Opt.none(WebSocketSecureConf))
+    )
+    conf.endpointConf.natStrategy = NatStrategy(kind: NatUpnp)
+    conf.endpointConf.p2pTcpPort = Port(60821)
+
+    let netConf = (
+      await networkConfiguration(
+        conf.clusterId,
+        conf.endpointConf,
+        conf.discv5Conf,
+        conf.webSocketConf,
+        conf.quicConf,
+        conf.wakuFlags,
+        conf.dnsAddrsNameServers,
+        Opt.some(parseIpAddress("203.0.113.9")),
+        Opt.some(Port(60111)),
+        Opt.none(Port),
+      )
+    ).valueOr:
+      raiseAssert "networkConfiguration failed: " & error
+
+    check:
+      netConf.announcedAddresses.anyIt("203.0.113.9/tcp/60111" in $it)
+      not netConf.announcedAddresses.anyIt("203.0.113.9" in $it and "/ws" in $it)
 
 suite "Announced addresses - multi-homed NAT":
   asyncTest "every mapped endpoint survives a resync from the recomputed config":

--- a/tests/test_nat_config.nim
+++ b/tests/test_nat_config.nim
@@ -1,55 +1,303 @@
-import std/net
-import chronos, results, testutils/unittests
+{.used.}
 
+import std/[net, strutils]
+import testutils/unittests, chronos, results
+import libp2p/services/nat/portmapper
 import ../logos_delivery/waku/net/nat_config
 
-suite "NAT strategy configuration":
-  test "parse named strategies":
+suite "NAT config - strategy parsing":
+  test "valid strategies parse":
     check:
-      parseNatStrategy("none").get().kind == NatNone
       parseNatStrategy("any").get().kind == NatAny
-      parseNatStrategy("UPNP").get().kind == NatUpnp
-      parseNatStrategy("pMp").get().kind == NatPmp
+      parseNatStrategy("none").get().kind == NatNone
+      parseNatStrategy("upnp").get().kind == NatUpnp
+      parseNatStrategy("pmp").get().kind == NatPmp
 
-  test "parse static external IP":
-    let strategy = parseNatStrategy("extip:203.0.113.4").get()
+  test "parsing is case-insensitive":
+    check:
+      parseNatStrategy("UPnP").get().kind == NatUpnp
+      parseNatStrategy("NONE").get().kind == NatNone
 
+  test "extip carries the address":
+    let strategy = parseNatStrategy("extip:203.0.113.7").get()
     check:
       strategy.kind == NatExtIp
-      strategy.extIp == parseIpAddress("203.0.113.4")
-      $strategy == "extip:203.0.113.4"
+      $strategy.extIp == "203.0.113.7"
 
-  test "reject invalid strategies":
+  test "invalid mechanism is rejected":
     check:
+      parseNatStrategy("bogus").isErr()
       parseNatStrategy("").isErr()
-      parseNatStrategy("automatic").isErr()
-      parseNatStrategy("extip:not-an-ip").isErr()
 
-  test "map strategies to libp2p NATConfig":
+  test "invalid extip address is rejected":
     check:
-      toNatConfig(NatStrategy(kind: NatUpnp)).get().portMapping.get().mode ==
-        PortMappingMode.Upnp
-      toNatConfig(NatStrategy(kind: NatAny)).get().portMapping.get().mode ==
-        PortMappingMode.Upnp
-      toNatConfig(NatStrategy(kind: NatPmp)).get().portMapping.get().mode ==
-        PortMappingMode.NatPmp
+      parseNatStrategy("extip:notanip").isErr()
+
+  test "strategies render back to their config strings":
+    check:
+      $parseNatStrategy("any").get() == "any"
+      $parseNatStrategy("extip:203.0.113.7").get() == "extip:203.0.113.7"
+
+suite "NAT config - NATConfig mapping":
+  test "upnp, any and pmp produce a NATConfig":
+    check:
+      toNatConfig(NatStrategy(kind: NatUpnp)).isSome()
+      toNatConfig(NatStrategy(kind: NatAny)).isSome()
+      toNatConfig(NatStrategy(kind: NatPmp)).isSome()
+
+  test "none and extip produce no NATConfig":
+    check:
       toNatConfig(NatStrategy(kind: NatNone)).isNone()
-      toNatConfig(NatStrategy(kind: NatExtIp, extIp: parseIpAddress("203.0.113.4")))
+      toNatConfig(NatStrategy(kind: NatExtIp, extIp: parseIpAddress("203.0.113.7")))
         .isNone()
 
-  asyncTest "fallback port mapper factory only overrides for any":
+  test "every NAT strategy gets a port mapper factory, the rest none":
     check:
+      not natPortMapperFactory(NatStrategy(kind: NatAny)).isNil()
+      not natPortMapperFactory(NatStrategy(kind: NatUpnp)).isNil()
+      not natPortMapperFactory(NatStrategy(kind: NatPmp)).isNil()
       natPortMapperFactory(NatStrategy(kind: NatNone)).isNil()
-      natPortMapperFactory(NatStrategy(kind: NatUpnp)).isNil()
-      natPortMapperFactory(NatStrategy(kind: NatPmp)).isNil()
+      natPortMapperFactory(
+        NatStrategy(kind: NatExtIp, extIp: parseIpAddress("203.0.113.7"))
+      )
+        .isNil()
 
-    let factory = natPortMapperFactory(NatStrategy(kind: NatAny))
-    check not factory.isNil()
+type StubMapper = ref object of PortMapper
+  ## Scripted port mapper: discovery yields `ip` when set, an error otherwise.
+  ## `mapRejections` makes that many leading map() calls fail, mimicking a
+  ## gateway whose requested slot is occupied until the entry is removed.
+  ip: Opt[IpAddress]
+  mapRejections: int
+  occupiedPort: Opt[Port]
+  unmapDenied: bool
+  discoverCalls: int
+  mapCalls: int
+  unmapCalls: int
+  closeCalls: int
+  lastMapProto: MapProto
+  lastMapLease: uint32
 
-    let mapper = factory(PortMappingMode.Upnp)
+method discover(
+    self: StubMapper, timeout: Duration
+): Future[Result[IpAddress, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  inc self.discoverCalls
+  let ip = self.ip.valueOr:
+    return err("stub discovery failure")
+  return ok(ip)
+
+method map(
+    self: StubMapper,
+    internalPort: Port,
+    externalPort: Port,
+    proto: MapProto,
+    lease: uint32,
+): Future[Result[Port, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  inc self.mapCalls
+  self.lastMapProto = proto
+  self.lastMapLease = lease
+  # Mirror libp2p's NAT-PMP mapper: a permanent (0) lease is invalid input —
+  # RFC 6886 uses a zero lifetime to delete a mapping. Keeping the stub as
+  # strict as the strictest real mapper prevents lease-semantics bugs from
+  # hiding behind a permissive test double.
+  if lease == 0:
+    return err("stub: lease 0 rejected (RFC 6886 delete semantics)")
+  if self.mapRejections > 0:
+    dec self.mapRejections
+    return err("stub mapping rejection")
+  if self.occupiedPort == Opt.some(externalPort):
+    return err("stub port occupied")
+  return ok(externalPort)
+
+method unmap(
+    self: StubMapper, externalPort: Port, proto: MapProto
+): Future[Result[void, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  inc self.unmapCalls
+  if self.unmapDenied:
+    return err("stub unmap denied")
+  return ok()
+
+method close(self: StubMapper) {.async: (raises: []), gcsafe.} =
+  inc self.closeCalls
+
+proc stub(ip = ""): StubMapper =
+  let address =
+    if ip.len > 0:
+      Opt.some(parseIpAddress(ip))
+    else:
+      Opt.none(IpAddress)
+  StubMapper(ip: address)
+
+suite "NAT config - fallback port mapper":
+  asyncTest "first successful candidate is elected, the rest are kept":
+    let
+      first = stub("203.0.113.1")
+      second = stub("203.0.113.2")
+      mapper = FallbackPortMapper.new(first, second)
+
+    let res = await mapper.discover(1.seconds)
     check:
-      mapper.isSome()
-      mapper.get() of FallbackPortMapper
+      $res.get() == "203.0.113.1"
+      second.discoverCalls == 0 # never probed, first already won
+      second.closeCalls == 0 # kept for possible re-election
+      first.closeCalls == 0
 
-    # The candidate mappers own worker threads: close before test teardown.
-    await mapper.get().close()
+  asyncTest "discovery falls back to the next candidate":
+    let
+      first = stub()
+      second = stub("203.0.113.2")
+      mapper = FallbackPortMapper.new(first, second)
+
+    let res = await mapper.discover(1.seconds)
+    check:
+      $res.get() == "203.0.113.2"
+      first.discoverCalls == 1
+      first.closeCalls == 0 # kept for possible re-election
+
+  asyncTest "a healthy active mapper is not re-elected":
+    let
+      first = stub("203.0.113.1")
+      second = stub("203.0.113.2")
+      mapper = FallbackPortMapper.new(first, second)
+
+    discard await mapper.discover(1.seconds)
+    discard await mapper.discover(1.seconds)
+    check:
+      first.discoverCalls == 2 # re-discovery delegates to the active mapper
+      second.discoverCalls == 0
+
+  asyncTest "a failing active mapper triggers re-election":
+    let
+      first = stub("203.0.113.1")
+      second = stub("203.0.113.2")
+      mapper = FallbackPortMapper.new(first, second)
+
+    discard await mapper.discover(1.seconds)
+    # the elected mapper stops finding the gateway (reboot, mechanism gone)
+    first.ip = Opt.none(IpAddress)
+
+    let res = await mapper.discover(1.seconds)
+    check:
+      res.isOk()
+      $res.get() == "203.0.113.2" # the other candidate takes over
+
+  asyncTest "discovery reports every candidate failure":
+    let mapper = FallbackPortMapper.new(stub(), stub())
+
+    let res = await mapper.discover(1.seconds)
+    check:
+      res.isErr()
+      "all NAT port mappers failed discovery" in res.error
+      res.error.count("stub discovery failure") == 2
+
+  asyncTest "map and unmap require a successful discovery":
+    let mapper = FallbackPortMapper.new(stub("203.0.113.1"))
+
+    check:
+      (await mapper.map(Port(1), Port(1), mpTcp, 60)).isErr()
+      (await mapper.unmap(Port(1), mpTcp)).isErr()
+
+  asyncTest "map and unmap delegate to the active mapper":
+    let
+      active = stub("203.0.113.1")
+      mapper = FallbackPortMapper.new(active)
+
+    discard await mapper.discover(1.seconds)
+    check:
+      (await mapper.map(Port(7), Port(9), mpTcp, 60)).get() == Port(9)
+      (await mapper.unmap(Port(9), mpTcp)).isOk()
+      active.mapCalls == 1
+      active.unmapCalls == 1
+
+  asyncTest "close closes the active mapper once":
+    let
+      active = stub("203.0.113.1")
+      loser = stub("203.0.113.2")
+      mapper = FallbackPortMapper.new(active, loser)
+
+    discard await mapper.discover(1.seconds)
+    await mapper.close()
+    await mapper.close()
+    check:
+      active.closeCalls == 1
+      loser.closeCalls == 1
+
+suite "NAT config - leased udp port mapping":
+  asyncTest "maps the port with a finite lease through the mapper":
+    let inner = stub("203.0.113.1")
+
+    let res = await mapUdpPort(PortMapper(inner), Port(9000), Port(9000))
+    check:
+      res.get().externalIp == parseIpAddress("203.0.113.1")
+      res.get().externalPort == Port(9000)
+      inner.discoverCalls == 1
+      inner.mapCalls == 1
+      inner.lastMapProto == mpUdp
+      # never 0: NAT-PMP has no permanent lease (0 deletes the mapping);
+      # the caller renews inside this lease instead
+      inner.lastMapLease == NatUdpLeaseSeconds
+
+  asyncTest "renewal can request the previously granted external port":
+    let inner = stub("203.0.113.1")
+
+    let res = await mapUdpPort(PortMapper(inner), Port(9000), Port(51234))
+    check:
+      res.get().externalPort == Port(51234)
+
+  asyncTest "reports discovery failure":
+    let res = await mapUdpPort(PortMapper(stub()), Port(9000), Port(9000))
+    check:
+      res.isErr()
+
+suite "NAT config - retrying port mapper":
+  asyncTest "a clean mapping needs no retry":
+    let
+      inner = stub("203.0.113.1")
+      mapper = RetryingPortMapper.new(inner)
+
+    check:
+      (await mapper.map(Port(7), Port(7), mpTcp, 60)).get() == Port(7)
+      inner.mapCalls == 1
+      inner.unmapCalls == 0
+
+  asyncTest "a rejected mapping is retried after removing the stale entry":
+    let inner = stub("203.0.113.1")
+    inner.mapRejections = 1
+    let mapper = RetryingPortMapper.new(inner)
+
+    check:
+      (await mapper.map(Port(7), Port(7), mpTcp, 60)).get() == Port(7)
+      inner.mapCalls == 2
+      inner.unmapCalls == 1 # the stale entry was removed between attempts
+
+  asyncTest "a mapping that keeps being rejected everywhere fails":
+    let inner = stub("203.0.113.1")
+    inner.mapRejections = 3
+    let mapper = RetryingPortMapper.new(inner)
+
+    check:
+      (await mapper.map(Port(7), Port(7), mpTcp, 60)).isErr()
+      inner.mapCalls == 3 # requested, delete-and-readd, alternate; no loop
+
+  asyncTest "a persistently occupied port falls back to an alternate external port":
+    let inner = stub("203.0.113.1")
+    inner.occupiedPort = Opt.some(Port(7))
+    let mapper = RetryingPortMapper.new(inner)
+
+    let res = await mapper.map(Port(7), Port(7), mpTcp, 60)
+    check:
+      res.isOk()
+      res.get() != Port(7) # mapped, on some other external port
+
+  asyncTest "discover, unmap and close delegate to the wrapped mapper":
+    let
+      inner = stub("203.0.113.1")
+      mapper = RetryingPortMapper.new(inner)
+
+    check:
+      $(await mapper.discover(1.seconds)).get() == "203.0.113.1"
+      (await mapper.unmap(Port(7), mpTcp)).isOk()
+    await mapper.close()
+    check:
+      inner.discoverCalls == 1
+      inner.unmapCalls == 1
+      inner.closeCalls == 1


### PR DESCRIPTION
## PR Description

NAT hardening PR (stack: PR 7 of 8)

Fixes from running against a real gateway: discovery that can hang, mappings a gateway rejects or hands back on a different port, and a mechanism that stops answering.

## Changes

* bound gateway discovery
* recover rejected mappings
* re-elect fallback mappers
* map discv5 UDP and renew it
* refresh the ENR when discv5 renews on a different external port
* project the discv5 external port only with a switch external address
* reject a zero NAT discovery timeout
* refresh ENR on announced-address changes
* announce no guessed external websocket port without a mapping
* extend NAT coverage
