### PR TITLE
fix(ci): misc CI fixes

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -10,6 +10,8 @@ env:
   MAKEFLAGS: "-j${NPROC}"
   NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
   NIM_PARAMS: "-d:disableMarchNative"
+  NIM_VERSION: '2.2.4'
+  NIMBLE_VERSION: '0.22.3'
 
 jobs:
   build:
@@ -24,6 +26,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # macos images ship no nim/nimble; make dies at "nimble: No such file or directory".
+      - name: Install Nim ${{ env.NIM_VERSION }}
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
+        run: |
+          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
+          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
 
       - name: Get submodules hash
         id: submodules

--- a/.github/workflows/ci-rln-simulator.yml
+++ b/.github/workflows/ci-rln-simulator.yml
@@ -161,6 +161,9 @@ jobs:
       - name: Write simulator .env
         working-directory: ${{ runner.temp }}/logos-delivery-simulator
         run: |
+          # Deploy the contract revision this repo vendors, so they can't drift.
+          CONTRACT_COMMIT=$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD:vendor/waku-rlnv2-contract)
+          echo "contract commit (from vendor/waku-rlnv2-contract): $CONTRACT_COMMIT"
           cat > .env <<EOF
           LD_IMAGE=nwaku-rln-ci:test
           NUM_LD_NODES=${{ steps.cfg.outputs.num_nodes }}
@@ -172,7 +175,7 @@ jobs:
           RPC_URL=http://foundry:8545
           PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
           ETH_FROM=0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
-          RLN_CONTRACT_REPO_COMMIT=e75ac913e579ad872f54b2225eec35d1de3d98b0
+          RLN_CONTRACT_REPO_COMMIT=${CONTRACT_COMMIT}
           WATCHTOWER_ENABLED=false
           EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,9 @@ jobs:
   # still run on docker-only PRs (no liblogosdelivery build required).
   nwaku-nwaku-interop-tests:
     needs: build-docker-image
