### PR TITLE
chore: bump dependencies for nim-libp2p 2.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 80
 
     name: test-${{ matrix.os }}
     steps:

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -28,9 +28,12 @@ requires "nim >= 2.2.4",
   "toml_serialization",
   "faststreams",
   # Networking & P2P
-  "https://github.com/vacp2p/nim-libp2p.git#v2.0.0",
+  # Pin by name: nimble treats a url requirement as a different package,
+  # and nim-sds and libp2p_mix require libp2p by name.
+  "libp2p == 2.2.1",
   "eth",
-  "nat_traversal",
+  # nat_traversal stays in the graph through libp2p, which links
+  # the miniupnpc and libnatpmp static libs. Nat.mk and the iOS steps stay.
   "dnsdisc",
   "dnsclient",
   "httputils >= 0.4.1",
@@ -56,7 +59,9 @@ requires "nim >= 2.2.4",
   "minilru",
   "zlib",
   # Debug & Testing
-  "testutils",
+  # testutils 0.8.2's fuzzing tool imports the results package and
+  # breaks the Windows --localdeps install.
+  "testutils == 0.8.1",
   "unittest2"
 
 # Packages not on nimble (use git URLs)
@@ -68,9 +73,13 @@ requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb
 
 requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 
-requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
+# Exact pin: libp2p only sets a floor, and a re-solve floats to
+# the newest lsquic release and rewrites the lock.
+requires "lsquic == 0.8.1"
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
-requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
+# Temporary pin to an unmerged mix commit that widens
+# mix's libp2p requirement. Mix master still requires libp2p 2.2.0 exactly.
+requires "https://github.com/logos-co/nim-libp2p-mix#39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94"
 
 proc getMyCPU(): string =
   ## Need to set cpu more explicit manner to avoid arch issues between dependencies

--- a/nimble.lock
+++ b/nimble.lock
@@ -11,81 +11,28 @@
         "sha1": "68bb85cbfb1832ce4db43943911b046c3af3caab"
       }
     },
-    "unittest2": {
-      "version": "0.2.5",
-      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
-      "url": "https://github.com/status-im/nim-unittest2",
+    "libbacktrace": {
+      "version": "0.2.0",
+      "vcsRevision": "95f1bbfe696b4b5c768f7cc52c2597cd782f1e7d",
+      "url": "https://github.com/status-im/nim-libbacktrace",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
+        "sha1": "4f89a505ec8bb97a5925e0b6537f2c32f817d512"
       }
     },
-    "bearssl": {
-      "version": "0.2.8",
-      "vcsRevision": "22c6a76ce015bc07e011562bdcfc51d9446c1e82",
-      "url": "https://github.com/status-im/nim-bearssl",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "da4dd7ae96d536bdaf42dca9c85d7aed024b6a86"
-      }
-    },
-    "bearssl_pkey_decoder": {
-      "version": "#21dd3710df9345ed2ad8bf8f882761e07863b8e0",
-      "vcsRevision": "21dd3710df9345ed2ad8bf8f882761e07863b8e0",
-      "url": "https://github.com/vacp2p/bearssl_pkey_decoder",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "bearssl"
-      ],
-      "checksums": {
-        "sha1": "21b42e2e6ddca6c875d3fc50f36a5115abf51714"
-      }
-    },
-    "jwt": {
-      "version": "#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
-      "vcsRevision": "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
-      "url": "https://github.com/vacp2p/nim-jwt.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "bearssl",
-        "bearssl_pkey_decoder"
-      ],
-      "checksums": {
-        "sha1": "3cd368666fd2bc7f99f253452289e827abcac13c"
-      }
-    },
-    "testutils": {
-      "version": "0.8.1",
-      "vcsRevision": "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d",
-      "url": "https://github.com/status-im/nim-testutils",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "96a11cf8b84fa9bd12d4a553afa1cc4b7f9df4e3"
-      }
-    },
-    "db_connector": {
-      "version": "0.1.0",
-      "vcsRevision": "29450a2063970712422e1ab857695c12d80112a6",
-      "url": "https://github.com/nim-lang/db_connector",
+    "npeg": {
+      "version": "1.3.0",
+      "vcsRevision": "409f6796d0e880b3f0222c964d1da7de6e450811",
+      "url": "https://github.com/zevv/npeg",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "4f2e67d0e4b61af9ac5575509305660b473f01a4"
+        "sha1": "64f15c85a059c889cb11c5fe72372677c50da621"
       }
     },
     "results": {
@@ -113,9 +60,111 @@
         "sha1": "1a376d3e710590ef2c48748a546369755f0a7c97"
       }
     },
