### PR TITLE
chore: adapt Logos Delivery to nim-libp2p 2.2.1

### DIFF
--- a/logos_delivery/messaging/delivery_service/recv_service/recv_service.nim
+++ b/logos_delivery/messaging/delivery_service/recv_service/recv_service.nim
@@ -3,7 +3,7 @@
 ##
 
 import results, std/[tables, sequtils, sets]
-import chronos, chronicles, libp2p/utility
+import chronos, chronicles
 import brokers/broker_context
 import
   logos_delivery/waku/[waku_core, waku_core/topics, waku_store/common],

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -2,7 +2,7 @@
 ##
 
 import std/[sequtils, tables, typetraits]
-import chronos, chronicles, metrics, libp2p/utility
+import chronos, chronicles, metrics
 import brokers/broker_context
 import
   ./[send_processor, relay_processor, lightpush_processor, delivery_task],

--- a/logos_delivery/waku/common/rate_limit/request_limiter.nim
+++ b/logos_delivery/waku/common/rate_limit/request_limiter.nim
@@ -16,7 +16,12 @@
 {.push raises: [].}
 
 import
-  results, std/math, chronicles, chronos/timer, libp2p/stream/connection, libp2p/utility
+  results,
+  std/math,
+  chronicles,
+  chronos/timer,
+  libp2p/stream/connection,
+  libp2p/utils/opt
 
 import std/times except TimeInterval, Duration, seconds, minutes
 

--- a/logos_delivery/waku/common/rate_limit/single_token_limiter.nim
+++ b/logos_delivery/waku/common/rate_limit/single_token_limiter.nim
@@ -2,7 +2,7 @@
 
 {.push raises: [].}
 
-import results, chronos/timer, libp2p/stream/connection, libp2p/utility
+import results, chronos/timer, libp2p/stream/connection
 
 import std/times except TimeInterval, Duration
 

--- a/logos_delivery/waku/common/rate_limit/timed_map.nim
+++ b/logos_delivery/waku/common/rate_limit/timed_map.nim
@@ -14,7 +14,6 @@
 
 import std/[hashes, sets]
 import chronos/timer, results
-import libp2p/utility
 
 export results
 

--- a/logos_delivery/waku/discovery/waku_kademlia.nim
+++ b/logos_delivery/waku/discovery/waku_kademlia.nim
@@ -54,14 +54,13 @@ proc extractMixPubKey*(service: ServiceInfo): Opt[Curve25519Key] =
   if service.id != MixProtocolID:
     return Opt.none(Curve25519Key)
 
-  if service.data.len != Curve25519KeySize:
+  let data = service.data.get(@[])
+  if data.len != Curve25519KeySize:
     trace "Invalid mix pub key length",
-      expected = Curve25519KeySize,
-      actual = service.data.len,
-      dataHex = byteutils.toHex(service.data)
+      expected = Curve25519KeySize, actual = data.len, dataHex = byteutils.toHex(data)
     return Opt.none(Curve25519Key)
 