-    uses: logos-messaging/logos-delivery-interop-tests/.github/workflows/nim_waku_PR.yml@SMOKE_TEST_2026.06.25
+    # The commit is tag SMOKE_TEST_2026.06.25; annotated tag refs break nested
+    # workflow resolution on push events, so pin the commit. Re-pin on bumps.
+    uses: logos-messaging/logos-delivery-interop-tests/.github/workflows/nim_waku_PR.yml@6980880dba70aebe443b1ea1864891940980ecea
     with:
       node_nwaku: ${{ needs.build-docker-image.outputs.image }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -14,6 +14,8 @@ env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
   NIMFLAGS: "--parallelBuild:${NPROC}"
+  NIM_VERSION: '2.2.4'
+  NIMBLE_VERSION: '0.22.3'
 
 jobs:
   tag-name:
@@ -43,6 +45,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # macos images ship no nim/nimble; make dies at "nimble: No such file or directory".
+      - name: Install Nim ${{ env.NIM_VERSION }}
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
+        run: |
+          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
+          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
 
       - name: prep variables
         id: vars
@@ -100,6 +114,10 @@ jobs:
   js-waku-node:
     needs: build-docker-image
     uses: logos-messaging/logos-delivery-js/.github/workflows/test-node.yml@master
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     with:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node
@@ -108,6 +126,10 @@ jobs:
   js-waku-node-optional:
     needs: build-docker-image
     uses: logos-messaging/logos-delivery-js/.github/workflows/test-node.yml@master
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     with:
       nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
       test_type: node-optional

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -9,6 +9,8 @@ on:
 
 env:
   NPROC: 2
+  NIM_VERSION: '2.2.4'
+  NIMBLE_VERSION: '0.22.3'
 
 jobs:
   # Release gate: the pushed tag MUST exactly match logos_delivery.nimble's version,
@@ -54,7 +56,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Install Nim ${{ env.NIM_VERSION }}
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
+        run: |
+          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
+          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
 
       - name: Get submodules hash
         id: submodules
@@ -74,6 +87,9 @@ jobs:
         run: |
           # Use full tag, e.g., v0.37.0
           echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+          # Same strip as verify-version's TAG_VERSION; dpkg rejects a version
+          # that does not start with a digit.
+          echo "deb_version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Prep variables
         id: vars
@@ -82,16 +98,6 @@ jobs:
 
           NWAKU_ARTIFACT_NAME=$(echo "waku-${{matrix.arch}}-${{runner.os}}.tar.gz" | tr "[:upper:]" "[:lower:]")
           echo "waku=${NWAKU_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
-
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            LIBWAKU_ARTIFACT_NAME=$(echo "libwaku-${VERSION}-${{matrix.arch}}-${{runner.os}}-linux.deb" | tr "[:upper:]" "[:lower:]")
-          fi
-
-          if [[ "${{ runner.os }}" == "macOS" ]]; then
-            LIBWAKU_ARTIFACT_NAME=$(echo "libwaku-${VERSION}-${{matrix.arch}}-macos.tar.gz" | tr "[:upper:]" "[:lower:]")
-          fi
-
-          echo "libwaku=${LIBWAKU_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             LIBLOGOSDELIVERY_ARTIFACT_NAME=$(echo "liblogosdelivery-${VERSION}-${{matrix.arch}}-${{runner.os}}-linux.deb" | tr "[:upper:]" "[:lower:]")
@@ -119,37 +125,8 @@ jobs:
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false logosdeliverynode
           tar -cvzf ${{steps.vars.outputs.waku}} ./build/
 
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false libwaku
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false STATIC=1 libwaku
-
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false liblogosdelivery
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false STATIC=1 liblogosdelivery
-
-      - name: Create distributable libwaku package
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            rm -rf pkg
-            mkdir -p pkg/DEBIAN pkg/usr/local/lib pkg/usr/local/include
-            cp build/libwaku.so pkg/usr/local/lib/
-            cp build/libwaku.a pkg/usr/local/lib/
-            cp library/libwaku.h pkg/usr/local/include/
-
-            echo "Package: waku" >> pkg/DEBIAN/control
-            echo "Version: ${VERSION}" >> pkg/DEBIAN/control
-            echo "Priority: optional" >> pkg/DEBIAN/control
-            echo "Section: libs" >> pkg/DEBIAN/control
-            echo "Architecture: ${{matrix.arch}}" >> pkg/DEBIAN/control
-            echo "Maintainer: Waku Team <ivansete@status.im>" >> pkg/DEBIAN/control
-            echo "Description: Waku library" >> pkg/DEBIAN/control
-
-            dpkg-deb --build pkg ${{steps.vars.outputs.libwaku}}
-          fi
-
-          if [[ "${{ runner.os }}" == "macOS" ]]; then
-            tar -cvzf ${{steps.vars.outputs.libwaku}} ./build/libwaku.dylib ./build/libwaku.a ./library/libwaku.h
-          fi
 
       - name: Create distributable liblogosdelivery package
         run: |
@@ -164,7 +141,7 @@ jobs:
             cp library/liblogosdelivery_kernel.h pkg/usr/local/include/
 
             echo "Package: logosdelivery" >> pkg/DEBIAN/control
-            echo "Version: ${VERSION}" >> pkg/DEBIAN/control
+            echo "Version: ${{ steps.version.outputs.deb_version }}" >> pkg/DEBIAN/control
             echo "Priority: optional" >> pkg/DEBIAN/control
             echo "Section: libs" >> pkg/DEBIAN/control
             echo "Architecture: ${{matrix.arch}}" >> pkg/DEBIAN/control
@@ -175,7 +152,7 @@ jobs:
           fi
 
           if [[ "${{ runner.os }}" == "macOS" ]]; then
-            tar -cvzf ${{steps.vars.outputs.liblogosdelivery}} ./build/liblogosdelivery.dylib ./build/liblogosdelivery.a ./liblogosdelivery/liblogosdelivery.h
+            tar -cvzf ${{steps.vars.outputs.liblogosdelivery}} ./build/liblogosdelivery.dylib ./build/liblogosdelivery.a ./library/liblogosdelivery.h ./library/liblogosdelivery_kernel.h
           fi
 
       - name: Upload waku artifact
@@ -183,13 +160,6 @@ jobs:
         with:
           name: waku-${{ steps.version.outputs.version }}-${{ matrix.arch }}-${{ runner.os }}
           path: ${{ steps.vars.outputs.waku }}
-          if-no-files-found: error
-
-      - name: Upload libwaku artifact
-        uses: actions/upload-artifact@v4.4.0
-        with:
-          name: libwaku-${{ steps.version.outputs.version }}-${{ matrix.arch }}-${{ runner.os }}
-          path: ${{ steps.vars.outputs.libwaku }}
           if-no-files-found: error
 
       - name: Upload liblogosdelivery artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,8 +101,7 @@ Note: The build uses `--mm:refc` memory management (passed automatically by the 
 make wakunode2          # Build main node binary
 make test               # Run all tests
 make testcommon         # Run common tests only
-make libwaku            # Build the legacy C library (libwaku)
-make liblogosdelivery. # Build actual C FFI library
+make liblogosdelivery   # Build the C FFI library
 make chat2              # Build chat example
 make install-nph        # Install git hook for auto-formatting
 ```

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -112,7 +112,7 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
 
   if `type` == "static":
     exec "nim c" & " --out:build/" & lib_name &
-      " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
+      " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
       getMyCPU() & getNimParams() & srcDir & "/" & srcFile
   else:
     # -Bsymbolic binds the library's references to its own symbols at link

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -17,7 +17,7 @@ const RequiredNimbleVersion = "0.22.3"
 
 ### Dependencies
 requires "nim >= 2.2.4",
-  "chronos >= 4.2.0",
+  "chronos >= 4.2.0 & < 4.4.0",
   "taskpools",
   # Logging & Configuration
   "chronicles",

--- a/logos_delivery/waku/persistency/persistency.nim
+++ b/logos_delivery/waku/persistency/persistency.nim
@@ -136,19 +136,17 @@ proc ensureRootDir(p: Persistency): Result[void, PersistencyError] =
   return ok()
 
 proc reset*(T: type Persistency) {.gcsafe.} =
-  ## Tear down the singleton: close every open job and free the slot so a
-  ## subsequent ``Persistency.instance`` starts fresh. Idempotent. Tests
-  ## use this in `defer`.
+  ## Tear down the singleton: close every open job, clear the Teardown
+  ## provider, and free the slot so a subsequent ``Persistency.instance``
+  ## starts fresh. Idempotent. Tests use this in `defer`;.
   {.cast(gcsafe).}:
     acquire(gPersistencyLock)
     defer:
       release(gPersistencyLock)
     if gPersistency != nil:
-      # Close first: refc emits no incref for `let p = gPersistency`, so
-      # nulling the global frees the object before close() can read it.
-      gPersistency.close()
-
+      let p = gPersistency
       gPersistency = nil
+      p.close()
 
 proc instance*(
     T: type Persistency, rootDir: string
@@ -181,12 +179,6 @@ proc instance*(
       )
 
     let p = ?Persistency.new(rootDir)
-
-    # Pin it for the process lifetime. Nodes run on pooled FFI threads, so this
-    # gets created on one thread and released on another, and under refc that
-    # frees into the wrong thread's heap. Leaks one small object per reset.
-    GC_ref(p)
-
     gPersistency = p
     return ok(p)
 

--- a/logos_delivery/waku/persistency/persistency.nim
+++ b/logos_delivery/waku/persistency/persistency.nim
@@ -136,17 +136,19 @@ proc ensureRootDir(p: Persistency): Result[void, PersistencyError] =
   return ok()
 
 proc reset*(T: type Persistency) {.gcsafe.} =
-  ## Tear down the singleton: close every open job, clear the Teardown
-  ## provider, and free the slot so a subsequent ``Persistency.instance``
-  ## starts fresh. Idempotent. Tests use this in `defer`;.
+  ## Tear down the singleton: close every open job and free the slot so a
+  ## subsequent ``Persistency.instance`` starts fresh. Idempotent. Tests
+  ## use this in `defer`.
   {.cast(gcsafe).}:
     acquire(gPersistencyLock)
     defer:
       release(gPersistencyLock)
     if gPersistency != nil:
-      let p = gPersistency
+      # Close first: refc emits no incref for `let p = gPersistency`, so
+      # nulling the global frees the object before close() can read it.
+      gPersistency.close()
+
       gPersistency = nil
-      p.close()
 
 proc instance*(
     T: type Persistency, rootDir: string
@@ -179,6 +181,12 @@ proc instance*(
       )
 
     let p = ?Persistency.new(rootDir)
+
+    # Pin it for the process lifetime. Nodes run on pooled FFI threads, so this
+    # gets created on one thread and released on another, and under refc that
+    # frees into the wrong thread's heap. Leaks one small object per reset.
+    GC_ref(p)
+
     gPersistency = p
     return ok(p)
 

--- a/tests/simulator/rln-e2e-test.py
+++ b/tests/simulator/rln-e2e-test.py
@@ -364,6 +364,10 @@ def main() -> int:
         print("\nABORTING — fleet never reached a publishable state.")
         return _summarize(results)
 
+    # A publish into an empty gossipsub mesh is dropped but still returns 200,
+    # so WARMUP can pass before the sender has peers. Let the mesh settle.
+    time.sleep(10)
+
     run(scenario_propagation, nodes[0], nodes[1:])
     # Rate limit: per-node burst, asserts exactly msg_limit then 500.
     # Requires epoch_sec large enough that the burst can't straddle an epoch.


### PR DESCRIPTION
## Description

This PR applies various CI fixes.

## Changes

* fix interop workflow pin not working due to using annotated tag
*  ̶f̶i̶x̶ ̶r̶e̶f̶c̶ ̶s̶e̶g̶f̶a̶u̶l̶t̶ ̶i̶n̶ ̶p̶e̶r̶s̶i̶s̶t̶e̶n̶c̶y̶.̶n̶i̶m̶
* fix logos_delivery.nimble to use --skipParentCfg:off for static lib
* install nim and nimble (missing in macos)
* pre-release.yml: set explicit permissions on the js-waku test jobs
* release-assets.yml: delete old libwaku steps
* release-assets.yml: package the macOS headers from library/
* release-assets.yml: strip the leading v for the deb Version field (dpkg rejects it)
* release-assets.yml: bump checkout v2 to v4
* ci-rln-simulator.yml: deploy the contract commit from vendor/waku-rlnv2-contract
* rln-e2e-test.py: 10s mesh settle before PROPAGATION (workaround for REST 200-on-zero-peers)
* drop the removed make libwaku target in AGENTS.md
* cap chronos to < 4.4.0 since logos-delivery isn't compatible yet

## Issue

Maintenance Y2026H2 #4043 