+    "unicodedb": {
+      "version": "0.13.2",
+      "vcsRevision": "66f2458710dc641dd4640368f9483c8a0ec70561",
+      "url": "https://github.com/nitely/nim-unicodedb",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "739102d885d99bb4571b1955f5f12aee423c935b"
+      }
+    },
+    "regex": {
+      "version": "0.26.3",
+      "vcsRevision": "4593305ed1e49731fc75af1dc572dd2559aad19c",
+      "url": "https://github.com/nitely/nim-regex",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unicodedb"
+      ],
+      "checksums": {
+        "sha1": "4d24e7d7441137cd202e16f2359a5807ddbdc31f"
+      }
+    },
+    "boringssl": {
+      "version": "0.0.10",
+      "vcsRevision": "084f2c8994137a72655b72745936a05949c768cc",
+      "url": "https://github.com/vacp2p/nim-boringssl",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "4ac575c18b11c0f06d6381279843aa8508f7940e"
+      }
+    },
+    "unittest2": {
+      "version": "0.2.5",
+      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
+      "url": "https://github.com/status-im/nim-unittest2.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
+      }
+    },
+    "intops": {
+      "version": "1.0.8",
+      "vcsRevision": "ade5d78d60124d1fd50d2109c5eb9416ed147231",
+      "url": "https://github.com/vacp2p/nim-intops",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "e9371f3fa2356d57fd3a5e516ad68e1e611b7b12"
+      }
+    },
+    "bearssl": {
+      "version": "0.2.12",
+      "vcsRevision": "945ac7beb5f18172c04f253e6210ebe9b0545050",
+      "url": "https://github.com/status-im/nim-bearssl",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "7279af96e24a0bc675222f8696cf6918b49e4fc1"
+      }
+    },
+    "bearssl_pkey_decoder": {
+      "version": "#d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368",
+      "vcsRevision": "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368",
+      "url": "https://github.com/vacp2p/bearssl_pkey_decoder",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "bearssl"
+      ],
+      "checksums": {
+        "sha1": "8666edbcb77cb9f97c659114d57c4ba0e7ab74c3"
+      }
+    },
+    "jwt": {
+      "version": "#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
+      "vcsRevision": "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
+      "url": "https://github.com/vacp2p/nim-jwt.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "bearssl",
+        "bearssl_pkey_decoder"
+      ],
+      "checksums": {
+        "sha1": "3cd368666fd2bc7f99f253452289e827abcac13c"
+      }
+    },
     "stew": {
-      "version": "0.5.0",
-      "vcsRevision": "4382b18f04b3c43c8409bfcd6b62063773b2bbaa",
+      "version": "0.5.1",
+      "vcsRevision": "232673b2c2ec5ef05962ad8082878869b3b6d084",
       "url": "https://github.com/status-im/nim-stew",
       "downloadMethod": "git",
       "dependencies": [
@@ -124,12 +173,25 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "db22942939773ab7d5a0f2b2668c237240c67dd6"
+        "sha1": "46b1ef3b95b3deaedf4cc02cb3b07e3b0ee840fa"
+      }
+    },
+    "testutils": {
+      "version": "0.8.1",
+      "vcsRevision": "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d",
+      "url": "https://github.com/status-im/nim-testutils",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "96a11cf8b84fa9bd12d4a553afa1cc4b7f9df4e3"
       }
     },
     "zlib": {
-      "version": "0.1.0",
-      "vcsRevision": "e680f269fb01af2c34a2ba879ff281795a5258fe",
+      "version": "0.2.0",
+      "vcsRevision": "190246aa0bb6569781370964fa2faa474203d6dd",
       "url": "https://github.com/status-im/nim-zlib",
       "downloadMethod": "git",
       "dependencies": [
@@ -138,12 +200,12 @@
         "results"
       ],
       "checksums": {
-        "sha1": "bbde4f5a97a84b450fef7d107461e5f35cf2b47f"
+        "sha1": "a8c0c569d82315f3ffc1249ab42b0404e84fddc3"
       }
     },
     "httputils": {
-      "version": "0.4.1",
-      "vcsRevision": "f142cb2e8bd812dd002a6493b6082827bb248592",
+      "version": "0.5.0",
+      "vcsRevision": "1e11ab929058e43c825d92006660c84caea9b1c0",
       "url": "https://github.com/status-im/nim-http-utils",
       "downloadMethod": "git",
       "dependencies": [
@@ -153,12 +215,12 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "016774ab31c3afff9a423f7d80584905ee59c570"
+        "sha1": "f5d8704b69fa9458eee9c7e17265f659bd726fd8"
       }
     },
     "chronos": {
-      "version": "4.2.2",
-      "vcsRevision": "45f43a9ad8bd8bcf5903b42f365c1c879bd54240",
+      "version": "4.2.4",
+      "vcsRevision": "90f543e447f6ade46f028bd7bdf882ae7fcb0ba9",
       "url": "https://github.com/status-im/nim-chronos",
       "downloadMethod": "git",
       "dependencies": [
@@ -170,12 +232,12 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "3a4c9477df8cef20a04e4f1b54a2d74fdfc2a3d0"
+        "sha1": "2161fffc20d6337784b5cee15a486b50f185e6ce"
       }
     },
     "metrics": {
-      "version": "0.2.1",
-      "vcsRevision": "a1296caf3ebb5f30f51a5feae7749a30df2824c2",
+      "version": "0.2.2",
+      "vcsRevision": "9f2e1d4a4164deb37603b16cedd1707408ee5955",
       "url": "https://github.com/status-im/nim-metrics",
       "downloadMethod": "git",
       "dependencies": [
@@ -185,12 +247,12 @@
         "stew"
       ],
       "checksums": {
-        "sha1": "84bb09873d7677c06046f391c7b473cd2fcff8a2"
+        "sha1": "d64e789ba2a3b848eb7c628d728623126182c3f1"
       }
     },
     "faststreams": {
-      "version": "0.5.0",
-      "vcsRevision": "ce27581a3e881f782f482cb66dc5b07a02bd615e",
+      "version": "0.5.1",
+      "vcsRevision": "50889cd16ec8771106cdd0eeea460039e8571e06",
       "url": "https://github.com/status-im/nim-faststreams",
       "downloadMethod": "git",
       "dependencies": [
@@ -199,7 +261,7 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "ee61e507b805ae1df7ec936f03f2d101b0d72383"
+        "sha1": "969ceb3666e807db8fe5c8df63466749822367a9"
       }
     },
     "snappy": {
@@ -212,15 +274,16 @@
         "faststreams",
         "unittest2",
         "results",
-        "stew"
+        "stew",
+        "testutils"
       ],
       "checksums": {
         "sha1": "e572d60d6a3178c5b1cde2400c51ad771812cd3d"
       }
     },
     "serialization": {
-      "version": "0.5.2",
-      "vcsRevision": "b0f2fa32960ea532a184394b0f27be37bd80248b",
+      "version": "0.5.3",
+      "vcsRevision": "4092500cea76154576539371709ae801afbd2a9d",
       "url": "https://github.com/status-im/nim-serialization",
       "downloadMethod": "git",
       "dependencies": [
@@ -230,7 +293,24 @@
         "stew"
       ],
       "checksums": {
-        "sha1": "fa35c1bb76a0a02a2379fe86eaae0957c7527cb8"
+        "sha1": "c087d26c50da40436599163888532660d6f9e631"
+      }
+    },
+    "protobuf_serialization": {
+      "version": "0.6.1",
+      "vcsRevision": "24ddb65800b351268412840b19a33c6b61bb3046",
+      "url": "https://github.com/status-im/nim-protobuf-serialization",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "stew",
+        "faststreams",
+        "serialization",
+        "npeg",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "6d42c6f78efb3d93c2ba87fe5a9be7e12622cc21"
       }
     },
     "toml_serialization": {
@@ -250,7 +330,7 @@
     },
     "confutils": {
       "version": "0.1.0",
-      "vcsRevision": "36f3115ca350f40841ac0eecc7dfa5fe7790c864",
+      "vcsRevision": "7728f6bd81a1eedcfe277d02ea85fdb805bcc05a",
       "url": "https://github.com/status-im/nim-confutils",
       "downloadMethod": "git",
       "dependencies": [
@@ -260,7 +340,7 @@
         "results"
       ],
       "checksums": {
-        "sha1": "2fbe6418ddd9f79fb11a0addd7666a3e787adbe0"
+        "sha1": "8bc8c30b107fdba73b677e5f257c6c42ae1cdc8e"
       }
     },
     "cbor_serialization": {
@@ -295,8 +375,8 @@
       }
     },
     "chronicles": {
-      "version": "0.12.2",
-      "vcsRevision": "27ec507429a4eb81edc20f28292ee8ec420be05b",
+      "version": "0.12.3",
+      "vcsRevision": "e7f87336d2fa47b7752b42f0be4cabd5663a5e5c",
       "url": "https://github.com/status-im/nim-chronicles",
       "downloadMethod": "git",
       "dependencies": [
@@ -307,12 +387,12 @@
         "testutils"
       ],
       "checksums": {
-        "sha1": "02febb20d088120b2836d3306cfa21f434f88f65"
+        "sha1": "3dab9aabf9c8bd53cfc4b6ecd956b90e5988defd"
       }
     },
     "presto": {
-      "version": "0.1.1",
-      "vcsRevision": "d66043dd7ede146442e6c39720c76a20bde5225f",
+      "version": "0.1.2",
+      "vcsRevision": "8549aa9d872272923825430f5580ba7b1784886e",
       "url": "https://github.com/status-im/nim-presto",
       "downloadMethod": "git",
       "dependencies": [
@@ -324,7 +404,7 @@
         "stew"
       ],
       "checksums": {
-        "sha1": "8df97c45683abe2337bdff43b844c4fbcc124ca2"
+        "sha1": "60ca7f636f4dcbc9bdbf2f5dc92f639dc878264f"
       }
     },
     "brokers": {
@@ -345,17 +425,47 @@
       }
     },
     "stint": {
-      "version": "0.8.2",
-      "vcsRevision": "470b7892561b5179ab20bd389a69217d6213fe58",
+      "version": "0.9.0",
+      "vcsRevision": "273fcdfa8dce4ceb975b383ffafe5e79e82766e2",
       "url": "https://github.com/status-im/nim-stint",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
         "stew",
+        "intops",
         "unittest2"
       ],
       "checksums": {
-        "sha1": "d8f871fd617e7857192d4609fe003b48942a8ae5"
+        "sha1": "9b292b0d627e6f6132a01e00f14e0f0527c6704a"
+      }
+    },
+    "taskpools": {
+      "version": "0.2.1",
+      "vcsRevision": "7d96007793fdb2d244d392eb7c5cfa4a695d4ecc",
+      "url": "https://github.com/status-im/nim-taskpools",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "4b113319a3145f22a9e51eaf7f89600f6741b88b"
+      }
+    },
+    "ffi": {
+      "version": "0.3.0",
+      "vcsRevision": "07ee8e1d6500762bab290465457a8d23559de546",
+      "url": "https://github.com/logos-messaging/nim-ffi",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "chronos",
+        "chronicles",
+        "taskpools",
+        "cbor_serialization"
+      ],
+      "checksums": {
+        "sha1": "a6ac9d68f58fa6b695ec77452396b99367f774c8"
       }
     },
     "minilru": {
@@ -372,16 +482,28 @@
         "sha1": "0be03a5da29fdd4409ea74a60fd0ccce882601b4"
       }
     },
