### PR TITLE
fix(networks): move logos.dev preset to cluster-id 3

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -96,7 +96,7 @@ Available presets:
 | Preset | Cluster ID | RLN | Sharding | Network |
 | --- | --- | --- | --- | --- |
 | `twn` | 1 | on | auto (8 shards) | The Waku Network |
-| `logos.dev` | 2 | off | auto (8 shards) | Logos Dev Network |
+| `logos.dev` | 3 | off | auto (8 shards) | Logos Dev Network |
 | `logos.test` | 2 | off | auto (8 shards) | Logos Test Network |
 | `status.prod` | 16 | off | auto (1 shard) | Status Production Network |
 

--- a/logos_delivery/waku/factory/networks_config.nim
+++ b/logos_delivery/waku/factory/networks_config.nim
@@ -65,13 +65,13 @@ proc TheWakuNetworkConf*(T: type NetworkPresetConf): NetworkPresetConf =
     ],
   )
 
-# cluster-id=2 (Logos Dev Network)
+# cluster-id=3 (Logos Dev Network)
 # Cluster configuration for the Logos Dev Network.
 proc LogosDevConf*(T: type NetworkPresetConf): NetworkPresetConf =
   const ZeroChainId = 0'u256
   return NetworkPresetConf(
     maxMessageSize: DefaultMaxWakuMessageSizeStr,
-    clusterId: 2,
+    clusterId: 3,
     rlnRelay: false,
     rlnRelayEthContractAddress: "",
     rlnRelayDynamic: false,

--- a/tests/api/test_node_conf.nim
+++ b/tests/api/test_node_conf.nim
@@ -37,7 +37,7 @@ suite "WakuNodeConf - preset integration":
     let wakuConf = wakuConfRes.get()
     require wakuConf.validate().isOk()
     check:
-      wakuConf.clusterId == 2
+      wakuConf.clusterId == 3
 
   test "LogosTest preset applies LogosTestConf":
     ## Given

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -164,7 +164,7 @@ type WakuNodeConf* = object
     ## General node config
     preset* {.
       desc:
-        "Network preset to use. 'twn' is The RLN-protected Waku Network (cluster 1). 'logos.dev' is the Logos Dev Network (cluster 2). 'logos.test' is the Logos Test Network (cluster 2). 'status.prod' is the Status Production Network (cluster 16, RLN off, auto-sharding with 1 shard). Overrides other values.",
+        "Network preset to use. 'twn' is The RLN-protected Waku Network (cluster 1). 'logos.dev' is the Logos Dev Network (cluster 3). 'logos.test' is the Logos Test Network (cluster 2). 'status.prod' is the Status Production Network (cluster 16, RLN off, auto-sharding with 1 shard). Overrides other values.",
       defaultValue: "",
       name: "preset"
     .}: string
@@ -983,9 +983,9 @@ proc toNetworkPresetConf*(
       "TWN - The Waku Network configuration will not be applied when `--cluster-id=1` is passed in future releases. Use `--preset=twn` instead."
     )
     lcPreset = "twn"
-  if clusterId.isSome() and clusterId.get() == 2:
+  if clusterId.isSome() and clusterId.get() == 3:
     warn(
-      "Logos.dev - Logos.dev configuration will not be applied when `--cluster-id=2` is passed in future releases. Use `--preset=logos.dev` instead."
+      "Logos.dev - Logos.dev configuration will not be applied when `--cluster-id=3` is passed in future releases. Use `--preset=logos.dev` instead."
     )
     lcPreset = "logos.dev"
 

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -983,9 +983,9 @@ proc toNetworkPresetConf*(
       "TWN - The Waku Network configuration will not be applied when `--cluster-id=1` is passed in future releases. Use `--preset=twn` instead."
     )
     lcPreset = "twn"
-  if clusterId.isSome() and clusterId.get() == 3:
+  if clusterId.isSome() and clusterId.get() == 2:
     warn(
-      "Logos.dev - Logos.dev configuration will not be applied when `--cluster-id=3` is passed in future releases. Use `--preset=logos.dev` instead."
+      "Logos.dev - Logos.dev configuration will not be applied when `--cluster-id=2` is passed in future releases. Use `--preset=logos.dev` instead."
     )
     lcPreset = "logos.dev"
 


### PR DESCRIPTION
Fixes https://github.com/logos-messaging/logos-delivery/issues/4114

## Description

The Logos Dev Network is now deployed on **cluster 3**, but the `logos.dev` preset still pins `clusterId: 2`. This updates the preset to match the deployed fleet.

Changes:
- `LogosDevConf`: `clusterId` 2 → 3 (+ header comment)
- `--preset` help text: logos.dev is now described as cluster 3
- `library/README.md` preset table
- `tests/api/test_node_conf.nim`: expects `clusterId == 3`
- `cli_args.nim`: the help text only — see the note below

## Note for reviewers: the legacy `--cluster-id` shim

`toNetworkPresetConf` has a deprecated shim that maps a bare `--cluster-id=N` onto a preset, and `--cluster-id=2` still maps to `logos.dev`. That mapping is now inconsistent: passing `--cluster-id=2` applies the logos.dev preset, which sets cluster **3** on top.

I first tried moving the shim to `--cluster-id=3`, and CI caught why that doesn't work: `tests/api/test_api_send.nim` uses cluster 3 as a plain local cluster id with no preset, so the shim silently applied the entire logos.dev preset (p2p reliability, mix, discv5, dev entry nodes) to those nodes. The extra reliability layer made `Send` emit `Sent` events the tests never asked for — 6 failures in `Waku API - Send` on both ubuntu and macOS. Any user picking cluster 3 for a local network would hit the same thing.

So the shim stays on cluster 2 here and this PR is limited to the preset itself. The real fix is probably to **drop the cluster-id → preset mapping altogether** (it already warns that it will stop working), but that's a separate call — happy to do it in a follow-up, or here if you'd prefer.

Also note `simulations/mixnet/run_chat_mix*.sh` pass `--cluster-id=2` and therefore pick up the logos.dev preset; after this change that preset puts them on cluster 3. Left alone since they're local mixnet sims, but worth a look.

## Changes checklist

- [x] `tests/api/test_node_conf.nim` (6/6), `tests/api/test_conf.nim` (45/45), `tests/factory/test_waku_conf.nim` (16/16)
- [x] The 6 `Waku API - Send` tests that failed on the first push pass locally after the revert
- [ ] Fleet/infra config confirmed to be on cluster 3

## Issue

n/a