-  let key = intoCurve25519Key(service.data)
+  let key = intoCurve25519Key(data)
 
   return Opt.some(key)
 

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -177,7 +177,7 @@ proc setupProtocols(
 
     if conf.mixConf.isSome():
       let mixService =
-        ServiceInfo(id: MixProtocolID, data: @(conf.mixConf.get().mixPubKey))
+        ServiceInfo(id: MixProtocolID, data: Opt.some(@(conf.mixConf.get().mixPubKey)))
       kadConf.servicesToAdvertise.incl(mixService)
       kadConf.servicesToDiscover.incl(mixService.id)
 

--- a/logos_delivery/waku/node/peer_manager/peer_store/waku_peer_storage.nim
+++ b/logos_delivery/waku/node/peer_manager/peer_store/waku_peer_storage.nim
@@ -29,10 +29,15 @@ proc decode*(T: type RemotePeerInfo, buffer: seq[byte]): ProtoResult[T] =
 
   var pb = initProtoBuffer(buffer)
 
+  var pubKeyBytes: seq[byte]
+
   discard ?pb.getField(1, storedInfo.peerId)
   discard ?pb.getRepeatedField(2, multiaddrSeq)
   discard ?pb.getRepeatedField(3, protoSeq)
-  discard ?pb.getField(4, storedInfo.publicKey)
+  # the stored public key is protobuf-encoded
+  let hasPublicKey = ?pb.getField(4, pubKeyBytes)
+  if hasPublicKey and not storedInfo.publicKey.init(pubKeyBytes):
+    return err(ProtoError.IncorrectBlob)
   discard ?pb.getField(5, connectedness)
   discard ?pb.getField(6, disconnectTime)
   let hasENR = ?pb.getField(7, rlpBytes)
@@ -61,10 +66,9 @@ proc encode*(remotePeerInfo: RemotePeerInfo): PeerStorageResult[ProtoBuffer] =
   for proto in remotePeerInfo.protocols.items:
     pb.write(3, proto)
 
-  let catchRes = catch:
-    pb.write(4, remotePeerInfo.publicKey)
-  catchRes.isOkOr:
-    return err("Enncoding public key failed: " & catchRes.error.msg)
+  let pubKeyBytes = remotePeerInfo.publicKey.getBytes().valueOr:
+    return err("Encoding public key failed: " & $error)
+  pb.write(4, pubKeyBytes)
 
   pb.write(5, uint32(ord(remotePeerInfo.connectedness)))
 

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -21,7 +21,6 @@ import
   libp2p/transports/transport,
   libp2p/transports/tcptransport,
   libp2p/transports/wstransport,
-  libp2p/utility,
   libp2p/utils/offsettedseq,
   libp2p_mix,
   libp2p_mix/mix_protocol,

--- a/logos_delivery/waku/node/waku_node/filter.nim
+++ b/logos_delivery/waku/node/waku_node/filter.nim
@@ -16,8 +16,7 @@ import
   libp2p/protocols/pubsub/rpc/messages,
   libp2p/builders,
   libp2p/transports/tcptransport,
-  libp2p/transports/wstransport,
-  libp2p/utility
+  libp2p/transports/wstransport
 
 import
   ../waku_node,

--- a/logos_delivery/waku/node/waku_node/lightpush.nim
+++ b/logos_delivery/waku/node/waku_node/lightpush.nim
@@ -16,7 +16,6 @@ import
   libp2p/builders,
   libp2p/transports/tcptransport,
   libp2p/transports/wstransport,
-  libp2p/utility,
   libp2p_mix
 
 import

--- a/logos_delivery/waku/node/waku_node/peer_exchange.nim
+++ b/logos_delivery/waku/node/waku_node/peer_exchange.nim
@@ -14,8 +14,7 @@ import
   libp2p/protocols/pubsub/rpc/messages,
   libp2p/builders,
   libp2p/transports/tcptransport,
-  libp2p/transports/wstransport,
-  libp2p/utility
+  libp2p/transports/wstransport
 
 import
   ../waku_node,

--- a/logos_delivery/waku/node/waku_node/ping.nim
+++ b/logos_delivery/waku/node/waku_node/ping.nim
@@ -7,8 +7,7 @@ import
   results,
   libp2p/protocols/ping,
   libp2p/builders,
-  libp2p/transports/tcptransport,
-  libp2p/utility
+  libp2p/transports/tcptransport
 
 import ../waku_node, ../peer_manager
 

--- a/logos_delivery/waku/node/waku_node/relay.nim
+++ b/logos_delivery/waku/node/waku_node/relay.nim
@@ -17,7 +17,6 @@ import
   libp2p/builders,
   libp2p/transports/tcptransport,
   libp2p/transports/wstransport,
-  libp2p/utility,
   brokers/broker_context
 
 import

--- a/logos_delivery/waku/node/waku_node/store.nim
+++ b/logos_delivery/waku/node/waku_node/store.nim
@@ -13,8 +13,7 @@ import
   libp2p/protocols/pubsub/rpc/messages,
   libp2p/builders,
   libp2p/transports/tcptransport,
-  libp2p/transports/wstransport,
-  libp2p/utility
+  libp2p/transports/wstransport
 
 import
   ../waku_node,

--- a/logos_delivery/waku/rest_api/endpoint/relay/handlers.nim
+++ b/logos_delivery/waku/rest_api/endpoint/relay/handlers.nim
@@ -229,9 +229,7 @@ proc installRelayApiHandlers*(
 
     # if we reach here its either a non-RLN message or a RLN message with a valid proof
     debug "Publishing message", pubSubTopic = pubSubTopic, rln = not node.rln.isNil()
-    if not (
-      waitFor node.publish(Opt.some(pubSubTopic), message).withTimeout(futTimeout)
-    ):
+    if not (await node.publish(Opt.some(pubSubTopic), message).withTimeout(futTimeout)):
       error "Failed to publish message to topic", pubSubTopic = pubSubTopic
       return RestApiResponse.internalServerError("Failed to publish: timedout")
 

--- a/logos_delivery/waku/waku_relay/message_id.nim
+++ b/logos_delivery/waku/waku_relay/message_id.nim
@@ -20,10 +20,16 @@ type MessageIdProvider* = pubsub.MsgIdProvider
 # Waku Relay (Gossipsub) protocol's message cache and the gossiping process, and
 # as a consequence the network.
 
+const EmptyPayload: seq[byte] = @[]
+
+template payloadBytes*(message: messages.Message): untyped =
+  ## `data[]` borrows the payload on the per-message hot path.
+  if message.data.isSome: message.data[] else: EmptyPayload
+
 proc defaultMessageIdProvider*(
     message: messages.Message
 ): Result[MessageID, ValidationResult] =
-  let hash = sha256.digest(message.data)
+  let hash = sha256.digest(message.payloadBytes)
   ok(@(hash.data))
 
 ## Waku message Unique ID provider

--- a/logos_delivery/waku/waku_relay/protocol.nim
+++ b/logos_delivery/waku/waku_relay/protocol.nim
@@ -17,6 +17,7 @@ import
   libp2p/protocols/pubsub/rpc/messages,
   libp2p/stream/connection,
   libp2p/switch,
+  libp2p/utils/opt,
   brokers/broker_context
 
 import
@@ -273,7 +274,7 @@ proc initRelayObservers(w: WakuRelay) =
 
     let msg_id_short = shortLog(msg_id)
 
-    let wakuMessage = WakuMessage.decode(msg.data).valueOr:
+    let wakuMessage = WakuMessage.decode(msg.payloadBytes).valueOr:
       debug "Error decoding to Waku Message",
         my_peer_id = w.switch.peerInfo.peerId,
         msg_id = msg_id_short,
@@ -282,7 +283,7 @@ proc initRelayObservers(w: WakuRelay) =
         error = $error
       return err()
 
-    let msgSize = msg.data.len + msg.topic.len
+    let msgSize = msg.payloadBytes.len + msg.topic.len
     return ok((msg_id_short, msg.topic, wakuMessage, msgSize))
 
   proc updateMetrics(
@@ -309,12 +310,14 @@ proc initRelayObservers(w: WakuRelay) =
       var topicsChanged = false
 
       for graft in ctrl.graft:
-        w.topicHealthDirty.incl(graft.topicID)
-        topicsChanged = true
+        graft.topicID.withValue(topic):
+          w.topicHealthDirty.incl(topic)
+          topicsChanged = true
 
       for prune in ctrl.prune:
-        w.topicHealthDirty.incl(prune.topicID)
-        topicsChanged = true
+        prune.topicID.withValue(topic):
+          w.topicHealthDirty.incl(topic)
+          topicsChanged = true
 
       if topicsChanged:
         w.topicHealthUpdateEvent.fire()
@@ -328,7 +331,7 @@ proc initRelayObservers(w: WakuRelay) =
 
   proc onValidated(peer: PubSubPeer, msg: Message, msgId: MessageId) =
     let msg_id_short = shortLog(msgId)
-    let wakuMessage = WakuMessage.decode(msg.data).valueOr:
+    let wakuMessage = WakuMessage.decode(msg.payloadBytes).valueOr:
       debug "onValidated: failed decoding to Waku Message",
         my_peer_id = w.switch.peerInfo.peerId,
         msg_id = msg_id_short,
@@ -544,7 +547,7 @@ proc generateOrderedValidator(w: WakuRelay): ValidatorHandler {.gcsafe.} =
   ): Future[ValidationResult] {.async.} =
     # can be optimized by checking if the message is a WakuMessage without allocating memory
     # see nim-libp2p protobuf library
-    let msg = WakuMessage.decode(message.data).valueOr:
+    let msg = WakuMessage.decode(message.payloadBytes).valueOr:
       debug "Rejecting relay message, decode error",
         pubsubTopic = pubsubTopic, error = $error
       return ValidationResult.Reject

--- a/logos_delivery/waku/waku_rendezvous/protocol.nim
+++ b/logos_delivery/waku/waku_rendezvous/protocol.nim
@@ -10,8 +10,7 @@ import
   libp2p/protocols/rendezvous/protobuf,
   libp2p/utils/offsettedseq,
   libp2p/crypto/curve25519,
-  libp2p/switch,
-  libp2p/utility
+  libp2p/switch
 
 import metrics except collect
 
@@ -59,8 +58,7 @@ proc advertise*(
   ).valueOr:
     return
       err("rendezvous advertisement failed: Failed to sign Waku Peer Record: " & $error)
-  let sprBuff = se.encode().valueOr:
-    return err("rendezvous advertisement failed: Wrong Signed Peer Record: " & $error)
+  let sprBuff = se.encode()
 
   # rendezvous.advertise expects already opened connections
   # must dial first

--- a/logos_delivery/waku/waku_rendezvous/waku_peer_record.nim
+++ b/logos_delivery/waku/waku_rendezvous/waku_peer_record.nim
@@ -8,6 +8,7 @@ import
     multiaddress,
     protobuf/minprotobuf,
     peerid,
+    utils/shortlog,
   ]
 
 type WakuPeerRecord* = object

--- a/logos_delivery/waku/waku_store_sync/reconciliation.nim
+++ b/logos_delivery/waku/waku_store_sync/reconciliation.nim
@@ -7,7 +7,6 @@ import
   chronicles,
   chronos,
   metrics,
-  libp2p/utility,
   libp2p/protocols/protocol,
   libp2p/stream/connection,
   libp2p/crypto/crypto,

--- a/logos_delivery/waku/waku_store_sync/transfer.nim
+++ b/logos_delivery/waku/waku_store_sync/transfer.nim
@@ -6,7 +6,6 @@ import
   chronicles,
   chronos,
   metrics,
-  libp2p/utility,
   libp2p/protocols/protocol,
   libp2p/stream/connection,
   libp2p/crypto/crypto,

--- a/tests/test_waku_keepalive.nim
+++ b/tests/test_waku_keepalive.nim
@@ -26,13 +26,12 @@ suite "Waku Keepalive":
 
     var completionFut = newFuture[bool]()
 
-    proc pingHandler(peerId: PeerID) {.async, gcsafe.} =
+    proc pingHandler(peerId: PeerID) {.async: (raises: []), gcsafe.} =
       info "Ping received"
 
-      check:
-        peerId == node1.switch.peerInfo.peerId
-
-      completionFut.complete(true)
+      # check raises on failure and this handler allows no raises, so
+      # complete the future with the comparison and check it below.
+      completionFut.complete(peerId == node1.switch.peerInfo.peerId)
 
     await node1.start()
     (await node1.mountRelay()).isOkOr:

--- a/tests/test_wakunode.nim
+++ b/tests/test_wakunode.nim
@@ -21,6 +21,7 @@ import
   eth/net/utils
 import
   logos_delivery/waku/[waku_core, waku_node, node/peer_manager],
+  logos_delivery/waku/factory/internal_config,
   ./testlib/wakucore,
   ./testlib/wakunode
 
@@ -291,9 +292,18 @@ suite "WakuNode":
       bindPort = Port(0)
 
       domainName = "status.im"
-      node = newTestWakuNode(
-        nodeKey, bindIp, bindPort, dns4DomainName = Opt.some(domainName)
-      )
+
+    let resolvedIp = (
+      await dnsResolve(domainName, defaultTestWakuConf().dnsAddrsNameServers)
+    ).valueOr:
+      raiseAssert "DNS resolution failed: " & error
+    let node = newTestWakuNode(
+      nodeKey,
+      bindIp,
+      bindPort,
+      extIp = Opt.some(parseIpAddress(resolvedIp)),
+      dns4DomainName = Opt.some(domainName),
+    )
 
     var ipStr = ""
     var enrIp = node.enr.tryGet("ip", array[4, byte])
@@ -308,38 +318,21 @@ suite "WakuNode":
       not ipStr.contains("0.0.0.0")
       not ipStr.contains("127.0.0.1")
 
-  asyncTest "Node creation fails when invalid dns4 address is provided":
+  asyncTest "dns4 resolution fails for inexistent and invalid domains":
     let
-      nodeKey = generateSecp256k1Key()
-      bindIp = parseIpAddress("0.0.0.0")
-      bindPort = Port(0)
-
       inexistentDomain = "thisdomain.doesnot.exist"
       invalidDomain = ""
       expectedError = "Could not resolve IP from DNS: empty response"
+      nameServers = defaultTestWakuConf().dnsAddrsNameServers
 
-    var inexistentDomainErr, invalidDomainErr: string = ""
+    let inexistentRes = await dnsResolve(inexistentDomain, nameServers)
+    let invalidRes = await dnsResolve(invalidDomain, nameServers)
 
-    # Create node with inexistent domain
-    try:
-      let node = newTestWakuNode(
-        nodeKey, bindIp, bindPort, dns4DomainName = Opt.some(inexistentDomain)
-      )
-    except Exception as e:
-      inexistentDomainErr = e.msg
-
-    # Create node with invalid domain
-    try:
-      let node = newTestWakuNode(
-        nodeKey, bindIp, bindPort, dns4DomainName = Opt.some(invalidDomain)
-      )
-    except Exception as e:
-      invalidDomainErr = e.msg
-
-    # Check that exceptions were raised in both cases
     check:
-      inexistentDomainErr == expectedError
-      invalidDomainErr == expectedError
+      inexistentRes.isErr()
+      inexistentRes.error == expectedError
+      invalidRes.isErr()
+      invalidRes.error == expectedError
 
   asyncTest "Agent string is set and advertised correctly":
     let

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -87,8 +87,6 @@ proc newTestWakuNode*(
   let quicBindPort =
     if quicEnabled and quicBindPort == Port(0): bindPort else: quicBindPort
 
-  var resolvedExtIp = extIp
-
   # Update extPort to default value if it's missing and there's an extIp or a DNS domain
   let extPort =
     if (extIp.isSome() or dns4DomainName.isSome()) and extPort.isNone():
@@ -101,18 +99,13 @@ proc newTestWakuNode*(
   conf.clusterId = clusterId
   conf.subscribeShards = subscribeShards
 
-  if dns4DomainName.isSome() and extIp.isNone():
-    # If there's an error resolving the IP, an exception is thrown and test fails
-    let dns = (waitFor dnsResolve(dns4DomainName.get(), conf.dnsAddrsNameServers)).valueOr:
-      raise newException(Defect, error)
-
-    resolvedExtIp = Opt.some(parseIpAddress(dns))
-
+  # A dns4 name is announced as-is. A caller that needs the resolved IP
+  # in the ENR resolves the name and passes it as extIp.
   let netConf = NetConfig.init(
     clusterId = conf.clusterId,
     bindIp = bindIp,
     bindPort = bindPort,
-    extIp = resolvedExtIp,
+    extIp = extIp,
     extPort = extPort,
     extMultiAddrs = extMultiAddrs,
     wsBindPort = Opt.some(wsBindPort),

--- a/tests/waku_kademlia/test_waku_kademlia.nim
+++ b/tests/waku_kademlia/test_waku_kademlia.nim
@@ -23,7 +23,9 @@ suite "Waku Kademlia service discovery":
     let
       switch = newTestSwitch()
       wk = kad_utils.newTestKademlia(
-        switch, servicesToAdvertise = @[ServiceInfo(id: "/seed/svc/1.0.0", data: @[])]
+        switch,
+        servicesToAdvertise =
+          @[ServiceInfo(id: "/seed/svc/1.0.0", data: Opt.some(newSeq[byte]()))],
       )
     await switch.start()
     await wk.start()
@@ -44,18 +46,18 @@ suite "Waku Kademlia service discovery":
       b
 
     test "non-mix service returns none":
-      let svc = ServiceInfo(id: "/foo/1.0.0", data: validKeyBytes())
+      let svc = ServiceInfo(id: "/foo/1.0.0", data: Opt.some(validKeyBytes()))
       check:
         extractMixPubKey(svc).isNone()
 
     test "mix service with wrong data length returns none":
-      let svc = ServiceInfo(id: MixProtocolID, data: @[0u8, 1u8, 2u8])
+      let svc = ServiceInfo(id: MixProtocolID, data: Opt.some(@[0u8, 1u8, 2u8]))
       check:
         extractMixPubKey(svc).isNone()
 
     test "mix service with correct length returns some":
       let bytes = validKeyBytes()
-      let svc = ServiceInfo(id: MixProtocolID, data: bytes)
+      let svc = ServiceInfo(id: MixProtocolID, data: Opt.some(bytes))
       let res = extractMixPubKey(svc)
       require:
         res.isSome()
@@ -65,7 +67,7 @@ suite "Waku Kademlia service discovery":
 
     test "round-trip matches intoCurve25519Key on raw bytes":
       let bytes = validKeyBytes()
-      let svc = ServiceInfo(id: MixProtocolID, data: bytes)
+      let svc = ServiceInfo(id: MixProtocolID, data: Opt.some(bytes))
       let extracted = extractMixPubKey(svc).get()
       let direct = intoCurve25519Key(bytes)
       check:
@@ -79,7 +81,7 @@ suite "Waku Kademlia service discovery":
       MultiAddress.init("/ip4/127.0.0.1/tcp/" & $port).tryGet()
 
     proc mixService(data: seq[byte]): ServiceInfo =
-      ServiceInfo(id: MixProtocolID, data: data)
+      ServiceInfo(id: MixProtocolID, data: Opt.some(data))
 
     proc validMixService(): ServiceInfo =
       var b = newSeq[byte](Curve25519KeySize)
@@ -115,12 +117,12 @@ suite "Waku Kademlia service discovery":
       let peerInfo = res.get()
       check:
         peerInfo.mixPubKey.isSome()
-        peerInfo.mixPubKey.get().getBytes() == svc.data
+        peerInfo.mixPubKey.get().getBytes() == svc.data.get(@[])
 
     test "mixPubKey stays none when no mix service present":
       let
         pid = randomPeerId()
-        svc = ServiceInfo(id: "/other/1.0.0", data: @[1u8])
+        svc = ServiceInfo(id: "/other/1.0.0", data: Opt.some(@[1u8]))
         record = buildExtendedPeerRecord(pid, @[testAddr(61600)], @[svc])
         res = remotePeerInfoFrom(record)
       require:

--- a/tests/waku_relay/test_message_id.nim
+++ b/tests/waku_relay/test_message_id.nim
@@ -9,7 +9,7 @@ import logos_delivery/waku/waku_relay/message_id
 
 suite "Message ID Provider":
   test "Non-empty string":
-    let message = Message(data: "Hello, world!".toBytes())
+    let message = Message(data: Opt.some("Hello, world!".toBytes()))
     let result = defaultMessageIdProvider(message)
     let expected = MDigest[256].fromHex(
       "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
@@ -19,7 +19,7 @@ suite "Message ID Provider":
       result.get() == expected.data
 
   test "Empty string":
-    let message = Message(data: "".toBytes())
+    let message = Message(data: Opt.some("".toBytes()))
     let result = defaultMessageIdProvider(message)
     let expected = MDigest[256].fromHex(
       "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
@@ -29,7 +29,7 @@ suite "Message ID Provider":
       result.get() == expected.data
 
   test "Empty array":
-    let message = Message(data: @[])
+    let message = Message(data: Opt.some(newSeq[byte]()))
     let result = defaultMessageIdProvider(message)
     let expected = MDigest[256].fromHex(
       "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -559,8 +559,10 @@ suite "WakuNode - Relay":
     await node2.stop()
 
   asyncTest "Bad peers with low reputation are disconnected":
-    # Create 5 nodes
-    let nodes = toSeq(0 ..< 5).mapIt(newTestWakuNode(generateSecp256k1Key()))
+    # The bad-peer scoring under test is transport agnostic.
+    # TCP teardown is deterministic enough to assert on connection counts.
+    let nodes =
+      toSeq(0 ..< 5).mapIt(newTestWakuNode(generateSecp256k1Key(), quicEnabled = false))
     await allFutures(nodes.mapIt(it.start()))
     await allFutures(nodes.mapIt(it.mountRelay()))
 


### PR DESCRIPTION
## PR Description

libp2p v2.2.1 adaptation PR (stack: PR 2 of 5)

Adapts the source to the 2.2.1 API. The stack compiles and runs from this PR on.

**NOTE: This PR's macOS test job can exit nonzero after all tests pass. The stack tip's full-suite job passed on its PR.**

## Changes

* adapt call sites to the 2.2.1 API
* read relay payloads via a payloadBytes template
* store peer public keys as bytes
* reject malformed peer keys on decode
* await the REST relay publish
* adapt Kademlia service data to its optional form
* drop dns4 resolution from the test-node constructor
* run the relay bad-peers test over TCP only