+    "db_connector": {
+      "version": "0.1.0",
+      "vcsRevision": "29450a2063970712422e1ab857695c12d80112a6",
+      "url": "https://github.com/nim-lang/db_connector",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "4f2e67d0e4b61af9ac5575509305660b473f01a4"
+      }
+    },
     "sqlite3_abi": {
-      "version": "3.53.0.0",
-      "vcsRevision": "8240e8e2819dfce1b67fa2733135d01b5cc80ae0",
+      "version": "3.53.4.0",
+      "vcsRevision": "9645cad7f8c6d27a322ef48a60722a3f88f44c27",
       "url": "https://github.com/arnetheduck/nim-sqlite3-abi",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "fb7a6e6f36fc4eb4dfa6634dbcbf5cd0dfd0ebf0"
+        "sha1": "c1fadde68fa0f133289975ebe4838f9690b9e118"
       }
     },
     "dnsclient": {
@@ -396,31 +518,6 @@
         "sha1": "65262c7e533ff49d6aca5539da4bc6c6ce132f40"
       }
     },
-    "unicodedb": {
-      "version": "0.13.2",
-      "vcsRevision": "66f2458710dc641dd4640368f9483c8a0ec70561",
-      "url": "https://github.com/nitely/nim-unicodedb",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "739102d885d99bb4571b1955f5f12aee423c935b"
-      }
-    },
-    "regex": {
-      "version": "0.26.3",
-      "vcsRevision": "4593305ed1e49731fc75af1dc572dd2559aad19c",
-      "url": "https://github.com/nitely/nim-regex",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unicodedb"
-      ],
-      "checksums": {
-        "sha1": "4d24e7d7441137cd202e16f2359a5807ddbdc31f"
-      }
-    },
     "nimcrypto": {
       "version": "0.6.4",
       "vcsRevision": "721fb99ee099b632eb86dfad1f0d96ee87583774",
@@ -433,9 +530,28 @@
         "sha1": "f9ab24fa940ed03d0fb09729a7303feb50b7eaec"
       }
     },
