### PR TITLE
chore(ffi): bump nim-ffi to v0.3.1-rc.0

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -57,11 +57,12 @@ requires "nim >= 2.2.4",
   "zlib",
   # Debug & Testing
   "testutils",
-  "unittest2",
-  # FFI
-  "ffi == 0.3.0"
+  "unittest2"
 
 # Packages not on nimble (use git URLs)
+
+# v0.3.1-rc.0
+requires "https://github.com/logos-messaging/nim-ffi#07ee8e1d6500762bab290465457a8d23559de546"
 
 requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb948b32a4ade1de3b5"
 

--- a/nimble.lock
+++ b/nimble.lock
@@ -644,7 +644,7 @@
     },
     "ffi": {
       "version": "0.3.0",
-      "vcsRevision": "b6c17dc822960b626d76d814de90208c0a40a44e",
+      "vcsRevision": "07ee8e1d6500762bab290465457a8d23559de546",
       "url": "https://github.com/logos-messaging/nim-ffi",
       "downloadMethod": "git",
       "dependencies": [
@@ -655,7 +655,7 @@
         "cbor_serialization"
       ],
       "checksums": {
-        "sha1": "74e796df3ef39d828e014df701127edfbee459e0"
+        "sha1": "a6ac9d68f58fa6b695ec77452396b99367f774c8"
       }
     },
     "boringssl": {

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -285,8 +285,8 @@
 
   ffi = pkgs.fetchgit {
     url = "https://github.com/logos-messaging/nim-ffi";
-    rev = "b6c17dc822960b626d76d814de90208c0a40a44e";
-    sha256 = "1sjnax54j39igsxkig095grj4x3j9div4fimrmz609byhp4qdavh";
+    rev = "07ee8e1d6500762bab290465457a8d23559de546";
+    sha256 = "04q5gmldyxd8jawrnjfws007zpyr4h08ijphp943iypbpblflfmz";
     fetchSubmodules = true;
   };
 

--- a/nix/submodules.json
+++ b/nix/submodules.json
@@ -56,7 +56,7 @@
   {
     "path": "vendor/nim-ffi",
     "url": "https://github.com/logos-messaging/nim-ffi",
-    "rev": "b6c17dc822960b626d76d814de90208c0a40a44e"
+    "rev": "07ee8e1d6500762bab290465457a8d23559de546"
   }
   ,
   {


### PR DESCRIPTION
## Description

Bumps nim-ffi from v0.3.0 to v0.3.1-rc.0 (`07ee8e1`).

The release hardens the pooled FFI context: the host now holds an opaque generation-stamped token instead of the raw slot address, a request carries the claim it was submitted under, a slot is reset before it serves the next owner, and a context whose `{.ffiDtor.}` did not finish is quarantined instead of recycled. It also caps ingress (`-d:ffiRequestQueueDepth`, 1024 per queue, 16 queues; `-d:ffiMaxRequestPayloadBytes`, 8 MiB) and stops a listener callback that adds or removes a listener from deadlocking the event thread. The C ABI is unchanged: the token is pointer-sized and the generated headers still declare `void* ctx`.

The pin moves back from a version constraint to a git revision. The tag `v0.3.1-rc.0` keeps `version = "0.3.0"` in `ffi.nimble`, so `ffi == 0.3.0` resolves the `v0.3.0` tag (commit `b6c17dc`) and `ffi == 0.3.1` does not resolve at all. A local `make liblogosdelivery` with only `nimble.lock` and `nix/deps.nix` updated built green against the old sources, so the `requires` line is what actually selects the revision here. `nimble.lock` keeps `"version": "0.3.0"` for the same reason: that field mirrors the version the package declares, not the git tag.

## Changes

- `logos_delivery.nimble`: replace `"ffi == 0.3.0"` with `requires "https://github.com/logos-messaging/nim-ffi#07ee8e1d6500762bab290465457a8d23559de546"`.
- `nimble.lock`: `vcsRevision` and the package `checksums.sha1`.
- `nix/deps.nix`: `rev` and `sha256`, from `nix-prefetch-git --fetch-submodules` as `tools/gen-nix-deps.sh` does.
- `nix/submodules.json`: `rev`.

## Notes for review

`library/logos_delivery_api/node_api.nim:206` awaits `stopNode` inside the `{.ffiDtor.}`. Under this release a teardown that overruns `-d:ffiTeardownTimeoutMs` (10 s) no longer only logs: the recycle fails, `logosdelivery_destroy` returns `RET_ERR`, and the pool slot stays claimed for the life of the process. `library/README.md` (the `logosdelivery_destroy` section) still describes the old behaviour and wants a follow-up.

## Issue

N/A
