### PR TITLE
fix(ci): daily build times out

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -20,7 +20,10 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    # The full examples+tools matrix compiles the whole stack once per
+    # binary (~10 min each at -j2); a cold-cache run needs ~55 min on the
+    # ubuntu runners, so 45 was killing the job mid-compile.
+    timeout-minutes: 90
 
     name: build-${{ matrix.os }}
     steps:
@@ -52,8 +55,25 @@ jobs:
             .git/modules
           key: ${{ runner.os }}-vendor-modules-${{ steps.submodules.outputs.hash }}
 
-      - name: Make update
-        run: make update
+      - name: Cache nimble deps
+        id: cache-nimbledeps
+        uses: actions/cache@v3
+        with:
+          path: |
+            nimbledeps/
+            nimble.paths
+          key: ${{ runner.os }}-nimbledeps-v2-nimble${{ env.NIMBLE_VERSION }}-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
+
+      - name: Install nimble deps
+        if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
+        run: |
+          # nim's source tree checksums differently across platforms, so its
+          # locked checksum is unreliable. --useSystemNim uses the CI nim and
+          # skips that check, while still verifying every other locked dep.
+          nimble setup --localdeps -y --useSystemNim
+          make rebuild-nat-libs-nimbledeps
+          make rebuild-bearssl-nimbledeps
+          touch nimbledeps/.nimble-setup
 
       - name: Build binaries
         run: make V=1 examples tools

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -20,9 +20,6 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
-    # The full examples+tools matrix compiles the whole stack once per
-    # binary (~10 min each at -j2); a cold-cache run needs ~55 min on the
-    # ubuntu runners, so 45 was killing the job mid-compile.
     timeout-minutes: 90
 
     name: build-${{ matrix.os }}


### PR DESCRIPTION
Closes https://github.com/logos-messaging/logos-delivery/issues/3968

## Description

This PR fixes the nightly build timeout on ubuntu.

The job builds all examples and tools and installs all nimble deps on every run, which takes more than the 45 minute limit.

The deps are cached with the same steps as ci.yml to help speed up builds (on a cache hit).

## Changes

* increase build timeout to 90 minutes
* keep nimble deps between runs (same as ci.yml)
* remove dead "Make update" step

## Issue

Maintenance Y2026H2 #4043