+    "lsquic": {
+      "version": "0.8.1",
+      "vcsRevision": "c9acf6a37347b24ba158f53ff4851e68245950b7",
+      "url": "https://github.com/vacp2p/nim-lsquic",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "zlib",
+        "stew",
+        "chronos",
+        "nimcrypto",
+        "unittest2",
+        "chronicles",
+        "boringssl"
+      ],
+      "checksums": {
+        "sha1": "94e84841563554409861fbe7dd3047c6ce05f1a6"
+      }
+    },
     "websock": {
-      "version": "0.4.0",
-      "vcsRevision": "387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d",
+      "version": "0.4.1",
+      "vcsRevision": "0432dc445c500b20963ef4b76e585c1a3943c254",
       "url": "https://github.com/status-im/nim-websock",
       "downloadMethod": "git",
       "dependencies": [
@@ -450,11 +566,11 @@
         "zlib"
       ],
       "checksums": {
-        "sha1": "fd17a854686d9a19af40aba51f05d06b82fc30ec"
+        "sha1": "7c240c080f618855411bb0ee3984f6062123bcd4"
       }
     },
     "json_rpc": {
-      "version": "0.6.1",
+      "version": "#v0.6.1",
       "vcsRevision": "6f1fff8ba685c9192fab153a9d66484ad9066e78",
       "url": "https://github.com/status-im/nim-json-rpc.git",
       "downloadMethod": "git",
@@ -475,25 +591,6 @@
         "sha1": "596db0aafcb3c83f5dba6d42993f2276e0d00eb5"
       }
     },
