### PR TITLE
fix(config): logosdeliverynode explicit flags override mode

### DIFF
--- a/apps/liteprotocoltester/diagnose_connections.nim
+++ b/apps/liteprotocoltester/diagnose_connections.nim
@@ -13,7 +13,7 @@ import
   libp2p/wire
 
 import
-  tools/confutils/cli_args,
+  tools/confutils/kernel_cli_args,
   logos_delivery/waku/[
     node/peer_manager,
     waku_lightpush/common,

--- a/apps/liteprotocoltester/liteprotocoltester.nim
+++ b/apps/liteprotocoltester/liteprotocoltester.nim
@@ -11,7 +11,7 @@ import
   confutils
 
 import
-  tools/confutils/cli_args,
+  tools/confutils/kernel_cli_args,
   logos_delivery/waku/[
     common/enr,
     common/logging,

--- a/apps/liteprotocoltester/service_peer_management.nim
+++ b/apps/liteprotocoltester/service_peer_management.nim
@@ -11,7 +11,7 @@ import
   libp2p/wire
 
 import
-  tools/confutils/cli_args,
+  tools/confutils/kernel_cli_args,
   logos_delivery/waku/[
     common/enr,
     waku_node,

--- a/apps/logos_delivery_node/logosdeliverynode.nim
+++ b/apps/logos_delivery_node/logosdeliverynode.nim
@@ -30,15 +30,15 @@ when isMainModule:
 
   const versionString = "version / git commit hash: " & git_version
 
-  var wakuNodeConf = WakuNodeConf.load(version = versionString).valueOr:
+  var nodeConf = LogosDeliveryNodeConf.load(version = versionString).valueOr:
     error "failure while loading the configuration", error = error
     quit(QuitFailure)
 
   ## Also called within LogosDelivery.new. The call to startRestServerEssentials
   ## needs the following line
-  logging.setupLog(wakuNodeConf.logLevel, wakuNodeConf.logFormat)
+  logging.setupLog(nodeConf.logLevel, nodeConf.logFormat)
 
-  case wakuNodeConf.cmd
+  case nodeConf.cmd
   of generateRlnKeystore:
     error "generateRlnKeystore not supported by logos_delivery_node; use wakunode2"
     quit(QuitFailure)
@@ -46,7 +46,7 @@ when isMainModule:
     # `LogosDelivery` derives the per-layer config from `WakuNodeConf` itself
     # (it runs `toWakuConf` internally), then builds the full stack bottom-up:
     #   Waku <- MessagingClient <- ReliableChannelManager
-    var node = (waitFor LogosDelivery.new(wakuNodeConf)).valueOr:
+    var node = (waitFor LogosDelivery.new(nodeConf)).valueOr:
       error "LogosDelivery initialization failed", error = error
       quit(QuitFailure)
 

--- a/apps/wakunode2/wakunode2.nim
+++ b/apps/wakunode2/wakunode2.nim
@@ -8,7 +8,7 @@ import
   system/ansi_c,
   libp2p/crypto/crypto
 import
-  ../../tools/[rln_keystore_generator/rln_keystore_generator, confutils/cli_args],
+  ../../tools/[rln_keystore_generator/rln_keystore_generator, confutils/kernel_cli_args],
   logos_delivery/waku/[
     common/logging,
     waku,

--- a/examples/api_example/api_example.nim
+++ b/examples/api_example/api_example.nim
@@ -58,22 +58,26 @@ when isMainModule:
 
   echo "Starting Waku node..."
 
-  # Use WakuNodeConf (the CLI configuration type) for node setup
-  var conf = defaultWakuNodeConf().valueOr:
-    echo "Failed to create default config: ", error
-    quit(QuitFailure)
-
+  var preset: string
+  var messagingOverrides = MessagingClientConf()
   if args.ethRpcEndpoint == "":
     # Create a basic configuration for the Waku node
     # No RLN as we don't have an ETH RPC Endpoint
-    conf.preset = "logos.dev"
+    preset = "logos.dev"
   else:
     # Connect to TWN, use ETH RPC Endpoint for RLN
-    conf.preset = "twn"
-    conf.ethClientUrls = @[EthRpcUrl(args.ethRpcEndpoint)]
+    preset = "twn"
+    messagingOverrides.ethRpcEndpoints = Opt.some(@[EthRpcUrl(args.ethRpcEndpoint)])
 
   # Create the full Logos Messaging stack (Waku + messaging + channels)
-  let node = (waitFor LogosDelivery.new(conf)).valueOr:
+  let node = (
+    waitFor LogosDelivery.new(
+      mode = LogosDeliveryMode.Core,
+      preset = preset,
+      messagingOverrides = messagingOverrides,
+      channelsOverrides = ReliableChannelManagerConf(),
+    )
+  ).valueOr:
     echo "Failed to create node: ", error
     quit(QuitFailure)
 

--- a/examples/wakustealthcommitments/node_spec.nim
+++ b/examples/wakustealthcommitments/node_spec.nim
@@ -1,6 +1,6 @@
 {.push raises: [].}
 
-import tools/confutils/cli_args
+import tools/confutils/kernel_cli_args
 import logos_delivery/waku/[common/logging, waku, factory/networks_config]
 import
   results,

--- a/logos_delivery/api/conf/kernel_conf.nim
+++ b/logos_delivery/api/conf/kernel_conf.nim
@@ -1,6 +1,7 @@
-import tools/confutils/cli_args
-export cli_args
+import tools/confutils/kernel_cli_args
+export kernel_cli_args
 
 type KernelConf* = distinct WakuNodeConf
-  ## Raw kernel config; distinct so `new(KernelConf)` doesn't collide with the
-  ## full-stack `new(WakuNodeConf)`.
+  ## Configuration of the kernel layer. `WakuNodeConf` is the legacy name for
+  ## this configuration and stays while wakunode2 exists; when wakunode2 is
+  ## deleted, `WakuNodeConf` is renamed `KernelConf` and this alias dies.

--- a/logos_delivery/api/conf/logos_delivery_conf.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf.nim
@@ -20,14 +20,12 @@ proc init*(T: type LogosDeliveryConf, kernelConf: KernelConf): LogosDeliveryConf
 
 proc init*(
     T: type LogosDeliveryConf,
-    entryLayer: EntryLayer = EntryLayer.channels,
     mode: LogosDeliveryMode,
     preset: string,
     messagingOverrides: MessagingClientConf,
-    channelsOverrides: ReliableChannelManagerConf,
+    channelsOverrides = Opt.none(ReliableChannelManagerConf),
 ): ConfResult[LogosDeliveryConf] =
-  ## Structured (preset + overrides) entry. Only `messaging` / `channels` layers
-  ## reach here; the `kernel` layer uses `init(kernelConf)` (raw, mode ignored).
+  ## Resolves the library config from given settings and per-layer config objects.
   let merged = merge(?resolvePreset(preset), messagingOverrides)
   var kernelConf = ?toWakuNodeConf(merged, mode)
   kernelConf.preset = preset
@@ -35,11 +33,7 @@ proc init*(
     LogosDeliveryConf(
       kernelConf: KernelConf(kernelConf),
       messagingConf: Opt.some(merged),
-      channelsConf:
-        if entryLayer == EntryLayer.channels:
-          Opt.some(channelsOverrides)
-        else:
-          Opt.none(ReliableChannelManagerConf),
+      channelsConf: channelsOverrides,
     )
   )
 

--- a/logos_delivery/api/conf/logos_delivery_conf_json.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf_json.nim
@@ -79,7 +79,7 @@ proc parseFlatConf(
   # the mode's protocol flags (the kernel no longer owns `mode`, so we expand it here,
   # like the old kernel builder did), then let explicit fields override.
   var kernel = ?defaultWakuNodeConf()
-  ?applyMode(kernel, mode)
+  applyMode(kernel, mode)
   ?applyJsonFieldsToConf(
     kernel, topJsonNode, "Failed to parse config field",
     "Unrecognized configuration option(s) found",
@@ -111,12 +111,14 @@ proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
   var top = ?collectJsonFields(node)
 
   var mode = LogosDeliveryMode.Core
+  var hasMode = false
   if top.hasKey(KeyMode):
     let (_, v) = top.getOrDefault(KeyMode)
     if v.kind != JString:
       return err("mode must be a string")
     mode = ?parseMode(v.getStr())
     top.del(KeyMode)
+    hasMode = true
 
   var entryLayer = EntryLayer.channels
   if top.hasKey(KeyEntryLayer):
@@ -127,7 +129,11 @@ proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
     top.del(KeyEntryLayer)
 
   if entryLayer == EntryLayer.kernel:
-    # Kernel-only: a raw kernelConf and no upper layers; mode is ignored.
+    # User has given a mode but the kernel entry layer takes no mode.
+    # That's inconsistent, so fail.
+    if hasMode:
+      return err("mode requires the 'messaging' or 'channels' entry layer")
+    # Kernel-only: a raw kernelConf and no upper layers.
     if not top.hasKey(KeyKernelConf):
       return err("kernel entry layer requires a 'kernelConf' object")
     let (_, v) = top.getOrDefault(KeyKernelConf)
@@ -170,21 +176,34 @@ proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
     messagingOverrides = ?parseOverrides(MessagingClientConf(), v, "messagingOverrides")
     top.del(KeyMessagingOverrides)
 
+  var hasChannelsOverrides = false
   if top.hasKey(KeyChannelsOverrides):
     let (_, v) = top.getOrDefault(KeyChannelsOverrides)
     channelsOverrides =
       ?parseOverrides(ReliableChannelManagerConf(), v, "channelsOverrides")
     top.del(KeyChannelsOverrides)
+    hasChannelsOverrides = true
 
   if top.len > 0:
     return err(unknownKeysError(top, "Unrecognized configuration option(s) found"))
 
+  # If channels are being requested, give whatever channelsOverrides we have
+  # at this point (either the defaults or parsed from user-given channels config).
+  if entryLayer == EntryLayer.channels:
+    return LogosDeliveryConf.init(
+      mode = mode,
+      preset = preset,
+      messagingOverrides = messagingOverrides,
+      channelsOverrides = Opt.some(channelsOverrides),
+    )
+
+  # User has given channelsOverrides but has requested a lower mount height.
+  # That's inconsistent, so fail.
+  if hasChannelsOverrides:
+    return err("channelsOverrides requires the 'channels' entry layer")
+
   return LogosDeliveryConf.init(
-    entryLayer = entryLayer,
-    mode = mode,
-    preset = preset,
-    messagingOverrides = messagingOverrides,
-    channelsOverrides = channelsOverrides,
+    mode = mode, preset = preset, messagingOverrides = messagingOverrides
   )
 
 {.pop.}

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -61,34 +61,12 @@ type MessagingClientConf* = object
     ## pragma or `parseCmdArg`, it is not reachable from the JSON config or a
     ## CLI flag.
 
-proc applyMode*(conf: var WakuNodeConf, mode: LogosDeliveryMode): ConfResult[void] =
-  ## Sets the protocol flags implied by the mode.
-  case mode
-  of LogosDeliveryMode.Core:
-    conf.relay = true
-    conf.filter = true
-    conf.lightpush = true
-    conf.discv5Discovery = Opt.some(true)
-    conf.peerExchange = true
-    conf.rendezvous = true
-  of LogosDeliveryMode.Edge:
-    conf.peerExchange = true
-    conf.relay = false
-    conf.filter = false
-    conf.lightpush = false
-    conf.store = false
-  return ok()
-
 proc toWakuNodeConf*(
     self: MessagingClientConf, mode: LogosDeliveryMode
 ): ConfResult[WakuNodeConf] =
   ## Mode sets the protocol flags; set fields map to their kernel counterpart.
   var conf = ?defaultWakuNodeConf()
-  ?applyMode(conf, mode)
-  # Keep the `mode` field consistent with the applied flags so a later
-  # `LogosDelivery.new(WakuNodeConf)` re-application is idempotent instead of
-  # clobbering these flags with the field's default (`Core`).
-  conf.mode = mode
+  applyMode(conf, mode)
 
   if self.store.isSome():
     conf.store = self.store.get()

--- a/logos_delivery/api/conf/modes.nim
+++ b/logos_delivery/api/conf/modes.nim
@@ -1,9 +1,11 @@
 ## Leaf module for the app-level mode / entry-layer enums.
 ##
-## These appear on `WakuNodeConf` (in the leaf `tools/confutils/cli_args`), so
+## These appear on `LogosDeliveryNodeConf` (in the leaf `tools/confutils/cli_args`), so
 ## they must live in a module that `cli_args` can import without a cycle — i.e.
 ## a module that imports nothing from the config/api layers. `logos_delivery_conf`
 ## re-exports them so consumers still get them from there.
+
+import results
 
 type LogosDeliveryMode* {.pure.} = enum
   ## Drives the kernel-internal protocol mountings. Applied only for the
@@ -12,7 +14,63 @@ type LogosDeliveryMode* {.pure.} = enum
   Core # full service node
 
 type EntryLayer* {.pure.} = enum
-  ## Selects which API layer `LogosDelivery` instantiates.
-  kernel # transport kernel only; ignores `mode` and uses the config as-is
+  ## Frontend (CLI/JSON) token that names a mount height. The frontends
+  ## translate it into which per-layer configs are present on
+  ## `LogosDeliveryConf`. The library mounts a layer iff its config is present.
+  kernel # transport kernel only; an explicit `mode` is rejected
   messaging # kernel + messaging client
   channels # kernel + messaging + reliable channels
+
+type ModeProtocolFlags* = object
+  ## The protocol flags a mode implies. An unset field means the mode has no
+  ## value for that protocol.
+  relay*: Opt[bool]
+  filter*: Opt[bool]
+  lightpush*: Opt[bool]
+  store*: Opt[bool]
+  discv5Discovery*: Opt[bool]
+  peerExchange*: Opt[bool]
+  rendezvous*: Opt[bool]
+
+proc protocolFlags*(mode: LogosDeliveryMode): ModeProtocolFlags =
+  ## The single source of what each mode means.
+  case mode
+  of LogosDeliveryMode.Core:
+    ModeProtocolFlags(
+      relay: Opt.some(true),
+      filter: Opt.some(true),
+      lightpush: Opt.some(true),
+      discv5Discovery: Opt.some(true),
+      peerExchange: Opt.some(true),
+      rendezvous: Opt.some(true),
+    )
+  of LogosDeliveryMode.Edge:
+    ModeProtocolFlags(
+      peerExchange: Opt.some(true),
+      relay: Opt.some(false),
+      filter: Opt.some(false),
+      lightpush: Opt.some(false),
+      store: Opt.some(false),
+    )
+
+proc applyMode*[T](conf: var T, mode: LogosDeliveryMode) =
+  ## Applies the mode's protocol flags (`protocolFlags`) to any config that
+  ## has those fields. A tri-state (`Opt`) field can hold an explicit user
+  ## value, so it is set only when it is unset; a plain field holds only
+  ## defaults, so it is set whenever the mode has a value.
+  let flags = protocolFlags(mode)
+  template apply(field, value: untyped) =
+    when field is Opt[bool]:
+      if field.isNone():
+        field = value
+    else:
+      if value.isSome():
+        field = value.get()
+
+  apply(conf.relay, flags.relay)
+  apply(conf.filter, flags.filter)
+  apply(conf.lightpush, flags.lightpush)
+  apply(conf.store, flags.store)
+  apply(conf.discv5Discovery, flags.discv5Discovery)
+  apply(conf.peerExchange, flags.peerExchange)
+  apply(conf.rendezvous, flags.rendezvous)

--- a/logos_delivery/logos_delivery.nim
+++ b/logos_delivery/logos_delivery.nim
@@ -73,26 +73,26 @@ type LogosDelivery* = ref object ## Entry point. Holds one instance of each API 
   messagingClient*: MessagingClient
   reliableChannelManager*: ReliableChannelManager
 
-proc new*(
-    T: type LogosDelivery, conf: LogosDeliveryConf, appCallbacks: AppCallbacks = nil
+proc buildStack(
+    wakuConf: WakuConf,
+    messagingConf: Opt[MessagingClientConf],
+    channelsConf: Opt[ReliableChannelManagerConf],
+    appCallbacks: AppCallbacks,
 ): Future[Result[LogosDelivery, string]] {.async.} =
-  ## Builds the stack bottom-up from a resolved per-layer config; each layer is
-  ## mounted iff its config is present.
-  let wakuConf = WakuNodeConf(conf.kernelConf).toWakuConf().valueOr:
-      return err("failed to handle the configuration: " & error)
+  ## Mounts each layer iff its config object is given.
   let waku = (await Waku.new(wakuConf, appCallbacks)).valueOr:
     return err("failed to create Waku: " & error)
 
   let messagingClient =
-    if conf.messagingConf.isSome():
-      MessagingClient.new(conf.messagingConf.get(), waku).valueOr:
+    if messagingConf.isSome():
+      MessagingClient.new(messagingConf.get(), waku).valueOr:
         return err("failed to create MessagingClient: " & error)
     else:
       nil
 
   let reliableChannelManager =
-    if conf.channelsConf.isSome():
-      ReliableChannelManager.new(conf.channelsConf.get(), waku.brokerCtx).valueOr:
+    if channelsConf.isSome():
+      ReliableChannelManager.new(channelsConf.get(), waku.brokerCtx).valueOr:
         return err("failed to create ReliableChannelManager: " & error)
     else:
       nil
@@ -105,35 +105,61 @@ proc new*(
     )
   )
 
-proc new*(
-    T: type LogosDelivery, conf: WakuNodeConf, appCallbacks: AppCallbacks = nil
-): Future[Result[LogosDelivery, string]] {.async.} =
-  ## Builds the stack from a kernel `WakuNodeConf`, selecting which API layers to
-  ## instantiate by `conf.entryLayer`:
-  ##   kernel    -> transport only; `conf.mode` is ignored and the config is used as-is
-  ##   messaging -> kernel + messaging client
-  ##   channels  -> kernel + messaging + reliable channels
-  ## For `messaging`/`channels`, `conf.mode` (Edge/Core) sets the kernel protocol
-  ## flags first (messaging-level concern); for `kernel` it is skipped.
-  var kernelConf = conf
-  if conf.entryLayer != EntryLayer.kernel:
-    applyMode(kernelConf, conf.mode).isOkOr:
-      return err("failed to apply mode: " & error)
+proc resolveCliConf*(
+    conf: LogosDeliveryNodeConf
+): Result[
+    tuple[
+      wakuConf: WakuConf,
+      messagingConf: Opt[MessagingClientConf],
+      channelsConf: Opt[ReliableChannelManagerConf],
+    ],
+    string,
+] =
+  ## CLI translation: `conf.entryLayer` selects which layers are mounted.
+  var messagingConf = Opt.none(MessagingClientConf)
+  var ldNodeConf = conf
 
-  let ldConf = LogosDeliveryConf(
-    kernelConf: KernelConf(kernelConf),
-    messagingConf:
-      if conf.entryLayer == EntryLayer.kernel:
-        Opt.none(MessagingClientConf)
-      else:
-        Opt.some(MessagingClientConf()),
-    channelsConf:
-      if conf.entryLayer == EntryLayer.channels:
-        Opt.some(ReliableChannelManagerConf())
-      else:
-        Opt.none(ReliableChannelManagerConf),
+  if ldNodeConf.entryLayer == EntryLayer.kernel:
+    # User has given a mode but the kernel entry layer takes no mode.
+    # That's inconsistent, so fail.
+    if ldNodeConf.mode.isSome():
+      return err("mode requires the 'messaging' or 'channels' entry layer")
+  else:
+    applyMode(ldNodeConf, ldNodeConf.mode.get(LogosDeliveryMode.Core))
+    messagingConf = Opt.some(?resolvePreset(ldNodeConf.preset))
+
+  let wakuConf = ?ldNodeConf.toWakuConf()
+
+  return ok(
+    (
+      wakuConf: wakuConf,
+      messagingConf: messagingConf,
+      channelsConf:
+        if ldNodeConf.entryLayer == EntryLayer.channels:
+          Opt.some(ReliableChannelManagerConf())
+        else:
+          Opt.none(ReliableChannelManagerConf),
+    )
   )
-  return await LogosDelivery.new(ldConf, appCallbacks)
+
+proc new*(
+    T: type LogosDelivery, conf: LogosDeliveryNodeConf, appCallbacks: AppCallbacks = nil
+): Future[Result[LogosDelivery, string]] {.async.} =
+  ## CLI adapter: translates the logosdeliverynode config and builds the stack.
+  let resolved = resolveCliConf(conf).valueOr:
+    return err("failed to translate the configuration: " & error)
+  return await buildStack(
+    resolved.wakuConf, resolved.messagingConf, resolved.channelsConf, appCallbacks
+  )
+
+proc new*(
+    T: type LogosDelivery, conf: LogosDeliveryConf, appCallbacks: AppCallbacks = nil
+): Future[Result[LogosDelivery, string]] {.async.} =
+  ## Builds the stack from a resolved per-layer config; each layer is
+  ## mounted iff its config is present.
+  let wakuConf = WakuNodeConf(conf.kernelConf).toWakuConf().valueOr:
+      return err("failed to handle the configuration: " & error)
+  return await buildStack(wakuConf, conf.messagingConf, conf.channelsConf, appCallbacks)
 
 proc new*(
     T: type LogosDelivery, kernelConf: KernelConf, appCallbacks: AppCallbacks = nil
@@ -162,22 +188,36 @@ proc new*(
 
 proc new*(
     T: type LogosDelivery,
-    entryLayer: EntryLayer = EntryLayer.channels,
     mode: LogosDeliveryMode = LogosDeliveryMode.Core,
     preset: string = "",
     messagingOverrides: MessagingClientConf = MessagingClientConf(),
-    channelsOverrides: ReliableChannelManagerConf = ReliableChannelManagerConf(),
     appCallbacks: AppCallbacks = nil,
 ): Future[Result[LogosDelivery, string]] {.async.} =
-  ## Messaging entry point (app dev). Builds the stack from preset, mode and
-  ## overrides; `entryLayer` selects messaging vs channels (use `new(kernelConf)`
-  ## for a kernel-only node).
+  ## Messaging entry point (app dev): kernel + messaging. The configs you pass
+  ## select the mount height: use `new(kernelConf)` for a kernel-only node, or
+  ## the overload that also takes `channelsOverrides` for the full channels
+  ## stack.
   let conf = LogosDeliveryConf.init(
-    entryLayer = entryLayer,
+    mode = mode, preset = preset, messagingOverrides = messagingOverrides
+  ).valueOr:
+    return err("failed to synthesize configuration: " & error)
+  return await LogosDelivery.new(conf, appCallbacks)
+
+proc new*(
+    T: type LogosDelivery,
+    mode: LogosDeliveryMode,
+    preset: string,
+    messagingOverrides: MessagingClientConf,
+    channelsOverrides: ReliableChannelManagerConf,
+    appCallbacks: AppCallbacks = nil,
+): Future[Result[LogosDelivery, string]] {.async.} =
+  ## Channels entry point (app dev): kernel + messaging + channels. The
+  ## channels config mounts the channels layer.
+  let conf = LogosDeliveryConf.init(
     mode = mode,
     preset = preset,
     messagingOverrides = messagingOverrides,
-    channelsOverrides = channelsOverrides,
+    channelsOverrides = Opt.some(channelsOverrides),
   ).valueOr:
     return err("failed to synthesize configuration: " & error)
   return await LogosDelivery.new(conf, appCallbacks)

--- a/tests/api/test_api_health.nim
+++ b/tests/api/test_api_health.nim
@@ -91,8 +91,9 @@ suite "LM API health checking":
     serviceNode.wakuRelay.subscribe(DefaultShard, dummyHandler)
 
     lockNewGlobalBrokerContext:
-      var conf = MessagingClientConf().toWakuNodeConf(Core).valueOr:
-          raiseAssert error
+      var conf = defaultLogosDeliveryNodeConf().valueOr:
+        raiseAssert error
+      conf.mode = Opt.some(Core)
       conf.listenAddress = parseIpAddress("0.0.0.0")
       conf.tcpPort = Port(0)
       conf.discv5UdpPort = Port(0)
@@ -271,8 +272,9 @@ suite "LM API health checking":
     var edgeWaku: LogosDelivery
 
     lockNewGlobalBrokerContext:
-      var edgeConf = MessagingClientConf().toWakuNodeConf(Edge).valueOr:
-          raiseAssert error
+      var edgeConf = defaultLogosDeliveryNodeConf().valueOr:
+        raiseAssert error
+      edgeConf.mode = Opt.some(Edge)
       edgeConf.listenAddress = parseIpAddress("0.0.0.0")
       edgeConf.tcpPort = Port(0)
       edgeConf.discv5UdpPort = Port(0)

--- a/tests/api/test_api_receive.nim
+++ b/tests/api/test_api_receive.nim
@@ -82,10 +82,10 @@ proc waitForConnectionStatus(
   finally:
     await EventConnectionStatusChange.dropListener(brokerCtx, handle)
 
-proc createApiNodeConf(numShards: uint16 = 1): WakuNodeConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
-      raiseAssert error
+proc createApiNodeConf(numShards: uint16 = 1): LogosDeliveryNodeConf =
+  var conf = defaultLogosDeliveryNodeConf().valueOr:
+    raiseAssert error
+  conf.mode = Opt.some(messaging_conf.LogosDeliveryMode.Core)
   conf.listenAddress = parseIpAddress("0.0.0.0")
   conf.tcpPort = Port(0)
   conf.discv5UdpPort = Port(0)

--- a/tests/api/test_api_send.nim
+++ b/tests/api/test_api_send.nim
@@ -122,9 +122,10 @@ proc validate(
 
 proc createApiNodeConf(
     mode: messaging_conf.LogosDeliveryMode = messaging_conf.LogosDeliveryMode.Core
-): WakuNodeConf =
-  var conf = MessagingClientConf().toWakuNodeConf(mode).valueOr:
-      raiseAssert error
+): LogosDeliveryNodeConf =
+  var conf = defaultLogosDeliveryNodeConf().valueOr:
+    raiseAssert error
+  conf.mode = Opt.some(mode)
   conf.listenAddress = parseIpAddress("0.0.0.0")
   conf.tcpPort = Port(0)
   conf.discv5UdpPort = Port(0)

--- a/tests/api/test_api_subscription.nim
+++ b/tests/api/test_api_subscription.nim
@@ -71,9 +71,10 @@ type TestNetwork = ref object
 proc createApiNodeConf(
     mode: messaging_conf.LogosDeliveryMode = messaging_conf.LogosDeliveryMode.Core,
     numShards: uint16 = 1,
-): WakuNodeConf =
-  var conf = MessagingClientConf().toWakuNodeConf(mode).valueOr:
-      raiseAssert error
+): LogosDeliveryNodeConf =
+  var conf = defaultLogosDeliveryNodeConf().valueOr:
+    raiseAssert error
+  conf.mode = Opt.some(mode)
   conf.listenAddress = parseIpAddress("0.0.0.0")
   conf.tcpPort = Port(0)
   conf.discv5UdpPort = Port(0)
@@ -82,7 +83,7 @@ proc createApiNodeConf(
   conf.rest = false
   result = conf
 
-proc setupSubscriberNode(conf: WakuNodeConf): Future[LogosDelivery] {.async.} =
+proc setupSubscriberNode(conf: LogosDeliveryNodeConf): Future[LogosDelivery] {.async.} =
   var node: LogosDelivery
   lockNewGlobalBrokerContext:
     node = (await LogosDelivery.new(conf)).expect("Failed to create subscriber node")

--- a/tests/api/test_conf.nim
+++ b/tests/api/test_conf.nim
@@ -6,6 +6,7 @@ import logos_delivery
 import logos_delivery/api/conf/logos_delivery_conf_json
 import logos_delivery/waku/factory/[waku_conf, networks_config]
 import logos_delivery/waku/common/logging
+import tools/confutils/cli_args
 
 suite "MessagingClientConf - mode expansion (toWakuNodeConf)":
   test "Core mode enables relay + service protocols":
@@ -301,8 +302,20 @@ suite "parseLogosDeliveryConf - JSON parsing":
     # surface as an unknown key.
     check parseLogosDeliveryConf("""{"mode": "core", "kernelConf": {}}""").isErr()
 
+  test "mode with the kernel entry layer is rejected":
+    check parseLogosDeliveryConf(
+      """{"entrylayer": "kernel", "mode": "edge", "kernelConf": {}}"""
+    )
+      .isErr()
+
+  test "channelsOverrides with the messaging entry layer is rejected":
+    check parseLogosDeliveryConf(
+      """{"entrylayer": "messaging", "channelsOverrides": {}}"""
+    )
+      .isErr()
+
 suite "LogosDelivery.new - construction (the app-dev entry)":
-  asyncTest "builds the full messaging stack from mode + overrides":
+  asyncTest "builds the messaging stack from mode + overrides":
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
       node = (
@@ -315,6 +328,25 @@ suite "LogosDelivery.new - construction (the app-dev entry)":
             listenIpv4: Opt.some(parseIpAddress("0.0.0.0")),
             reliabilityEnabled: Opt.some(true),
           ),
+        )
+      ).valueOr:
+        raiseAssert error
+    check:
+      not node.waku.isNil()
+      not node.messagingClient.isNil()
+      node.reliableChannelManager.isNil() # no channels config: layer stays unmounted
+    (await node.stop()).expect("stop")
+
+  asyncTest "builds the full channels stack when a channels config is passed":
+    var node: LogosDelivery
+    lockNewGlobalBrokerContext:
+      node = (
+        await LogosDelivery.new(
+          mode = LogosDeliveryMode.Core,
+          preset = "",
+          messagingOverrides =
+            MessagingClientConf(listenIpv4: Opt.some(parseIpAddress("0.0.0.0"))),
+          channelsOverrides = ReliableChannelManagerConf(),
         )
       ).valueOr:
         raiseAssert error
@@ -347,7 +379,9 @@ suite "MessagingClientConf - store override":
       raiseAssert error
     check:
       kc.store == true # Edge defaults store off; the explicit opt-in wins
-      kc.relay == false # protocols are owned by the mode, not overridable
+      kc.relay == false
+        # MessagingClientConf has no relay field (per spec); only the mode
+        # sets relay on the library API path
 
 suite "LogosDelivery.new - raw kernel construction":
   asyncTest "a kernel-only node mounts the kernel only; start/stop tolerate the nil layers":
@@ -446,3 +480,78 @@ suite "parseLogosDeliveryConf - flat WakuNodeConf shape (interop compatibility)"
     # not flip to flat; the leftover bare field (relay) then has no structured home and
     # is rejected. Guards against the discriminator silently splitting a mixed object.
     check parseLogosDeliveryConf("""{"messagingOverrides": {}, "relay": true}""").isErr()
+
+suite "LogosDeliveryConf - mount height from config presence":
+  test "library API init without channels config mounts no channels layer":
+    let res = LogosDeliveryConf.init(
+      mode = LogosDeliveryMode.Core,
+      preset = "",
+      messagingOverrides = MessagingClientConf(),
+    )
+    check:
+      res.isOk()
+      res.get().messagingConf.isSome()
+      res.get().channelsConf.isNone()
+
+  test "library API init with channels config mounts the channels layer":
+    let res = LogosDeliveryConf.init(
+      mode = LogosDeliveryMode.Core,
+      preset = "",
+      messagingOverrides = MessagingClientConf(),
+      channelsOverrides = Opt.some(ReliableChannelManagerConf()),
+    )
+    check:
+      res.isOk()
+      res.get().messagingConf.isSome()
+      res.get().channelsConf.isSome()
+
+suite "LogosDeliveryNodeConf - CLI frontend translation (resolveCliConf)":
+  proc cliConf(
+      entryLayer: EntryLayer, mode = Opt.none(LogosDeliveryMode)
+  ): LogosDeliveryNodeConf =
+    var conf = defaultLogosDeliveryNodeConf().expect("defaults")
+    conf.entryLayer = entryLayer
+    conf.mode = mode
+    return conf
+
+  test "kernel entry: no upper layers; no mode is applied":
+    let plan = resolveCliConf(cliConf(EntryLayer.kernel)).expect("translate")
+    check:
+      plan.messagingConf.isNone()
+      plan.channelsConf.isNone()
+      plan.wakuConf.relay == false # no mode ran; the builder default applies
+
+  test "kernel entry rejects an explicit mode":
+    check resolveCliConf(cliConf(EntryLayer.kernel, Opt.some(LogosDeliveryMode.Edge)))
+      .isErr()
+
+  test "channels entry: both layer configs present; the mode runs":
+    let plan = resolveCliConf(
+        cliConf(EntryLayer.channels, Opt.some(LogosDeliveryMode.Edge))
+      )
+      .expect("translate")
+    check:
+      plan.messagingConf.isSome()
+      plan.channelsConf.isSome()
+      plan.wakuConf.relay == false # set by the Edge mode
+
+  test "an unset mode resolves to Core":
+    let plan = resolveCliConf(cliConf(EntryLayer.messaging)).expect("translate")
+    check:
+      plan.channelsConf.isNone()
+      plan.wakuConf.relay == true # set by the Core mode
+
+  test "an explicit flag has priority over the mode":
+    var conf = cliConf(EntryLayer.channels)
+    conf.relay = Opt.some(false)
+    let plan = resolveCliConf(conf).expect("translate")
+    check plan.wakuConf.relay == false # explicit wins over Core
+
+  test "the preset's messaging fields reach the messaging layer":
+    var conf = cliConf(EntryLayer.messaging)
+    conf.preset = "twn"
+    let plan = resolveCliConf(conf).expect("translate")
+    check:
+      # TWN sets p2pReliability off; the hard default is on. The flat-JSON and
+      # library API paths resolve this too, so all doors agree.
+      plan.messagingConf.get().reliabilityEnabled == Opt.some(false)

--- a/tests/api/test_entry_layer.nim
+++ b/tests/api/test_entry_layer.nim
@@ -19,11 +19,10 @@ import ../testlib/testasync
 ##   messaging -> waku + messagingClient
 ##   channels  -> waku + messagingClient + reliableChannelManager
 
-proc nodeConf(entryLayer: EntryLayer, rest = false): WakuNodeConf =
-  var conf = defaultWakuNodeConf().valueOr:
+proc nodeConf(entryLayer: EntryLayer, rest = false): LogosDeliveryNodeConf =
+  var conf = defaultLogosDeliveryNodeConf().valueOr:
     raiseAssert error
   conf.entryLayer = entryLayer
-  conf.mode = LogosDeliveryMode.Core
   conf.listenAddress = parseIpAddress("0.0.0.0")
   conf.tcpPort = Port(0)
   conf.discv5UdpPort = Port(0)

--- a/tests/api/test_messaging_rest.nim
+++ b/tests/api/test_messaging_rest.nim
@@ -26,11 +26,11 @@ import ../testlib/[wakucore, testasync]
 ## the same context the send/recv services emit on — so we do not depend on real
 ## network delivery.
 
-proc restNodeConf(): WakuNodeConf =
-  var conf = defaultWakuNodeConf().valueOr:
+proc restNodeConf(): LogosDeliveryNodeConf =
+  var conf = defaultLogosDeliveryNodeConf().valueOr:
     raiseAssert error
   conf.entryLayer = EntryLayer.messaging
-  conf.mode = LogosDeliveryMode.Core
+  conf.mode = Opt.some(LogosDeliveryMode.Core)
   conf.listenAddress = parseIpAddress("0.0.0.0")
   conf.tcpPort = Port(0)
   conf.discv5UdpPort = Port(0)

--- a/tests/api/test_node_conf.nim
+++ b/tests/api/test_node_conf.nim
@@ -2,7 +2,7 @@
 
 import results, testutils/unittests
 import
-  tools/confutils/cli_args,
+  tools/confutils/kernel_cli_args,
   logos_delivery/waku/factory/waku_conf,
   logos_delivery/waku/factory/networks_config
 

--- a/tests/channels/test_reliable_channel_send_receive.nim
+++ b/tests/channels/test_reliable_channel_send_receive.nim
@@ -27,10 +27,10 @@ import snapshot_codec
 
 const TestTimeout = chronos.seconds(15)
 
-proc createApiNodeConf(): WakuNodeConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
-      raiseAssert error
+proc createApiNodeConf(): LogosDeliveryNodeConf =
+  var conf = defaultLogosDeliveryNodeConf().valueOr:
+    raiseAssert error
+  conf.mode = Opt.some(messaging_conf.LogosDeliveryMode.Core)
   conf.listenAddress = parseIpAddress("0.0.0.0")
   conf.tcpPort = Port(0)
   conf.discv5UdpPort = Port(0)

--- a/tests/test_waku.nim
+++ b/tests/test_waku.nim
@@ -5,7 +5,7 @@ import results, std/net
 import chronos, testutils/unittests
 
 import logos_delivery
-import tools/confutils/cli_args
+import tools/confutils/kernel_cli_args
 import logos_delivery/waku/factory/networks_config
 import logos_delivery/waku/factory/conf_builder/conf_builder
 
@@ -20,7 +20,11 @@ suite "LogosDelivery API - Create node":
     # This is the actual minimal config but as the node auto-start, it is not suitable for tests
 
     ## When
-    let ld = (await LogosDelivery.new(nodeConf)).valueOr:
+    let ld = (
+      await LogosDelivery.new(
+        KernelConf(nodeConf), MessagingClientConf(), ReliableChannelManagerConf()
+      )
+    ).valueOr:
       raiseAssert "LogosDelivery.new (minimal config) failed: " & error
 
     ## Then
@@ -45,7 +49,11 @@ suite "LogosDelivery API - Create node":
     ]
 
     ## When
-    let ld = (await LogosDelivery.new(nodeConf)).valueOr:
+    let ld = (
+      await LogosDelivery.new(
+        KernelConf(nodeConf), MessagingClientConf(), ReliableChannelManagerConf()
+      )
+    ).valueOr:
       raiseAssert "LogosDelivery.new (full config) failed: " & error
 
     ## Then
@@ -72,7 +80,11 @@ suite "LogosDelivery API - Create node":
     ]
 
     ## When
-    let ld = (await LogosDelivery.new(nodeConf)).valueOr:
+    let ld = (
+      await LogosDelivery.new(
+        KernelConf(nodeConf), MessagingClientConf(), ReliableChannelManagerConf()
+      )
+    ).valueOr:
       raiseAssert "LogosDelivery.new (mixed entry nodes) failed: " & error
 
     ## Then

--- a/tests/wakunode2/test_cli_args.nim
+++ b/tests/wakunode2/test_cli_args.nim
@@ -11,7 +11,7 @@ import
   confutils,
   stint
 
-import tools/confutils/cli_args
+import tools/confutils/kernel_cli_args
 
 import
   ../../logos_delivery/waku/factory/networks_config,

--- a/tests/wakunode2/test_validators.nim
+++ b/tests/wakunode2/test_validators.nim
@@ -15,7 +15,7 @@ import
 import
   logos_delivery/waku/
     [waku_core, node/peer_manager, waku_node, factory/validator_signed],
-  tools/confutils/cli_args,
+  tools/confutils/kernel_cli_args,
   ../testlib/wakucore,
   ../testlib/wakunode
 

--- a/tools/confutils/kernel_cli_args.nim
+++ b/tools/confutils/kernel_cli_args.nim
@@ -1,5 +1,3 @@
-## CLI configuration of logosdeliverynode.
-
 import
   std/[strutils, strformat, sequtils],
   results,
@@ -33,33 +31,37 @@ import
     waku_core/message/default_values,
     waku_mix,
   ],
+  ../../tools/rln_keystore_generator/rln_keystore_generator,
   ./entry_nodes
 
 import ./envvar as confEnvvarDefs, ./envvar_net as confEnvvarNet
-import ./kernel_cli_args
 
-export modes, kernel_cli_args
+export
+  confTomlDefs, confTomlNet, confEnvvarDefs, confEnvvarNet, ProtectedShard,
+  DefaultMaxWakuMessageSizeStr, DefaultAgentString, modes
 
 logScope:
-  topics = "delivery cli args"
+  topics = "waku cli args"
 
-proc `$`*(u: EthRpcUrl): string =
-  ## `load` and `defaultLogosDeliveryNodeConf` are generic over the conf type,
-  ## so confutils expands its default-value printing in the caller's scope;
-  ## this `$` must be exported for those expansions to resolve.
-  string(u)
+# Git version in git describe format (defined at compile time)
+const git_version* {.strdefine.} = "n/a"
 
-type LogosDeliveryNodeConf* = object
-  ## LogosDeliveryNodeConf is the kernel configuration with two additional
-  ## fields.
-  ##
-  ## `entryLayer` lets logosdeliverynode users specify the layer-mount height,
-  ## which is never guessed from given CLI parameters.
-  ##
-  ## `mode` is a messaging-only option. The kernel layer has no mode: its
-  ## entire configuration must be given explicitly and it has its own
-  ## per-config-option defaults which add up to what you'd expect for
-  ## fleet-node use.
+# CLI defaults that differ from confbuilder defaults
+const
+  DefaultCLIRelay* = true
+  DefaultCLIPeerExchange* = true
+  DefaultCLIRendezvous* = true
+  DefaultCLINat* = "any"
+
+type ConfResult*[T] = Result[T, string]
+
+type EthRpcUrl* = distinct string
+
+type StartUpCommand* = enum
+  noCommand # default, runs waku
+  generateRlnKeystore # generates a new RLN keystore
+
+type WakuNodeConf* = object
   configFile* {.
     desc: "Loads configuration from a TOML file (cmd-line parameters take precedence)",
     name: "config-file"
@@ -166,20 +168,6 @@ type LogosDeliveryNodeConf* = object
       defaultValue: "",
       name: "preset"
     .}: string
-
-    entryLayer* {.
-      desc:
-        "Top API layer to run: kernel (transport only), messaging, or channels (messaging + reliable channels).",
-      defaultValue: EntryLayer.channels,
-      name: "entry-layer"
-    .}: EntryLayer
-
-    mode* {.
-      desc:
-        "Node operating mode: Edge (client-only) or Core (full service node). Applies to --entry-layer=messaging|channels; rejected for --entry-layer=kernel. Default is Core.",
-      defaultValue: Opt.none(LogosDeliveryMode),
-      name: "mode"
-    .}: Opt[LogosDeliveryMode]
 
     # Opt-typed; desc states the default since the CLI can't auto-show it for Opt.none().
     clusterId* {.
@@ -290,10 +278,10 @@ hence would have reachability issues.""",
 
     ## Relay config
     relay* {.
-      desc: "Enable relay protocol: true|false. Default is true.",
-      defaultValue: Opt.none(bool),
+      desc: "Enable relay protocol: true|false",
+      defaultValue: DefaultCLIRelay,
       name: "relay"
-    .}: Opt[bool]
+    .}: bool
 
     relayPeerExchange* {.
       desc: "Enable gossipsub peer exchange in relay protocol: true|false",
@@ -368,10 +356,8 @@ hence would have reachability issues.""",
 
     ## Store and message store config
     store* {.
-      desc: "Enable/disable waku store protocol. Default is false.",
-      defaultValue: Opt.none(bool),
-      name: "store"
-    .}: Opt[bool]
+      desc: "Enable/disable waku store protocol", defaultValue: false, name: "store"
+    .}: bool
 
     storenode* {.
       desc: "Peer multiaddress to query for storage",
@@ -445,10 +431,8 @@ hence would have reachability issues.""",
 
     ## Filter config
     filter* {.
-      desc: "Enable filter protocol: true|false. Default is true.",
-      defaultValue: Opt.none(bool),
-      name: "filter"
-    .}: Opt[bool]
+      desc: "Enable filter protocol: true|false", defaultValue: true, name: "filter"
+    .}: bool
 
     filternode* {.
       desc: "Peer multiaddr to request content filtering of messages.",
@@ -478,10 +462,10 @@ hence would have reachability issues.""",
 
     ## Lightpush config
     lightpush* {.
-      desc: "Enable lightpush protocol: true|false. Default is true.",
-      defaultValue: Opt.none(bool),
+      desc: "Enable lightpush protocol: true|false",
+      defaultValue: true,
       name: "lightpush"
-    .}: Opt[bool]
+    .}: bool
 
     lightpushnode* {.
       desc: "Peer multiaddr to request lightpush of published messages.",
@@ -574,7 +558,8 @@ hence would have reachability issues.""",
     ## Discovery v5 config
     discv5Discovery* {.
       desc: "Enable discovering nodes via Node Discovery v5. Default is true.",
-      defaultValue: Opt.none(bool),
+      defaultValue: Opt.some(true),
+      defaultValueDesc: "true",
       name: "discv5-discovery"
     .}: Opt[bool]
 
@@ -622,11 +607,10 @@ hence would have reachability issues.""",
 
     ## waku peer exchange config
     peerExchange* {.
-      desc:
-        "Enable waku peer exchange protocol (responder side): true|false. Default is true.",
-      defaultValue: Opt.none(bool),
+      desc: "Enable waku peer exchange protocol (responder side): true|false",
+      defaultValue: DefaultCLIPeerExchange,
       name: "peer-exchange"
-    .}: Opt[bool]
+    .}: bool
 
     peerExchangeNode* {.
       desc:
@@ -637,10 +621,10 @@ hence would have reachability issues.""",
 
     ## Rendez vous
     rendezvous* {.
-      desc: "Enable waku rendezvous discovery server. Default is true.",
-      defaultValue: Opt.none(bool),
+      desc: "Enable waku rendezvous discovery server",
+      defaultValue: DefaultCLIRendezvous,
       name: "rendezvous"
-    .}: Opt[bool]
+    .}: bool
 
     #Mix config
     # Opt-typed; desc states the default since the CLI can't auto-show it for Opt.none().
@@ -749,28 +733,202 @@ hence would have reachability issues.""",
       name: "local-storage-path"
     .}: string
 
-proc parseCmdArg*(T: type LogosDeliveryMode, s: string): T {.raises: [ValueError].} =
-  ## The generic `Opt[T]` flag parser dispatches to `parseCmdArg(T, ...)` for
-  ## the inner type, so `Opt[LogosDeliveryMode]` needs this overload (bare enum
-  ## fields parse through confutils' internal enum support instead).
-  case s.strip().toLowerAscii()
-  of "edge":
-    LogosDeliveryMode.Edge
-  of "core":
-    LogosDeliveryMode.Core
-  else:
-    raise
-      newException(ValueError, "Invalid mode: '" & s & "' (expected 'Edge' or 'Core')")
+## Parsing
 
-proc completeCmdArg*(T: type LogosDeliveryMode, val: string): seq[string] =
+# NOTE: Keys are different in nim-libp2p
+proc parseCmdArg*(T: type crypto.PrivateKey, p: string): T =
+  try:
+    let key = SkPrivateKey.init(utils.fromHex(p)).tryGet()
+    crypto.PrivateKey(scheme: Secp256k1, skkey: key)
+  except CatchableError:
+    raise newException(ValueError, "Invalid private key")
+
+proc parseCmdArg*[T](_: type seq[T], s: string): seq[T] {.raises: [ValueError].} =
+  var
+    inputSeq: JsonNode
+    res: seq[T] = @[]
+
+  try:
+    inputSeq = s.parseJson()
+  except Exception:
+    raise newException(ValueError, fmt"Could not parse sequence: {s}")
+
+  for entry in inputSeq:
+    let formattedString = ($entry).strip(chars = {'\"'})
+    res.add(parseCmdArg(T, formattedString))
+
+  return res
+
+proc completeCmdArg*(T: type crypto.PrivateKey, val: string): seq[string] =
   return @[]
 
-proc load*(T: type LogosDeliveryNodeConf, version = ""): ConfResult[T] =
+# TODO: Remove when removing protected-topic configuration
+proc isNumber(x: string): bool =
   try:
-    let conf = LogosDeliveryNodeConf.load(
+    discard parseInt(x)
+    result = true
+  except ValueError:
+    result = false
+
+proc parseCmdArg*(T: type MixNodePubInfo, p: string): T =
+  let elements = p.split(":")
+  if elements.len != 2:
+    raise newException(
+      ValueError, "Invalid format for mix node expected multiaddr:mixPublicKey"
+    )
+  let multiaddr = MultiAddress.init(elements[0]).valueOr:
+    raise newException(ValueError, "Invalid multiaddress format")
+  if not multiaddr.contains(multiCodec("ip4")).get():
+    raise newException(
+      ValueError, "Invalid format for ip address, expected a ipv4 multiaddress"
+    )
+  return MixNodePubInfo(
+    multiaddr: elements[0], pubKey: intoCurve25519Key(ncrutils.fromHex(elements[1]))
+  )
+
+proc parseCmdArg*(T: type ProtectedShard, p: string): T =
+  let elements = p.split(":")
+  if elements.len != 2:
+    raise newException(
+      ValueError, "Invalid format for protected shard expected shard:publickey"
+    )
+  let publicKey = secp256k1.SkPublicKey.fromHex(elements[1]).valueOr:
+    raise newException(ValueError, "Invalid public key")
+
+  if isNumber(elements[0]):
+    return ProtectedShard(shard: uint16.parseCmdArg(elements[0]), key: publicKey)
+
+  # TODO: Remove when removing protected-topic configuration
+  let shard = RelayShard.parse(elements[0]).valueOr:
+    raise newException(
+      ValueError,
+      "Invalid pubsub topic. Pubsub topics must be in the format /waku/2/rs/<cluster-id>/<shard-id>",
+    )
+  return ProtectedShard(shard: shard.shardId, key: publicKey)
+
+proc completeCmdArg*(T: type ProtectedShard, val: string): seq[string] =
+  return @[]
+
+proc completeCmdArg*(T: type IpAddress, val: string): seq[string] =
+  return @[]
+
+proc defaultListenAddress*(): IpAddress =
+  # TODO: Should probably listen on both ipv4 and ipv6 by default.
+  (static IpAddress(family: IpAddressFamily.IPv4, address_v4: [0'u8, 0, 0, 0]))
+
+proc defaultColocationLimit*(): int =
+  return DefaultColocationLimit
+
+proc completeCmdArg*(T: type Port, val: string): seq[string] =
+  return @[]
+
+proc completeCmdArg*(T: type EthRpcUrl, val: string): seq[string] =
+  return @[]
+
+proc parseCmdArg*(T: type EthRpcUrl, s: string): T =
+  ## allowed patterns:
+  ## http://url:port
+  ## https://url:port
+  ## http://url:port/path
+  ## https://url:port/path
+  ## http://url/with/path
+  ## http://url:port/path?query
+  ## https://url:port/path?query
+  ## https://username:password@url:port/path
+  ## https://username:password@url:port/path?query
+  ## supports IPv4, IPv6, URL-encoded credentials
+  ## disallowed patterns:
+  ## any valid/invalid ws or wss url
+  var httpPattern =
+    re2"^(https?):\/\/(([^\s:@]*(?:%[0-9A-Fa-f]{2})*):([^\s:@]*(?:%[0-9A-Fa-f]{2})*)@)?((?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?|(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|\[[0-9a-fA-F:]+\])(?::([0-9]{1,5}))?(\/[^\s?#]*)?(\?[^\s#]*)?(#[^\s]*)?$"
+  var wsPattern =
+    re2"^(wss?):\/\/([\w-]+(\.[\w-]+)+)(:[0-9]{1,5})?(\/[\w.,@?^=%&:\/~+#-]*)?$"
+  if regex.match(s, wsPattern):
+    raise newException(
+      ValueError, "Websocket RPC URL is not supported, Please use an HTTP URL"
+    )
+  if not regex.match(s, httpPattern):
+    raise newException(ValueError, "Invalid HTTP RPC URL")
+  return EthRpcUrl(s)
+
+## Load
+
+proc readValue*(
+    r: var TomlReader, value: var crypto.PrivateKey
+) {.raises: [SerializationError].} =
+  try:
+    value = parseCmdArg(crypto.PrivateKey, r.readValue(string))
+  except CatchableError:
+    raise newException(SerializationError, getCurrentExceptionMsg())
+
+proc readValue*(
+    r: var EnvvarReader, value: var crypto.PrivateKey
+) {.raises: [SerializationError].} =
+  try:
+    value = parseCmdArg(crypto.PrivateKey, r.readValue(string))
+  except CatchableError:
+    raise newException(SerializationError, getCurrentExceptionMsg())
+
+proc readValue*(
+    r: var TomlReader, value: var MixNodePubInfo
+) {.raises: [SerializationError].} =
+  try:
+    value = parseCmdArg(MixNodePubInfo, r.readValue(string))
+  except CatchableError:
+    raise newException(SerializationError, getCurrentExceptionMsg())
+
+proc readValue*(
+    r: var EnvvarReader, value: var MixNodePubInfo
+) {.raises: [SerializationError].} =
+  try:
+    value = parseCmdArg(MixNodePubInfo, r.readValue(string))
+  except CatchableError:
+    raise newException(SerializationError, getCurrentExceptionMsg())
+
+proc readValue*(
+    r: var TomlReader, value: var ProtectedShard
+) {.raises: [SerializationError].} =
+  try:
+    value = parseCmdArg(ProtectedShard, r.readValue(string))
+  except CatchableError:
+    raise newException(SerializationError, getCurrentExceptionMsg())
+
+proc readValue*(
+    r: var EnvvarReader, value: var ProtectedShard
+) {.raises: [SerializationError].} =
+  try:
+    value = parseCmdArg(ProtectedShard, r.readValue(string))
+  except CatchableError:
+    raise newException(SerializationError, getCurrentExceptionMsg())
+
+proc readValue*(
+    r: var TomlReader, value: var EthRpcUrl
+) {.raises: [SerializationError].} =
+  try:
+    value = parseCmdArg(EthRpcUrl, r.readValue(string))
+  except CatchableError:
+    raise newException(SerializationError, getCurrentExceptionMsg())
+
+proc readValue*(
+    r: var EnvvarReader, value: var EthRpcUrl
+) {.raises: [SerializationError].} =
+  try:
+    value = parseCmdArg(EthRpcUrl, r.readValue(string))
+  except CatchableError:
+    raise newException(SerializationError, getCurrentExceptionMsg())
+
+proc readValue*[T](
+    r: var TomlReader, value: var Opt[T]
+) {.gcsafe, raises: [SerializationError, IOError].} =
+  mixin readValue
+  value = Opt.some(r.readValue(T))
+
+proc load*(T: type WakuNodeConf, version = ""): ConfResult[T] =
+  try:
+    let conf = WakuNodeConf.load(
       version = version,
       secondarySources = proc(
-          conf: LogosDeliveryNodeConf, sources: auto
+          conf: WakuNodeConf, sources: auto
       ) {.gcsafe, raises: [ConfigurationError].} =
         sources.addConfigFile(Envvar, InputFile("wakunode2"))
 
@@ -783,14 +941,55 @@ proc load*(T: type LogosDeliveryNodeConf, version = ""): ConfResult[T] =
   except CatchableError:
     err(getCurrentExceptionMsg())
 
-proc defaultLogosDeliveryNodeConf*(): ConfResult[LogosDeliveryNodeConf] =
+proc defaultWakuNodeConf*(): ConfResult[WakuNodeConf] =
   try:
-    let conf = LogosDeliveryNodeConf.load(version = "", cmdLine = @[])
+    let conf = WakuNodeConf.load(version = "", cmdLine = @[])
     return ok(conf)
   except CatchableError:
-    return err("exception in defaultLogosDeliveryNodeConf: " & getCurrentExceptionMsg())
+    return err("exception in defaultWakuNodeConf: " & getCurrentExceptionMsg())
 
-proc toWakuConf*(n: LogosDeliveryNodeConf): ConfResult[WakuConf] =
+proc toKeystoreGeneratorConf*(n: WakuNodeConf): RlnKeystoreGeneratorConf =
+  RlnKeystoreGeneratorConf(
+    execute: n.execute,
+    chainId: UInt256.fromBytesBE(n.rlnRelayChainId.toBytesBE()),
+    ethClientUrls: n.ethClientUrls.mapIt(string(it)),
+    ethContractAddress: n.rlnRelayEthContractAddress,
+    userMessageLimit: n.rlnRelayUserMessageLimit.get(DefaultRlnRelayUserMessageLimit),
+    ethPrivateKey: n.rlnRelayEthPrivateKey,
+    credPath: n.rlnRelayCredPath,
+    credPassword: n.rlnRelayCredPassword,
+  )
+
+proc toNetworkPresetConf*(
+    preset: string, clusterId: Opt[uint16]
+): ConfResult[Opt[NetworkPresetConf]] =
+  var lcPreset = toLowerAscii(preset)
+  if clusterId.isSome() and clusterId.get() == 1:
+    warn(
+      "TWN - The Waku Network configuration will not be applied when `--cluster-id=1` is passed in future releases. Use `--preset=twn` instead."
+    )
+    lcPreset = "twn"
+  if clusterId.isSome() and clusterId.get() == 2:
+    warn(
+      "Logos.dev - Logos.dev configuration will not be applied when `--cluster-id=2` is passed in future releases. Use `--preset=logos.dev` instead."
+    )
+    lcPreset = "logos.dev"
+
+  case lcPreset
+  of "":
+    ok(Opt.none(NetworkPresetConf))
+  of "twn":
+    ok(Opt.some(NetworkPresetConf.TheWakuNetworkConf()))
+  of "logos.dev", "logosdev":
+    ok(Opt.some(NetworkPresetConf.LogosDevConf()))
+  of "logos.test", "logostest":
+    ok(Opt.some(NetworkPresetConf.LogosTestConf()))
+  of "status.prod", "statusprod":
+    ok(Opt.some(NetworkPresetConf.StatusProdConf()))
+  else:
+    err("Invalid --preset value passed: " & lcPreset)
+
+proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   var b = WakuConfBuilder.init()
 
   let networkPresetConf = toNetworkPresetConf(n.preset, n.clusterId).valueOr:
@@ -856,8 +1055,7 @@ proc toWakuConf*(n: LogosDeliveryNodeConf): ConfResult[WakuConf] =
   b.withDnsAddrsNameServers(n.dnsAddrsNameServers)
   b.withDns4DomainName(n.dns4DomainName)
   b.withCircuitRelayClient(n.isRelayClient)
-  if n.relay.isSome():
-    b.withRelay(n.relay.get())
+  b.withRelay(n.relay)
   b.withRelayPeerExchange(n.relayPeerExchange)
   b.withRelayShardedPeerManagement(n.relayShardedPeerManagement)
   b.withStaticNodes(n.staticNodes)
@@ -895,8 +1093,7 @@ proc toWakuConf*(n: LogosDeliveryNodeConf): ConfResult[WakuConf] =
 
   b.withContentTopics(n.contentTopics)
 
-  if n.store.isSome():
-    b.storeServiceConf.withEnabled(n.store.get())
+  b.storeServiceConf.withEnabled(n.store)
   b.storeServiceConf.withRetentionPolicies(n.storeMessageRetentionPolicy)
   b.storeServiceConf.withDbUrl(n.storeMessageDbUrl)
   b.storeServiceConf.withDbVacuum(n.storeMessageDbVacuum)
@@ -926,14 +1123,12 @@ proc toWakuConf*(n: LogosDeliveryNodeConf): ConfResult[WakuConf] =
   if n.mixkey.isSome():
     b.mixConf.withMixKey(n.mixkey.get())
 
-  if n.filter.isSome():
-    b.filterServiceConf.withEnabled(n.filter.get())
+  b.filterServiceConf.withEnabled(n.filter)
   b.filterServiceConf.withSubscriptionTimeout(n.filterSubscriptionTimeout)
   b.filterServiceConf.withMaxPeersToServe(n.filterMaxPeersToServe)
   b.filterServiceConf.withMaxCriteria(n.filterMaxCriteria)
 
-  if n.lightpush.isSome():
-    b.withLightPush(n.lightpush.get())
+  b.withLightPush(n.lightpush)
 
   b.restServerConf.withEnabled(n.rest)
   b.restServerConf.withListenAddress(n.restAddress)
@@ -961,11 +1156,9 @@ proc toWakuConf*(n: LogosDeliveryNodeConf): ConfResult[WakuConf] =
   b.discv5Conf.withBucketIpLimit(n.discv5BucketIpLimit)
   b.discv5Conf.withBitsPerHop(n.discv5BitsPerHop)
 
-  if n.peerExchange.isSome():
-    b.withPeerExchange(n.peerExchange.get())
+  b.withPeerExchange(n.peerExchange)
 
-  if n.rendezvous.isSome():
-    b.withRendezvous(n.rendezvous.get())
+  b.withRendezvous(n.rendezvous)
 
   b.webSocketConf.withEnabled(n.websocketSupport)
   b.webSocketConf.withWebSocketPort(n.websocketPort)


### PR DESCRIPTION
## Description

This PR gives logosdeliverynode its own CLI config instead of sharing wakunode2's.

The shared config code between logosdeliverynode and wakunode2 had two problems:

* entry-layer/mode were grafted onto WakuNodeConf (kernel config) but they don't apply to the kernel layer config
* applyMode overwrote explicit CLI flags whenever the entry layer wasn't kernel, so a node started with `--relay=false` and the default entry layer became a relay node

Now the kernel CLI (`kernel_cli_args.nim`) is kernel-only and logosdeliverynode has its own `cli_args.nim` with optionalized protocol flags.

Precedence is `builder defaults < preset < mode < explicit flags`, so an explicit override switch (e.g. --relay) in the logosdeliverynode CLI overrides everything else, including --mode toggles.

In logosdeliverynode, `--mode` with `--entry-layer=kernel` is an error instead of being silently ignored. EntryLayer is also gone from the library new/init procs, since the layers you mount follow from which configs you pass.

## Changes

* remove entry-layer/mode fields from wakunode2's renamed kernel_cli_args.nim
* logosdeliverynode's new cli_args.nim allows mode and optional protocol flags
* logosdeliverynode rejects --mode with --entry-layer=kernel
* delete EntryLayer from library API new/init (redundant with proc signatures)

## Issue

Maintenance Y2026H2 #4043
