### PR TITLE
fix: resolve announced addresses from a configured base at switch start

### DIFF
--- a/logos_delivery/waku/net/net_config.nim
+++ b/logos_delivery/waku/net/net_config.nim
@@ -1,6 +1,7 @@
 {.push raises: [].}
 
-import std/[sequtils, strutils, net], results, libp2p/[multiaddress, multicodec, wire]
+import std/[sequtils, strutils, net], results, stew/endians2
+import libp2p/[multiaddress, multicodec, wire]
 import ../../waku/waku_core/peers
 import ../waku_enr
 
@@ -58,10 +59,18 @@ template ipQuicEndPoint(address: IpAddress, port: Port): MultiAddress =
 template dns4QuicEndPoint(dns4DomainName: string, port: Port): MultiAddress =
   dns4Ma(dns4DomainName) & udpPortMa(port) & quicFlag()
 
-proc formatListenAddress(inputMultiAdd: MultiAddress): MultiAddress =
-  let inputStr = $inputMultiAdd
-  # If MultiAddress contains "0.0.0.0", replace it for "127.0.0.1"
-  return MultiAddress.init(inputStr.replace("0.0.0.0", "127.0.0.1")).get()
+func hasZeroPort*(ma: MultiAddress): bool =
+  ## Port 0 means "the kernel picks a port at bind time".
+  ## initTAddress cannot parse dns-hosted entries, so read the port
+  ## bytes from the tcp or udp component directly.
+  for code in [multiCodec("tcp"), multiCodec("udp")]:
+    let part = ma[code].valueOr:
+      continue
+    let portBytes = part.protoArgument().valueOr:
+      continue
+    if portBytes.len == 2 and uint16.fromBytesBE(portBytes) == 0:
+      return true
+  false
 
 proc isWsAddress*(ma: MultiAddress): bool =
   let