-    "lsquic": {
-      "version": "0.5.1",
-      "vcsRevision": "2f01046bf1d513de8b5f8296c3d8bec819ab0cb9",
-      "url": "https://github.com/vacp2p/nim-lsquic",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "zlib",
-        "stew",
-        "chronos",
-        "nimcrypto",
-        "unittest2",
-        "chronicles",
-        "boringssl"
-      ],
-      "checksums": {
-        "sha1": "959df1a9ac2a574d6fe30a4faf37c37b443e1cfb"
-      }
-    },
     "secp256k1": {
       "version": "0.6.0.3.2",
       "vcsRevision": "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15",
@@ -507,6 +604,74 @@
       ],
       "checksums": {
         "sha1": "6618ef9de17121846a8c1d0317026b0ce8584e10"
+      }
+    },
+    "libp2p": {
+      "version": "2.2.1",
+      "vcsRevision": "95d3925db8a3d093dd86647165650472a5342b81",
+      "url": "https://github.com/vacp2p/nim-libp2p",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "libbacktrace",
+        "nimcrypto",
+        "bearssl",
+        "boringssl",
+        "chronicles",
+        "chronos",
+        "metrics",
+        "secp256k1",
+        "stew",
+        "unittest2",
+        "results",
+        "serialization",
+        "lsquic",
+        "protobuf_serialization",
+        "websock",
+        "nat_traversal"
+      ],
+      "checksums": {
+        "sha1": "9c0bfc6ee9e01bab0f46b9e1fd559de0f29f9724"
+      }
+    },
+    "sds": {
+      "version": "#b12f5ee07c5b764303b51fb948b32a4ade1de3b5",
+      "vcsRevision": "b12f5ee07c5b764303b51fb948b32a4ade1de3b5",
+      "url": "https://github.com/logos-messaging/nim-sds.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "chronos",
+        "libp2p",
+        "chronicles",
+        "stew",
+        "stint",
+        "metrics",
+        "results",
+        "ffi"
+      ],
+      "checksums": {
+        "sha1": "175f65038b9877cdf974b07c5f83081f810d5fbe"
+      }
+    },
+    "libp2p_mix": {
+      "version": "#39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94",
+      "vcsRevision": "39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94",
+      "url": "https://github.com/logos-co/nim-libp2p-mix",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "libp2p",
+        "chronicles",
+        "chronos",
+        "metrics",
+        "nimcrypto",
+        "stew",
+        "results",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "053909f0933b725018f7d87b27403a4b06d7f23a"
       }
     },
     "eth": {
@@ -561,8 +726,8 @@
       }
     },
     "dnsdisc": {
-      "version": "0.1.0",
-      "vcsRevision": "38f2e0f52c0a8f032ef4530835e519d550706d9e",
+      "version": "0.1.1",
+      "vcsRevision": "6cb1b7e3922645275043c68e476cac1501a45e55",
       "url": "https://github.com/status-im/nim-dnsdisc",
       "downloadMethod": "git",
       "dependencies": [
@@ -579,144 +744,7 @@
         "results"
       ],
       "checksums": {
-        "sha1": "055b882a0f6b1d1e57a25a7af99d2e5ac6268154"
-      }
-    },
-    "libp2p": {
-      "version": "2.0.0",
-      "vcsRevision": "c43199378f46d0aaf61be1cad1ee1d63e8f665d6",
-      "url": "https://github.com/vacp2p/nim-libp2p.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "nimcrypto",
-        "dnsclient",
-        "bearssl",
-        "boringssl",
-        "chronicles",
-        "chronos",
-        "metrics",
-        "secp256k1",
-        "stew",
-        "unittest2",
-        "results",
-        "serialization",
-        "lsquic",
-        "protobuf_serialization",
-        "websock",
-        "jwt"
-      ],
-      "checksums": {
-        "sha1": "327dc7a0cb7e9d0be3d6083841bd496c4cbc48dc"
-      }
-    },
-    "taskpools": {
-      "version": "0.1.0",
-      "vcsRevision": "9e8ccc754631ac55ac2fd495e167e74e86293edb",
-      "url": "https://github.com/status-im/nim-taskpools",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "09e1b2fdad55b973724d61227971afc0df0b7a81"
-      }
-    },
-    "sds": {
-      "version": "#b12f5ee07c5b764303b51fb948b32a4ade1de3b5",
-      "vcsRevision": "b12f5ee07c5b764303b51fb948b32a4ade1de3b5",
-      "url": "https://github.com/logos-messaging/nim-sds.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "chronos",
-        "libp2p",
-        "chronicles",
-        "stew",
-        "stint",
-        "metrics",
-        "results",
-        "ffi"
-      ],
-      "checksums": {
-        "sha1": "175f65038b9877cdf974b07c5f83081f810d5fbe"
-      }
-    },
-    "ffi": {
-      "version": "0.3.0",
-      "vcsRevision": "07ee8e1d6500762bab290465457a8d23559de546",
-      "url": "https://github.com/logos-messaging/nim-ffi",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "chronos",
-        "chronicles",
-        "taskpools",
-        "cbor_serialization"
-      ],
-      "checksums": {
-        "sha1": "a6ac9d68f58fa6b695ec77452396b99367f774c8"
-      }
-    },
-    "boringssl": {
-      "version": "0.0.8",
-      "vcsRevision": "e77caabae78fbc9aa5b78a0a521181b077c82571",
-      "url": "https://github.com/vacp2p/nim-boringssl",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "2f603bb6d70683393bbb091bf6bd325d9c52be9f"
-      }
-    },
-    "protobuf_serialization": {
-      "version": "0.4.0",
-      "vcsRevision": "38d24eb3bd93e605fb88199da71d36b1ec0ad60d",
-      "url": "https://github.com/status-im/nim-protobuf-serialization",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "stew",
-        "faststreams",
-        "serialization",
-        "npeg",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "5a7a80fb8cca29e41899ce9540b74e49c874f8fd"
-      }
-    },
-    "npeg": {
-      "version": "1.3.0",
-      "vcsRevision": "409f6796d0e880b3f0222c964d1da7de6e450811",
-      "url": "https://github.com/zevv/npeg",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "64f15c85a059c889cb11c5fe72372677c50da621"
-      }
-    },
-    "libp2p_mix": {
-      "version": "0.1.0",
-      "vcsRevision": "380513117d556bf8f70066f5e72a7fd74fe36ba6",
-      "url": "https://github.com/logos-co/nim-libp2p-mix",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "libp2p",
-        "chronicles",
-        "chronos",
-        "metrics",
-        "nimcrypto",
-        "stew",
-        "results",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "ccfb0f0160ac15ac970471964c730d57edacad91"
+        "sha1": "6451cab35990f334a46927f49f9176579460934d"
       }
     }
   },

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -3,45 +3,17 @@
 { pkgs }:
 
 {
-  unittest2 = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-unittest2";
-    rev = "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189";
-    sha256 = "1n8n36kad50m97b64y7bzzknz9n7szffxhp0bqpk3g2v7zpda8sw";
+  libbacktrace = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-libbacktrace";
+    rev = "95f1bbfe696b4b5c768f7cc52c2597cd782f1e7d";
+    sha256 = "0pkhwmzidh82ilm4hcd1hwg25jbkcnqgq41ky52y1z6hgxyj6ddm";
     fetchSubmodules = true;
   };
 
-  bearssl = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-bearssl";
-    rev = "22c6a76ce015bc07e011562bdcfc51d9446c1e82";
-    sha256 = "1cvdd7lfrpa6asmc39al3g4py5nqhpqmvypc36r5qyv7p5arc8a3";
-    fetchSubmodules = true;
-  };
-
-  bearssl_pkey_decoder = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/bearssl_pkey_decoder";
-    rev = "21dd3710df9345ed2ad8bf8f882761e07863b8e0";
-    sha256 = "0bl3f147zmkazbhdkr4cj1nipf9rqiw3g4hh1j424k9hpl55zdpg";
-    fetchSubmodules = true;
-  };
-
-  jwt = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-jwt.git";
-    rev = "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2";
-    sha256 = "1hnxsl5762fdn80hl4xxfdqrcgmxrrfck66js1iqaqfxc4m0fv63";
-    fetchSubmodules = true;
-  };
-
-  testutils = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-testutils";
-    rev = "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d";
-    sha256 = "1vbkr6i5yxhc2ai3b7rbglhmyc98f99x874fqdp6a152a6kqgwxy";
-    fetchSubmodules = true;
-  };
-
-  db_connector = pkgs.fetchgit {
-    url = "https://github.com/nim-lang/db_connector";
-    rev = "29450a2063970712422e1ab857695c12d80112a6";
-    sha256 = "11dna09ccdhj3pzpqa04j7a95ibx907z6n1ff33yf0n92qa4x59z";
+  npeg = pkgs.fetchgit {
+    url = "https://github.com/zevv/npeg";
+    rev = "409f6796d0e880b3f0222c964d1da7de6e450811";
+    sha256 = "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm";
     fetchSubmodules = true;
   };
 
@@ -59,45 +31,108 @@
     fetchSubmodules = true;
   };
 
