### PR TITLE
fix: partition messages_lookup to stop the index bloat 

### DIFF
--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/migrations.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/migrations.nim
@@ -9,7 +9,7 @@ import
 logScope:
   topics = "waku archive migration"
 
-const SchemaVersion* = 7 # increase this when there is an update in the database schema
+const SchemaVersion* = 8 # increase this when there is an update in the database schema
 
 proc breakIntoStatements*(script: string): seq[string] =
   ## Given a full migration script, that can potentially contain a list

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1230,7 +1230,8 @@ proc addPartition(
   let partitionName = "messages_" & fromInSec & "_" & untilInSec
 
   ## Lookup sibling first: if interrupted here, the missing messages partition
-  ## makes the factory loop retry both (ensureLookupPartitions drops the stray).
+  ## makes the factory loop retry both (dropStrayLookupPartitions removes the
+  ## stray before the next attempt).
   ## PARTITION OF takes a brief ACCESS EXCLUSIVE lock on the small
   ## messages_lookup parent — acceptable hourly; messages avoids it below via
   ## the detached-create + ATTACH dance because its parent sees heavy reads.
@@ -1314,29 +1315,71 @@ proc refreshPartitionsInfo(
 
   return ok()
 
-proc ensureLookupPartitions*(
+proc getAllLookupTableNames(
+    s: PostgresDriver
+): Future[ArchiveDriverResult[seq[string]]] {.async.} =
+  ## Every table named like a lookup partition — attached to messages_lookup
+  ## or left detached by an interrupted reconcile pass.
+  var names: seq[string]
+  proc rowCallback(pqResult: ptr PGresult) =
+    for iRow in 0 ..< pqResult.pqNtuples():
+      names.add($(pqgetvalue(pqResult, iRow, 0)))
+
+  (
+    await s.readConnPool.pgQuery(
+      """SELECT c.relname FROM pg_class c
+           JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE c.relname LIKE 'lookup\_%' AND c.relkind = 'r' AND n.nspname = 'public'
+           ORDER BY c.relname ASC""",
+      newSeq[string](0),
+      rowCallback,
+    )
+  ).isOkOr:
+    return err("getAllLookupTableNames failed in query: " & $error)
+
+  return ok(names)
+
+proc dropStrayLookupPartitions*(
     self: PostgresDriver
 ): Future[ArchiveDriverResult[void]] {.async.} =
-  ## Reconciles the messages_lookup partitions with the messages partitions:
-  ## drops stray lookup partitions left by an interrupted addPartition (their
-  ## range could overlap the next aligned sibling and fail its creation), and
-  ## creates+backfills missing siblings. Runs every factory loop iteration, so
-  ## it also heals gaps opened by old-binary writers sharing the database.
+  ## Drops lookup tables (attached or detached) that have no messages sibling:
+  ## crash leftovers whose range could overlap the next sibling to be created
+  ## and make addPartition fail. Must run before the factory's partition
+  ## checks, else that overlap fatals the boot before the cleanup can act.
   let messagesPartitions = (await self.getPartitionsList()).valueOr:
-    return err("ensureLookupPartitions could not list messages partitions: " & $error)
-  let lookupPartitions = (await self.getPartitionsList("messages_lookup")).valueOr:
-    return err("ensureLookupPartitions could not list lookup partitions: " & $error)
+    return
+      err("dropStrayLookupPartitions could not list messages partitions: " & $error)
+  let lookupTables = (await self.getAllLookupTableNames()).valueOr:
+    return err("dropStrayLookupPartitions could not list lookup tables: " & $error)
 
   ## Partition suffixes ("<startSec>_<endSec>") pair a lookup with its sibling.
   let messagesSuffixes = messagesPartitions.mapIt(it.replace("messages_", ""))
 
-  ## Drop strays first: a stray's range can overlap a sibling about to be created.
-  for lookupPartitionName in lookupPartitions:
-    if lookupPartitionName.replace("lookup_", "") in messagesSuffixes:
+  for lookupTableName in lookupTables:
+    if lookupTableName.replace("lookup_", "") in messagesSuffixes:
       continue
-    info "dropping stray lookup partition", lookupPartitionName
-    (await self.performWriteQuery("DROP TABLE IF EXISTS " & lookupPartitionName)).isOkOr:
-      return err(fmt"error dropping stray [{lookupPartitionName}]: " & $error)
+    info "dropping stray lookup partition", lookupTableName
+    (await self.performWriteQuery("DROP TABLE IF EXISTS " & lookupTableName)).isOkOr:
+      return err(fmt"error dropping stray [{lookupTableName}]: " & $error)
+
+  return ok()
+
+proc ensureLookupPartitions*(
+    self: PostgresDriver
+): Future[ArchiveDriverResult[void]] {.async.} =
+  ## Creates and backfills the lookup sibling of any messages partition that
+  ## lacks one. Runs every factory loop iteration, so it also heals gaps
+  ## opened by old-binary writers sharing the database.
+  ##
+  ## Mirrors the messages-side detached-create + CHECK + ATTACH dance so that
+  ## neither the parent's ACCESS EXCLUSIVE lock nor the advisory lock is held
+  ## for the backfill's duration. Every step is idempotent, and a sibling only
+  ## becomes attached after its backfill committed — an interruption can never
+  ## leave an empty attached partition that the existence check would skip.
+  let messagesPartitions = (await self.getPartitionsList()).valueOr:
+    return err("ensureLookupPartitions could not list messages partitions: " & $error)
+  let lookupPartitions = (await self.getPartitionsList("messages_lookup")).valueOr:
+    return err("ensureLookupPartitions could not list lookup partitions: " & $error)
 
   ## Newest-first, so the partition receiving current writes heals first.
   for i in countdown(messagesPartitions.high, 0):
@@ -1350,18 +1393,47 @@ proc ensureLookupPartitions*(
     if times.len != 2:
       return err(fmt"ensureLookupPartitions wrong partition name {partitionName}")
 
-    ## Create and backfill in one protected DO block (a single transaction):
-    ## an interruption can never leave an empty partition behind, which the
-    ## existence check above would then skip forever.
-    let createAndBackfill =
+    let fromInNanoSec = times[0] & "000000000"
+    let untilInNanoSec = times[1] & "000000000"
+    let constraintName = lookupPartitionName & "_by_range_check"
+
+    ## Detached create: no lock on the parent. INCLUDING INDEXES brings the
+    ## PK along, which the backfill's ON CONFLICT and the ATTACH both need.
+    let createQuery =
       "CREATE TABLE IF NOT EXISTS " & lookupPartitionName &
-      " PARTITION OF messages_lookup FOR VALUES FROM (" & times[0] & "000000000) TO (" &
-      times[1] & "000000000);" &
-      " INSERT INTO messages_lookup (messageHash, timestamp) SELECT messageHash, timestamp FROM " &
-      partitionName & " ON CONFLICT DO NOTHING;"
-    (await self.performWriteQueryWithLock(createAndBackfill)).isOkOr:
+      " (LIKE messages_lookup INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES);"
+    (await self.performWriteQueryWithLock(createQuery)).isOkOr:
       return
         err(fmt"error creating lookup partition [{lookupPartitionName}]: " & $error)
+
+    ## Deliberately NOT the lock wrapper: a failure here must abort the pass
+    ## (retried next iteration) rather than be skip-tolerated, so that a
+    ## sibling can only reach the ATTACH below with a completed backfill.
+    let backfillQuery =
+      "INSERT INTO " & lookupPartitionName &
+      " (messageHash, timestamp) SELECT messageHash, timestamp FROM " & partitionName &
+      " ON CONFLICT DO NOTHING;"
+    (await self.performWriteQuery(backfillQuery)).isOkOr:
+      return err(fmt"error backfilling [{lookupPartitionName}]: " & $error)
+
+    ## The CHECK lets ATTACH validate without a scan, so its lock is brief.
+    let addConstraintQuery =
+      "ALTER TABLE " & lookupPartitionName & " ADD CONSTRAINT " & constraintName &
+      " CHECK ( timestamp >= " & fromInNanoSec & " AND timestamp < " & untilInNanoSec &
+      " );"
+    (await self.performWriteQueryWithLock(addConstraintQuery)).isOkOr:
+      return err(fmt"error adding constraint [{lookupPartitionName}]: " & $error)
+
+    let attachQuery =
+      "ALTER TABLE messages_lookup ATTACH PARTITION " & lookupPartitionName &
+      " FOR VALUES FROM (" & fromInNanoSec & ") TO (" & untilInNanoSec & ");"
+    (await self.performWriteQueryWithLock(attachQuery)).isOkOr:
+      return err(fmt"error attaching [{lookupPartitionName}]: " & $error)
+
+    let dropConstraintQuery =
+      "ALTER TABLE " & lookupPartitionName & " DROP CONSTRAINT " & constraintName & ";"
+    (await self.performWriteQueryWithLock(dropConstraintQuery)).isOkOr:
+      return err(fmt"error dropping constraint [{lookupPartitionName}]: " & $error)
 
     info "created and backfilled lookup partition", lookupPartitionName
 
@@ -1382,6 +1454,13 @@ proc loopPartitionFactory(
 
   while true:
     trace "loopPartitionFactory iteration started"
+
+    ## Before the partition checks: a crash-leftover stray lookup partition
+    ## could overlap the range addPartition is about to create and fatal the
+    ## boot otherwise. Non-fatal so a transient DB error doesn't kill the node.
+    (await self.dropStrayLookupPartitions()).isOkOr:
+      error "failed to drop stray lookup partitions", error = $error
+
     (await self.dropOrphanPartitions()).isOkOr:
       onFatalError("error when dropping orphan partitions: " & $error)
 

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1032,6 +1032,11 @@ method getNewestMessageTimestamp*(
 method deleteOldestMessagesNotWithinLimit*(
     s: PostgresDriver, limit: int
 ): Future[ArchiveDriverResult[void]] {.async.} =
+  ## Capacity retention (`capacity:N`) — known gap: still row-deletes from
+  ## messages and messages_lookup, so heavy use regrows the index bloat that
+  ## #3790 removed for time/size retention. Row-count semantics cannot be
+  ## expressed as partition drops without becoming approximate; converting
+  ## this policy to hourly-drop granularity is left to a follow-up.
   (
     await s.writeConnPool.pgQuery(
       """DELETE FROM messages WHERE messageHash NOT IN
@@ -1540,8 +1545,8 @@ proc dropPartition(
 proc detachAndDropPartition(
     self: PostgresDriver, partition: Partition
 ): Future[ArchiveDriverResult[void]] {.async.} =
-  ## Detaches and drops the desired partition and also removes the rows from messages_lookup table
-  ## whose rows belong to the partition time range
+  ## Detaches and drops the desired messages partition together with its
+  ## messages_lookup sibling partition (no row deletes involved).
 
   let partitionName = partition.getName()
   info "beginning of detachAndDropPartition", partitionName

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -367,12 +367,11 @@ method getAllMessages*(
 
   return ok(rows)
 
-proc getPartitionsList(
-    s: PostgresDriver
+proc getPartitionsList*(
+    s: PostgresDriver, parentTable: string = "messages"
 ): Future[ArchiveDriverResult[seq[string]]] {.async.} =
-  ## Retrieves the seq of partition table names.
+  ## Retrieves the seq of partition table names attached to `parentTable`.
   ## e.g: @["messages_1708534333_1708534393", "messages_1708534273_1708534333"]
-  ## This returns the partitions that are attached to the main messages table.
   var partitions: seq[string]
   proc rowCallback(pqResult: ptr PGresult) =
     for iRow in 0 ..< pqResult.pqNtuples():
@@ -388,7 +387,8 @@ proc getPartitionsList(
                           JOIN pg_class child             ON pg_inherits.inhrelid   = child.oid
                           JOIN pg_namespace nmsp_parent   ON nmsp_parent.oid  = parent.relnamespace
                           JOIN pg_namespace nmsp_child    ON nmsp_child.oid   = child.relnamespace
-                          WHERE parent.relname='messages'
+                          WHERE parent.relname='""" &
+        parentTable & """'
                           ORDER BY partition_name ASC
                           """,
       newSeq[string](0),
@@ -1230,6 +1230,17 @@ proc addPartition(
 
   let partitionName = "messages_" & fromInSec & "_" & untilInSec
 
+  ## Lookup sibling first: if interrupted here, the missing messages partition
+  ## makes the factory loop retry both.
+  let lookupPartitionName = "lookup_" & fromInSec & "_" & untilInSec
+  let createLookupQuery =
+    "CREATE TABLE IF NOT EXISTS " & lookupPartitionName &
+    " PARTITION OF messages_lookup FOR VALUES FROM (" & fromInNanoSec & ") TO (" &
+    untilInNanoSec & ");"
+
+  (await self.performWriteQueryWithLock(createLookupQuery)).isOkOr:
+    return err(fmt"error adding lookup partition [{lookupPartitionName}]: " & $error)
+
   ## Create the partition table but not attach it yet to the main table
   let createPartitionQuery =
     "CREATE TABLE IF NOT EXISTS " & partitionName &
@@ -1301,6 +1312,45 @@ proc refreshPartitionsInfo(
 
   return ok()
 
+proc ensureLookupPartitions*(
+    self: PostgresDriver
+): Future[ArchiveDriverResult[void]] {.async.} =
+  ## Creates and backfills the lookup sibling of any messages partition that
+  ## lacks one. No-op in steady state; does real work right after migration
+  ## v8, or when messages_lookup partitions were dropped by hand.
+  let messagesPartitions = (await self.getPartitionsList()).valueOr:
+    return err("ensureLookupPartitions could not list messages partitions: " & $error)
+  let lookupPartitions = (await self.getPartitionsList("messages_lookup")).valueOr:
+    return err("ensureLookupPartitions could not list lookup partitions: " & $error)
+
+  for partitionName in messagesPartitions:
+    let suffix = partitionName.replace("messages_", "") ## "<start>_<end>" in seconds
+    let lookupPartitionName = "lookup_" & suffix
+    if lookupPartitionName in lookupPartitions:
+      continue
+
+    let times = suffix.split("_")
+    if times.len != 2:
+      return err(fmt"ensureLookupPartitions wrong partition name {partitionName}")
+
+    let createQuery =
+      "CREATE TABLE IF NOT EXISTS " & lookupPartitionName &
+      " PARTITION OF messages_lookup FOR VALUES FROM (" & times[0] & "000000000) TO (" &
+      times[1] & "000000000);"
+    (await self.performWriteQueryWithLock(createQuery)).isOkOr:
+      return
+        err(fmt"error creating lookup partition [{lookupPartitionName}]: " & $error)
+
+    let backfillQuery =
+      "INSERT INTO messages_lookup (messageHash, timestamp) SELECT messageHash, timestamp FROM " &
+      partitionName & " ON CONFLICT DO NOTHING;"
+    (await self.performWriteQuery(backfillQuery)).isOkOr:
+      return err(fmt"error backfilling [{lookupPartitionName}]: " & $error)
+
+    info "created and backfilled lookup partition", lookupPartitionName
+
+  return ok()
+
 const DefaultDatabasePartitionCheckTimeInterval = timer.minutes(10)
 
 proc loopPartitionFactory(
@@ -1313,6 +1363,11 @@ proc loopPartitionFactory(
   ## new partitions when needed.
 
   info "starting loopPartitionFactory"
+
+  ## Non-fatal: hash queries for unbackfilled ranges degrade until the next
+  ## restart, while current-partition pairs are still created by the loop.
+  (await self.ensureLookupPartitions()).isOkOr:
+    error "failed to ensure lookup partitions", error = $error
 
   while true:
     trace "loopPartitionFactory iteration started"
@@ -1395,6 +1450,13 @@ proc detachAndDropPartition(
   let partitionName = partition.getName()
   info "beginning of detachAndDropPartition", partitionName
 
+  ## Drop the lookup sibling first: if interrupted below, the surviving
+  ## messages partition makes the next retention pass retry both.
+  let timeRange = partition.getTimeRange()
+  let lookupPartitionName = "lookup_" & $timeRange.beginning & "_" & $timeRange.`end`
+  (await self.performWriteQuery("DROP TABLE IF EXISTS " & lookupPartitionName)).isOkOr:
+    return err(fmt"error dropping lookup partition [{lookupPartitionName}]: " & $error)
+
   let partSize = (await self.getTableSize(partitionName)).valueOr("")
 
   ## Detach and remove the partition concurrently to not block the parent table (messages)
@@ -1423,13 +1485,6 @@ proc detachAndDropPartition(
 
   info "removed partition", partition_name = partitionName, partition_size = partSize
   self.partitionMngr.removeOldestPartitionName()
-
-  ## Now delete rows from the messages_lookup table
-  let timeRange = partition.getTimeRange()
-  let `end` = timeRange.`end` * 1_000_000_000
-  let deleteRowsQuery = "DELETE FROM messages_lookup WHERE timestamp < " & $`end`
-  (await self.performWriteQuery(deleteRowsQuery)).isOkOr:
-    return err(fmt"error in {deleteRowsQuery}: " & $error)
 
   return ok()
 

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -387,11 +387,10 @@ proc getPartitionsList*(
                           JOIN pg_class child             ON pg_inherits.inhrelid   = child.oid
                           JOIN pg_namespace nmsp_parent   ON nmsp_parent.oid  = parent.relnamespace
                           JOIN pg_namespace nmsp_child    ON nmsp_child.oid   = child.relnamespace
-                          WHERE parent.relname='""" &
-        parentTable & """'
+                          WHERE parent.relname = ?
                           ORDER BY partition_name ASC
                           """,
-      newSeq[string](0),
+      @[parentTable],
       rowCallback,
     )
   ).isOkOr:
@@ -1231,7 +1230,10 @@ proc addPartition(
   let partitionName = "messages_" & fromInSec & "_" & untilInSec
 
   ## Lookup sibling first: if interrupted here, the missing messages partition
-  ## makes the factory loop retry both.
+  ## makes the factory loop retry both (ensureLookupPartitions drops the stray).
+  ## PARTITION OF takes a brief ACCESS EXCLUSIVE lock on the small
+  ## messages_lookup parent — acceptable hourly; messages avoids it below via
+  ## the detached-create + ATTACH dance because its parent sees heavy reads.
   let lookupPartitionName = "lookup_" & fromInSec & "_" & untilInSec
   let createLookupQuery =
     "CREATE TABLE IF NOT EXISTS " & lookupPartitionName &
@@ -1315,16 +1317,31 @@ proc refreshPartitionsInfo(
 proc ensureLookupPartitions*(
     self: PostgresDriver
 ): Future[ArchiveDriverResult[void]] {.async.} =
-  ## Creates and backfills the lookup sibling of any messages partition that
-  ## lacks one. No-op in steady state; does real work right after migration
-  ## v8, or when messages_lookup partitions were dropped by hand.
+  ## Reconciles the messages_lookup partitions with the messages partitions:
+  ## drops stray lookup partitions left by an interrupted addPartition (their
+  ## range could overlap the next aligned sibling and fail its creation), and
+  ## creates+backfills missing siblings. Runs every factory loop iteration, so
+  ## it also heals gaps opened by old-binary writers sharing the database.
   let messagesPartitions = (await self.getPartitionsList()).valueOr:
     return err("ensureLookupPartitions could not list messages partitions: " & $error)
   let lookupPartitions = (await self.getPartitionsList("messages_lookup")).valueOr:
     return err("ensureLookupPartitions could not list lookup partitions: " & $error)
 
-  for partitionName in messagesPartitions:
-    let suffix = partitionName.replace("messages_", "") ## "<start>_<end>" in seconds
+  ## Partition suffixes ("<startSec>_<endSec>") pair a lookup with its sibling.
+  let messagesSuffixes = messagesPartitions.mapIt(it.replace("messages_", ""))
+
+  ## Drop strays first: a stray's range can overlap a sibling about to be created.
+  for lookupPartitionName in lookupPartitions:
+    if lookupPartitionName.replace("lookup_", "") in messagesSuffixes:
+      continue
+    info "dropping stray lookup partition", lookupPartitionName
+    (await self.performWriteQuery("DROP TABLE IF EXISTS " & lookupPartitionName)).isOkOr:
+      return err(fmt"error dropping stray [{lookupPartitionName}]: " & $error)
+
+  ## Newest-first, so the partition receiving current writes heals first.
+  for i in countdown(messagesPartitions.high, 0):
+    let partitionName = messagesPartitions[i]
+    let suffix = partitionName.replace("messages_", "") ## "<startSec>_<endSec>"
     let lookupPartitionName = "lookup_" & suffix
     if lookupPartitionName in lookupPartitions:
       continue
@@ -1333,19 +1350,18 @@ proc ensureLookupPartitions*(
     if times.len != 2:
       return err(fmt"ensureLookupPartitions wrong partition name {partitionName}")
 
-    let createQuery =
+    ## Create and backfill in one protected DO block (a single transaction):
+    ## an interruption can never leave an empty partition behind, which the
+    ## existence check above would then skip forever.
+    let createAndBackfill =
       "CREATE TABLE IF NOT EXISTS " & lookupPartitionName &
       " PARTITION OF messages_lookup FOR VALUES FROM (" & times[0] & "000000000) TO (" &
-      times[1] & "000000000);"
-    (await self.performWriteQueryWithLock(createQuery)).isOkOr:
+      times[1] & "000000000);" &
+      " INSERT INTO messages_lookup (messageHash, timestamp) SELECT messageHash, timestamp FROM " &
+      partitionName & " ON CONFLICT DO NOTHING;"
+    (await self.performWriteQueryWithLock(createAndBackfill)).isOkOr:
       return
         err(fmt"error creating lookup partition [{lookupPartitionName}]: " & $error)
-
-    let backfillQuery =
-      "INSERT INTO messages_lookup (messageHash, timestamp) SELECT messageHash, timestamp FROM " &
-      partitionName & " ON CONFLICT DO NOTHING;"
-    (await self.performWriteQuery(backfillQuery)).isOkOr:
-      return err(fmt"error backfilling [{lookupPartitionName}]: " & $error)
 
     info "created and backfilled lookup partition", lookupPartitionName
 
@@ -1363,11 +1379,6 @@ proc loopPartitionFactory(
   ## new partitions when needed.
 
   info "starting loopPartitionFactory"
-
-  ## Non-fatal: hash queries for unbackfilled ranges degrade until the next
-  ## restart, while current-partition pairs are still created by the loop.
-  (await self.ensureLookupPartitions()).isOkOr:
-    error "failed to ensure lookup partitions", error = $error
 
   while true:
     trace "loopPartitionFactory iteration started"
@@ -1406,6 +1417,12 @@ proc loopPartitionFactory(
         ## Then, let's create the needed partition to contain 'now'.
         (await self.addPartition(now)).isOkOr:
           onFatalError("could not add the next partition: " & $error)
+
+    ## Reconcile lookup siblings every pass. Runs after the partition checks
+    ## so a potentially long backfill never gates the startup partition wait
+    ## in builder.nim. Non-fatal: the next iteration retries.
+    (await self.ensureLookupPartitions()).isOkOr:
+      error "failed to ensure lookup partitions", error = $error
 
     await sleepAsync(DefaultDatabasePartitionCheckTimeInterval)
 
@@ -1450,6 +1467,8 @@ proc detachAndDropPartition(
   let partitionName = partition.getName()
   info "beginning of detachAndDropPartition", partitionName
 
+  ## DROP takes a brief ACCESS EXCLUSIVE lock on the messages_lookup parent
+  ## (queues behind in-flight readers); fine for this small hourly table.
   ## Drop the lookup sibling first: if interrupted below, the surviving
   ## messages partition makes the next retention pass retry both.
   let timeRange = partition.getTimeRange()

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1032,11 +1032,8 @@ method getNewestMessageTimestamp*(
 method deleteOldestMessagesNotWithinLimit*(
     s: PostgresDriver, limit: int
 ): Future[ArchiveDriverResult[void]] {.async.} =
-  ## Capacity retention (`capacity:N`) — known gap: still row-deletes from
-  ## messages and messages_lookup, so heavy use regrows the index bloat that
-  ## #3790 removed for time/size retention. Row-count semantics cannot be
-  ## expressed as partition drops without becoming approximate; converting
-  ## this policy to hourly-drop granularity is left to a follow-up.
+  ## Known gap: capacity retention still row-deletes both tables, regrowing
+  ## index bloat under heavy use. Converting it to partition drops is a follow-up.
   (
     await s.writeConnPool.pgQuery(
       """DELETE FROM messages WHERE messageHash NOT IN
@@ -1234,12 +1231,8 @@ proc addPartition(
 
   let partitionName = "messages_" & fromInSec & "_" & untilInSec
 
-  ## Lookup sibling first: if interrupted here, the missing messages partition
-  ## makes the factory loop retry both (dropStrayLookupPartitions removes the
-  ## stray before the next attempt).
-  ## PARTITION OF takes a brief ACCESS EXCLUSIVE lock on the small
-  ## messages_lookup parent — acceptable hourly; messages avoids it below via
-  ## the detached-create + ATTACH dance because its parent sees heavy reads.
+  ## Sibling first: a crash here leaves a stray that dropStrayLookupPartitions
+  ## removes; the brief ACCESS EXCLUSIVE on the small parent is acceptable.
   let lookupPartitionName = "lookup_" & fromInSec & "_" & untilInSec
   let createLookupQuery =
     "CREATE TABLE IF NOT EXISTS " & lookupPartitionName &
@@ -1323,8 +1316,7 @@ proc refreshPartitionsInfo(
 proc getAllLookupTableNames(
     s: PostgresDriver
 ): Future[ArchiveDriverResult[seq[string]]] {.async.} =
-  ## Every table named like a lookup partition — attached to messages_lookup
-  ## or left detached by an interrupted reconcile pass.
+  ## Lookup-named tables, attached or left detached by an interrupted reconcile.
   var names: seq[string]
   proc rowCallback(pqResult: ptr PGresult) =
     for iRow in 0 ..< pqResult.pqNtuples():
@@ -1347,17 +1339,15 @@ proc getAllLookupTableNames(
 proc dropStrayLookupPartitions*(
     self: PostgresDriver
 ): Future[ArchiveDriverResult[void]] {.async.} =
-  ## Drops lookup tables (attached or detached) that have no messages sibling:
-  ## crash leftovers whose range could overlap the next sibling to be created
-  ## and make addPartition fail. Must run before the factory's partition
-  ## checks, else that overlap fatals the boot before the cleanup can act.
+  ## Drops lookup tables with no messages sibling (crash leftovers). Must run
+  ## before the factory's partition checks: a stray can overlap the next
+  ## sibling's range and make addPartition fail.
   let messagesPartitions = (await self.getPartitionsList()).valueOr:
     return
       err("dropStrayLookupPartitions could not list messages partitions: " & $error)
   let lookupTables = (await self.getAllLookupTableNames()).valueOr:
     return err("dropStrayLookupPartitions could not list lookup tables: " & $error)
 
-  ## Partition suffixes ("<startSec>_<endSec>") pair a lookup with its sibling.
   let messagesSuffixes = messagesPartitions.mapIt(it.replace("messages_", ""))
 
   for lookupTableName in lookupTables:
@@ -1372,15 +1362,9 @@ proc dropStrayLookupPartitions*(
 proc ensureLookupPartitions*(
     self: PostgresDriver
 ): Future[ArchiveDriverResult[void]] {.async.} =
-  ## Creates and backfills the lookup sibling of any messages partition that
-  ## lacks one. Runs every factory loop iteration, so it also heals gaps
-  ## opened by old-binary writers sharing the database.
-  ##
-  ## Mirrors the messages-side detached-create + CHECK + ATTACH dance so that
-  ## neither the parent's ACCESS EXCLUSIVE lock nor the advisory lock is held
-  ## for the backfill's duration. Every step is idempotent, and a sibling only
-  ## becomes attached after its backfill committed — an interruption can never
-  ## leave an empty attached partition that the existence check would skip.
+  ## Creates and backfills missing lookup siblings, newest-first, every loop
+  ## iteration. Detached create + backfill + brief ATTACH keeps parent locks
+  ## short; every step is idempotent and attach implies a completed backfill.
   let messagesPartitions = (await self.getPartitionsList()).valueOr:
     return err("ensureLookupPartitions could not list messages partitions: " & $error)
   let lookupPartitions = (await self.getPartitionsList("messages_lookup")).valueOr:
@@ -1402,8 +1386,7 @@ proc ensureLookupPartitions*(
     let untilInNanoSec = times[1] & "000000000"
     let constraintName = lookupPartitionName & "_by_range_check"
 
-    ## Detached create: no lock on the parent. INCLUDING INDEXES brings the
-    ## PK along, which the backfill's ON CONFLICT and the ATTACH both need.
+    ## INCLUDING INDEXES brings the PK, needed by ON CONFLICT and ATTACH.
     let createQuery =
       "CREATE TABLE IF NOT EXISTS " & lookupPartitionName &
       " (LIKE messages_lookup INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES);"
@@ -1411,9 +1394,8 @@ proc ensureLookupPartitions*(
       return
         err(fmt"error creating lookup partition [{lookupPartitionName}]: " & $error)
 
-    ## Deliberately NOT the lock wrapper: a failure here must abort the pass
-    ## (retried next iteration) rather than be skip-tolerated, so that a
-    ## sibling can only reach the ATTACH below with a completed backfill.
+    ## Plain query on purpose: a failure must abort the pass, never be
+    ## skip-tolerated — the ATTACH below must imply a completed backfill.
     let backfillQuery =
       "INSERT INTO " & lookupPartitionName &
       " (messageHash, timestamp) SELECT messageHash, timestamp FROM " & partitionName &
@@ -1460,9 +1442,7 @@ proc loopPartitionFactory(
   while true:
     trace "loopPartitionFactory iteration started"
 
-    ## Before the partition checks: a crash-leftover stray lookup partition
-    ## could overlap the range addPartition is about to create and fatal the
-    ## boot otherwise. Non-fatal so a transient DB error doesn't kill the node.
+    ## Must precede the partition checks (see dropStrayLookupPartitions).
     (await self.dropStrayLookupPartitions()).isOkOr:
       error "failed to drop stray lookup partitions", error = $error
 
@@ -1502,9 +1482,8 @@ proc loopPartitionFactory(
         (await self.addPartition(now)).isOkOr:
           onFatalError("could not add the next partition: " & $error)
 
-    ## Reconcile lookup siblings every pass. Runs after the partition checks
-    ## so a potentially long backfill never gates the startup partition wait
-    ## in builder.nim. Non-fatal: the next iteration retries.
+    ## After the partition checks, so a long backfill never gates builder.nim's
+    ## startup partition wait; non-fatal, the next pass retries.
     (await self.ensureLookupPartitions()).isOkOr:
       error "failed to ensure lookup partitions", error = $error
 
@@ -1545,16 +1524,13 @@ proc dropPartition(
 proc detachAndDropPartition(
     self: PostgresDriver, partition: Partition
 ): Future[ArchiveDriverResult[void]] {.async.} =
-  ## Detaches and drops the desired messages partition together with its
-  ## messages_lookup sibling partition (no row deletes involved).
+  ## Detaches and drops the messages partition together with its lookup sibling.
 
   let partitionName = partition.getName()
   info "beginning of detachAndDropPartition", partitionName
 
-  ## DROP takes a brief ACCESS EXCLUSIVE lock on the messages_lookup parent
-  ## (queues behind in-flight readers); fine for this small hourly table.
-  ## Drop the lookup sibling first: if interrupted below, the surviving
-  ## messages partition makes the next retention pass retry both.
+  ## Sibling first: a crash below leaves the messages partition, so the next
+  ## retention pass retries both.
   let timeRange = partition.getTimeRange()
   let lookupPartitionName = "lookup_" & $timeRange.beginning & "_" & $timeRange.`end`
   (await self.performWriteQuery("DROP TABLE IF EXISTS " & lookupPartitionName)).isOkOr:

--- a/migrations/message_store_postgres/content_script_version_8.nim
+++ b/migrations/message_store_postgres/content_script_version_8.nim
@@ -6,6 +6,8 @@ const ContentScriptVersion_8* = """
 -- Rows are rebuilt from the messages partitions by ensureLookupPartitions at
 -- driver startup. The redundant idx_messages_lookup_messagehash is not
 -- recreated: the primary key already covers messagehash as leading column.
+-- idx_messages_lookup_timestamp is likewise gone: retention no longer deletes
+-- by timestamp, and partition pruning plus the per-partition PK cover reads.
 DROP TABLE IF EXISTS messages_lookup;
 
 CREATE TABLE messages_lookup (

--- a/migrations/message_store_postgres/content_script_version_8.nim
+++ b/migrations/message_store_postgres/content_script_version_8.nim
@@ -1,0 +1,20 @@
+const ContentScriptVersion_8* = """
+
+-- Recreate messages_lookup as a partitioned table (issue #3790): retention now
+-- drops hourly lookup partitions in lockstep with the messages partitions,
+-- instead of bulk-DELETEs whose dead index space was never reclaimed.
+-- Rows are rebuilt from the messages partitions by ensureLookupPartitions at
+-- driver startup. The redundant idx_messages_lookup_messagehash is not
+-- recreated: the primary key already covers messagehash as leading column.
+DROP TABLE IF EXISTS messages_lookup;
+
+CREATE TABLE messages_lookup (
+   timestamp BIGINT NOT NULL,
+   messageHash VARCHAR NOT NULL,
+   CONSTRAINT messageIndexLookupTable PRIMARY KEY (messageHash, timestamp)
+  ) PARTITION BY RANGE (timestamp);
+
+-- Update to new version
+UPDATE version SET version = 8 WHERE version = 7;
+
+"""

--- a/migrations/message_store_postgres/content_script_version_8.nim
+++ b/migrations/message_store_postgres/content_script_version_8.nim
@@ -3,8 +3,8 @@ const ContentScriptVersion_8* = """
 -- Recreate messages_lookup as a partitioned table (issue #3790): retention now
 -- drops hourly lookup partitions in lockstep with the messages partitions,
 -- instead of bulk-DELETEs whose dead index space was never reclaimed.
--- Rows are rebuilt from the messages partitions by ensureLookupPartitions at
--- driver startup. The redundant idx_messages_lookup_messagehash is not
+-- Rows are rebuilt from the messages partitions by the partition factory's
+-- reconcile pass (ensureLookupPartitions, every iteration). The redundant idx_messages_lookup_messagehash is not
 -- recreated: the primary key already covers messagehash as leading column.
 -- idx_messages_lookup_timestamp is likewise gone: retention no longer deletes
 -- by timestamp, and partition pruning plus the per-partition PK cover reads.

--- a/migrations/message_store_postgres/content_script_version_8.nim
+++ b/migrations/message_store_postgres/content_script_version_8.nim
@@ -1,13 +1,10 @@
 const ContentScriptVersion_8* = """
 
--- Recreate messages_lookup as a partitioned table (issue #3790): retention now
--- drops hourly lookup partitions in lockstep with the messages partitions,
--- instead of bulk-DELETEs whose dead index space was never reclaimed.
--- Rows are rebuilt from the messages partitions by the partition factory's
--- reconcile pass (ensureLookupPartitions, every iteration). The redundant idx_messages_lookup_messagehash is not
--- recreated: the primary key already covers messagehash as leading column.
--- idx_messages_lookup_timestamp is likewise gone: retention no longer deletes
--- by timestamp, and partition pruning plus the per-partition PK cover reads.
+-- Recreate messages_lookup as a partitioned table (#3790): retention drops
+-- hourly lookup partitions with their messages siblings instead of running
+-- bulk DELETEs that bloat the indexes. Rows are rebuilt from the messages
+-- partitions by ensureLookupPartitions. The old secondary indexes are not
+-- recreated: the PK covers hash lookups, partition pruning covers time.
 DROP TABLE IF EXISTS messages_lookup;
 
 CREATE TABLE messages_lookup (

--- a/migrations/message_store_postgres/pg_migration_manager.nim
+++ b/migrations/message_store_postgres/pg_migration_manager.nim
@@ -1,7 +1,7 @@
 import
   content_script_version_1, content_script_version_2, content_script_version_3,
   content_script_version_4, content_script_version_5, content_script_version_6,
-  content_script_version_7
+  content_script_version_7, content_script_version_8
 
 type MigrationScript* = object
   version*: int
@@ -18,6 +18,7 @@ const PgMigrationScripts* = @[
   MigrationScript(version: 5, scriptContent: ContentScriptVersion_5),
   MigrationScript(version: 6, scriptContent: ContentScriptVersion_6),
   MigrationScript(version: 7, scriptContent: ContentScriptVersion_7),
+  MigrationScript(version: 8, scriptContent: ContentScriptVersion_8),
 ]
 
 proc getMigrationScripts*(currentVersion: int64, targetVersion: int64): seq[string] =

--- a/tests/testlib/postgres.nim
+++ b/tests/testlib/postgres.nim
@@ -7,7 +7,7 @@ import
     waku_archive/driver/postgres_driver,
   ]
 
-const storeMessageDbUrl = "postgres://postgres:test123@localhost:5432/postgres"
+const storeMessageDbUrl* = "postgres://postgres:test123@localhost:5432/postgres"
 
 proc newTestPostgresDriver*(): Future[Result[ArchiveDriver, string]] {.async.} =
   proc onErr(errMsg: string) {.gcsafe, closure.} =

--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -219,25 +219,35 @@ suite "Postgres driver":
 
     check (await driver.getMessages(hashes = @[hash])).expect("healed query").len == 1
 
-  asyncTest "ensureLookupPartitions drops stray lookup partitions":
-    ## A crash between sibling creations can leave a lookup partition with no
-    ## messages sibling; unremoved, its range could overlap a future sibling
-    ## and make addPartition fail. The reconcile pass must drop it.
-    const strayName = "lookup_4102444800_4102448400" ## far future: year 2100
+  asyncTest "dropStrayLookupPartitions removes attached and detached strays":
+    ## A crash can leave a lookup partition with no messages sibling — either
+    ## attached (addPartition interrupted) or detached (reconcile interrupted).
+    ## Unremoved, an attached stray's range could overlap a future sibling and
+    ## make addPartition fatal on boot; the cleanup must drop both kinds.
+    const attachedStray = "lookup_4102444800_4102448400" ## far future: year 2100
+    const detachedStray = "lookup_4102448400_4102452000"
 
     let rawPool = PgAsyncPool.new(storeMessageDbUrl, 1).expect("raw pool")
     (
       await rawPool.pgQuery(
-        "CREATE TABLE IF NOT EXISTS " & strayName &
+        "CREATE TABLE IF NOT EXISTS " & attachedStray &
           " PARTITION OF messages_lookup FOR VALUES FROM (4102444800000000000) TO (4102448400000000000);"
       )
-    ).expect("create stray")
+    ).expect("create attached stray")
+    (
+      await rawPool.pgQuery(
+        "CREATE TABLE IF NOT EXISTS " & detachedStray &
+          " (timestamp BIGINT NOT NULL, messageHash VARCHAR NOT NULL);"
+      )
+    ).expect("create detached stray")
     (await rawPool.close()).expect("close raw pool")
 
-    check strayName in
+    check attachedStray in
       (await driver.getPartitionsList("messages_lookup")).expect("lookup list")
+    check (await driver.existsTable(detachedStray)).expect("existsTable")
 
-    (await driver.ensureLookupPartitions()).expect("ensureLookupPartitions")
+    (await driver.dropStrayLookupPartitions()).expect("dropStrayLookupPartitions")
 
-    check strayName notin
+    check attachedStray notin
       (await driver.getPartitionsList("messages_lookup")).expect("lookup list")
+    check not (await driver.existsTable(detachedStray)).expect("existsTable")

--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -1,16 +1,19 @@
 {.used.}
 
-import results, std/sequtils, testutils/unittests, chronos
+import results, std/[sequtils, strutils], testutils/unittests, chronos
 import
   logos_delivery/waku/[
     waku_archive,
     waku_archive/driver/postgres_driver,
     waku_core,
     waku_core/message/digest,
+    common/databases/db_postgres/pgasyncpool,
   ],
   ../testlib/wakucore,
   ../testlib/testasync,
   ../testlib/postgres
+
+const TestDbUrl = "postgres://postgres:test123@localhost:5432/postgres"
 
 suite "Postgres driver":
   ## Unique driver instance
@@ -169,3 +172,51 @@ suite "Postgres driver":
 
     assert newNumMsgs == (initialNumMsgs + 1.int64),
       "wrong number of messages: " & $newNumMsgs
+
+  asyncTest "messages_lookup partitions are created and dropped with messages partitions":
+    ## Issue #3790: lookup rows are pruned by dropping hourly partitions in
+    ## lockstep with the messages partitions, never by bulk DELETEs.
+    let msg = fakeWakuMessage(ts = now())
+    require (
+      await driver.put(
+        computeMessageHash(DefaultPubsubTopic, msg), DefaultPubsubTopic, msg
+      )
+    ).isOk()
+
+    let msgPartitions =
+      (await driver.getPartitionsList("messages")).expect("messages list")
+    let lookupPartitions =
+      (await driver.getPartitionsList("messages_lookup")).expect("lookup list")
+    check msgPartitions.len > 0
+    check lookupPartitions.len == msgPartitions.len
+    for p in msgPartitions:
+      check ("lookup_" & p.replace("messages_", "")) in lookupPartitions
+
+    ## dropping every messages partition must take the lookup siblings with it
+    require (await driver.reset()).isOk()
+    check (await driver.getPartitionsList("messages_lookup")).expect("lookup list").len ==
+      0
+
+  asyncTest "ensureLookupPartitions rebuilds dropped lookup partitions":
+    ## Simulates a hand-dropped messages_lookup: hash queries degrade, and
+    ## ensureLookupPartitions recreates and backfills from messages partitions.
+    let msg = fakeWakuMessage(ts = now())
+    let hash = computeMessageHash(DefaultPubsubTopic, msg)
+    require (await driver.put(hash, DefaultPubsubTopic, msg)).isOk()
+
+    check (await driver.getMessages(hashes = @[hash])).expect("hash query").len == 1
+
+    ## drop every lookup partition behind the driver's back
+    let rawPool = PgAsyncPool.new(TestDbUrl, 1).expect("raw pool")
+    let lookupPartitions =
+      (await driver.getPartitionsList("messages_lookup")).expect("lookup list")
+    require lookupPartitions.len > 0
+    for p in lookupPartitions:
+      (await rawPool.pgQuery("DROP TABLE IF EXISTS " & p)).expect("drop " & p)
+    (await rawPool.close()).expect("close raw pool")
+
+    check (await driver.getMessages(hashes = @[hash])).expect("degraded query").len == 0
+
+    (await driver.ensureLookupPartitions()).expect("ensureLookupPartitions")
+
+    check (await driver.getMessages(hashes = @[hash])).expect("healed query").len == 1

--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -172,8 +172,7 @@ suite "Postgres driver":
       "wrong number of messages: " & $newNumMsgs
 
   asyncTest "messages_lookup partitions are created and dropped with messages partitions":
-    ## Issue #3790: lookup rows are pruned by dropping hourly partitions in
-    ## lockstep with the messages partitions, never by bulk DELETEs.
+    ## Lookup partitions are created and dropped in lockstep — no row deletes.
     let msg = fakeWakuMessage(ts = now())
     require (
       await driver.put(
@@ -196,8 +195,7 @@ suite "Postgres driver":
       0
 
   asyncTest "ensureLookupPartitions rebuilds dropped lookup partitions":
-    ## Simulates a hand-dropped messages_lookup: hash queries degrade, and
-    ## ensureLookupPartitions recreates and backfills from messages partitions.
+    ## Dropped lookup partitions degrade hash queries; ensure heals them.
     let msg = fakeWakuMessage(ts = now())
     let hash = computeMessageHash(DefaultPubsubTopic, msg)
     require (await driver.put(hash, DefaultPubsubTopic, msg)).isOk()
@@ -220,10 +218,8 @@ suite "Postgres driver":
     check (await driver.getMessages(hashes = @[hash])).expect("healed query").len == 1
 
   asyncTest "dropStrayLookupPartitions removes attached and detached strays":
-    ## A crash can leave a lookup partition with no messages sibling — either
-    ## attached (addPartition interrupted) or detached (reconcile interrupted).
-    ## Unremoved, an attached stray's range could overlap a future sibling and
-    ## make addPartition fatal on boot; the cleanup must drop both kinds.
+    ## Crash leftovers: lookup tables with no messages sibling, attached or
+    ## detached — the cleanup must drop both kinds.
     const attachedStray = "lookup_4102444800_4102448400" ## far future: year 2100
     const detachedStray = "lookup_4102448400_4102452000"
 

--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -13,8 +13,6 @@ import
   ../testlib/testasync,
   ../testlib/postgres
 
-const TestDbUrl = "postgres://postgres:test123@localhost:5432/postgres"
-
 suite "Postgres driver":
   ## Unique driver instance
   var driver {.threadvar.}: PostgresDriver
@@ -207,7 +205,7 @@ suite "Postgres driver":
     check (await driver.getMessages(hashes = @[hash])).expect("hash query").len == 1
 
     ## drop every lookup partition behind the driver's back
-    let rawPool = PgAsyncPool.new(TestDbUrl, 1).expect("raw pool")
+    let rawPool = PgAsyncPool.new(storeMessageDbUrl, 1).expect("raw pool")
     let lookupPartitions =
       (await driver.getPartitionsList("messages_lookup")).expect("lookup list")
     require lookupPartitions.len > 0
@@ -220,3 +218,26 @@ suite "Postgres driver":
     (await driver.ensureLookupPartitions()).expect("ensureLookupPartitions")
 
     check (await driver.getMessages(hashes = @[hash])).expect("healed query").len == 1
+
+  asyncTest "ensureLookupPartitions drops stray lookup partitions":
+    ## A crash between sibling creations can leave a lookup partition with no
+    ## messages sibling; unremoved, its range could overlap a future sibling
+    ## and make addPartition fail. The reconcile pass must drop it.
+    const strayName = "lookup_4102444800_4102448400" ## far future: year 2100
+
+    let rawPool = PgAsyncPool.new(storeMessageDbUrl, 1).expect("raw pool")
+    (
+      await rawPool.pgQuery(
+        "CREATE TABLE IF NOT EXISTS " & strayName &
+          " PARTITION OF messages_lookup FOR VALUES FROM (4102444800000000000) TO (4102448400000000000);"
+      )
+    ).expect("create stray")
+    (await rawPool.close()).expect("close raw pool")
+
+    check strayName in
+      (await driver.getPartitionsList("messages_lookup")).expect("lookup list")
+
+    (await driver.ensureLookupPartitions()).expect("ensureLookupPartitions")
+
+    check strayName notin
+      (await driver.getPartitionsList("messages_lookup")).expect("lookup list")


### PR DESCRIPTION
## Problem

Store nodes have two tables. The big one (`messages`) is cleaned by dropping hourly partitions — instant and clean. The small helper table (`messages_lookup`) is cleaned by deleting rows every 30 minutes. In Postgres, deleted rows leave dead space in indexes that is never given back. After months of this, ~20 MB of real data was buried under up to 1.3 GB of dead index per node — and while each cleanup pass waded through that dead space, the whole database briefly stalled, so any query running at that moment took >1s, even `SELECT version();`. That is the slowQuery alert storm in #3790.

## Fix

Make `messages_lookup` partitioned, exactly like `messages`:

- a lookup partition is created together with each hourly messages partition,
- retention drops them together — no row deletes in time/size retention, so the dead-space buildup becomes impossible,
- every factory pass reconciles the two tables: missing lookup partitions are rebuilt from stored messages (crash-safe — a partition only becomes visible after its backfill completed), which also auto-repairs databases where the table was dropped by hand.

Tests: three new ones (partition lockstep; rebuild path; stray cleanup), plus the full archive suite — 155/155 against real Postgres 15.

## Upgrade note

Right after the migration, hash-based store queries may briefly return empty while `messages_lookup` is rebuilt from stored messages (newest first; seconds on current fleet data).

## What this PR does NOT fix (known, tracked separately)

- **`capacity:N` retention** still row-deletes — an exact row-count promise cannot be expressed as partition drops. Documented in code; unused by our fleets; convert-or-deprecate tracked in #4123.
- **Client query storms:** a single js-waku client sending ~800 concurrent store queries each morning saturates the DB regardless of schema. Needs store request rate-limiting enabled in the fleet config (the code support already exists) — follow-up issue.

close #3790
