### PR TITLE
ci(e2e): point the S11/S25 store peers at the built image too

### DIFF
--- a/.github/workflows/e2e-api-tests.yml
+++ b/.github/workflows/e2e-api-tests.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 45
     name: api-e2e
     env:
+      NODE_1: ${{ inputs.node_image }}
       NODE_2: ${{ inputs.node_image }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
The e2e API workflow sets only `NODE_2`, so `NODE_1` falls back to the hardcoded
default in `tests-e2e/src/env_vars.py:17` — our `v0.38.1` release from July. Two
tests read it: the store peers behind S11 and S25
(`test_send_lightpush_and_edge.py:80` and `:441`). They have been checking a July
release instead of the image built from the PR, and nothing in the logs said so.

One line: `NODE_1: ${{ inputs.node_image }}`.

An empty `node_image` still falls back to `v0.38.1` — `get_env_var` treats the
empty string as unset — so fork PRs and the non-docker subset behave exactly as
before (`ci.yml:222`).

`ADDITIONAL_NODES` and `DEFAULT_NWAKU` are deliberately left alone: their only
readers (`setup_additional_publishing_nodes`, `setup_additional_store_nodes`) have
no callers under `tests-e2e/`, and `DEFAULT_NWAKU` there is a hardcoded literal
rather than an env lookup, so setting either would be a no-op today.