+  unicodedb = pkgs.fetchgit {
+    url = "https://github.com/nitely/nim-unicodedb";
+    rev = "66f2458710dc641dd4640368f9483c8a0ec70561";
+    sha256 = "092z3glgdb7rmwajm7dmqzvralkm7ixighixk8ycf8sf17zm72ck";
+    fetchSubmodules = true;
+  };
+
+  regex = pkgs.fetchgit {
+    url = "https://github.com/nitely/nim-regex";
+    rev = "4593305ed1e49731fc75af1dc572dd2559aad19c";
+    sha256 = "1b666qws5sva3n5allin0ycvnqlzdjd7xzprpdvv632ccqddzcl9";
+    fetchSubmodules = true;
+  };
+
+  boringssl = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-boringssl";
+    rev = "084f2c8994137a72655b72745936a05949c768cc";
+    sha256 = "0j62rq4hzxs2xbkvbv6i6hw21nx1l9j1g587gmk656xzgi61gfri";
+    fetchSubmodules = true;
+  };
+
+  unittest2 = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-unittest2.git";
+    rev = "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189";
+    sha256 = "1n8n36kad50m97b64y7bzzknz9n7szffxhp0bqpk3g2v7zpda8sw";
+    fetchSubmodules = true;
+  };
+
+  intops = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-intops";
+    rev = "ade5d78d60124d1fd50d2109c5eb9416ed147231";
+    sha256 = "1q0dg49g8m99m3vrmxxqqhlci62y0mihlp8aq1ssm19597kpvjhz";
+    fetchSubmodules = true;
+  };
+
+  bearssl = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-bearssl";
+    rev = "945ac7beb5f18172c04f253e6210ebe9b0545050";
+    sha256 = "1k2dmlp0ggpbii2p6d6q1kdnfwhbfzmwjj7k83cdgf6waabrgn7x";
+    fetchSubmodules = true;
+  };
+
+  bearssl_pkey_decoder = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/bearssl_pkey_decoder";
+    rev = "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368";
+    sha256 = "0200f7lf3x2hypwr2v9gms6qv7wj8m1phwd25025bfa1w9f2nkbg";
+    fetchSubmodules = true;
+  };
+
+  jwt = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-jwt.git";
+    rev = "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2";
+    sha256 = "1hnxsl5762fdn80hl4xxfdqrcgmxrrfck66js1iqaqfxc4m0fv63";
+    fetchSubmodules = true;
+  };
+
   stew = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-stew";
-    rev = "4382b18f04b3c43c8409bfcd6b62063773b2bbaa";
-    sha256 = "0mx9g5m636h3sk5pllcpylk51brf7lx91izx3gc23k3ih3hrxyk2";
+    rev = "232673b2c2ec5ef05962ad8082878869b3b6d084";
+    sha256 = "19rvs2a7azrad3wqwp1i9cvgs3b4alskyfclizsc26m3y2fd27k3";
+    fetchSubmodules = true;
+  };
+
+  testutils = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-testutils";
+    rev = "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d";
+    sha256 = "1vbkr6i5yxhc2ai3b7rbglhmyc98f99x874fqdp6a152a6kqgwxy";
     fetchSubmodules = true;
   };
 
   zlib = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-zlib";
-    rev = "e680f269fb01af2c34a2ba879ff281795a5258fe";
-    sha256 = "1xw9f1gjsgqihdg7kdkbaq1wankgnx2vn9l3ihc6nqk2jzv5bvk5";
+    rev = "190246aa0bb6569781370964fa2faa474203d6dd";
+    sha256 = "0x5l55gwzb1ay3k9inmi1g25jiv7flry247fcwd8rw3zw9pgchfv";
     fetchSubmodules = true;
   };
 
   httputils = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-http-utils";
-    rev = "f142cb2e8bd812dd002a6493b6082827bb248592";
-    sha256 = "03msj4zdxraz4qx9cidb17g7v0asazxv91nng6xxbzjxz0qaqxw6";
+    rev = "1e11ab929058e43c825d92006660c84caea9b1c0";
+    sha256 = "1mh0pwm1h4xj8bmdp49c3s4va2r1p99j86rxg0bpgmm7yz8akszy";
     fetchSubmodules = true;
   };
 
   chronos = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-chronos";
-    rev = "45f43a9ad8bd8bcf5903b42f365c1c879bd54240";
-    sha256 = "1v1n59zfzznp97pvwgs9kf136bqmv4x2s2y9f24msspa7qv27w39";
+    rev = "90f543e447f6ade46f028bd7bdf882ae7fcb0ba9";
+    sha256 = "0grbkcr4whiadzcszx84ch4mpa71hhr77n3z0dlzyb4d4iykj6cr";
     fetchSubmodules = true;
   };
 
   metrics = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-metrics";
-    rev = "a1296caf3ebb5f30f51a5feae7749a30df2824c2";
-    sha256 = "02vxqy20g8012ks939ac25ksc25k727q84si0p2cmihy5bw1a3qm";
+    rev = "9f2e1d4a4164deb37603b16cedd1707408ee5955";
+    sha256 = "05fwkysgj1q3p9ya15pl48nkvl5jv43bmrrkg70z7b6may6fgvqj";
     fetchSubmodules = true;
   };
 
   faststreams = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-faststreams";
-    rev = "ce27581a3e881f782f482cb66dc5b07a02bd615e";
-    sha256 = "0y6bw2scnmr8cxj4fg18w7f34l2bh9qwg5nhlgd84m9fpr5bqarn";
+    rev = "50889cd16ec8771106cdd0eeea460039e8571e06";
+    sha256 = "1hd4bhvw5lzwg924i8dif5mi61h0ayiplq38djvrdbfsjdhw2zvw";
     fetchSubmodules = true;
   };
 
@@ -110,8 +145,15 @@
 
   serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-serialization";