@@ -165,7 +174,8 @@ proc init*(
   if dns4DomainName.isSome():
     # Use dns4 for externally announced addresses
     try:
-      hostExtAddress = Opt.some(dns4TcpEndPoint(dns4DomainName.get(), extPort.get()))
+      hostExtAddress =
+        Opt.some(dns4TcpEndPoint(dns4DomainName.get(), extPort.get(bindPort)))
     except CatchableError:
       return err(getCurrentExceptionMsg())
 
@@ -215,7 +225,7 @@ proc init*(
     if hostExtAddress.isSome():
       announcedAddresses.add(hostExtAddress.get())
     else:
-      announcedAddresses.add(formatListenAddress(hostAddress))
+      announcedAddresses.add(hostAddress)
         # We always have at least a bind address for the host
 
     if wsExtAddress.isSome():
@@ -227,7 +237,7 @@ proc init*(
     if quicExtAddress.isSome():
       announcedAddresses.add(quicExtAddress.get())
     elif quicHostAddress.isSome() and not containsQuicAddress(extMultiAddrs):
-      announcedAddresses.add(formatListenAddress(quicHostAddress.get()))
+      announcedAddresses.add(quicHostAddress.get())
 
   # External multiaddrs that the operator may have configured
   if extMultiAddrs.len > 0:

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -13,7 +13,7 @@ import
   eth/p2p/discoveryv5/enr,
   libp2p/crypto/crypto,
   libp2p/crypto/curve25519,
-  libp2p/[multiaddress, multicodec],
+  libp2p/[multiaddress, multicodec, wire],
   libp2p/protocols/ping,
   libp2p/protocols/pubsub/gossipsub,
   libp2p/protocols/pubsub/rpc/messages,
@@ -124,6 +124,13 @@ type
     wakuRendezvous*: WakuRendezVous
     wakuRendezvousClient*: rendezvous_client.WakuRendezVousClient
     announcedAddresses*: seq[MultiAddress]
+    configuredAnnounced: seq[MultiAddress]
+      ## Operator-configured addresses, set at construction.
+      ## Every recomputation of the announced addresses starts from this field.
+    baseAnnounced: Opt[seq[MultiAddress]]
+      ## The configured addresses made concrete at start: bound ports
+      ## substituted, wildcard hosts rewritten to the primary IP.
+      ## The first mapper in the chain answers with this set.
     extMultiAddrsOnly*: bool # When true, skip automatic IP address replacement
     started*: bool # Indicates that node has started listening
     topicSubscriptionQueue*: AsyncEventQueue[SubscriptionEvent]
@@ -230,10 +237,21 @@ proc new*(
     brokerCtx: brokerCtx,
     enr: enr,
     announcedAddresses: netConfig.announcedAddresses,
+    configuredAnnounced: netConfig.announcedAddresses,
     topicSubscriptionQueue: queue,
     rateLimitSettings: rateLimitSettings,
     ports: BoundPorts.init(),
   )
+
+  ## The base mapper answers with the resolved addresses.
+  ## NAT and relay mappers run after it. Until then it drops zero-port entries.
+  let baseMapper = proc(
+      listenAddrs: seq[MultiAddress]
+  ): Future[seq[MultiAddress]] {.gcsafe, async: (raises: [CancelledError]).} =
+    let base = node.baseAnnounced.valueOr:
+      return listenAddrs.filterIt(not it.hasZeroPort())
+    return base
+  switch.peerInfo.addressMappers.add(baseMapper)
 
   peerManager.setShardGetter(node.getShardsGetter(@[]))
 
@@ -460,58 +478,96 @@ proc mountRendezvous*(
   except LPError:
     error "Failed to mount wakuRendezvous", error = getCurrentExceptionMsg()
 
-proc isBindIpWithZeroPort(inputMultiAdd: MultiAddress): bool =
-  let inputStr = $inputMultiAdd
-  if inputStr.contains("0.0.0.0/tcp/0") or inputStr.contains("127.0.0.1/tcp/0"):
-    return true
+func replacePort(ma: MultiAddress, port: Port): Opt[MultiAddress] =
+  ## Rebuild `ma` with its tcp or udp component set to `port`.
+  let
+    tcp = multiCodec("tcp")
+    udp = multiCodec("udp")
+  var res = MultiAddress.init()
+  for item in ma.items:
+    let part = item.valueOr:
+      return Opt.none(MultiAddress)
+    let code = part.protoCode.valueOr:
+      return Opt.none(MultiAddress)
+    if code == tcp or code == udp:
+      let portMa = MultiAddress.init(code, int(port)).valueOr:
+        return Opt.none(MultiAddress)
+      res.append(portMa).isOkOr:
+        return Opt.none(MultiAddress)
+    else:
+      res.append(part).isOkOr:
+        return Opt.none(MultiAddress)
+  Opt.some(res)
 
-  return false
+proc substituteBoundPorts(
+    addrs: seq[MultiAddress], listenAddrs: seq[MultiAddress]
+): seq[MultiAddress] =
+  ## Replace port 0 with the port the entry's transport bound.
+  ## Drop a port-0 entry whose transport did not bind.
+  ## Entries with concrete ports pass through unchanged.
+  if not addrs.anyIt(it.hasZeroPort()):
+    return addrs
 
-proc updateAnnouncedAddrWithPrimaryIpAddr*(node: WakuNode): Result[void, string] =
-  # Skip automatic IP replacement if extMultiAddrsOnly is set
-  # This respects the user's explicitly configured announced addresses
-  if node.extMultiAddrsOnly:
-    return ok()
+  let bound = getPorts(listenAddrs).valueOr:
+    ## If getPorts fails, drop the zero-port entries.
+    error "failed to read bound ports; dropping zero-port entries", error = error
+    return addrs.filterIt(not it.hasZeroPort())
 
-  let peerInfo = node.switch.peerInfo
-  var announcedStr = ""
-  var listenStr = ""
-  var localIp = "0.0.0.0"
+  var resolved: seq[MultiAddress]
+  for ma in addrs:
+    if not ma.hasZeroPort():
+      resolved.add(ma)
+      continue
+    let port = (
+      if ma.isWsAddress():
+        bound.websocketPort
+      elif ma.isQuicAddress():
+        bound.quicPort
+      else:
+        bound.tcpPort
+    ).valueOr:
+      continue
+    let substituted = ma.replacePort(port).valueOr:
+      continue
+    resolved.add(substituted)
+  resolved
 
+proc resolveAnnouncedBaseAddresses(node: WakuNode) =
+  ## Runs once per start, after the sockets bind.
+  ## Here the configured addresses become real: port 0 becomes
+  ## the bound port, and a wildcard host becomes the primary IP.
+  ## Everything the node announces builds on this set.
+  let substituted =
+    substituteBoundPorts(node.configuredAnnounced, node.switch.peerInfo.listenAddrs)
+
+  const LoopbackIp = parseIpAddress("127.0.0.1")
+  const RewrittenHosts =
+    [static(parseIpAddress("0.0.0.0")), static(parseIpAddress("::"))]
+  var primaryIp = LoopbackIp
   try:
-    localIp = $getPrimaryIPAddr()
+    primaryIp = getPrimaryIPAddr()
   except Exception as e:
-    debug "Could not retrieve localIp", msg = e.msg
+    ## getPrimaryIPAddr declares a bare Exception effect on Windows, so
+    ## a narrower catch fails the raises check there.
+    debug "Could not retrieve the primary IP address", msg = e.msg
 
-  info "PeerInfo", peerId = peerInfo.peerId, addrs = peerInfo.addrs
+  var resolved = newSeq[MultiAddress](0)
+  for address in substituted:
+    let ip = address.getIp().valueOr:
+      resolved.add(address)
+      continue
+    if ip notin RewrittenHosts:
+      resolved.add(address)
+      continue
+    let rewritten = address.replaceIp(primaryIp).valueOr:
+      resolved.add(address)
+      continue
+    resolved.add(rewritten)
 
-  ## Update the WakuNode addresses
-  var newAnnouncedAddresses = newSeq[MultiAddress](0)
-  for address in node.announcedAddresses:
-    ## Replace "0.0.0.0" or "127.0.0.1" with the localIp
-    let newAddr = ($address).replace("0.0.0.0", localIp).replace("127.0.0.1", localIp)
-    let fulladdr = "[" & $newAddr & "/p2p/" & $peerInfo.peerId & "]"
-    announcedStr &= fulladdr
-    let newMultiAddr = MultiAddress.init(newAddr).valueOr:
-      return err("error in updateAnnouncedAddrWithPrimaryIpAddr: " & $error)
-    newAnnouncedAddresses.add(newMultiAddr)
-
-  node.announcedAddresses = newAnnouncedAddresses
-
-  ## Update the Switch addresses
-  node.switch.peerInfo.addrs = newAnnouncedAddresses
-
-  for transport in node.switch.transports:
-    for address in transport.addrs:
-      let fulladdr = "[" & $address & "/p2p/" & $peerInfo.peerId & "]"
-      listenStr &= fulladdr
-
-  info "Listening on",
-    full = listenStr, localIp = localIp, switchAddress = $(node.switch.peerInfo.addrs)
-  info "Announcing addresses", full = announcedStr
-  info "DNS: discoverable ENR ", enr = node.enr.toUri()
-
-  return ok()
+  let base = resolved.filterIt(not it.hasZeroPort())
+  node.baseAnnounced = Opt.some(base)
+  node.announcedAddresses = base
+  info "Announced base resolved", addrs = $base
 
 proc startProvidersAndListeners*(node: WakuNode) =
   RequestRelayShard.setProvider(
@@ -596,28 +652,18 @@ proc start*(node: WakuNode) {.async.} =
   logos_delivery_version.set(1, labelValues = [git_version])
   info "Starting Waku node", version = git_version
 
-  var zeroPortPresent = false
-  for address in node.announcedAddresses:
-    if isBindIpWithZeroPort(address):
-      zeroPortPresent = true
-
   if not node.wakuStoreResume.isNil():
     await node.wakuStoreResume.start()
 
   if not node.wakuRendezvousClient.isNil():
     await node.wakuRendezvousClient.start()
 
-  ## The switch uses this mapper to update peer info addrs
-  ## with announced addrs after start
-  let addressMapper = proc(
-      listenAddrs: seq[MultiAddress]
-  ): Future[seq[MultiAddress]] {.gcsafe, async: (raises: [CancelledError]).} =
-    return node.announcedAddresses
-  node.switch.peerInfo.addressMappers.add(addressMapper)
-
-  ## The switch will update addresses after start using the addressMapper
   ## NOTE: This will dispatch gossipsub start to the WakuRelay.start method override
   await node.switch.start()
+
+  ## The sockets are bound now. Resolve the announced addresses and commit them.
+  resolveAnnouncedBaseAddresses(node)
+  await node.switch.peerInfo.update()
 
   # Reconnect to known relay peers in the background; it waits a prune backoff
   # and must not block startup.
@@ -638,12 +684,6 @@ proc start*(node: WakuNode) {.async.} =
 
   node.subscriptionManager.start().isOkOr:
     error "failed to start subscription manager", error = error
-
-  if not zeroPortPresent:
-    updateAnnouncedAddrWithPrimaryIpAddr(node).isOkOr:
-      error "Failed update announced addr", error = $error
-  else:
-    info "Listening port is dynamically allocated, address and ENR generation postponed"
 
   info "Node started successfully"
 
@@ -686,6 +726,7 @@ proc stop*(node: WakuNode) {.async.} =
     await node.wakuRendezvousClient.stopWait()
 
   node.started = false
+  node.baseAnnounced = Opt.none(seq[MultiAddress])
 
 proc isReady*(node: WakuNode): Future[bool] {.async: (raises: [Exception]).} =
   if node.rln == nil:

--- a/logos_delivery/waku/waku.nim
+++ b/logos_delivery/waku/waku.nim
@@ -327,8 +327,6 @@ proc updateWaku(waku: Waku): Future[Result[void, string]] {.async.} =
   (await updateEnr(waku)).isOkOr:
     return err("error calling updateEnr: " & $error)
 
-  ?updateAnnouncedAddrWithPrimaryIpAddr(waku.node)
-
   ?updateAddressInENR(waku)
 
   return ok()

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -55,6 +55,7 @@ import
 
 import
   # Waku v2 tests
+  ./test_announced_addresses,
   ./test_wakunode,
   ./test_peer_store_extended,
   ./test_message_cache,

--- a/tests/test_announced_addresses.nim
+++ b/tests/test_announced_addresses.nim
@@ -1,0 +1,50 @@
+{.used.}
+
+## libp2p commits the final announced addresses into peerInfo after
+## the address mappers run. These tests check that node.announcedAddresses
+## and the ENR multiaddrs field copy that committed set.
+
+import results
+import std/[net, sequtils, strutils]
+import testutils/unittests, chronos
+import libp2p/[multiaddress, peerinfo, switch, wire]
+import ../logos_delivery/waku/node/waku_node
+import ./testlib/[common, wakucore, wakunode]
+
+suite "Announced addresses":
+  asyncTest "the resolved base reaches peerInfo and the API projection":
+    let node =
+      newTestWakuNode(generateSecp256k1Key(), parseIpAddress("0.0.0.0"), Port(0))
+    await node.start()
+    check:
+      node.announcedAddresses.len > 0
+      node.announcedAddresses == node.switch.peerInfo.addrs
+      node.announcedAddresses.allIt("/tcp/0" notin $it and "/udp/0/" notin $it)
+      node.announcedAddresses.allIt("0.0.0.0" notin $it)
+    await node.stop()
+
+  asyncTest "a loopback bind stays loopback in the base":
+    ## Rewriting loopback to the LAN IP once crashed the test suite
+    ## because it announces endpoints nothing listens on.
+    let node =
+      newTestWakuNode(generateSecp256k1Key(), parseIpAddress("127.0.0.1"), Port(0))
+    await node.start()
+    check:
+      node.announcedAddresses.len > 0
+      node.announcedAddresses.allIt("/ip4/127.0.0.1/" in $it)
+    await node.stop()
+
+  asyncTest "an operator host containing the wildcard substring survives intact":
+    ## The host string contains "0.0.0.0". Text replacement corrupted it.
+    ## Matching the parsed IP keeps it unchanged.
+    let tricky = MultiAddress.init("/ip4/10.0.0.0/tcp/60123").get()
+    let node = newTestWakuNode(
+      generateSecp256k1Key(),
+      parseIpAddress("127.0.0.1"),
+      Port(0),
+      extMultiAddrs = @[tricky],
+    )
+    await node.start()
+    check:
+      tricky in node.announcedAddresses
+    await node.stop()

--- a/tests/test_waku_netconfig.nim
+++ b/tests/test_waku_netconfig.nim
@@ -61,11 +61,7 @@ suite "Waku NetConfig":
     check:
       netConfig.announcedAddresses.len == 1 # Only bind address should be present
       netConfig.announcedAddresses[0] ==
-        formatListenAddress(
-          ip4TcpEndPoint(
-            conf.endpointConf.p2pListenAddress, conf.endpointConf.p2pTcpPort
-          )
-        )
+        ip4TcpEndPoint(conf.endpointConf.p2pListenAddress, conf.endpointConf.p2pTcpPort)
 
   asyncTest "AnnouncedAddresses contains external address if extIp/Port are provided":
     let


### PR DESCRIPTION
## PR Description

Announced-address source fix (stack: PR 3 of 5)

Every networked program has two different addresses. The bind address is an instruction to the kernel (`0.0.0.0` means "accept packets on every interface") and is not something a peer can dial. The advertised address is what the node tells peers to dial. In this codebase the advertised list is `announcedAddresses`, and the operator's configuration of it may contain two placeholders: port 0 ("kernel picks the port at bind time") and the host `0.0.0.0` ("every interface").

Before this PR, the node derived its advertisement from the bind address by rewriting its text. The list was assembled before the sockets bound, so port-0 placeholders reached peers as-is. The wildcard host was patched in two string-replacement steps: `0.0.0.0` became `127.0.0.1` at config build (`formatListenAddress`), and at start every `127.0.0.1`, including a deliberately configured loopback bind, became the machine's LAN address, with the result assigned straight into `peerInfo.addrs`, bypassing `peerInfo.update()`. Two consequences: a loopback-bound node advertised an endpoint nothing listened on, and the signed peer record, which only regenerates inside `update()`, could disagree with the advertisement.

Now the operator's configured list (`configuredAnnounced`) is the only source, and it never changes after construction. At start, once the sockets bind, the node resolves the placeholders (`resolveAnnouncedBaseAddresses`). Port 0 becomes the port that entry's own transport actually bound: tcp, websocket, or quic (e.g. `/ip4/192.168.1.7/tcp/0` becomes `/ip4/192.168.1.7/tcp/60321`). An entry whose transport did not bind is dropped (e.g. a websocket entry when the websocket transport is off). The host `0.0.0.0` becomes the machine's outbound IP: the source address the kernel picks for internet-bound traffic (`getPrimaryIPAddr`), which on a LAN host is its interface address and on a public server is the public address itself (e.g. `/ip4/0.0.0.0/tcp/60000` becomes `/ip4/192.168.1.7/tcp/60000`). The match is on the parsed IP, and a loopback bind stays loopback. The host of an `extip:` or dns4 entry stays as configured. Only its port can change. In the code the resolved list is `baseAnnounced`, served by the base mapper.

The base mapper answers first in libp2p's mapper chain, so NAT and relay derive from real addresses. Before the resolution runs it forwards only entries with real ports, so no service ever sees port 0. Right after resolving, the node runs one `peerInfo.update()` of its own, which commits the resolved list into `peerInfo.addrs` and regenerates the signed peer record. The record and the advertisement now match. A restart resolves the configured list again from scratch.

`NetConfig` keeps the bind entry verbatim: binding `/ip4/0.0.0.0/tcp/60000` puts exactly that in the configured list, so the wildcard is still present for the resolution to match. The rule: a wildcard bind advertises the outbound IP, a loopback bind advertises loopback, and loopback is the fallback when the machine has no outbound route.

**NOTE: This PR's docker e2e job fails three tests that dial addresses read from `announcedAddresses`, which keeps its configured wildcard until PR 5.**

## Changes

* substitute bound ports into port-0 entries per transport
* drop entries whose transport did not bind
* rewrite wildcard hosts to the primary IP
* install the base mapper before switch start
* answer the mapper chain from the resolved base
* commit the base with one startup peerInfo update
* export the zero-port check from net_config
* delete the primary-IP string rewrite
* announce the bind address verbatim from NetConfig
* delete formatListenAddress
