### PR TITLE
fix(ci): nightly pre-release and release-assets fixes

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ env:
 
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC}"
+  NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.4'
   NIMBLE_VERSION: '0.22.3'
 
@@ -27,7 +27,9 @@ jobs:
     - name: Vars
       id: vars
       run: |
-        TAG=$([[ "${{github.ref}}" == "refs/heads/master" ]] && echo "${{env.RELEASE_NAME}}" || echo ${{github.ref}} | sed 's#refs/tags/##')
+        # master -> nightly; other refs use their bare name, "/" replaced by "-".
+        # TAG=$([[ "${{github.ref}}" == "refs/heads/master" ]] && echo "${{env.RELEASE_NAME}}" || echo ${{github.ref}} | sed 's#refs/tags/##')
+        TAG=$([[ "${{github.ref}}" == "refs/heads/master" ]] && echo "${{env.RELEASE_NAME}}" || echo "${{github.ref_name}}" | tr '/' '-')
         echo "tag=${TAG}" >> $GITHUB_OUTPUT
     outputs:
       tag: ${{steps.vars.outputs.tag}}
@@ -35,10 +37,14 @@ jobs:
   build-and-publish:
     needs: tag-name
     strategy:
+      # Without fail-fast: false, one failed job cancels the other jobs and
+      # hides their results.
+      fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-15]
-        arch: [amd64]
+        # GitHub macOS runners are arm64 only; darwin/amd64 needs a cross-compilation setup.
         include:
+        - os: ubuntu-22.04
+          arch: amd64
         - os: macos-15
           arch: arm64
     runs-on: ${{ matrix.os }}
@@ -75,13 +81,11 @@ jobs:
       - name: build artifacts
         id: build
         run: |
-          OS=$([[ "${{runner.os}}" == "macOS" ]] && echo "macosx" || echo "linux")
+          make V=1 CI=false update
 
-          make V=1 CI=false NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" \
-            update
-
-          make V=1 CI=false POSTGRES=1\
-            NIMFLAGS="-d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" \
+          # -j1: each target starts one nimble process. Two parallel nimble
+          # processes corrupt the shared package metadata (nimblemeta.json).
+          make V=1 -j1 CI=false POSTGRES=1\
             wakunode2\
             logosdeliverynode\
             chat2\
@@ -90,38 +94,42 @@ jobs:
           tar -cvzf ${{steps.vars.outputs.nwaku}} ./build/wakunode2 ./build/logosdeliverynode ./build/chat2
           tar -cvzf ${{steps.vars.outputs.nwakutools}} ./build/wakucanary ./build/networkmonitor
 
+      # Each matrix job must use a unique artifact name. With one shared
+      # name, download-artifact@v4 keeps only the last upload and the release
+      # loses platforms.
       - name: upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wakunode2
+          name: wakunode2-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{steps.vars.outputs.nwaku}}
           retention-days: 2
 
       - name: upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wakutools
+          name: wakutools-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{steps.vars.outputs.nwakutools}}
           retention-days: 2
 
   build-docker-image:
     needs: tag-name
-    uses: logos-messaging/logos-delivery/.github/workflows/container-image.yml@master
+    # uses: logos-messaging/logos-delivery/.github/workflows/container-image.yml@master
+    uses: ./.github/workflows/container-image.yml
     with:
       image_tag: ${{ needs.tag-name.outputs.tag }}
     secrets: inherit
 
-  js-waku-node:
-    needs: build-docker-image
-    uses: logos-messaging/logos-delivery-js/.github/workflows/test-node.yml@master
-    permissions:
-      contents: read
-      actions: read
-      checks: write
-    with:
-      nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
-      test_type: node
-      debug: waku*
+  # js-waku-node:
+  #   needs: build-docker-image
+  #   uses: logos-messaging/logos-delivery-js/.github/workflows/test-node.yml@master
+  #   permissions:
+  #     contents: read
+  #     actions: read
+  #     checks: write
+  #   with:
+  #     nim_wakunode_image: ${{ needs.build-docker-image.outputs.image }}
+  #     test_type: node
+  #     debug: waku*
 
   js-waku-node-optional:
     needs: build-docker-image