-    rev = "b0f2fa32960ea532a184394b0f27be37bd80248b";
-    sha256 = "0wip1fjx7ka39ck1g1xvmyarzq1p5dlngpqil6zff8k8z5skiz27";
+    rev = "4092500cea76154576539371709ae801afbd2a9d";
+    sha256 = "04pz6d6p3nd1y2khbb667fcd6p2jk4bxv65iaffzq06bqqhalcwc";
+    fetchSubmodules = true;
+  };
+
+  protobuf_serialization = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-protobuf-serialization";
+    rev = "24ddb65800b351268412840b19a33c6b61bb3046";
+    sha256 = "13sr90fzfbn8915fmkkfgkknqbc05m7gpghv14c1z8sqri12yha2";
     fetchSubmodules = true;
   };
 
@@ -124,8 +166,8 @@
 
   confutils = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-confutils";
-    rev = "36f3115ca350f40841ac0eecc7dfa5fe7790c864";
-    sha256 = "1vppqplwlpl7a61r8iki5hlzvhd8lnq41ixpqslv35dnm482c55j";
+    rev = "7728f6bd81a1eedcfe277d02ea85fdb805bcc05a";
+    sha256 = "18bj1ilx10jm2vmqx2wy2xl9rzy7alymi2m4n9jgpa4sbxnfh0x3";
     fetchSubmodules = true;
   };
 
@@ -145,15 +187,15 @@
 
   chronicles = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-chronicles";
-    rev = "27ec507429a4eb81edc20f28292ee8ec420be05b";
-    sha256 = "1xx9fcfwgcaizq3s7i3s03mclz253r5j8va38l9ycl19fcbc96z9";
+    rev = "e7f87336d2fa47b7752b42f0be4cabd5663a5e5c";
+    sha256 = "0bisxny06d354jwb88zx3yrnqkqh1qywcvi7bfqj27jc28832zjl";
     fetchSubmodules = true;
   };
 
   presto = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-presto";
-    rev = "d66043dd7ede146442e6c39720c76a20bde5225f";
-    sha256 = "1hrppcak32aigrdv3mqk124w81yy9jv1prs57vqqhfj83gl930vi";
+    rev = "8549aa9d872272923825430f5580ba7b1784886e";
+    sha256 = "1cmxclj0x4gn4gnm6jmd72hbc4id5a7ngdis82fnb5dnmgqscc4g";
     fetchSubmodules = true;
   };
 
@@ -166,8 +208,22 @@
 
   stint = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-stint";
-    rev = "470b7892561b5179ab20bd389a69217d6213fe58";
-    sha256 = "1isfwmbj98qfi5pm9acy0yyvq0vlz38nxp30xl43jx2mmaga2w22";
+    rev = "273fcdfa8dce4ceb975b383ffafe5e79e82766e2";
+    sha256 = "0a82y2c3s8bfzvaz8bpcfdn22xy79cqzhrkrncbb70lkdnnsyd4h";
+    fetchSubmodules = true;
+  };
+
+  taskpools = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-taskpools";
+    rev = "7d96007793fdb2d244d392eb7c5cfa4a695d4ecc";
+    sha256 = "0qi2kf1lj5ki101whjq68k5l00hh1vrz3izp2riv9q29zicwczyc";
+    fetchSubmodules = true;
+  };
+
+  ffi = pkgs.fetchgit {
+    url = "https://github.com/logos-messaging/nim-ffi";
+    rev = "07ee8e1d6500762bab290465457a8d23559de546";
+    sha256 = "04q5gmldyxd8jawrnjfws007zpyr4h08ijphp943iypbpblflfmz";
     fetchSubmodules = true;
   };
 
@@ -178,10 +234,17 @@
     fetchSubmodules = true;
   };
 
+  db_connector = pkgs.fetchgit {
+    url = "https://github.com/nim-lang/db_connector";
+    rev = "29450a2063970712422e1ab857695c12d80112a6";
+    sha256 = "11dna09ccdhj3pzpqa04j7a95ibx907z6n1ff33yf0n92qa4x59z";
+    fetchSubmodules = true;
+  };
+
   sqlite3_abi = pkgs.fetchgit {
     url = "https://github.com/arnetheduck/nim-sqlite3-abi";
-    rev = "8240e8e2819dfce1b67fa2733135d01b5cc80ae0";
-    sha256 = "0g8bc0kiwxxh3h5w06ksa23cw81hnx87rdn93v64m2f053nb6bcm";
+    rev = "9645cad7f8c6d27a322ef48a60722a3f88f44c27";
+    sha256 = "0vy8viiqbpf28pqy5s515qfsc0ygxxishmyz56xjqa29l3qslqjk";
     fetchSubmodules = true;
   };
 
@@ -192,20 +255,6 @@
     fetchSubmodules = true;
   };
 
-  unicodedb = pkgs.fetchgit {
-    url = "https://github.com/nitely/nim-unicodedb";
-    rev = "66f2458710dc641dd4640368f9483c8a0ec70561";
-    sha256 = "092z3glgdb7rmwajm7dmqzvralkm7ixighixk8ycf8sf17zm72ck";
-    fetchSubmodules = true;
-  };
-
-  regex = pkgs.fetchgit {
-    url = "https://github.com/nitely/nim-regex";
-    rev = "4593305ed1e49731fc75af1dc572dd2559aad19c";
-    sha256 = "1b666qws5sva3n5allin0ycvnqlzdjd7xzprpdvv632ccqddzcl9";
-    fetchSubmodules = true;
-  };
-
   nimcrypto = pkgs.fetchgit {
     url = "https://github.com/cheatfate/nimcrypto";
     rev = "721fb99ee099b632eb86dfad1f0d96ee87583774";
@@ -213,10 +262,17 @@
     fetchSubmodules = true;
   };
 
+  lsquic = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-lsquic";
+    rev = "c9acf6a37347b24ba158f53ff4851e68245950b7";
+    sha256 = "10v2cj6vhsxlmakj70q028mm4rzw10idcv8zvnz1irv939158d4p";
+    fetchSubmodules = true;
+  };
+
   websock = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-websock";
