### PR TITLE
chore(deps): bump nim-ffi to v0.3.0

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -61,7 +61,7 @@ requires "nim >= 2.2.4",
 
 # Packages not on nimble (use git URLs)
 
-requires "https://github.com/logos-messaging/nim-ffi#53515de17af0ef3e88b2aec9675b8163dddc14ae" # v0.3.0-rc.2
+requires "https://github.com/logos-messaging/nim-ffi#b6c17dc822960b626d76d814de90208c0a40a44e" # v0.3.0
 
 requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb948b32a4ade1de3b5"
 

--- a/nimble.lock
+++ b/nimble.lock
@@ -644,7 +644,7 @@
     },
     "ffi": {
       "version": "0.3.0",
-      "vcsRevision": "53515de17af0ef3e88b2aec9675b8163dddc14ae",
+      "vcsRevision": "b6c17dc822960b626d76d814de90208c0a40a44e",
       "url": "https://github.com/logos-messaging/nim-ffi",
       "downloadMethod": "git",
       "dependencies": [
@@ -655,7 +655,7 @@
         "cbor_serialization"
       ],
       "checksums": {
-        "sha1": "1d84ceaf8594f4970c5a37f916003ffc0531dc4e"
+        "sha1": "74e796df3ef39d828e014df701127edfbee459e0"
       }
     },
     "boringssl": {

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -285,8 +285,8 @@
 
   ffi = pkgs.fetchgit {
     url = "https://github.com/logos-messaging/nim-ffi";
-    rev = "53515de17af0ef3e88b2aec9675b8163dddc14ae";
-    sha256 = "0ncf9j7fhgd3nswr4rh19jx77dl974sajphdl04cb602hshgj5ij";
+    rev = "b6c17dc822960b626d76d814de90208c0a40a44e";
+    sha256 = "1sjnax54j39igsxkig095grj4x3j9div4fimrmz609byhp4qdavh";
     fetchSubmodules = true;
   };
 

--- a/nix/submodules.json
+++ b/nix/submodules.json
@@ -56,7 +56,7 @@
   {
     "path": "vendor/nim-ffi",
     "url": "https://github.com/logos-messaging/nim-ffi",
-    "rev": "53515de17af0ef3e88b2aec9675b8163dddc14ae"
+    "rev": "b6c17dc822960b626d76d814de90208c0a40a44e"
   }
   ,
   {


### PR DESCRIPTION
## Summary

Bumps `nim-ffi` from **v0.3.0-rc.2** (`53515de`) to the **v0.3.0** release (`b6c17dc`).

Note: the `v0.3.0` tag is annotated — the tag object is `69779c9`, the commit it points at is `b6c17dc`. The pins use the commit SHA, matching the existing convention in this repo.

## Upstream changes picked up

| Commit | Change |
| --- | --- |
| `b6c17dc` | fix(ffi): run the `{.ffiDtor.}` teardown on the recycle path (logos-messaging/nim-ffi#147) |
| `587c8f0` | feat(perf): C++ e2e perf test harness (`tests/perf`) (logos-messaging/nim-ffi#144) |

`#147` is the upstream fix for the FFI destroy/stop teardown gap (#4108).

## Files updated

| File | Change |
| --- | --- |
| `logos_delivery.nimble` | pinned revision + comment `# v0.3.0` |
| `nimble.lock` | `ffi` `vcsRevision` + package `sha1` checksum |
| `nix/deps.nix` | `ffi` `rev` + `sha256` (via `nix-prefetch-git --fetch-submodules`) |
| `nix/submodules.json` | `ffi` `rev` |

`flake.lock` pins only `nixpkgs` / `rust-overlay` / `zerokit` — it carries no `nim-ffi` node, so it needs no change.

## Scope note

`nimble lock` re-resolves the whole graph and wanted to bump 12 unrelated packages (nim 2.2.4→2.2.10, boringssl 0.0.8→0.0.10, sqlite 3.53.0→3.53.2, zippy, …). Those were reverted — the lock delta here is confined to the `ffi` entry. nim-ffi's own requirements are identical between the two revisions (`cbor_serialization == 0.3.0`, already locked at 0.3.0), so no transitive change is needed.

## Verification

- `nimble setup --localdeps` resolves the new lock cleanly; the new checksum is accepted and the package installs as `ffi-0.3.0-74e796df…` with `nimblemeta.json` `vcsRevision = b6c17dc…`.
- `nim check` on `library/liblogosdelivery.nim` (full build flags, including `-d:ffiGenBindings`) exits **0** — no API drift against v0.3.0. Warnings/hints only, all pre-existing.
- Not run locally: the full `make liblogosdelivery` link step, which additionally needs a `librln` (Rust zerokit) build. That is a link-stage dependency unrelated to this bump; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)