### PR TITLE
chore: raise the CI test job timeout for the nim-libp2p v2.2.0 test cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 80
 
     name: test-${{ matrix.os }}
     steps:


### PR DESCRIPTION
## PR Description

CI timeout PR (stack: PR 8 of 8)

The nim-libp2p v2.2.0 stack adds a module and about 60 tests. The ubuntu test job measured ~57 minutes
against ~49 on master, which leaves too little of the old 60 minute ceiling for a slow
runner. Raises it to 80.

## Changes

* raise the test job timeout from 60 to 80 minutes