-    rev = "387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d";
-    sha256 = "1v0m3x96fbp9jdzsys6mbxxc2xw3k3dqiv7wksfla89gc6z8w377";
+    rev = "0432dc445c500b20963ef4b76e585c1a3943c254";
+    sha256 = "17kdlywwrlnqx8chf8l1b5gsbix5mmgkpgcwrxgj58af029h4yhr";
     fetchSubmodules = true;
   };
 
@@ -227,17 +283,31 @@
     fetchSubmodules = true;
   };
 
-  lsquic = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-lsquic";
-    rev = "2f01046bf1d513de8b5f8296c3d8bec819ab0cb9";
-    sha256 = "16xj0hx13nc95x7scck8lyir0kzx4wqnd6d4h79aai8j9hlcmbsl";
-    fetchSubmodules = true;
-  };
-
   secp256k1 = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-secp256k1";
     rev = "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15";
     sha256 = "1qjrmwbngb73f6r1fznvig53nyal7wj41d1cmqfksrmivk2sgrn2";
+    fetchSubmodules = true;
+  };
+
+  libp2p = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-libp2p";
+    rev = "95d3925db8a3d093dd86647165650472a5342b81";
+    sha256 = "0swvnvwngp1lkirsp3h7ark9gv5l3f5ka6zcas81c5j9s55zr1nk";
+    fetchSubmodules = true;
+  };
+
+  sds = pkgs.fetchgit {
+    url = "https://github.com/logos-messaging/nim-sds.git";
+    rev = "b12f5ee07c5b764303b51fb948b32a4ade1de3b5";
+    sha256 = "1z8f0v1ww7y6zssdacjxfs6s4862dwckw25df3yn1v0qnz40rpc8";
+    fetchSubmodules = true;
+  };
+
+  libp2p_mix = pkgs.fetchgit {
+    url = "https://github.com/logos-co/nim-libp2p-mix";
+    rev = "39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94";
+    sha256 = "098db702wviph33mzvlj4b20cpj10csfya2yx80rwlppc2brxqc4";
     fetchSubmodules = true;
   };
 
@@ -257,64 +327,8 @@
 
   dnsdisc = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-dnsdisc";
-    rev = "38f2e0f52c0a8f032ef4530835e519d550706d9e";
-    sha256 = "0dk787ny49n41bmzhlrvm87giwajr01gwdw9nlmphch89rdqpxxn";
-    fetchSubmodules = true;
-  };
-
-  libp2p = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-libp2p.git";
-    rev = "c43199378f46d0aaf61be1cad1ee1d63e8f665d6";
-    sha256 = "0q1hkwwz08zfdwwz7cfql1hqil0iyv3dn8jypdwqmg7497l1bmxk";
-    fetchSubmodules = true;
-  };
-
-  taskpools = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-taskpools";
-    rev = "9e8ccc754631ac55ac2fd495e167e74e86293edb";
-    sha256 = "1y78l33vdjxmb9dkr455pbphxa73rgdsh8m9gpkf4d9b1wm1yivy";
-    fetchSubmodules = true;
-  };
-
-  sds = pkgs.fetchgit {
-    url = "https://github.com/logos-messaging/nim-sds.git";
-    rev = "b12f5ee07c5b764303b51fb948b32a4ade1de3b5";
-    sha256 = "1z8f0v1ww7y6zssdacjxfs6s4862dwckw25df3yn1v0qnz40rpc8";
-    fetchSubmodules = true;
-  };
-
-  ffi = pkgs.fetchgit {
-    url = "https://github.com/logos-messaging/nim-ffi";
-    rev = "07ee8e1d6500762bab290465457a8d23559de546";
-    sha256 = "04q5gmldyxd8jawrnjfws007zpyr4h08ijphp943iypbpblflfmz";
-    fetchSubmodules = true;
-  };
-
-  boringssl = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
-    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
-    fetchSubmodules = true;
-  };
-
-  protobuf_serialization = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-protobuf-serialization";
-    rev = "38d24eb3bd93e605fb88199da71d36b1ec0ad60d";
-    sha256 = "0jr0a41b4r444si6xfa7bclw8mjsk6id10lrdvbxzp99750zspb9";
-    fetchSubmodules = true;
-  };
-
-  npeg = pkgs.fetchgit {
-    url = "https://github.com/zevv/npeg";
-    rev = "409f6796d0e880b3f0222c964d1da7de6e450811";
-    sha256 = "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm";
-    fetchSubmodules = true;
-  };
-
-  libp2p_mix = pkgs.fetchgit {
-    url = "https://github.com/logos-co/nim-libp2p-mix";
-    rev = "380513117d556bf8f70066f5e72a7fd74fe36ba6";
-    sha256 = "05zjf98nl2hxx62m9blk4yip2f31y44r5x4n98lmm5hghb7wbcpk";
+    rev = "6cb1b7e3922645275043c68e476cac1501a45e55";
+    sha256 = "02vxprjw4ixicdfczznns62izys9jgmsvy28rzlfd0wqg79gn9mc";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## PR Description

libp2p v2.2.1 bump PR (stack: PR 1 of 5)

Upgrades the dependencies to nim-libp2p 2.2.1.

This PR does not compile on its own. The next PR in the stack adapts the source.

Pins libp2p 2.2.1, lsquic 0.8.1 and testutils 0.8.1, restores the nim entry in the lock file, and raises the CI test timeout to 80 minutes.

**NOTE: This PR pins libp2p_mix to an unmerged branch that relaxes its libp2p version requirement. This will be patched before merging.**

## Changes

* pin nim-libp2p 2.2.1
* pin lsquic 0.8.1
* pin testutils 0.8.1
* pin libp2p_mix to a 2.2.x-compatible commit
* drop the direct nat_traversal requirement
* restore the nim lock entry
* raise the CI test timeout to 80 minutes