@@ -145,8 +153,20 @@ jobs:
           fetch-depth: 0
           ref: master
 
-      - name: download artifacts
+      # merge-multiple puts all matching artifacts into one directory.
+      - name: download node artifacts
         uses: actions/download-artifact@v4
+        with:
+          pattern: wakunode2-*
+          path: wakunode2
+          merge-multiple: true
+
+      - name: download tools artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wakutools-*
+          path: wakutools
+          merge-multiple: true
 
       - name: prep variables
         id: vars
@@ -154,6 +174,31 @@ jobs:
           REF=$(echo ${{github.ref}} | sed 's#.*/##')
 
           echo "ref=${REF}" >> $GITHUB_OUTPUT
+
+      # Gate before publish. Make sure that each platform sent one tarball
+      # and that each binary has the correct CPU type. Without this gate,
+      # these two faults do not stop the release.
+      - name: verify release artifacts
+        run: |
+          set -e
+          echo "### artifacts received ###"
+          ls -lR wakunode2 wakutools
+          echo
+          echo "### tarball contents and binary CPU type ###"
+          for t in wakunode2/*.tar.gz wakutools/*.tar.gz; do
+            echo "== $t =="
+            tar -tzf "$t"
+            rm -rf /tmp/x && mkdir -p /tmp/x && tar -xzf "$t" -C /tmp/x
+            find /tmp/x -type f -exec file {} \;
+            echo
+          done
+          echo "### tarball count check ###"
+          # One node tarball for each entry in the build matrix. If you
+          # change the matrix, update EXPECTED.
+          EXPECTED=2
+          n=$(ls wakunode2/*.tar.gz | wc -l)
+          echo "wakunode2 tarballs: $n (expected $EXPECTED)"
+          [ "$n" -eq "$EXPECTED" ] || { echo "FAIL: expected $EXPECTED tarballs, found $n"; exit 1; }
 
       - name: generate release notes
         env:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -11,6 +11,9 @@ on:
 env:
   RELEASE_NAME: nightly
 
+  NODE_BINARIES: "wakunode2 logosdeliverynode chat2"
+  TOOLS_BINARIES: "wakucanary networkmonitor"
+
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
   NIM_PARAMS: "-d:disableMarchNative"
@@ -36,9 +39,11 @@ jobs:
 
   build-and-publish:
     needs: tag-name
+    # Matrix job count for the verify step; every matrix job writes the same value.
+    outputs:
+      platform-count: ${{ strategy.job-total }}
     strategy:
-      # Without fail-fast: false, one failed job cancels the other jobs and
-      # hides their results.
+      # Keep the other jobs running when one fails.
       fail-fast: false
       matrix:
         # GitHub macOS runners are arm64 only; darwin/amd64 needs a cross-compilation setup.
@@ -81,18 +86,12 @@ jobs:
       - name: build artifacts
         id: build
         run: |
-          make V=1 CI=false update
-
           # -j1: each target starts one nimble process. Two parallel nimble
           # processes corrupt the shared package metadata (nimblemeta.json).
-          make V=1 -j1 CI=false POSTGRES=1\
-            wakunode2\
-            logosdeliverynode\
-            chat2\
-            tools
+          make V=1 -j1 CI=false POSTGRES=1 $NODE_BINARIES tools
 
-          tar -cvzf ${{steps.vars.outputs.nwaku}} ./build/wakunode2 ./build/logosdeliverynode ./build/chat2
-          tar -cvzf ${{steps.vars.outputs.nwakutools}} ./build/wakucanary ./build/networkmonitor
+          tar -cvzf ${{steps.vars.outputs.nwaku}} $(printf './build/%s ' $NODE_BINARIES)
+          tar -cvzf ${{steps.vars.outputs.nwakutools}} $(printf './build/%s ' $TOOLS_BINARIES)
 
       # Each matrix job must use a unique artifact name. With one shared
       # name, download-artifact@v4 keeps only the last upload and the release
@@ -146,6 +145,9 @@ jobs:
   create-release-candidate:
     runs-on: ubuntu-22.04
     needs: [ tag-name, build-and-publish ]
+    permissions:
+      contents: write
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -175,41 +177,83 @@ jobs:
 
           echo "ref=${REF}" >> $GITHUB_OUTPUT
 
-      # Gate before publish. Make sure that each platform sent one tarball
-      # and that each binary has the correct CPU type. Without this gate,
-      # these two faults do not stop the release.
+      # A fault in the release artifacts stops the release here.
       - name: verify release artifacts
         run: |
           set -e
-          echo "### artifacts received ###"
-          ls -lR wakunode2 wakutools
-          echo
-          echo "### tarball contents and binary CPU type ###"
-          for t in wakunode2/*.tar.gz wakutools/*.tar.gz; do
-            echo "== $t =="
-            tar -tzf "$t"
-            rm -rf /tmp/x && mkdir -p /tmp/x && tar -xzf "$t" -C /tmp/x
-            find /tmp/x -type f -exec file {} \;
-            echo
-          done
-          echo "### tarball count check ###"
-          # One node tarball for each entry in the build matrix. If you
-          # change the matrix, update EXPECTED.
-          EXPECTED=2
-          n=$(ls wakunode2/*.tar.gz | wc -l)
-          echo "wakunode2 tarballs: $n (expected $EXPECTED)"
-          [ "$n" -eq "$EXPECTED" ] || { echo "FAIL: expected $EXPECTED tarballs, found $n"; exit 1; }
+          # One node tarball and one tools tarball for each matrix job. The count
+          # comes from the build job's own matrix at run time, thus a matrix
+          # change needs no edit here.
+          EXPECTED=${{ needs.build-and-publish.outputs.platform-count }}
+          echo "expected platform count: $EXPECTED"
+
+          # check_dir <dir> <binaries>
+          # e.g. check_dir wakunode2 "wakunode2 logosdeliverynode chat2"
+          # Every tarball in <dir> must extract and must contain each named
+          # binary with the CPU type that the tarball name shows.
+          check_dir() {
+            local dir="$1"       # artifact directory, e.g. wakunode2
+            local binaries="$2"  # in each tarball, e.g. "wakunode2 logosdeliverynode chat2"
+
+            echo "== $dir (binaries: $binaries) =="
+            ls -l "$dir"
+
+            local count
+            count=$(ls "$dir"/*.tar.gz | wc -l)
+            [ "$count" -eq "$EXPECTED" ] || { echo "FAIL: $dir: expected $EXPECTED tarballs, found $count"; exit 1; }
+
+            for tarball in "$dir"/*.tar.gz; do
+              echo "-- $tarball --"
+
+              # A truncated tarball stops the step here.
+              tar -tzf "$tarball"
+              local unpacked
+              unpacked=$(mktemp -d)
+              tar -xzf "$tarball" -C "$unpacked"
+
+              # The tarball name shows the correct CPU type,
+              # e.g. nwaku-amd64-linux-nightly.tar.gz -> binaries must be x86-64.
+              case "$tarball" in
+                *-amd64-*) want='x86-64' ;;
+                *-arm64-*) want='arm64|aarch64' ;;  # macOS says arm64, Linux says aarch64
+                *) echo "FAIL: unknown arch in name: $tarball"; exit 1 ;;
+              esac
+
+              # file reads the bytes of each binary,
+              # e.g. "build/wakunode2: ELF 64-bit LSB pie executable, x86-64, ...".
+              # A missing, zero-size, truncated, or wrong-arch binary fails here.
+              for binary in $binaries; do
+                line=$(file "$unpacked/build/$binary" 2>/dev/null || true)
+                echo "$line"
+                echo "$line" | grep -E "executable|shared object|shared library" | grep -Eq ": .*($want)" \
+                  || { echo "FAIL: $binary (want: $want)"; exit 1; }
+              done
+            done
+          }
+
+          check_dir wakunode2 "$NODE_BINARIES"
+          check_dir wakutools "$TOOLS_BINARIES"
 
       - name: generate release notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -x
-          gh release view ${{ needs.tag-name.outputs.tag }} &>/dev/null &&\
-            gh release delete -y ${{ needs.tag-name.outputs.tag }} &&\
-            [[ "${{ needs.tag-name.outputs.tag }}" == "nightly" ]] && git tag -d ${{ needs.tag-name.outputs.tag }}
+          TAG="${{ needs.tag-name.outputs.tag }}"
 
-          RELEASE_NOTES_TAG=$([[ "${{ needs.tag-name.outputs.tag }}" != "nightly" ]] && echo "-t ${{steps.vars.outputs.ref}}" || echo "")
+          # NOTE: gh release create refuses to create over an existing release.
+          if [[ "$TAG" == "nightly" ]]; then
+            # Each run replaces the nightly release and its tag. gh release
+            # create reuses an existing tag and ignores --target.
+            gh release delete -y "$TAG" || true
+            # --exit-code: nonzero exit when the tag is absent.
+            if git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null; then
+              git push origin ":refs/tags/$TAG"
+            fi
+            git tag -d "$TAG" || true
+          fi
+
+          RELEASE_NOTES_TAG=$([[ "$TAG" != "nightly" ]] && echo "-t ${{steps.vars.outputs.ref}}" || echo "")
 
           docker run \
               -t \
@@ -224,8 +268,8 @@ jobs:
 
           cat release_notes.md
 
-          TARGET=$([[ "${{ needs.tag-name.outputs.tag }}" == "nightly" ]] && echo "--target ${{steps.vars.outputs.ref}}" || echo "")
+          TARGET=$([[ "$TAG" == "nightly" ]] && echo "--target ${{steps.vars.outputs.ref}}" || echo "")
 
-          gh release create ${{ needs.tag-name.outputs.tag }} --prerelease ${TARGET} \
-            --title ${{ needs.tag-name.outputs.tag }} --notes-file release_notes.md \
+          gh release create "$TAG" --prerelease ${TARGET} \
+            --title "$TAG" --notes-file release_notes.md \
             wakunode2/* wakutools/*

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -125,7 +125,6 @@ jobs:
         run: |
           # One make target for each line. Two parallel nimble processes
           # corrupt the shared package metadata.
-          make -j${NPROC} V=1 update
           make -j${NPROC} POSTGRES=1 CI=false wakunode2
           make -j${NPROC} CI=false chat2
           make -j${NPROC} POSTGRES=1 CI=false logosdeliverynode

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   NPROC: 2
+  NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.4'
   NIMBLE_VERSION: '0.22.3'
 
@@ -43,10 +44,12 @@ jobs:
   build-and-upload:
     needs: verify-version
     strategy:
+      # GitHub macOS runners are arm64 only; darwin/amd64 needs a cross-compilation setup.
+      fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-15]
-        arch: [amd64]
         include:
+        - os: ubuntu-22.04
+          arch: amd64
         - os: macos-15
           arch: arm64
     runs-on: ${{ matrix.os }}
@@ -87,9 +90,12 @@ jobs:
         run: |
           # Use full tag, e.g., v0.37.0
           echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
-          # Same strip as verify-version's TAG_VERSION; dpkg rejects a version
-          # that does not start with a digit.
-          echo "deb_version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          # dpkg needs a version that starts with a digit. A dispatch from a
+          # branch gives a branch name here. Use 0.0.0~<branch> for such test
+          # builds, so the workflow also runs from a branch.
+          DEB_VERSION="${GITHUB_REF_NAME#v}"
+          [[ "$DEB_VERSION" =~ ^[0-9] ]] || DEB_VERSION="0.0.0~${DEB_VERSION//\//-}"
+          echo "deb_version=${DEB_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Prep variables
         id: vars
@@ -117,16 +123,16 @@ jobs:
 
       - name: Build Waku artifacts
         run: |
-          OS=$([[ "${{runner.os}}" == "macOS" ]] && echo "macosx" || echo "linux")
-
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" V=1 update
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false wakunode2
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" CI=false chat2
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false logosdeliverynode
+          # One make target for each line. Two parallel nimble processes
+          # corrupt the shared package metadata.
+          make -j${NPROC} V=1 update
+          make -j${NPROC} POSTGRES=1 CI=false wakunode2
+          make -j${NPROC} CI=false chat2
+          make -j${NPROC} POSTGRES=1 CI=false logosdeliverynode
           tar -cvzf ${{steps.vars.outputs.waku}} ./build/
 
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false liblogosdelivery
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC} -d:disableMarchNative --os:${OS} --cpu:${{matrix.arch}}" POSTGRES=1 CI=false STATIC=1 liblogosdelivery
+          make -j${NPROC} POSTGRES=1 CI=false liblogosdelivery
+          make -j${NPROC} POSTGRES=1 CI=false STATIC=1 liblogosdelivery
 
       - name: Create distributable liblogosdelivery package
         run: |

--- a/Nat.mk
+++ b/Nat.mk
@@ -44,6 +44,20 @@ ifeq ($(OS), Windows_NT)
 		CFLAGS="-Wall -Wno-cpp -Os -fPIC -DWIN32 -DNATPMP_STATICLIB -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 $(CFLAGS)" \
 		libnatpmp.a $(HANDLE_OUTPUT)
 else
+# Delete the archives that the nimble install hook of nat_traversal already
+# built before nimble copied the package into nimbledeps/pkgs2/.
+#
+# The vendored Makefiles give the archiver only the out-of-date objects ($?).
+# On macOS the archiver is "libtool -static", which makes a new archive and
+# drops all other objects. The file times from the nimble copy can make only
+# some objects out of date. The link then fails with undefined _UPNP_*,
+# _connecthostport, _soapPostSubmit and _addr_is_reserved symbols.
+#
+# When the archive is absent, make expands $? to all objects. On Linux this
+# deletion is safe: "ar crs" merges into an existing archive, and the rule
+# only makes the archive again from the same objects.
+	@rm -f "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor/miniupnp/miniupnpc/build/libminiupnpc.a" \
+	       "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor/libnatpmp-upstream/libnatpmp.a"
 	+ "$(MAKE)" -C "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor/miniupnp/miniupnpc" \
 		CC=$(CC) CFLAGS="-Os -fPIC $(PORTABLE_NAT_MARCH)" build/libminiupnpc.a $(HANDLE_OUTPUT)
 	+ "$(MAKE)" CFLAGS="-Wall -Wno-cpp -Os -fPIC $(PORTABLE_NAT_MARCH) -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 $(CFLAGS)" \


### PR DESCRIPTION
## Description

This PR tries to fix all remaining master/nightly CI/CD issues (some jobs/steps need to be tested in the real nightly).

## Changes

* Nat.mk: delete old nat-lib archives before rebuild; macOS libtool keeps only changed objects
* drop the macOS amd64 build: runners are arm64, the "amd64" binaries were arm64
* set `NIM_PARAMS="-d:disableMarchNative"`; it sat in NIMFLAGS, which nothing reads
* remove the dead NIMFLAGS make arguments
* fail-fast: false, so one failed job no longer cancels the others
* release-assets: valid deb version on branch runs; dpkg needs a leading digit
* pre-release: build with -j1; parallel nimble corrupts shared package metadata
* pre-release: one artifact name per matrix job; a shared name kept only the last upload
* pre-release: verify tarballs before publish: binaries present, correct CPU type, one per platform
* pre-release: delete the remote nightly tag before the recreate, so nightly moves with master
* pre-release: an rc re-run no longer deletes the existing release before dying
* pre-release: explicit job permissions (contents: write, actions: read) for release and tag ops
* pre-release: take TAG from github.ref_name; branch runs kept refs/heads/ and tar failed on the slashes
* pre-release: call container-image by relative path, so runs use their own branch's workflow
* pre-release: comment out js-waku-node job (failing)
* pre-release, release-assets: drop `make update` dead target
* misc refactors

## Issue

Maintenance Y2026H2 #4043